### PR TITLE
fix(ci): resolve Launchpad PPA build failures with Rust 1.85 compatibility

### DIFF
--- a/.github/workflows/launchpad_build_test.yml
+++ b/.github/workflows/launchpad_build_test.yml
@@ -1,0 +1,188 @@
+# .github/workflows/launchpad_build_test.yml
+name: Launchpad Build Test
+
+# ═══════════════════════════════════════════════════════════════
+# Simulates the Launchpad PPA build environment to catch issues
+# before uploading to the actual PPA.
+#
+# Launchpad constraints:
+# - Ubuntu 22.04 (jammy) or 24.04 (noble) base
+# - No network access during build
+# - Uses system Rust from rust-1.85-all package
+# - Must use vendored dependencies
+# ═══════════════════════════════════════════════════════════════
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src/**'
+      - 'debian/**'
+      - '.github/workflows/launchpad_build_test.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src/**'
+      - 'debian/**'
+      - '.github/workflows/launchpad_build_test.yml'
+  workflow_dispatch:
+
+jobs:
+  test-launchpad-build:
+    name: Test Launchpad Build (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [jammy, noble]
+
+    steps:
+    # ───────────────────────────────────────────────────────────────
+    # Step 1: Checkout source code
+    # ───────────────────────────────────────────────────────────────
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # ───────────────────────────────────────────────────────────────
+    # Step 2: Install Rust toolchain (for vendoring only)
+    # ───────────────────────────────────────────────────────────────
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    # ───────────────────────────────────────────────────────────────
+    # Step 3: Vendor dependencies
+    # ───────────────────────────────────────────────────────────────
+    - name: Vendor Rust dependencies
+      run: |
+        # Vendor all dependencies for offline build
+        cargo vendor debian/vendor
+
+        # Create .cargo/config.toml to use vendored sources
+        mkdir -p .cargo
+        cat > .cargo/config.toml << 'EOF'
+        [source.crates-io]
+        replace-with = "vendored-sources"
+
+        [source.vendored-sources]
+        directory = "debian/vendor"
+        EOF
+
+        echo "Vendored dependencies: $(du -sh debian/vendor | cut -f1)"
+
+    # ───────────────────────────────────────────────────────────────
+    # Step 4: Build Docker image simulating Launchpad environment
+    # ───────────────────────────────────────────────────────────────
+    - name: Build Launchpad simulation image
+      run: |
+        cat > Dockerfile.launchpad << 'DOCKERFILE'
+        ARG DISTRO=noble
+        FROM ubuntu:${DISTRO}
+
+        # Install build dependencies (same as debian/control Build-Depends)
+        RUN apt-get update && apt-get install -y \
+            build-essential \
+            pkg-config \
+            libssl-dev \
+            protobuf-compiler \
+            cmake \
+            libdrm-dev \
+            curl \
+            ca-certificates \
+            && rm -rf /var/lib/apt/lists/*
+
+        # Install Rust 1.85 (simulating rust-1.85-all package)
+        # Note: Launchpad uses rust-1.85-all from Ubuntu repos
+        RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+            sh -s -- -y --default-toolchain 1.85.0
+        ENV PATH="/root/.cargo/bin:${PATH}"
+
+        # Create wrapper scripts to match rust-1.85-all package naming
+        # Note: Can't use symlinks because rustup uses argv[0] to determine proxy
+        RUN echo '#!/bin/bash\nexec /root/.cargo/bin/rustc "$@"' > /usr/bin/rustc-1.85 && \
+            chmod +x /usr/bin/rustc-1.85 && \
+            echo '#!/bin/bash\nexec /root/.cargo/bin/cargo "$@"' > /usr/bin/cargo-1.85 && \
+            chmod +x /usr/bin/cargo-1.85
+
+        WORKDIR /build
+        DOCKERFILE
+
+        docker build \
+          --build-arg DISTRO=${{ matrix.distro }} \
+          -t launchpad-sim:${{ matrix.distro }} \
+          -f Dockerfile.launchpad .
+
+    # ───────────────────────────────────────────────────────────────
+    # Step 5: Test offline build (simulating Launchpad)
+    # ───────────────────────────────────────────────────────────────
+    - name: Test offline build (network disabled)
+      run: |
+        echo "=== Testing Launchpad-like offline build ==="
+        echo "Distro: ${{ matrix.distro }}"
+        echo "Network: DISABLED (--network none)"
+        echo ""
+
+        # Run build in network-isolated container
+        docker run --rm \
+          --network none \
+          -v "${{ github.workspace }}:/build" \
+          -w /build \
+          launchpad-sim:${{ matrix.distro }} \
+          bash -c '
+            set -e
+
+            echo "=== Environment ==="
+            rustc-1.85 --version
+            cargo-1.85 --version
+            echo ""
+
+            echo "=== Verifying network is disabled ==="
+            if curl --connect-timeout 2 https://crates.io 2>/dev/null; then
+              echo "ERROR: Network should be disabled!"
+              exit 1
+            else
+              echo "Network is disabled (expected)"
+            fi
+            echo ""
+
+            echo "=== Verifying vendored dependencies ==="
+            if [ ! -d "debian/vendor" ]; then
+              echo "ERROR: debian/vendor not found!"
+              exit 1
+            fi
+            echo "Vendor directory: $(du -sh debian/vendor | cut -f1)"
+            echo ""
+
+            echo "=== Verifying .cargo/config.toml ==="
+            if [ ! -f ".cargo/config.toml" ]; then
+              echo "ERROR: .cargo/config.toml not found!"
+              exit 1
+            fi
+            cat .cargo/config.toml
+            echo ""
+
+            echo "=== Building with cargo-1.85 --frozen ==="
+            export CARGO_HOME=/build/debian/cargo
+            export CARGO_TARGET_DIR=/build/target
+            mkdir -p $CARGO_HOME
+
+            cargo-1.85 build --release --frozen
+
+            echo ""
+            echo "=== Build successful! ==="
+            ls -la target/release/all-smi
+            ./target/release/all-smi --version || true
+          '
+
+    # ───────────────────────────────────────────────────────────────
+    # Step 6: Cleanup
+    # ───────────────────────────────────────────────────────────────
+    - name: Cleanup
+      if: always()
+      run: |
+        # Clean up build artifacts to avoid permission issues
+        sudo rm -rf target debian/cargo debian/vendor .cargo
+        docker rmi launchpad-sim:${{ matrix.distro }} 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ __pycache__/
 # Project maintenance (custom)
 *.md
 .*
+!.github/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "hyper-util",
  "libamdgpu_top",
  "libc",
- "libloading 0.9.0",
+ "libloading",
  "num_cpus",
  "nvml-wrapper",
  "once_cell",
@@ -585,7 +585,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -596,14 +596,14 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.9",
+ "libloading",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -741,6 +741,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1646,12 +1665,13 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libamdgpu_top"
-version = "0.11.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312cfd4096a86e7c89b963abbe31f69e464be11bcf671c7e8703bd3fdae4946"
+checksum = "61a8cd2b20728d48e70f337eb4f218c7118b01e535aeffe91e7682ef37c3448c"
 dependencies = [
+ "anyhow",
  "libdrm_amdgpu_sys",
- "nix 0.30.1",
+ "nix 0.29.0",
 ]
 
 [[package]]
@@ -1676,17 +1696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "libloading"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
-dependencies = [
- "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1871,6 +1881,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -1953,7 +1975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
 dependencies = [
  "bitflags 2.10.0",
- "libloading 0.8.9",
+ "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
  "thiserror 1.0.69",
@@ -1966,26 +1988,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
 dependencies = [
- "libloading 0.8.9",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
+ "libloading",
 ]
 
 [[package]]
@@ -2096,7 +2099,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2398,6 +2401,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2925,16 +2948,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
+ "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
+ "rayon",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -3618,15 +3641,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3635,19 +3655,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
+ "windows-collections",
  "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -3661,15 +3672,14 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3678,22 +3688,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
  "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3703,8 +3702,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -3712,6 +3722,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3731,25 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -3758,7 +3763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3767,18 +3772,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3787,16 +3792,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -3805,7 +3801,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3850,7 +3846,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3890,7 +3886,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3903,20 +3899,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4281,9 +4268,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9211a9f64b825911bdf0240f58b7a8dac217fe260fc61f080a07f61372fbd5"
+checksum = "317f17ff091ac4515f17cc7a190d2769a8c9a96d227de5d64b500b01cda8f2cd"
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ redundant_closure = "warn"
 manual_range_contains = "warn"
 module_inception = "warn"
 bool_comparison = "warn"
+# Allow manual modulo check for Rust 1.85 compatibility (Launchpad)
+# is_multiple_of() is unstable until Rust 1.88+ (rust-lang/rust#128101)
+manual_is_multiple_of = "allow"
 
 [lints.rust]
 # Rust compiler lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { version = "0.12", features = ["json"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 regex = "1.12.2"
-sysinfo = "0.37.2"
+sysinfo = "0.33"  # Pinned for Rust 1.85 compatibility (Launchpad)
 anyhow = { version = "1.0.100", optional = true }
 hyper = { version = "1.8.1", features = ["full"] }
 hyper-util = { version = "0.1.18", features = ["full"] }
@@ -53,11 +53,11 @@ all-smi-ttkmd-if = "0.2.2"
 furiosa-smi-rs = { version = "2025.3.0", optional = true }
 cgroups-rs = "0.5.0"
 # Dynamic library loading for tpu_pjrt
-libloading = "0.9"
+libloading = "0.8"  # Pinned for Rust 1.85 compatibility (Launchpad)
 
 # AMD GPU support (glibc only, not compatible with musl static linking)
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
-libamdgpu_top = "0.11.0"
+libamdgpu_top = "0.10"  # Pinned for Rust 1.85 compatibility (Launchpad, 0.11 uses 2024 edition)
 
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl = { version = "0.10.75", features = ["vendored"] }
@@ -68,7 +68,7 @@ openssl = { version = "0.10.75", features = ["vendored"] }
 # Windows-specific dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
 wmi = "0.18"
-libloading = "0.9"
+libloading = "0.8"  # Pinned for Rust 1.85 compatibility (Launchpad)
 
 # macOS-specific dependencies
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/api/metrics/chassis.rs
+++ b/src/api/metrics/chassis.rs
@@ -90,6 +90,8 @@ impl MetricPresenceFlags {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for ChassisMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         let mut builder = MetricBuilder::new();

--- a/src/api/metrics/cpu.rs
+++ b/src/api/metrics/cpu.rs
@@ -297,6 +297,8 @@ impl<'a> CpuMetricExporter<'a> {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for CpuMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         let mut builder = MetricBuilder::new();

--- a/src/api/metrics/disk.rs
+++ b/src/api/metrics/disk.rs
@@ -54,6 +54,8 @@ impl<'a> DiskMetricExporter<'a> {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for DiskMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         let mut builder = MetricBuilder::new();

--- a/src/api/metrics/gpu.rs
+++ b/src/api/metrics/gpu.rs
@@ -307,6 +307,8 @@ impl<'a> GpuMetricExporter<'a> {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for GpuMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         let mut builder = MetricBuilder::new();

--- a/src/api/metrics/memory.rs
+++ b/src/api/metrics/memory.rs
@@ -158,6 +158,8 @@ impl<'a> MemoryMetricExporter<'a> {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for MemoryMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         let mut builder = MetricBuilder::new();

--- a/src/api/metrics/npu/mod.rs
+++ b/src/api/metrics/npu/mod.rs
@@ -148,6 +148,8 @@ impl<'a> NpuMetricExporter<'a> {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for NpuMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         let mut builder = MetricBuilder::new();

--- a/src/api/metrics/process.rs
+++ b/src/api/metrics/process.rs
@@ -50,6 +50,8 @@ impl<'a> ProcessMetricExporter<'a> {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for ProcessMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         if self.process_info.is_empty() {

--- a/src/api/metrics/runtime.rs
+++ b/src/api/metrics/runtime.rs
@@ -30,6 +30,8 @@ impl<'a> RuntimeMetricExporter<'a> {
     }
 }
 
+// Allow for Rust 1.85 compatibility (Launchpad)
+#[allow(clippy::needless_lifetimes)]
 impl<'a> MetricExporter for RuntimeMetricExporter<'a> {
     fn export_metrics(&self) -> String {
         let mut output = String::new();

--- a/src/device/readers/rebellions.rs
+++ b/src/device/readers/rebellions.rs
@@ -38,6 +38,8 @@ where
 {
     struct StringOrU32Visitor;
 
+    // Allow for Rust 1.85 compatibility (Launchpad)
+    #[allow(clippy::needless_lifetimes)]
     impl<'de> Visitor<'de> for StringOrU32Visitor {
         type Value = u32;
 

--- a/src/view/data_collection/local_collector.rs
+++ b/src/view/data_collection/local_collector.rs
@@ -419,7 +419,7 @@ impl LocalCollector {
 
         // Determine if we should do a full refresh or selective refresh
         let cycle = self.refresh_cycle.fetch_add(1, Ordering::Relaxed);
-        let do_full_refresh = cycle.is_multiple_of(FULL_REFRESH_INTERVAL);
+        let do_full_refresh = cycle % FULL_REFRESH_INTERVAL == 0;
 
         // Read tracked PIDs for selective refresh (outside the closure)
         let tracked_pids_for_refresh: Vec<sysinfo::Pid> = if do_full_refresh {


### PR DESCRIPTION
## Summary

* Fix Launchpad PPA build failures by ensuring Rust 1.85 compatibility
* Add CI workflow to test Launchpad build environment before uploading
* Pin dependencies to versions compatible with Rust 1.85 (Launchpad's toolchain)

## Problem
Launchpad PPA builds were failing due to:
1. Dependency incompatibility: Several crates require Rust versions newer than 1.85
    * `sysinfo@0.37.2` requires Rust 1.88
    * `libloading@0.9` requires Rust 1.88
    * `libamdgpu_top@0.11` uses Rust 2024 edition (requires Rust 1.88+)
2. Unstable feature usage: Code used `is_multiple_of()` which is unstable until Rust 1.88+ ([rust-lang/rust#128101](https://github.com/rust-lang/rust/issues/128101))
3. No pre-upload testing: No way to verify builds would succeed on Launchpad before uploading

## Solution
1. Pin dependencies to Rust 1.85-compatible versions:
    * `sysinfo`: 0.37 → 0.33 (MSRV 1.69)
    * `libloading`: 0.9 → 0.8 (MSRV 1.71)
    * `libamdgpu_top`: 0.11 → 0.10 (uses Rust 2021 edition)
2. Replace unstable feature: Use `cycle % FULL_REFRESH_INTERVAL == 0` instead of `cycle.is_multiple_of()`
3. Add clippy lint allowances for cross-version compatibility:
    * `manual_is_multiple_of = "allow"` in Cargo.toml (for latest Rust)
    * `#[allow(clippy::needless_lifetimes)]` on 9 impl blocks (for Rust 1.85)
4. Add Launchpad build test CI (launchpad_build_test.yml):
    * Tests offline build with --network none (simulates Launchpad)
    * Tests with Rust 1.85 toolchain
    * Runs on push/PR to catch issues early

## Test Plan
    * `cargo build --release` passes with latest Rust
    * `cargo build --release` passes with Rust 1.85
    * `cargo clippy --release -- -D` warnings passes with latest Rust
    * `cargo clippy --release -- -D` warnings passes with Rust 1.85
    * `cargo test` passes
    * Launchpad PPA build succeeds after merge

Closes #112 