### PR TITLE
Fix Rebellions NPU detection with rbln SDK 2.0.x

### DIFF
--- a/src/device/readers/rebellions.rs
+++ b/src/device/readers/rebellions.rs
@@ -22,10 +22,41 @@ use crate::device::GpuReader;
 use crate::utils::get_hostname;
 use chrono::Local;
 use once_cell::sync::Lazy;
+use serde::de::{self, Deserializer, Visitor};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
+
+/// Custom deserializer that accepts both string and integer for the `npu` field.
+/// This ensures backward compatibility across different SDK versions:
+/// - SDK 1.x: outputs `"npu": "0"` (string)
+/// - SDK 2.0.x: outputs `"npu": 0` (integer)
+fn deserialize_string_or_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringOrU32Visitor;
+
+    impl<'de> Visitor<'de> for StringOrU32Visitor {
+        type Value = u32;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or u32")
+        }
+
+        fn visit_u64<E: de::Error>(self, v: u64) -> Result<u32, E> {
+            u32::try_from(v).map_err(|_| E::custom(format!("u64 {v} out of range for u32")))
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<u32, E> {
+            v.parse()
+                .map_err(|_| E::custom(format!("failed to parse '{v}' as u32")))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrU32Visitor)
+}
 
 /// JSON structures for Rebellions device information
 #[derive(Debug, Deserialize)]
@@ -46,6 +77,7 @@ struct RblnMemoryInfo {
 
 #[derive(Debug, Deserialize)]
 struct RblnDevice {
+    #[serde(deserialize_with = "deserialize_string_or_u32")]
     #[allow(dead_code)]
     npu: u32,
     name: String,


### PR DESCRIPTION
# Fix Rebellions NPU detection with rbln SDK 2.0.x

## Summary
Fixes Rebellions NPU detection failure when using rbln SDK 2.0.x by correcting the type of the `npu` field in JSON deserialization.

## Problem
all-smi fails to detect Rebellions NPUs on systems running rbln SDK 2.0.x, despite `rbln-stat`/`rbln-smi` working correctly. The tool runs without errors but shows no NPU devices.

## Root Cause
There is a type mismatch between all-smi's expected schema and the actual JSON output from rbln SDK 2.0.x:

**all-smi expectation (`src/device/readers/rebellions.rs`):**
```rust
struct RblnDevice {
    npu: String,  // Expects string
    ...
}
```

**Actual rbln-stat/rbln-smi 2.0.1 output:**
```json
{
  "devices": [
    { "npu": 0, "name": "RBLN-CA22", ... }  // Returns integer
  ]
}
```

This type mismatch causes silent JSON deserialization failures in serde, preventing NPU detection.

## Changes
Changed the `npu` field type from `String` to `u32` in the `RblnDevice` struct:

```diff
 struct RblnDevice {
     #[allow(dead_code)]
-    npu: String,
+    npu: u32,
     name: String,
     sid: String,
```

This is a **one-line fix** that restores compatibility with current rbln SDK versions.

## Testing
Tested on:
- **Hardware**: 4x Rebellions ATOM RBLN-CA22 NPUs
- **Software**: rbln SDK 2.0.1, rbln-stat 2.0.1, rbln-smi 2.0.1
- **OS**: Ubuntu 22.04 (Linux 6.8.0-40-generic)

**Before fix:**
```
$ ./all-smi
# No Rebellions NPUs detected
```

**After fix:**
```
$ ./all-smi
Rebellions ATOM (4 NPUs detected):
  NPU 0: RBLN-CA22 (rbln0) - 41°C, 19.2W, 0.0% util, 0.0B/15.7GiB
  NPU 1: RBLN-CA22 (rbln1) - 37°C, 18.7W, 0.0% util, 0.0B/15.7GiB
  NPU 2: RBLN-CA22 (rbln2) - 38°C, 18.2W, 0.0% util, 0.0B/15.7GiB
  NPU 3: RBLN-CA22 (rbln3) - 39°C, 19.0W, 0.0% util, 0.0B/15.7GiB
```

All NPU metrics (temperature, power, memory, utilization) are correctly displayed.

## Backward Compatibility
This fix ensures compatibility with rbln SDK 2.0.1 (September 2025), which is the current stable version. The change is minimal (single line) and aligns the code with the documented SDK behavior.

If older SDK versions used a different format, this could be addressed with custom deserialization to support both types,.