### PR TITLE
feat: reduce TUI idle CPU with event-driven UI wakeups

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -21,8 +21,16 @@ impl AppConfig {
     // Optimized for CPU efficiency: 10 FPS is sufficient for monitoring tools
     // This significantly reduces CPU usage while maintaining smooth visuals
     pub const MIN_RENDER_INTERVAL_MS: u64 = 100; // ~10 FPS (was 33ms/30 FPS)
+    #[allow(dead_code)] // Retained for configuration reference; replaced by TERMINAL_READER_POLL_MS in event-driven model
     pub const EVENT_POLL_TIMEOUT_MS: u64 = 100; // Poll every 100ms (was 50ms)
     pub const SCROLL_UPDATE_FREQUENCY: u64 = 1; // Every N frames for text scrolling (1 = every 100ms at 10 FPS)
+
+    // Event-driven UI constants
+    /// Animation tick interval in milliseconds (loading indicator, marquee scroll, clock)
+    pub const ANIMATION_TICK_MS: u64 = 200;
+    /// Poll timeout for the dedicated terminal reader task (ms).
+    /// Short enough to detect shutdown promptly, long enough to avoid busy-spinning.
+    pub const TERMINAL_READER_POLL_MS: u64 = 50;
 
     // Network Configuration
     pub const BACKEND_AI_DEFAULT_PORT: u16 = 9090;

--- a/src/view/data_collector.rs
+++ b/src/view/data_collector.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::app_state::AppState;
 use crate::cli::ViewArgs;
@@ -27,11 +27,32 @@ pub use super::data_collection::{
 
 pub struct DataCollector {
     app_state: Arc<Mutex<AppState>>,
+    /// Optional notification handle to wake the UI loop when data changes.
+    data_notify: Option<Arc<Notify>>,
 }
 
 impl DataCollector {
+    #[allow(dead_code)] // Available for callers that do not need event-driven wakeups
     pub fn new(app_state: Arc<Mutex<AppState>>) -> Self {
-        Self { app_state }
+        Self {
+            app_state,
+            data_notify: None,
+        }
+    }
+
+    /// Create a data collector with a notification handle for event-driven UI wakeups.
+    pub fn with_notify(app_state: Arc<Mutex<AppState>>, notify: Arc<Notify>) -> Self {
+        Self {
+            app_state,
+            data_notify: Some(notify),
+        }
+    }
+
+    /// Signal the UI loop that new data is available.
+    fn notify_ui(&self) {
+        if let Some(ref notify) = self.data_notify {
+            notify.notify_one();
+        }
     }
 
     pub async fn run_local_mode(&self, args: ViewArgs) {
@@ -83,6 +104,7 @@ impl DataCollector {
             collector
                 .update_state(self.app_state.clone(), data, &config)
                 .await;
+            self.notify_ui();
 
             if first_iteration {
                 first_iteration = false;
@@ -199,6 +221,7 @@ impl DataCollector {
                     collector
                         .update_state(self.app_state.clone(), data, &config)
                         .await;
+                    self.notify_ui();
                 }
                 Err(e) => {
                     eprintln!("Error collecting remote data: {e}");

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -17,6 +17,7 @@ pub mod data_collector;
 pub mod event_handler;
 pub mod runner;
 pub mod terminal_manager;
+pub mod ui_events;
 pub mod ui_loop;
 
 pub use runner::*;

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::app_state::AppState;
 use crate::cli::{LocalArgs, ViewArgs};
@@ -32,6 +32,9 @@ pub async fn run_local_mode(args: &LocalArgs) {
     let app_state = Arc::new(Mutex::new(initial_state));
     startup_profiler.checkpoint("AppState initialized");
 
+    // Create shared notification handle for collector -> UI wakeups
+    let data_notify = Arc::new(Notify::new());
+
     // Initialize terminal
     let _terminal_manager = match TerminalManager::new() {
         Ok(manager) => manager,
@@ -42,8 +45,9 @@ pub async fn run_local_mode(args: &LocalArgs) {
     };
     startup_profiler.checkpoint("Terminal initialized");
 
-    // Start data collection in background
-    let data_collector = DataCollector::new(Arc::clone(&app_state));
+    // Start data collection in background with notification handle
+    let data_collector =
+        DataCollector::with_notify(Arc::clone(&app_state), Arc::clone(&data_notify));
     let view_args = ViewArgs {
         hosts: None,
         hostfile: None,
@@ -54,8 +58,8 @@ pub async fn run_local_mode(args: &LocalArgs) {
     });
     startup_profiler.checkpoint("Data collector spawned");
 
-    // Run UI loop
-    let mut ui_loop = match UiLoop::new(app_state) {
+    // Run UI loop with the same notification handle
+    let mut ui_loop = match UiLoop::new(app_state, data_notify) {
         Ok(ui_loop) => ui_loop,
         Err(e) => {
             eprintln!("Failed to initialize UI: {e}");
@@ -84,6 +88,9 @@ pub async fn run_view_mode(args: &ViewArgs) {
     initial_state.is_local_mode = false;
     let app_state = Arc::new(Mutex::new(initial_state));
 
+    // Create shared notification handle for collector -> UI wakeups
+    let data_notify = Arc::new(Notify::new());
+
     // Initialize terminal
     let _terminal_manager = match TerminalManager::new() {
         Ok(manager) => manager,
@@ -93,8 +100,9 @@ pub async fn run_view_mode(args: &ViewArgs) {
         }
     };
 
-    // Start data collection in background
-    let data_collector = DataCollector::new(Arc::clone(&app_state));
+    // Start data collection in background with notification handle
+    let data_collector =
+        DataCollector::with_notify(Arc::clone(&app_state), Arc::clone(&data_notify));
     let args_clone = args.clone();
     tokio::spawn(async move {
         let hosts = args_clone.hosts.clone().unwrap_or_default();
@@ -106,8 +114,8 @@ pub async fn run_view_mode(args: &ViewArgs) {
             .await;
     });
 
-    // Run UI loop
-    let mut ui_loop = match UiLoop::new(app_state) {
+    // Run UI loop with the same notification handle
+    let mut ui_loop = match UiLoop::new(app_state, data_notify) {
         Ok(ui_loop) => ui_loop,
         Err(e) => {
             eprintln!("Failed to initialize UI: {e}");

--- a/src/view/ui_events.rs
+++ b/src/view/ui_events.rs
@@ -1,0 +1,166 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Event-driven wakeup coordinator for the TUI loop.
+//!
+//! Replaces the fixed `event::poll(100ms)` model with a `tokio::select!`-based
+//! coordinator that wakes the UI only for meaningful reasons: terminal input,
+//! resize, fresh collector data, and animation ticks.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossterm::event::{self, Event};
+use tokio::sync::{mpsc, Notify};
+
+use crate::common::config::AppConfig;
+
+/// All possible reasons the UI loop should wake up and consider re-rendering.
+#[derive(Debug)]
+pub enum UiEvent {
+    /// A terminal input event (key press, mouse click, etc.)
+    TerminalInput(Event),
+    /// The terminal was resized
+    Resize(u16, u16),
+    /// A background data collector has new data ready
+    DataReady,
+    /// An animation tick fired (for loading indicator, marquee scroll, clock)
+    AnimationTick,
+}
+
+/// Manages all event sources and delivers them through a unified channel.
+///
+/// The coordinator spawns a dedicated blocking task for crossterm event reading
+/// (since crossterm uses synchronous I/O) and combines it with async notification
+/// sources in a `tokio::select!` loop.
+pub struct UiEventCoordinator {
+    /// Sender for terminal events from the blocking reader task
+    term_tx: mpsc::Sender<Event>,
+    /// Receiver for terminal events
+    term_rx: mpsc::Receiver<Event>,
+    /// Notification from data collectors when new data is available
+    data_notify: Arc<Notify>,
+    /// Animation tick interval (only active when animations are visible)
+    animation_interval: tokio::time::Interval,
+    /// Whether animation ticks should be active
+    animations_active: bool,
+}
+
+impl UiEventCoordinator {
+    /// Create a new event coordinator with the given data notification handle.
+    ///
+    /// `data_notify` should be shared with data collectors so they can signal
+    /// the UI when fresh data is available.
+    pub fn new(data_notify: Arc<Notify>) -> Self {
+        // Bounded channel prevents unbounded memory growth if UI is slow.
+        // 64 events is generous enough to buffer rapid keystrokes.
+        let (term_tx, term_rx) = mpsc::channel::<Event>(64);
+
+        let mut animation_interval =
+            tokio::time::interval(Duration::from_millis(AppConfig::ANIMATION_TICK_MS));
+        // Don't burst-fire missed ticks -- just skip them
+        animation_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        Self {
+            term_tx,
+            term_rx,
+            data_notify,
+            animation_interval,
+            animations_active: true, // Start active for loading screen
+        }
+    }
+
+    /// Spawn the background terminal event reader task.
+    ///
+    /// This must be called once before entering the event loop. The task reads
+    /// crossterm events in a blocking context and forwards them through the
+    /// channel. It exits automatically when the sender is dropped (i.e., when
+    /// the coordinator is dropped).
+    pub fn spawn_terminal_reader(&self) {
+        let tx = self.term_tx.clone();
+        tokio::task::spawn_blocking(move || {
+            Self::terminal_reader_loop(tx);
+        });
+    }
+
+    /// Blocking loop that reads terminal events and forwards them.
+    ///
+    /// Uses a short poll timeout so the task can detect channel closure
+    /// promptly and exit.
+    fn terminal_reader_loop(tx: mpsc::Sender<Event>) {
+        loop {
+            // Poll with a short timeout so we can detect shutdown
+            match event::poll(Duration::from_millis(AppConfig::TERMINAL_READER_POLL_MS)) {
+                Ok(true) => match event::read() {
+                    Ok(evt) => {
+                        // blocking_send is fine here -- we are in a blocking context
+                        if tx.blocking_send(evt).is_err() {
+                            // Receiver dropped, UI loop ended -- exit
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        // Terminal read error; likely terminal gone -- exit
+                        break;
+                    }
+                },
+                Ok(false) => {
+                    // No event within the poll window -- check if channel still alive
+                    if tx.is_closed() {
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Poll error -- exit
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Set whether animation ticks should fire.
+    ///
+    /// When `active` is false the animation interval is effectively paused:
+    /// `next_event()` will not return `AnimationTick` variants.
+    pub fn set_animations_active(&mut self, active: bool) {
+        self.animations_active = active;
+    }
+
+    /// Wait for the next UI event from any source.
+    ///
+    /// This is the main select point. It sleeps efficiently until one of the
+    /// registered sources has something to deliver. When multiple sources fire
+    /// simultaneously, `tokio::select!` picks one at random, ensuring fairness.
+    pub async fn next_event(&mut self) -> UiEvent {
+        tokio::select! {
+            // Branch 1: terminal input/resize from the blocking reader
+            Some(evt) = self.term_rx.recv() => {
+                match evt {
+                    Event::Resize(w, h) => UiEvent::Resize(w, h),
+                    other => UiEvent::TerminalInput(other),
+                }
+            }
+
+            // Branch 2: data collector notification
+            _ = self.data_notify.notified() => {
+                UiEvent::DataReady
+            }
+
+            // Branch 3: animation tick (only when active)
+            _ = self.animation_interval.tick(), if self.animations_active => {
+                UiEvent::AnimationTick
+            }
+        }
+    }
+}

--- a/src/view/ui_events.rs
+++ b/src/view/ui_events.rs
@@ -37,6 +37,9 @@ pub enum UiEvent {
     DataReady,
     /// An animation tick fired (for loading indicator, marquee scroll, clock)
     AnimationTick,
+    /// The terminal reader task has exited (terminal closed or error).
+    /// The UI loop should shut down gracefully.
+    TerminalClosed,
 }
 
 /// Manages all event sources and delivers them through a unified channel.
@@ -45,8 +48,10 @@ pub enum UiEvent {
 /// (since crossterm uses synchronous I/O) and combines it with async notification
 /// sources in a `tokio::select!` loop.
 pub struct UiEventCoordinator {
-    /// Sender for terminal events from the blocking reader task
-    term_tx: mpsc::Sender<Event>,
+    /// Sender passed to the terminal reader task.
+    /// Stored as `Option` so we can `take()` it in `spawn_terminal_reader`,
+    /// ensuring no extra sender keeps the channel open after the reader exits.
+    term_tx: Option<mpsc::Sender<Event>>,
     /// Receiver for terminal events
     term_rx: mpsc::Receiver<Event>,
     /// Notification from data collectors when new data is available
@@ -73,7 +78,7 @@ impl UiEventCoordinator {
         animation_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         Self {
-            term_tx,
+            term_tx: Some(term_tx),
             term_rx,
             data_notify,
             animation_interval,
@@ -85,10 +90,16 @@ impl UiEventCoordinator {
     ///
     /// This must be called once before entering the event loop. The task reads
     /// crossterm events in a blocking context and forwards them through the
-    /// channel. It exits automatically when the sender is dropped (i.e., when
-    /// the coordinator is dropped).
-    pub fn spawn_terminal_reader(&self) {
-        let tx = self.term_tx.clone();
+    /// channel. It exits automatically when the channel is closed.
+    ///
+    /// The sender is *moved* into the spawned task so that the channel closes
+    /// naturally when the reader exits, allowing `next_event()` to detect
+    /// terminal loss via `TerminalClosed`.
+    pub fn spawn_terminal_reader(&mut self) {
+        let tx = self
+            .term_tx
+            .take()
+            .expect("spawn_terminal_reader must be called exactly once");
         tokio::task::spawn_blocking(move || {
             Self::terminal_reader_loop(tx);
         });
@@ -142,13 +153,19 @@ impl UiEventCoordinator {
     /// This is the main select point. It sleeps efficiently until one of the
     /// registered sources has something to deliver. When multiple sources fire
     /// simultaneously, `tokio::select!` picks one at random, ensuring fairness.
+    ///
+    /// Returns `TerminalClosed` when the terminal reader task has exited,
+    /// signalling that the UI loop should shut down.
     pub async fn next_event(&mut self) -> UiEvent {
         tokio::select! {
-            // Branch 1: terminal input/resize from the blocking reader
-            Some(evt) = self.term_rx.recv() => {
-                match evt {
-                    Event::Resize(w, h) => UiEvent::Resize(w, h),
-                    other => UiEvent::TerminalInput(other),
+            // Branch 1: terminal input/resize from the blocking reader.
+            // When the channel closes (reader exited), recv() returns None
+            // and we signal TerminalClosed for graceful shutdown.
+            result = self.term_rx.recv() => {
+                match result {
+                    Some(Event::Resize(w, h)) => UiEvent::Resize(w, h),
+                    Some(other) => UiEvent::TerminalInput(other),
+                    None => UiEvent::TerminalClosed,
                 }
             }
 

--- a/src/view/ui_events.rs
+++ b/src/view/ui_events.rs
@@ -181,3 +181,230 @@ impl UiEventCoordinator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    // -----------------------------------------------------------------------
+    // UiEvent: basic enum behaviour
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_ui_event_debug_variants() {
+        // Verify Debug can be derived for all variants without panicking.
+        let events: Vec<UiEvent> = vec![
+            UiEvent::DataReady,
+            UiEvent::AnimationTick,
+            UiEvent::TerminalClosed,
+            UiEvent::Resize(80, 24),
+        ];
+        for e in events {
+            let _ = format!("{e:?}");
+        }
+    }
+
+    #[test]
+    fn test_resize_event_carries_dimensions() {
+        let ev = UiEvent::Resize(120, 40);
+        match ev {
+            UiEvent::Resize(w, h) => {
+                assert_eq!(w, 120);
+                assert_eq!(h, 40);
+            }
+            _ => panic!("Expected Resize variant"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // UiEventCoordinator: construction
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_coordinator_new_does_not_panic() {
+        let notify = Arc::new(Notify::new());
+        let _coordinator = UiEventCoordinator::new(notify);
+    }
+
+    #[tokio::test]
+    async fn test_coordinator_animations_active_by_default() {
+        // The coordinator starts with animations active so the loading screen
+        // shows its spinner immediately.  Drop it to confirm no panic occurs.
+        let notify = Arc::new(Notify::new());
+        let coordinator = UiEventCoordinator::new(notify);
+        drop(coordinator);
+    }
+
+    // -----------------------------------------------------------------------
+    // UiEventCoordinator: set_animations_active
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_set_animations_active_toggle() {
+        let notify = Arc::new(Notify::new());
+        let mut coordinator = UiEventCoordinator::new(notify);
+
+        // Toggle off and on; neither call should panic.
+        coordinator.set_animations_active(false);
+        coordinator.set_animations_active(true);
+        coordinator.set_animations_active(false);
+    }
+
+    // -----------------------------------------------------------------------
+    // UiEventCoordinator: DataReady path
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_next_event_data_ready() {
+        let notify = Arc::new(Notify::new());
+        let mut coordinator = UiEventCoordinator::new(Arc::clone(&notify));
+        // Disable animation ticks so they don't race with our assertion.
+        coordinator.set_animations_active(false);
+
+        // Pre-notify before calling next_event so there is no blocking wait.
+        notify.notify_one();
+
+        let event = tokio::time::timeout(Duration::from_secs(1), coordinator.next_event())
+            .await
+            .expect("next_event timed out");
+
+        assert!(
+            matches!(event, UiEvent::DataReady),
+            "Expected DataReady, got {event:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // UiEventCoordinator: TerminalClosed path
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_next_event_terminal_closed_when_channel_drops() {
+        let notify = Arc::new(Notify::new());
+        let mut coordinator = UiEventCoordinator::new(Arc::clone(&notify));
+        coordinator.set_animations_active(false);
+
+        // spawn_terminal_reader consumes the internal sender by moving it into
+        // the blocking task.  That task will try to read from the real terminal
+        // and exit quickly when the channel receiver is gone; however in a test
+        // environment the reader task may linger until the poll timeout fires.
+        // Instead of relying on the real reader, we simulate channel closure by
+        // dropping the coordinator's term_tx via spawn_terminal_reader and then
+        // waiting for the coordinator to observe the closed channel.
+        coordinator.spawn_terminal_reader();
+
+        // Drive next_event in a loop; the blocking task will eventually close
+        // the channel sender (it exits when tx.blocking_send fails or the poll
+        // timeout elapses and tx.is_closed() returns true).
+        let event = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match coordinator.next_event().await {
+                    UiEvent::TerminalClosed => return UiEvent::TerminalClosed,
+                    // Animation ticks or DataReady may fire before the reader
+                    // task exits; skip them.
+                    _ => continue,
+                }
+            }
+        })
+        .await
+        .expect("TerminalClosed event never arrived");
+
+        assert!(matches!(event, UiEvent::TerminalClosed));
+    }
+
+    // -----------------------------------------------------------------------
+    // Event mapping logic (unit-tested in isolation)
+    // -----------------------------------------------------------------------
+
+    /// Verify that the Event::Resize mapping logic used inside next_event
+    /// produces UiEvent::Resize with correct dimensions.
+    #[test]
+    fn test_resize_event_mapping() {
+        let crossterm_event = Event::Resize(100, 50);
+        let ui_event = match crossterm_event {
+            Event::Resize(w, h) => UiEvent::Resize(w, h),
+            other => UiEvent::TerminalInput(other),
+        };
+        assert!(matches!(ui_event, UiEvent::Resize(100, 50)));
+    }
+
+    /// Verify that a non-Resize crossterm event is wrapped in TerminalInput.
+    #[test]
+    fn test_terminal_input_wrapping() {
+        let key_event = Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        let ui_event = match key_event {
+            Event::Resize(w, h) => UiEvent::Resize(w, h),
+            other => UiEvent::TerminalInput(other),
+        };
+        assert!(
+            matches!(ui_event, UiEvent::TerminalInput(_)),
+            "Expected TerminalInput, got {ui_event:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AppConfig: event-driven constants are sane
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_animation_tick_ms_reasonable() {
+        // Must be positive and not unreasonably large.
+        assert!(AppConfig::ANIMATION_TICK_MS > 0);
+        assert!(AppConfig::ANIMATION_TICK_MS <= 500);
+    }
+
+    #[test]
+    fn test_terminal_reader_poll_ms_reasonable() {
+        // Must be positive and not so large that shutdown detection is sluggish.
+        assert!(AppConfig::TERMINAL_READER_POLL_MS > 0);
+        assert!(AppConfig::TERMINAL_READER_POLL_MS <= 200);
+    }
+
+    #[test]
+    fn test_animation_tick_ms_value() {
+        assert_eq!(AppConfig::ANIMATION_TICK_MS, 200);
+    }
+
+    #[test]
+    fn test_terminal_reader_poll_ms_value() {
+        assert_eq!(AppConfig::TERMINAL_READER_POLL_MS, 50);
+    }
+
+    // -----------------------------------------------------------------------
+    // DataCollector: notify_ui wiring
+    // -----------------------------------------------------------------------
+
+    /// Verify that DataCollector::with_notify stores the notify handle and
+    /// that the coordinator observes a DataReady event when the collector
+    /// calls notify_one() on the shared handle.
+    #[tokio::test]
+    async fn test_data_collector_notify_wiring() {
+        use crate::app_state::AppState;
+        use crate::view::data_collector::DataCollector;
+        use tokio::sync::Mutex;
+
+        let app_state = Arc::new(Mutex::new(AppState::new()));
+        let notify = Arc::new(Notify::new());
+
+        // Build collector and coordinator sharing the same notify.
+        let _collector = DataCollector::with_notify(Arc::clone(&app_state), Arc::clone(&notify));
+        let mut coordinator = UiEventCoordinator::new(Arc::clone(&notify));
+        coordinator.set_animations_active(false);
+
+        // Signal as the collector would after a successful data update.
+        notify.notify_one();
+
+        let event = tokio::time::timeout(Duration::from_millis(200), coordinator.next_event())
+            .await
+            .expect("DataReady event never arrived");
+
+        assert!(
+            matches!(event, UiEvent::DataReady),
+            "Expected DataReady, got {event:?}"
+        );
+    }
+}

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -188,6 +188,10 @@ impl UiLoop {
                     UiEvent::DataReady => {
                         needs_render = true;
                     }
+                    UiEvent::TerminalClosed => {
+                        // Terminal reader exited -- shut down gracefully
+                        break;
+                    }
                     UiEvent::AnimationTick => {
                         needs_render = true;
                     }

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -16,17 +16,16 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::io::{stdout, Write};
 use std::sync::Arc;
-use std::time::Duration;
 
 use chrono::Local;
 use crossterm::{
     cursor,
-    event::{self, Event},
+    event::Event,
     queue,
     style::{Color, Print},
     terminal::size,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::app_state::AppState;
 use crate::cli::ViewArgs;
@@ -42,6 +41,7 @@ use crate::ui::renderer::{
 use crate::ui::tabs::draw_tabs;
 use crate::ui::text::print_colored_text;
 use crate::view::event_handler::handle_key_event;
+use crate::view::ui_events::{UiEvent, UiEventCoordinator};
 
 pub struct UiLoop {
     app_state: Arc<Mutex<AppState>>,
@@ -61,6 +61,8 @@ pub struct UiLoop {
     previous_process_horizontal_scroll_offset: usize,
     previous_tab_scroll_offset: usize,
     previous_gpu_filter_enabled: bool,
+    /// Event coordinator for event-driven wakeups
+    event_coordinator: UiEventCoordinator,
     #[cfg(target_os = "linux")]
     hlsmi_notified: bool,
     #[cfg(target_os = "linux")]
@@ -70,9 +72,14 @@ pub struct UiLoop {
 }
 
 impl UiLoop {
-    pub fn new(app_state: Arc<Mutex<AppState>>) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(
+        app_state: Arc<Mutex<AppState>>,
+        data_notify: Arc<Notify>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let differential_renderer =
             DifferentialRenderer::new().map_err(|_| "Failed to create differential renderer")?;
+
+        let event_coordinator = UiEventCoordinator::new(data_notify);
 
         Ok(Self {
             app_state,
@@ -90,6 +97,7 @@ impl UiLoop {
             previous_process_horizontal_scroll_offset: 0,
             previous_tab_scroll_offset: 0,
             previous_gpu_filter_enabled: false,
+            event_coordinator,
             #[cfg(target_os = "linux")]
             hlsmi_notified: false,
             #[cfg(target_os = "linux")]
@@ -100,6 +108,12 @@ impl UiLoop {
     }
 
     pub async fn run(&mut self, args: &ViewArgs) -> Result<(), Box<dyn std::error::Error>> {
+        // Start the background terminal event reader
+        self.event_coordinator.spawn_terminal_reader();
+
+        // Track whether we need to render after processing events
+        let mut needs_render = true; // Render once at startup
+
         loop {
             // Check hl-smi initialization on Linux (periodic check for performance)
             #[cfg(target_os = "linux")]
@@ -136,47 +150,63 @@ impl UiLoop {
                     }
                 }
             }
-            // Handle events with timeout
-            if let Ok(has_event) =
-                event::poll(Duration::from_millis(AppConfig::EVENT_POLL_TIMEOUT_MS))
-            {
-                if has_event {
-                    match event::read() {
-                        Ok(Event::Key(key_event)) => {
-                            let mut state = self.app_state.lock().await;
-                            let should_break = handle_key_event(key_event, &mut state, args).await;
-                            if should_break {
-                                break;
-                            }
-                            drop(state);
+
+            // If nothing needs rendering, wait for the next event (fully async sleep)
+            if !needs_render {
+                match self.event_coordinator.next_event().await {
+                    UiEvent::TerminalInput(Event::Key(key_event)) => {
+                        let mut state = self.app_state.lock().await;
+                        let should_break = handle_key_event(key_event, &mut state, args).await;
+                        if should_break {
+                            break;
                         }
-                        Ok(Event::Mouse(mouse_event)) => {
-                            let mut state = self.app_state.lock().await;
-                            let should_break = crate::view::event_handler::handle_mouse_event(
-                                mouse_event,
-                                &mut state,
-                                args,
-                            )
-                            .await;
-                            if should_break {
-                                break;
-                            }
-                            drop(state);
+                        drop(state);
+                        needs_render = true;
+                    }
+                    UiEvent::TerminalInput(Event::Mouse(mouse_event)) => {
+                        let mut state = self.app_state.lock().await;
+                        let should_break = crate::view::event_handler::handle_mouse_event(
+                            mouse_event,
+                            &mut state,
+                            args,
+                        )
+                        .await;
+                        if should_break {
+                            break;
                         }
-                        Ok(Event::Resize(_width, _height)) => {
-                            // Force a re-render on terminal resize
-                            self.differential_renderer.force_clear().ok();
-                            self.resize_occurred = true;
-                        }
-                        _ => {
-                            // Ignore other event types (focus, paste)
-                        }
+                        drop(state);
+                        needs_render = true;
+                    }
+                    UiEvent::TerminalInput(_) => {
+                        // Ignore other terminal event types (focus, paste)
+                    }
+                    UiEvent::Resize(_w, _h) => {
+                        self.differential_renderer.force_clear().ok();
+                        self.resize_occurred = true;
+                        needs_render = true;
+                    }
+                    UiEvent::DataReady => {
+                        needs_render = true;
+                    }
+                    UiEvent::AnimationTick => {
+                        needs_render = true;
                     }
                 }
             }
 
-            // Update display with throttling
+            if !needs_render {
+                continue;
+            }
+
+            // Acquire state for rendering decisions
             let mut state = self.app_state.lock().await;
+
+            // Activate animation ticks only when there are animated elements visible
+            let animations_needed = state.loading
+                || !state.device_name_scroll_offsets.is_empty()
+                || !state.is_local_mode;
+            self.event_coordinator
+                .set_animations_active(animations_needed);
 
             // Check if we need to force clear due to mode change or tab change
             let force_clear = state.show_help != self.previous_show_help
@@ -197,21 +227,17 @@ impl UiLoop {
                     != self.previous_process_horizontal_scroll_offset
                 || state.tab_scroll_offset != self.previous_tab_scroll_offset;
 
-            // Check if enough time has passed for rendering (throttle to prevent visual artifacts)
+            // Throttle rendering to prevent visual artifacts from too-frequent updates
             let now = std::time::Instant::now();
             let time_to_render = now.duration_since(self.last_render_time).as_millis()
                 >= AppConfig::MIN_RENDER_INTERVAL_MS as u128;
 
-            // Only render if there's something worth rendering
-            // Note: We always render when time_to_render is true to ensure smooth
-            // text scrolling animations. DifferentialRenderer's hash check will
-            // skip actual rendering if content is unchanged.
+            // Only render if there is something worth rendering
             let should_render = force_clear
                 || self.resize_occurred
                 || (time_to_render && (data_changed || scroll_changed));
 
-            // Update scroll offsets for long text (controlled by SCROLL_UPDATE_FREQUENCY)
-            // This runs independently of should_render to keep animations smooth
+            // Update scroll offsets for long text (marquee animation)
             if time_to_render {
                 state.frame_counter += 1;
                 #[allow(clippy::modulo_one)]
@@ -221,11 +247,15 @@ impl UiLoop {
             }
 
             if !should_render && !time_to_render {
+                // Nothing to render yet, but we were woken up -- go back to waiting
+                needs_render = false;
                 drop(state);
-                continue; // Skip if nothing changed and not time to render yet
+                continue;
             }
 
             self.last_render_time = now;
+            // Mark render consumed so we go back to waiting after this iteration
+            needs_render = false;
 
             let (cols, rows) = match size() {
                 Ok((c, r)) => (c, r),


### PR DESCRIPTION
## Summary

- Replace fixed 100ms `event::poll()` loop with `tokio::select!`-based event coordinator that sleeps fully when idle
- Add `UiEventCoordinator` with dedicated blocking terminal reader task, `Notify` channel from data collectors, and isolated animation ticks
- Wire data collectors to notify the UI immediately on fresh data via `Arc<Notify>`, eliminating polling-interval latency for screen refresh
- Isolate animation cadence so ticks only fire when animated elements (loading indicator, marquee scroll) are visible

## Test plan

- [ ] Verify local mode (`all-smi`) starts up, renders GPU/CPU/memory info, and responds to keyboard navigation
- [ ] Verify remote mode (`all-smi view`) starts up, renders multi-host data, and tab switching works
- [ ] Confirm keyboard/mouse input feels immediate (no perceptible delay from old 100ms poll gate)
- [ ] Confirm loading animation and marquee text scrolling still work during startup
- [ ] Confirm terminal resize triggers immediate re-render
- [ ] Verify idle CPU usage is measurably lower compared to the fixed-poll baseline
- [ ] Run `cargo test --features cli` and confirm all existing tests pass
- [ ] Run `cargo clippy --features cli -- -D warnings` with no warnings

Closes #135