### PR TITLE
feat: feature-gate CLI/TUI deps behind `cli` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Build binary
         run: cargo build --release --bin all-smi
 
+      - name: Build library-only (no default features)
+        run: cargo build --no-default-features --lib
+
   docker-check:
     name: Docker Build Check
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1.48.0", features = ["full"] }
 chrono = "0.4.42"
-crossterm = "0.29.0"
-clap = { version = "4.5.53", features = ["derive"] }
-axum = "0.8.8"
-tower-http = { version = "0.6.8", features = ["cors", "trace"] }
+crossterm = { version = "0.29.0", optional = true }
+clap = { version = "4.5.53", features = ["derive"], optional = true }
+axum = { version = "0.8.8", optional = true }
+tower-http = { version = "0.6.8", features = ["cors", "trace"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.13", features = ["json"] }
@@ -27,9 +27,9 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 regex = "1.12.2"
 sysinfo = "0.38"
 anyhow = { version = "1.0.100", optional = true }
-hyper = { version = "1.8.1", features = ["full"] }
-hyper-util = { version = "0.1.18", features = ["full"] }
-rand = "0.10"
+hyper = { version = "1.8.1", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["full"], optional = true }
+rand = { version = "0.10", optional = true }
 futures-util = "0.3.31"
 nvml-wrapper = "0.11.0"
 once_cell = "1.21.3"
@@ -81,7 +81,9 @@ tempfile = "3.23"
 tonic-prost-build = "0.14"
 
 [features]
-mock = ["anyhow"]
+default = ["cli"]
+cli = ["dep:clap", "dep:crossterm", "dep:axum", "dep:tower-http"]
+mock = ["cli", "dep:anyhow", "dep:rand", "dep:hyper", "dep:hyper-util"]
 
 [lib]
 name = "all_smi"
@@ -90,6 +92,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "all-smi"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "all-smi-mock-server"

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -102,9 +102,11 @@ impl EnvConfig {
     }
 }
 
-/// UI Theme configuration
+/// UI Theme configuration (requires `cli` feature for crossterm color support)
+#[cfg(feature = "cli")]
 pub struct ThemeConfig;
 
+#[cfg(feature = "cli")]
 impl ThemeConfig {
     pub fn progress_bar_color(fill_ratio: f64) -> crossterm::style::Color {
         use crossterm::style::Color;
@@ -196,6 +198,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn test_progress_bar_color_thresholds() {
         use crossterm::style::Color;
 
@@ -217,6 +220,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn test_utilization_color_thresholds() {
         use crossterm::style::Color;
 
@@ -288,7 +292,14 @@ mod tests {
 
         assert_eq!(EnvConfig::retry_delay(0), 0);
         assert_eq!(EnvConfig::retry_delay(1000), 50000);
+    }
 
+    #[test]
+    #[cfg(all(
+        feature = "cli",
+        not(all(target_os = "macos", target_arch = "aarch64"))
+    ))]
+    fn test_non_apple_silicon_theme_boundary_values() {
         use crossterm::style::Color;
         assert_eq!(
             ThemeConfig::progress_bar_color(f64::NEG_INFINITY),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -14,4 +14,5 @@
 
 pub mod config;
 pub mod error_handling;
+#[cfg(feature = "cli")]
 pub mod progress_bar;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,12 +110,15 @@ pub mod device;
 pub mod parsing;
 
 /// Application state management.
+#[cfg(feature = "cli")]
 pub mod app_state;
 
 /// Command-line interface definitions.
+#[cfg(feature = "cli")]
 pub mod cli;
 
 /// Network client for remote monitoring.
+#[cfg(feature = "cli")]
 pub mod network;
 
 /// Storage monitoring.
@@ -125,6 +128,7 @@ pub mod storage;
 pub mod traits;
 
 /// Terminal UI components.
+#[cfg(feature = "cli")]
 pub mod ui;
 
 /// Utility functions.

--- a/src/utils/runtime_environment.rs
+++ b/src/utils/runtime_environment.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::common::config::AppConfig;
+#[cfg(feature = "cli")]
 use crossterm::style::Color;
 use std::env;
 use std::fs;
@@ -45,6 +46,7 @@ impl ContainerRuntime {
         }
     }
 
+    #[cfg(feature = "cli")]
     pub fn brand_color(&self) -> Color {
         match self {
             ContainerRuntime::Docker => Color::Rgb {
@@ -288,6 +290,7 @@ impl VirtualizationType {
         }
     }
 
+    #[cfg(feature = "cli")]
     pub fn brand_color(&self) -> Color {
         match self {
             VirtualizationType::VMware => Color::Rgb {
@@ -633,6 +636,7 @@ impl RuntimeEnvironment {
 
     /// Get the display name and color for the runtime environment
     /// Prioritizes container environment over VM if both are detected
+    #[cfg(feature = "cli")]
     pub fn display_info(&self) -> Option<(&str, Color)> {
         if self.container.is_containerized() {
             match self.container.runtime {

--- a/tests/cpu_model_test.rs
+++ b/tests/cpu_model_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "cli")]
+
 use all_smi::device::CpuPlatformType;
 use all_smi::network::metrics_parser::MetricsParser;
 use regex::Regex;


### PR DESCRIPTION
## Summary

- Add a `cli` feature (enabled by default) that gates CLI/TUI-only dependencies (`clap`, `crossterm`, `axum`, `tower-http`) and modules (`cli`, `ui`, `app_state`, `network`)
- Make `hyper`, `hyper-util`, `rand` optional under the `mock` feature (which now implies `cli`)
- Gate `ThemeConfig`, `progress_bar` module, and crossterm-dependent methods (`brand_color`, `display_info`) behind `#[cfg(feature = "cli")]`
- Add `required-features = ["cli"]` to the main binary target
- Add `--no-default-features` library-only build check to CI

Library consumers can now use `default-features = false` for a significantly lighter dependency footprint while retaining access to the core monitoring API (`AllSmi`, device readers, etc.).

## Test plan

- [x] `cargo build --no-default-features --lib` compiles successfully
- [x] `cargo build` (with defaults) continues to work as before
- [x] `cargo build --features mock` works correctly
- [x] `cargo test` passes with default features
- [x] `cargo clippy --no-default-features --lib` passes cleanly
- [x] `cargo clippy` passes cleanly with default features

Closes #124