### PR TITLE
fix: Mock server CPU metrics incompatible with remote mode parser

### DIFF
--- a/src/mock/templates/common.rs
+++ b/src/mock/templates/common.rs
@@ -76,10 +76,16 @@ pub fn add_system_metrics(template: &mut String, instance_name: &str) {
         "all_smi_cpu_utilization{{instance=\"{instance_name}\"}} {{{{CPU_UTIL}}}}\n"
     ));
 
-    template.push_str("# HELP all_smi_cpu_cores Number of CPU cores\n");
-    template.push_str("# TYPE all_smi_cpu_cores gauge\n");
+    template.push_str("# HELP all_smi_cpu_core_count Total number of CPU cores\n");
+    template.push_str("# TYPE all_smi_cpu_core_count gauge\n");
     template.push_str(&format!(
-        "all_smi_cpu_cores{{instance=\"{instance_name}\"}} {{{{CPU_CORES}}}}\n"
+        "all_smi_cpu_core_count{{instance=\"{instance_name}\"}} {{{{CPU_CORES}}}}\n"
+    ));
+
+    template.push_str("# HELP all_smi_cpu_temperature_celsius CPU temperature in celsius\n");
+    template.push_str("# TYPE all_smi_cpu_temperature_celsius gauge\n");
+    template.push_str(&format!(
+        "all_smi_cpu_temperature_celsius{{instance=\"{instance_name}\"}} {{{{CPU_TEMP}}}}\n"
     ));
 
     // Memory metrics
@@ -136,6 +142,7 @@ pub fn render_system_metrics(mut response: String) -> String {
             &format!("{:.2}", rng.random_range(10.0..90.0)),
         )
         .replace("{{CPU_CORES}}", "128")
+        .replace("{{CPU_TEMP}}", &rng.random_range(35..75).to_string())
         .replace(
             "{{MEM_USED}}",
             &rng.random_range(10_000_000_000u64..500_000_000_000u64)

--- a/src/mock/templates/nvidia.rs
+++ b/src/mock/templates/nvidia.rs
@@ -189,12 +189,21 @@ impl NvidiaMockGenerator {
             self.instance_name
         ));
 
-        template.push_str("# HELP all_smi_cpu_cores Number of CPU cores\n");
-        template.push_str("# TYPE all_smi_cpu_cores gauge\n");
+        template.push_str("# HELP all_smi_cpu_core_count Total number of CPU cores\n");
+        template.push_str("# TYPE all_smi_cpu_core_count gauge\n");
         template.push_str(&format!(
-            "all_smi_cpu_cores{{instance=\"{}\"}} {}\n",
+            "all_smi_cpu_core_count{{instance=\"{}\"}} {}\n",
             self.instance_name, cpu.core_count
         ));
+
+        template.push_str("# HELP all_smi_cpu_temperature_celsius CPU temperature in celsius\n");
+        template.push_str("# TYPE all_smi_cpu_temperature_celsius gauge\n");
+        if let Some(temp) = cpu.temperature_celsius {
+            template.push_str(&format!(
+                "all_smi_cpu_temperature_celsius{{instance=\"{}\"}} {}\n",
+                self.instance_name, temp
+            ));
+        }
 
         // Memory metrics
         template.push_str("# HELP all_smi_memory_used_bytes System memory used in bytes\n");


### PR DESCRIPTION
## Summary
- Fixed mock server CPU metric names to match API specification
- Added missing CPU temperature metric generation
- Updated both common.rs and nvidia.rs templates

## Changes Made

### Metric Name Correction
- Changed `all_smi_cpu_cores` to `all_smi_cpu_core_count` to match the API metrics format defined in `src/api/metrics/cpu.rs:64-66`
- This ensures compatibility with the remote mode parser at `src/network/metrics_parser.rs:316`

### Added CPU Temperature Metric
- Added `all_smi_cpu_temperature_celsius` metric generation
- Generates random temperature values in realistic range (35-75 celsius)
- Matches the API format defined in `src/api/metrics/cpu.rs:88-92`

### Files Modified
- `src/mock/templates/common.rs`: Updated base template functions
- `src/mock/templates/nvidia.rs`: Updated NVIDIA-specific template

## Testing
- Built and tested mock server with changes
- Verified correct metric names are generated:
  ```
  all_smi_cpu_core_count{instance="node-0001"} 34
  all_smi_cpu_temperature_celsius{instance="node-0001"} 68
  ```
- Confirmed metrics are now compatible with remote mode parser

## Related Issue
Fixes #58

## Checklist
- [x] Code follows project style guidelines
- [x] Changes have been tested locally
- [x] Metric names match API specification
- [x] CPU temperature metric added with realistic values