### PR TITLE
feat: snapshot AppState before rendering to shorten critical section

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -55,7 +55,9 @@ impl AppConfig {
     pub const PROGRESS_BAR_TEXT_WIDTH: usize = 8;
     #[allow(dead_code)] // Future UI configuration
     pub const DASHBOARD_ITEM_WIDTH: usize = 15;
+    #[allow(dead_code)] // Default terminal fallback values for future use
     pub const DEFAULT_TERMINAL_WIDTH: u16 = 80;
+    #[allow(dead_code)] // Default terminal fallback values for future use
     pub const DEFAULT_TERMINAL_HEIGHT: u16 = 24;
 
     // Memory and Performance

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -527,3 +527,160 @@ impl FrameRenderer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_state::AppState;
+    use crate::view::render_snapshot::RenderSnapshot;
+
+    fn make_local_args() -> ViewArgs {
+        ViewArgs {
+            hosts: None,
+            hostfile: None,
+            interval: None,
+        }
+    }
+
+    fn make_snapshot() -> RenderSnapshot {
+        let state = AppState::new();
+        RenderSnapshot::capture(&state)
+    }
+
+    // -----------------------------------------------------------------------
+    // FrameRenderer: construction
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_frame_renderer_is_zero_sized() {
+        // FrameRenderer is a unit struct; assert it holds no state.
+        assert_eq!(std::mem::size_of::<FrameRenderer>(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // render_loading: smoke tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_render_loading_does_not_panic() {
+        let snapshot = make_snapshot();
+        let output = FrameRenderer::render_loading(&snapshot, false, 80, 24);
+        // Loading screen must produce some output even when state is empty.
+        assert!(!output.is_empty());
+    }
+
+    #[test]
+    fn test_render_loading_remote_does_not_panic() {
+        let snapshot = make_snapshot();
+        let output = FrameRenderer::render_loading(&snapshot, true, 80, 24);
+        assert!(!output.is_empty());
+    }
+
+    #[test]
+    fn test_render_loading_with_startup_status_lines() {
+        let mut state = AppState::new();
+        state
+            .startup_status_lines
+            .push("Connecting to GPUs...".to_string());
+        let snapshot = RenderSnapshot::capture(&state);
+        // Should not panic and produce output with the status line.
+        let output = FrameRenderer::render_loading(&snapshot, false, 80, 24);
+        assert!(!output.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // render_main: smoke tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_render_main_does_not_panic_empty_state() {
+        let snapshot = make_snapshot();
+        let args = make_local_args();
+        let output = FrameRenderer::render_main(&snapshot, &args, 80, 24);
+        // Header must be present.
+        assert!(output.contains("all-smi"));
+    }
+
+    #[test]
+    fn test_render_main_contains_header_timestamp() {
+        let snapshot = make_snapshot();
+        let args = make_local_args();
+        let output = FrameRenderer::render_main(&snapshot, &args, 120, 40);
+        // The header includes the current year which is deterministic for the test run.
+        assert!(output.contains("all-smi - 20"));
+    }
+
+    #[test]
+    fn test_render_main_contains_version() {
+        let snapshot = make_snapshot();
+        let args = make_local_args();
+        let output = FrameRenderer::render_main(&snapshot, &args, 80, 24);
+        let version = env!("CARGO_PKG_VERSION");
+        assert!(output.contains(version));
+    }
+
+    // -----------------------------------------------------------------------
+    // render_disconnection_notification: box geometry
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_disconnection_notification_width_too_narrow_produces_no_box() {
+        // width=9 → box_width = min(9-4, 60) = 5 which is < 6, so nothing is rendered
+        // (only the two leading blank lines appear).
+        let mut buffer = BufferWriter::new();
+        FrameRenderer::render_disconnection_notification(&mut buffer, "node1", 9);
+        let output = buffer.get_buffer().to_string();
+        // The box should NOT be rendered; the output must not contain the box corner.
+        assert!(!output.contains('\u{250c}'));
+    }
+
+    #[test]
+    fn test_disconnection_notification_normal_width_contains_hostname() {
+        let mut buffer = BufferWriter::new();
+        FrameRenderer::render_disconnection_notification(&mut buffer, "my-node", 80);
+        let output = buffer.get_buffer().to_string();
+        assert!(output.contains("my-node"));
+        assert!(output.contains("CONNECTION LOST"));
+    }
+
+    #[test]
+    fn test_disconnection_notification_box_max_width_capped_at_60() {
+        // With a very wide terminal (200 cols) the box should be capped at 60 chars.
+        let mut buffer = BufferWriter::new();
+        FrameRenderer::render_disconnection_notification(&mut buffer, "node1", 200);
+        let output = buffer.get_buffer().to_string();
+        // The box top border is: "─" repeated (box_width-2) times, capped at 58 for width=200.
+        // Count the number of consecutive box-drawing horizontal lines.
+        let horizontal_line_count = output.matches('\u{2500}').count();
+        // max box_width = 60, so max horizontal lines per border = 58
+        // Two borders (top + bottom) → at most 116.
+        assert!(horizontal_line_count <= 116);
+        // But there must be at least some lines (it renders).
+        assert!(horizontal_line_count > 0);
+    }
+
+    #[test]
+    fn test_disconnection_notification_long_hostname_is_truncated() {
+        // A hostname that exceeds inner_width (box_width - 4) should be truncated.
+        let long_hostname = "a".repeat(200);
+        let mut buffer = BufferWriter::new();
+        FrameRenderer::render_disconnection_notification(&mut buffer, &long_hostname, 80);
+        let output = buffer.get_buffer().to_string();
+        // "Node: " prefix plus some of the hostname must appear, but not all 200 'a's.
+        assert!(output.contains("Node: "));
+        assert!(!output.contains(&long_hostname));
+    }
+
+    // -----------------------------------------------------------------------
+    // render_help: smoke test
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_render_help_does_not_panic() {
+        let snapshot = make_snapshot();
+        let args = make_local_args();
+        let output = FrameRenderer::render_help(&snapshot, &args, 80, 24);
+        // Help popup must produce output.
+        assert!(!output.is_empty());
+    }
+}

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -1,0 +1,509 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Frame content assembly operating on a `RenderSnapshot`.
+//!
+//! All methods here are pure functions: they read the snapshot and produce
+//! a `String` (or write into a `BufferWriter`) without touching shared state.
+//! This means the `AppState` mutex is not held during any of this work.
+
+use std::borrow::Cow;
+use std::io::Write;
+
+use chrono::Local;
+use crossterm::{
+    queue,
+    style::{Color, Print},
+};
+
+use crate::cli::ViewArgs;
+use crate::common::config::AppConfig;
+use crate::device::ProcessInfo;
+use crate::ui::buffer::BufferWriter;
+use crate::ui::dashboard::{draw_dashboard_items, draw_system_view};
+use crate::ui::layout::LayoutCalculator;
+use crate::ui::renderer::{
+    print_chassis_info, print_cpu_info, print_function_keys, print_gpu_info,
+    print_loading_indicator, print_memory_info, print_process_info, print_storage_info,
+};
+use crate::ui::tabs::draw_tabs;
+use crate::ui::text::print_colored_text;
+use crate::view::render_snapshot::RenderSnapshot;
+
+/// Stateless frame renderer that operates on a `RenderSnapshot`.
+///
+/// This struct holds no mutable state of its own. Each method takes an
+/// immutable snapshot and returns the assembled frame content as a `String`.
+pub struct FrameRenderer;
+
+impl FrameRenderer {
+    /// Render help popup content from the snapshot.
+    pub fn render_help(snapshot: &RenderSnapshot, args: &ViewArgs, cols: u16, rows: u16) -> String {
+        let is_remote = args.hosts.is_some() || args.hostfile.is_some();
+        let view_state = snapshot.as_app_state();
+        crate::ui::help::generate_help_popup_content(cols, rows, &view_state, is_remote)
+    }
+
+    /// Render loading screen content from the snapshot.
+    pub fn render_loading(
+        snapshot: &RenderSnapshot,
+        is_remote: bool,
+        cols: u16,
+        rows: u16,
+    ) -> String {
+        let mut buffer = BufferWriter::new();
+        let view_state = snapshot.as_app_state();
+        print_function_keys(&mut buffer, cols, rows, &view_state, is_remote);
+        print_loading_indicator(
+            &mut buffer,
+            cols,
+            rows,
+            snapshot.frame_counter,
+            &snapshot.startup_status_lines,
+        );
+        buffer.get_buffer().to_string()
+    }
+
+    /// Render main content (the primary monitoring view) from the snapshot.
+    pub fn render_main(snapshot: &RenderSnapshot, args: &ViewArgs, cols: u16, rows: u16) -> String {
+        let width = cols as usize;
+        let mut buffer = BufferWriter::new();
+
+        // Reconstruct AppState view for downstream UI functions
+        let view_state = snapshot.as_app_state();
+
+        // Write time/date header to buffer first
+        let current_time = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        let version = env!("CARGO_PKG_VERSION");
+        let header_text = format!("all-smi - {current_time}");
+        let version_text = format!("v{version}");
+
+        // Get runtime environment info
+        let runtime_shield =
+            if let Some((name, color)) = snapshot.runtime_environment.display_info() {
+                let shield_content = format!(" {name} ");
+                let shield_len = shield_content.len();
+                Some((shield_content, color, shield_len))
+            } else {
+                None
+            };
+
+        // Calculate spacing to right-align version, accounting for runtime shield
+        let total_width = cols as usize;
+        let runtime_shield_len = runtime_shield
+            .as_ref()
+            .map(|(_, _, len)| len + 1)
+            .unwrap_or(0);
+        let content_length = header_text.len() + runtime_shield_len + version_text.len();
+        let spacing = if total_width > content_length {
+            " ".repeat(total_width - content_length)
+        } else {
+            " ".to_string()
+        };
+
+        // Print header with runtime environment shield
+        print_colored_text(&mut buffer, &header_text, Color::White, None, None);
+
+        if let Some((shield_content, shield_color, _)) = runtime_shield {
+            print_colored_text(&mut buffer, " ", Color::White, None, None);
+            print_colored_text(
+                &mut buffer,
+                &shield_content,
+                Color::Black,
+                Some(shield_color),
+                None,
+            );
+        }
+
+        print_colored_text(
+            &mut buffer,
+            &format!("{spacing}{version_text}\r\n"),
+            Color::White,
+            None,
+            None,
+        );
+
+        // Write remaining header content to buffer
+        print_colored_text(&mut buffer, "Cluster Overview\r\n", Color::Cyan, None, None);
+        draw_system_view(&mut buffer, &view_state, cols);
+
+        draw_dashboard_items(&mut buffer, &view_state, cols);
+        draw_tabs(&mut buffer, &view_state, cols);
+
+        let is_remote = args.hosts.is_some() || args.hostfile.is_some();
+
+        // Render chassis information (node-level metrics)
+        Self::render_chassis_section(&mut buffer, snapshot, width);
+
+        // Render GPU information
+        Self::render_gpu_section(&mut buffer, snapshot, args, cols, rows);
+
+        // Render other device information based on mode
+        if is_remote {
+            Self::render_remote_devices(&mut buffer, snapshot, width);
+        } else {
+            Self::render_local_devices(&mut buffer, snapshot, width);
+        }
+
+        // Add function keys to main content view
+        print_function_keys(&mut buffer, cols, rows, &view_state, is_remote);
+
+        buffer.get_buffer().to_string()
+    }
+
+    fn render_gpu_section(
+        buffer: &mut BufferWriter,
+        snapshot: &RenderSnapshot,
+        args: &ViewArgs,
+        cols: u16,
+        rows: u16,
+    ) {
+        let mut gpu_info_to_display: Vec<_> = if snapshot.current_tab < snapshot.tabs.len()
+            && snapshot.tabs[snapshot.current_tab] == "All"
+        {
+            snapshot.gpu_info.iter().collect()
+        } else {
+            snapshot
+                .gpu_info
+                .iter()
+                .filter(|info| info.host_id == snapshot.tabs[snapshot.current_tab])
+                .collect()
+        };
+
+        // Sort GPUs based on current sort criteria
+        gpu_info_to_display.sort_by(|a, b| snapshot.sort_criteria.sort_gpus(a, b));
+
+        // Calculate content area and GPU display parameters
+        let view_state = snapshot.as_app_state();
+        let content_area = LayoutCalculator::calculate_content_area(&view_state, cols, rows);
+        let gpu_display_params =
+            LayoutCalculator::calculate_gpu_display_params(&view_state, args, &content_area);
+        let max_gpu_items = gpu_display_params.max_items;
+
+        // Display GPUs with scrolling
+        let start_gpu_index = snapshot.gpu_scroll_offset;
+        let end_gpu_index = (start_gpu_index + max_gpu_items).min(gpu_info_to_display.len());
+
+        for (i, gpu_info) in gpu_info_to_display
+            .iter()
+            .enumerate()
+            .skip(start_gpu_index)
+            .take(end_gpu_index - start_gpu_index)
+        {
+            let device_name_scroll_offset = snapshot
+                .device_name_scroll_offsets
+                .get(&gpu_info.uuid)
+                .copied()
+                .unwrap_or(0);
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&gpu_info.host_id)
+                .copied()
+                .unwrap_or(0);
+
+            print_gpu_info(
+                buffer,
+                i,
+                gpu_info,
+                cols as usize,
+                device_name_scroll_offset,
+                hostname_scroll_offset,
+            );
+        }
+    }
+
+    fn render_chassis_section(buffer: &mut BufferWriter, snapshot: &RenderSnapshot, width: usize) {
+        if snapshot.chassis_info.is_empty() {
+            return;
+        }
+
+        // Filter chassis info based on mode and current tab
+        let chassis_to_display: Vec<_> = if snapshot.is_local_mode {
+            snapshot.chassis_info.iter().collect()
+        } else if snapshot.current_tab == 0 {
+            // Remote mode, "All" tab - don't show individual chassis
+            return;
+        } else if snapshot.current_tab < snapshot.tabs.len() {
+            let current_host = &snapshot.tabs[snapshot.current_tab];
+            snapshot
+                .chassis_info
+                .iter()
+                .filter(|c| c.host_id == *current_host || c.hostname == *current_host)
+                .collect()
+        } else {
+            snapshot.chassis_info.iter().collect()
+        };
+
+        for (i, chassis) in chassis_to_display.iter().enumerate() {
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&chassis.host_id)
+                .copied()
+                .unwrap_or(0);
+
+            print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
+        }
+    }
+
+    fn render_remote_devices(buffer: &mut BufferWriter, snapshot: &RenderSnapshot, width: usize) {
+        if snapshot.current_tab > 0 && snapshot.current_tab < snapshot.tabs.len() {
+            let current_hostname = &snapshot.tabs[snapshot.current_tab];
+
+            // Check connection status for the current node
+            let is_connected =
+                if let Some(host_id) = snapshot.hostname_to_host_id.get(current_hostname) {
+                    snapshot
+                        .connection_status
+                        .get(host_id)
+                        .map(|status| status.is_connected)
+                        .unwrap_or(false)
+                } else {
+                    snapshot
+                        .connection_status
+                        .get(current_hostname)
+                        .map(|status| status.is_connected)
+                        .unwrap_or(true)
+                };
+
+            if !is_connected {
+                Self::render_disconnection_notification(buffer, current_hostname, width);
+                return;
+            }
+
+            // CPU information for specific host
+            let cpu_info_to_display: Vec<_> = snapshot
+                .cpu_info
+                .iter()
+                .filter(|info| info.host_id == *current_hostname)
+                .collect();
+
+            for (i, cpu_info) in cpu_info_to_display.iter().enumerate() {
+                let cpu_name_scroll_offset = snapshot
+                    .cpu_name_scroll_offsets
+                    .get(&format!("{}-{}", cpu_info.hostname, cpu_info.cpu_model))
+                    .copied()
+                    .unwrap_or(0);
+                let hostname_scroll_offset = snapshot
+                    .host_id_scroll_offsets
+                    .get(&cpu_info.host_id)
+                    .copied()
+                    .unwrap_or(0);
+                print_cpu_info(
+                    buffer,
+                    i,
+                    cpu_info,
+                    width,
+                    snapshot.show_per_core_cpu,
+                    cpu_name_scroll_offset,
+                    hostname_scroll_offset,
+                );
+            }
+
+            // Memory information for specific host
+            let memory_info_to_display: Vec<_> = snapshot
+                .memory_info
+                .iter()
+                .filter(|info| info.host_id == *current_hostname)
+                .collect();
+
+            for (i, memory_info) in memory_info_to_display.iter().enumerate() {
+                let hostname_scroll_offset = snapshot
+                    .host_id_scroll_offsets
+                    .get(&memory_info.host_id)
+                    .copied()
+                    .unwrap_or(0);
+                print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
+            }
+
+            // Storage information for specific host
+            let storage_info_to_display: Vec<_> = snapshot
+                .storage_info
+                .iter()
+                .filter(|info| info.host_id == *current_hostname)
+                .collect();
+
+            let visible_storage = storage_info_to_display
+                .iter()
+                .skip(snapshot.storage_scroll_offset)
+                .take(10);
+
+            for (i, storage_info) in visible_storage.enumerate() {
+                let hostname_scroll_offset = snapshot
+                    .host_id_scroll_offsets
+                    .get(&storage_info.host_id)
+                    .copied()
+                    .unwrap_or(0);
+                print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
+            }
+        }
+    }
+
+    fn render_disconnection_notification(buffer: &mut BufferWriter, hostname: &str, width: usize) {
+        writeln!(buffer).unwrap();
+        writeln!(buffer).unwrap();
+
+        let box_width = (width - 4).min(60);
+        let margin = (width - box_width) / 2;
+        let margin_str = " ".repeat(margin);
+
+        // Top border
+        write!(buffer, "{margin_str}").unwrap();
+        print_colored_text(buffer, "\u{250c}", Color::Red, None, None);
+        print_colored_text(
+            buffer,
+            &"\u{2500}".repeat(box_width - 2),
+            Color::Red,
+            None,
+            None,
+        );
+        print_colored_text(buffer, "\u{2510}", Color::Red, None, None);
+        writeln!(buffer).unwrap();
+
+        // Content rows: title, blank, hostname, status, blank
+        let rows: &[(&str, Color)] = &[
+            ("CONNECTION LOST", Color::Red),
+            ("", Color::White),
+            (&format!("Node: {hostname}"), Color::Yellow),
+            ("Unable to retrieve node information", Color::DarkGrey),
+            ("", Color::White),
+        ];
+        for (text, color) in rows {
+            write!(buffer, "{margin_str}").unwrap();
+            if text.is_empty() {
+                // Empty row
+                print_colored_text(buffer, "\u{2502}", Color::Red, None, None);
+                print_colored_text(buffer, &" ".repeat(box_width - 2), Color::White, None, None);
+                print_colored_text(buffer, "\u{2502}", Color::Red, None, None);
+            } else {
+                let pad_left = (box_width - 4 - text.len()) / 2;
+                let pad_right = box_width - 4 - pad_left - text.len();
+                print_colored_text(buffer, "\u{2502} ", Color::Red, None, None);
+                print_colored_text(buffer, &" ".repeat(pad_left), Color::White, None, None);
+                print_colored_text(buffer, text, *color, None, None);
+                print_colored_text(buffer, &" ".repeat(pad_right), Color::White, None, None);
+                print_colored_text(buffer, " \u{2502}", Color::Red, None, None);
+            }
+            writeln!(buffer).unwrap();
+        }
+
+        // Bottom border
+        write!(buffer, "{margin_str}").unwrap();
+        print_colored_text(buffer, "\u{2514}", Color::Red, None, None);
+        print_colored_text(
+            buffer,
+            &"\u{2500}".repeat(box_width - 2),
+            Color::Red,
+            None,
+            None,
+        );
+        print_colored_text(buffer, "\u{2518}", Color::Red, None, None);
+        writeln!(buffer).unwrap();
+    }
+
+    fn render_local_devices(buffer: &mut BufferWriter, snapshot: &RenderSnapshot, width: usize) {
+        // CPU information for local mode
+        for (i, cpu_info) in snapshot.cpu_info.iter().enumerate() {
+            let cpu_name_scroll_offset = snapshot
+                .cpu_name_scroll_offsets
+                .get(&format!("{}-{}", cpu_info.hostname, cpu_info.cpu_model))
+                .copied()
+                .unwrap_or(0);
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&cpu_info.host_id)
+                .copied()
+                .unwrap_or(0);
+            print_cpu_info(
+                buffer,
+                i,
+                cpu_info,
+                width,
+                snapshot.show_per_core_cpu,
+                cpu_name_scroll_offset,
+                hostname_scroll_offset,
+            );
+        }
+
+        // Memory information for local mode
+        for (i, memory_info) in snapshot.memory_info.iter().enumerate() {
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&memory_info.host_id)
+                .copied()
+                .unwrap_or(0);
+            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
+        }
+
+        // Storage information for local mode
+        for (i, storage_info) in snapshot.storage_info.iter().enumerate() {
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&storage_info.host_id)
+                .copied()
+                .unwrap_or(0);
+            print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
+        }
+
+        // Process information for local mode (if available)
+        if !snapshot.process_info.is_empty() {
+            let (cols, rows) = match crossterm::terminal::size() {
+                Ok((c, r)) => (c, r),
+                Err(_) => (
+                    AppConfig::DEFAULT_TERMINAL_WIDTH,
+                    AppConfig::DEFAULT_TERMINAL_HEIGHT,
+                ),
+            };
+
+            let lines_used = buffer.line_count();
+
+            // Add a blank line before process list
+            queue!(buffer, Print("\r\n")).unwrap();
+
+            // Reserve 1 line for function keys at the bottom
+            let function_key_rows = 1;
+
+            let available_rows = rows.saturating_sub(lines_used as u16 + 1 + function_key_rows);
+
+            // Get current user for process coloring
+            let current_user = whoami::username().unwrap_or_default();
+
+            // Apply GPU filter if enabled
+            let processes_to_display: Cow<'_, [ProcessInfo]> = if snapshot.gpu_filter_enabled {
+                Cow::Owned(
+                    snapshot
+                        .process_info
+                        .iter()
+                        .filter(|p| p.used_memory > 0)
+                        .cloned()
+                        .collect(),
+                )
+            } else {
+                Cow::Borrowed(&snapshot.process_info)
+            };
+
+            print_process_info(
+                buffer,
+                &processes_to_display,
+                snapshot.selected_process_index,
+                snapshot.start_index,
+                available_rows,
+                cols,
+                snapshot.process_horizontal_scroll_offset,
+                &current_user,
+                &snapshot.sort_criteria,
+                &snapshot.sort_direction,
+            );
+        }
+    }
+}

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -27,8 +27,8 @@ use crossterm::{
     style::{Color, Print},
 };
 
+use crate::app_state::AppState;
 use crate::cli::ViewArgs;
-use crate::common::config::AppConfig;
 use crate::device::ProcessInfo;
 use crate::ui::buffer::BufferWriter;
 use crate::ui::dashboard::{draw_dashboard_items, draw_system_view};
@@ -80,7 +80,9 @@ impl FrameRenderer {
         let width = cols as usize;
         let mut buffer = BufferWriter::new();
 
-        // Reconstruct AppState view for downstream UI functions
+        // Reconstruct AppState view once for all downstream UI functions that
+        // still accept `&AppState`. This single allocation is shared across
+        // the header, dashboard, tabs, GPU layout, and function-key bar.
         let view_state = snapshot.as_app_state();
 
         // Write time/date header to buffer first
@@ -146,14 +148,14 @@ impl FrameRenderer {
         // Render chassis information (node-level metrics)
         Self::render_chassis_section(&mut buffer, snapshot, width);
 
-        // Render GPU information
-        Self::render_gpu_section(&mut buffer, snapshot, args, cols, rows);
+        // Render GPU information (reuse the single view_state for layout calculation)
+        Self::render_gpu_section(&mut buffer, snapshot, &view_state, args, cols, rows);
 
         // Render other device information based on mode
         if is_remote {
             Self::render_remote_devices(&mut buffer, snapshot, width);
         } else {
-            Self::render_local_devices(&mut buffer, snapshot, width);
+            Self::render_local_devices(&mut buffer, snapshot, cols, rows);
         }
 
         // Add function keys to main content view
@@ -165,6 +167,7 @@ impl FrameRenderer {
     fn render_gpu_section(
         buffer: &mut BufferWriter,
         snapshot: &RenderSnapshot,
+        view_state: &AppState,
         args: &ViewArgs,
         cols: u16,
         rows: u16,
@@ -184,11 +187,11 @@ impl FrameRenderer {
         // Sort GPUs based on current sort criteria
         gpu_info_to_display.sort_by(|a, b| snapshot.sort_criteria.sort_gpus(a, b));
 
-        // Calculate content area and GPU display parameters
-        let view_state = snapshot.as_app_state();
-        let content_area = LayoutCalculator::calculate_content_area(&view_state, cols, rows);
+        // Calculate content area and GPU display parameters using the shared
+        // view_state from render_main, avoiding a second as_app_state() call.
+        let content_area = LayoutCalculator::calculate_content_area(view_state, cols, rows);
         let gpu_display_params =
-            LayoutCalculator::calculate_gpu_display_params(&view_state, args, &content_area);
+            LayoutCalculator::calculate_gpu_display_params(view_state, args, &content_area);
         let max_gpu_items = gpu_display_params.max_items;
 
         // Display GPUs with scrolling
@@ -353,8 +356,12 @@ impl FrameRenderer {
         writeln!(buffer).unwrap();
         writeln!(buffer).unwrap();
 
-        let box_width = (width - 4).min(60);
-        let margin = (width - box_width) / 2;
+        let box_width = width.saturating_sub(4).min(60);
+        // Ensure minimum box width for the border characters
+        if box_width < 6 {
+            return;
+        }
+        let margin = width.saturating_sub(box_width) / 2;
         let margin_str = " ".repeat(margin);
 
         // Top border
@@ -362,7 +369,7 @@ impl FrameRenderer {
         print_colored_text(buffer, "\u{250c}", Color::Red, None, None);
         print_colored_text(
             buffer,
-            &"\u{2500}".repeat(box_width - 2),
+            &"\u{2500}".repeat(box_width.saturating_sub(2)),
             Color::Red,
             None,
             None,
@@ -378,19 +385,33 @@ impl FrameRenderer {
             ("Unable to retrieve node information", Color::DarkGrey),
             ("", Color::White),
         ];
+        // Inner width available for text content (between "| " and " |")
+        let inner_width = box_width.saturating_sub(4);
         for (text, color) in rows {
             write!(buffer, "{margin_str}").unwrap();
             if text.is_empty() {
                 // Empty row
                 print_colored_text(buffer, "\u{2502}", Color::Red, None, None);
-                print_colored_text(buffer, &" ".repeat(box_width - 2), Color::White, None, None);
+                print_colored_text(
+                    buffer,
+                    &" ".repeat(box_width.saturating_sub(2)),
+                    Color::White,
+                    None,
+                    None,
+                );
                 print_colored_text(buffer, "\u{2502}", Color::Red, None, None);
             } else {
-                let pad_left = (box_width - 4 - text.len()) / 2;
-                let pad_right = box_width - 4 - pad_left - text.len();
+                // Truncate text if it exceeds available inner width
+                let display_text: Cow<'_, str> = if text.len() > inner_width {
+                    Cow::Owned(text.chars().take(inner_width).collect())
+                } else {
+                    Cow::Borrowed(text)
+                };
+                let pad_left = inner_width.saturating_sub(display_text.len()) / 2;
+                let pad_right = inner_width.saturating_sub(pad_left + display_text.len());
                 print_colored_text(buffer, "\u{2502} ", Color::Red, None, None);
                 print_colored_text(buffer, &" ".repeat(pad_left), Color::White, None, None);
-                print_colored_text(buffer, text, *color, None, None);
+                print_colored_text(buffer, &display_text, *color, None, None);
                 print_colored_text(buffer, &" ".repeat(pad_right), Color::White, None, None);
                 print_colored_text(buffer, " \u{2502}", Color::Red, None, None);
             }
@@ -402,7 +423,7 @@ impl FrameRenderer {
         print_colored_text(buffer, "\u{2514}", Color::Red, None, None);
         print_colored_text(
             buffer,
-            &"\u{2500}".repeat(box_width - 2),
+            &"\u{2500}".repeat(box_width.saturating_sub(2)),
             Color::Red,
             None,
             None,
@@ -411,7 +432,14 @@ impl FrameRenderer {
         writeln!(buffer).unwrap();
     }
 
-    fn render_local_devices(buffer: &mut BufferWriter, snapshot: &RenderSnapshot, width: usize) {
+    fn render_local_devices(
+        buffer: &mut BufferWriter,
+        snapshot: &RenderSnapshot,
+        cols: u16,
+        rows: u16,
+    ) {
+        let width = cols as usize;
+
         // CPU information for local mode
         for (i, cpu_info) in snapshot.cpu_info.iter().enumerate() {
             let cpu_name_scroll_offset = snapshot
@@ -457,14 +485,6 @@ impl FrameRenderer {
 
         // Process information for local mode (if available)
         if !snapshot.process_info.is_empty() {
-            let (cols, rows) = match crossterm::terminal::size() {
-                Ok((c, r)) => (c, r),
-                Err(_) => (
-                    AppConfig::DEFAULT_TERMINAL_WIDTH,
-                    AppConfig::DEFAULT_TERMINAL_HEIGHT,
-                ),
-            };
-
             let lines_used = buffer.line_count();
 
             // Add a blank line before process list

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -15,6 +15,8 @@
 pub mod data_collection;
 pub mod data_collector;
 pub mod event_handler;
+pub mod frame_renderer;
+pub mod render_snapshot;
 pub mod runner;
 pub mod terminal_manager;
 pub mod ui_events;

--- a/src/view/render_snapshot.rs
+++ b/src/view/render_snapshot.rs
@@ -1,0 +1,396 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Lightweight render snapshot captured from `AppState` under lock.
+//!
+//! The snapshot contains only the data needed for a single frame, allowing
+//! the mutex to be released before expensive frame composition begins.
+//! This keeps the critical section short so that background data collectors
+//! are not blocked while the UI assembles its output.
+
+use std::collections::HashMap;
+
+use crate::app_state::{AppState, ConnectionStatus, SortCriteria, SortDirection};
+use crate::device::{ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, ProcessInfo};
+use crate::storage::info::StorageInfo;
+use crate::ui::notification::NotificationManager;
+use crate::utils::RuntimeEnvironment;
+
+/// Pre-computed rendering decisions captured from `AppState` under lock.
+///
+/// These booleans let the UI loop decide how to proceed without re-reading
+/// shared state after the lock is released.
+#[derive(Clone, Debug)]
+pub struct RenderDecisions {
+    pub force_clear: bool,
+    #[allow(dead_code)] // Future caching: skip composition when nothing changed
+    pub should_render: bool,
+    #[allow(dead_code)] // Exposed for coordinator queries outside the main loop
+    pub animations_needed: bool,
+}
+
+/// A snapshot of `AppState` containing only the data needed for one frame.
+///
+/// Created quickly under the mutex lock, then used without the lock held
+/// for the full (potentially expensive) frame composition path.
+///
+/// The snapshot mirrors the `AppState` fields that are read during rendering.
+/// Mutable UI-only bookkeeping (e.g., frame counters, scroll offsets) is
+/// updated under the lock before the snapshot is taken, so the snapshot
+/// itself is immutable from the render path's perspective.
+#[derive(Clone)]
+pub struct RenderSnapshot {
+    // Mode and display flags
+    pub show_help: bool,
+    pub loading: bool,
+    pub is_local_mode: bool,
+    pub show_per_core_cpu: bool,
+    pub gpu_filter_enabled: bool,
+
+    // Tab state
+    pub tabs: Vec<String>,
+    pub current_tab: usize,
+    pub tab_scroll_offset: usize,
+
+    // Scroll and selection state
+    pub gpu_scroll_offset: usize,
+    pub storage_scroll_offset: usize,
+    pub selected_process_index: usize,
+    pub start_index: usize,
+    pub process_horizontal_scroll_offset: usize,
+
+    // Scroll animation offsets (marquee text)
+    pub device_name_scroll_offsets: HashMap<String, usize>,
+    pub host_id_scroll_offsets: HashMap<String, usize>,
+    pub cpu_name_scroll_offsets: HashMap<String, usize>,
+
+    // Frame counter for animation
+    pub frame_counter: u64,
+
+    // Sort state
+    pub sort_criteria: SortCriteria,
+    pub sort_direction: SortDirection,
+
+    // Device data
+    pub gpu_info: Vec<GpuInfo>,
+    pub cpu_info: Vec<CpuInfo>,
+    pub memory_info: Vec<MemoryInfo>,
+    pub process_info: Vec<ProcessInfo>,
+    pub chassis_info: Vec<ChassisInfo>,
+    pub storage_info: Vec<StorageInfo>,
+
+    // Connection tracking (remote mode)
+    pub connection_status: HashMap<String, ConnectionStatus>,
+    pub hostname_to_host_id: HashMap<String, String>,
+
+    // Runtime environment display
+    pub runtime_environment: RuntimeEnvironment,
+
+    // Dashboard history data (Vec instead of VecDeque for lighter clone)
+    pub utilization_history: Vec<f64>,
+    pub memory_history: Vec<f64>,
+    pub temperature_history: Vec<f64>,
+    pub cpu_utilization_history: Vec<f64>,
+    pub system_memory_history: Vec<f64>,
+    pub cpu_temperature_history: Vec<f64>,
+
+    // Notifications (cloned for display)
+    pub notifications: NotificationManager,
+
+    // Loading status
+    pub startup_status_lines: Vec<String>,
+
+    // Data version for change detection
+    pub data_version: u64,
+}
+
+impl RenderSnapshot {
+    /// Capture a snapshot from the live `AppState`.
+    ///
+    /// This clones only the data needed for rendering. The caller should drop
+    /// the `AppState` lock immediately after this returns.
+    ///
+    /// History VecDeques are converted to Vec to avoid cloning the deque
+    /// ring-buffer internals; the rendering path only iterates forward.
+    pub fn capture(state: &AppState) -> Self {
+        Self {
+            // Flags -- Copy types, no allocation
+            show_help: state.show_help,
+            loading: state.loading,
+            is_local_mode: state.is_local_mode,
+            show_per_core_cpu: state.show_per_core_cpu,
+            gpu_filter_enabled: state.gpu_filter_enabled,
+
+            // Tab state -- cheap Vec<String> clone
+            tabs: state.tabs.clone(),
+            current_tab: state.current_tab,
+            tab_scroll_offset: state.tab_scroll_offset,
+
+            // Scroll/selection -- Copy types
+            gpu_scroll_offset: state.gpu_scroll_offset,
+            storage_scroll_offset: state.storage_scroll_offset,
+            selected_process_index: state.selected_process_index,
+            start_index: state.start_index,
+            process_horizontal_scroll_offset: state.process_horizontal_scroll_offset,
+
+            // Scroll animation offsets
+            device_name_scroll_offsets: state.device_name_scroll_offsets.clone(),
+            host_id_scroll_offsets: state.host_id_scroll_offsets.clone(),
+            cpu_name_scroll_offsets: state.cpu_name_scroll_offsets.clone(),
+
+            // Frame counter
+            frame_counter: state.frame_counter,
+
+            // Sort state -- Copy types
+            sort_criteria: state.sort_criteria,
+            sort_direction: state.sort_direction,
+
+            // Device data -- Vec clones (main cost of snapshot)
+            gpu_info: state.gpu_info.clone(),
+            cpu_info: state.cpu_info.clone(),
+            memory_info: state.memory_info.clone(),
+            process_info: state.process_info.clone(),
+            chassis_info: state.chassis_info.clone(),
+            storage_info: state.storage_info.clone(),
+
+            // Connection tracking
+            connection_status: state.connection_status.clone(),
+            hostname_to_host_id: state.hostname_to_host_id.clone(),
+
+            // Runtime environment
+            runtime_environment: state.runtime_environment.clone(),
+
+            // History -- convert VecDeque -> Vec (avoids deque ring-buffer clone)
+            utilization_history: state.utilization_history.iter().copied().collect(),
+            memory_history: state.memory_history.iter().copied().collect(),
+            temperature_history: state.temperature_history.iter().copied().collect(),
+            cpu_utilization_history: state.cpu_utilization_history.iter().copied().collect(),
+            system_memory_history: state.system_memory_history.iter().copied().collect(),
+            cpu_temperature_history: state.cpu_temperature_history.iter().copied().collect(),
+
+            // Notifications
+            notifications: state.notifications.clone(),
+
+            // Loading status
+            startup_status_lines: state.startup_status_lines.clone(),
+
+            // Data version
+            data_version: state.data_version,
+        }
+    }
+
+    /// Reconstruct a temporary `AppState` from this snapshot.
+    ///
+    /// This is used for backward compatibility with existing UI functions
+    /// (e.g., `draw_system_view`, `draw_tabs`, `print_function_keys`) that
+    /// accept `&AppState`. The returned state is a read-only view and should
+    /// never be written back to shared state.
+    ///
+    /// As UI functions are gradually migrated to accept `&RenderSnapshot`
+    /// directly, uses of this method should decrease.
+    pub fn as_app_state(&self) -> AppState {
+        let mut state = AppState::new();
+
+        // Flags
+        state.show_help = self.show_help;
+        state.loading = self.loading;
+        state.is_local_mode = self.is_local_mode;
+        state.show_per_core_cpu = self.show_per_core_cpu;
+        state.gpu_filter_enabled = self.gpu_filter_enabled;
+
+        // Tab state
+        state.tabs = self.tabs.clone();
+        state.current_tab = self.current_tab;
+        state.tab_scroll_offset = self.tab_scroll_offset;
+
+        // Scroll/selection
+        state.gpu_scroll_offset = self.gpu_scroll_offset;
+        state.storage_scroll_offset = self.storage_scroll_offset;
+        state.selected_process_index = self.selected_process_index;
+        state.start_index = self.start_index;
+        state.process_horizontal_scroll_offset = self.process_horizontal_scroll_offset;
+
+        // Scroll offsets
+        state.device_name_scroll_offsets = self.device_name_scroll_offsets.clone();
+        state.host_id_scroll_offsets = self.host_id_scroll_offsets.clone();
+        state.cpu_name_scroll_offsets = self.cpu_name_scroll_offsets.clone();
+
+        // Frame counter
+        state.frame_counter = self.frame_counter;
+
+        // Sort
+        state.sort_criteria = self.sort_criteria;
+        state.sort_direction = self.sort_direction;
+
+        // Device data
+        state.gpu_info = self.gpu_info.clone();
+        state.cpu_info = self.cpu_info.clone();
+        state.memory_info = self.memory_info.clone();
+        state.process_info = self.process_info.clone();
+        state.chassis_info = self.chassis_info.clone();
+        state.storage_info = self.storage_info.clone();
+
+        // Connection tracking
+        state.connection_status = self.connection_status.clone();
+        state.hostname_to_host_id = self.hostname_to_host_id.clone();
+
+        // Runtime environment
+        state.runtime_environment = self.runtime_environment.clone();
+
+        // History (Vec -> VecDeque)
+        state.utilization_history = self.utilization_history.iter().copied().collect();
+        state.memory_history = self.memory_history.iter().copied().collect();
+        state.temperature_history = self.temperature_history.iter().copied().collect();
+        state.cpu_utilization_history = self.cpu_utilization_history.iter().copied().collect();
+        state.system_memory_history = self.system_memory_history.iter().copied().collect();
+        state.cpu_temperature_history = self.cpu_temperature_history.iter().copied().collect();
+
+        // Notifications
+        state.notifications = self.notifications.clone();
+
+        // Loading
+        state.startup_status_lines = self.startup_status_lines.clone();
+
+        // Data version
+        state.data_version = self.data_version;
+
+        state
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snapshot_capture_preserves_flags() {
+        let mut state = AppState::new();
+        state.show_help = true;
+        state.loading = false;
+        state.is_local_mode = true;
+        state.show_per_core_cpu = true;
+        state.gpu_filter_enabled = true;
+
+        let snapshot = RenderSnapshot::capture(&state);
+
+        assert!(snapshot.show_help);
+        assert!(!snapshot.loading);
+        assert!(snapshot.is_local_mode);
+        assert!(snapshot.show_per_core_cpu);
+        assert!(snapshot.gpu_filter_enabled);
+    }
+
+    #[test]
+    fn test_snapshot_capture_preserves_tab_state() {
+        let mut state = AppState::new();
+        state.tabs = vec!["All".to_string(), "Node1".to_string(), "Node2".to_string()];
+        state.current_tab = 1;
+        state.tab_scroll_offset = 0;
+
+        let snapshot = RenderSnapshot::capture(&state);
+
+        assert_eq!(snapshot.tabs.len(), 3);
+        assert_eq!(snapshot.current_tab, 1);
+        assert_eq!(snapshot.tabs[1], "Node1");
+    }
+
+    #[test]
+    fn test_snapshot_capture_preserves_scroll_state() {
+        let mut state = AppState::new();
+        state.gpu_scroll_offset = 5;
+        state.storage_scroll_offset = 3;
+        state.selected_process_index = 10;
+        state.process_horizontal_scroll_offset = 20;
+
+        let snapshot = RenderSnapshot::capture(&state);
+
+        assert_eq!(snapshot.gpu_scroll_offset, 5);
+        assert_eq!(snapshot.storage_scroll_offset, 3);
+        assert_eq!(snapshot.selected_process_index, 10);
+        assert_eq!(snapshot.process_horizontal_scroll_offset, 20);
+    }
+
+    #[test]
+    fn test_snapshot_capture_preserves_sort_state() {
+        let mut state = AppState::new();
+        state.sort_criteria = SortCriteria::Utilization;
+        state.sort_direction = SortDirection::Ascending;
+
+        let snapshot = RenderSnapshot::capture(&state);
+
+        assert_eq!(snapshot.sort_criteria, SortCriteria::Utilization);
+        assert_eq!(snapshot.sort_direction, SortDirection::Ascending);
+    }
+
+    #[test]
+    fn test_snapshot_capture_preserves_data_version() {
+        let mut state = AppState::new();
+        state.mark_data_changed();
+        state.mark_data_changed();
+
+        let snapshot = RenderSnapshot::capture(&state);
+        assert_eq!(snapshot.data_version, 2);
+    }
+
+    #[test]
+    fn test_snapshot_capture_converts_history_from_vecdeque() {
+        let mut state = AppState::new();
+        state.utilization_history.push_back(50.0);
+        state.utilization_history.push_back(75.0);
+        state.memory_history.push_back(40.0);
+
+        let snapshot = RenderSnapshot::capture(&state);
+
+        assert_eq!(snapshot.utilization_history, vec![50.0, 75.0]);
+        assert_eq!(snapshot.memory_history, vec![40.0]);
+    }
+
+    #[test]
+    fn test_snapshot_is_independent_of_source_state() {
+        let mut state = AppState::new();
+        state.current_tab = 0;
+        state.gpu_scroll_offset = 5;
+
+        let snapshot = RenderSnapshot::capture(&state);
+
+        // Mutate source state after snapshot
+        state.current_tab = 2;
+        state.gpu_scroll_offset = 99;
+
+        // Snapshot should retain original values
+        assert_eq!(snapshot.current_tab, 0);
+        assert_eq!(snapshot.gpu_scroll_offset, 5);
+    }
+
+    #[test]
+    fn test_as_app_state_roundtrip() {
+        let mut state = AppState::new();
+        state.show_help = true;
+        state.current_tab = 2;
+        state.gpu_scroll_offset = 10;
+        state.sort_criteria = SortCriteria::GpuMemory;
+        state.data_version = 42;
+        state.utilization_history.push_back(60.0);
+
+        let snapshot = RenderSnapshot::capture(&state);
+        let restored = snapshot.as_app_state();
+
+        assert!(restored.show_help);
+        assert_eq!(restored.current_tab, 2);
+        assert_eq!(restored.gpu_scroll_offset, 10);
+        assert_eq!(restored.sort_criteria, SortCriteria::GpuMemory);
+        assert_eq!(restored.data_version, 42);
+        assert_eq!(restored.utilization_history.len(), 1);
+    }
+}

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -12,35 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::io::{stdout, Write};
 use std::sync::Arc;
 
-use chrono::Local;
-use crossterm::{
-    cursor,
-    event::Event,
-    queue,
-    style::{Color, Print},
-    terminal::size,
-};
+use crossterm::{cursor, event::Event, queue, terminal::size};
 use tokio::sync::{Mutex, Notify};
 
 use crate::app_state::AppState;
 use crate::cli::ViewArgs;
 use crate::common::config::AppConfig;
-use crate::device::ProcessInfo;
-use crate::ui::buffer::{BufferWriter, DifferentialRenderer};
-use crate::ui::dashboard::{draw_dashboard_items, draw_system_view};
-use crate::ui::layout::LayoutCalculator;
-use crate::ui::renderer::{
-    print_chassis_info, print_cpu_info, print_function_keys, print_gpu_info,
-    print_loading_indicator, print_memory_info, print_process_info, print_storage_info,
-};
-use crate::ui::tabs::draw_tabs;
-use crate::ui::text::print_colored_text;
+use crate::ui::buffer::DifferentialRenderer;
 use crate::view::event_handler::handle_key_event;
+use crate::view::frame_renderer::FrameRenderer;
+use crate::view::render_snapshot::{RenderDecisions, RenderSnapshot};
 use crate::view::ui_events::{UiEvent, UiEventCoordinator};
 
 pub struct UiLoop {
@@ -117,39 +102,7 @@ impl UiLoop {
         loop {
             // Check hl-smi initialization on Linux (periodic check for performance)
             #[cfg(target_os = "linux")]
-            {
-                use std::time::Duration;
-
-                // Early exit: skip all checks if both notifications have been shown
-                if !(self.hlsmi_notified && self.hlsmi_pending_notified) {
-                    // Only check if enough time has passed since last check (500ms)
-                    if self.last_hlsmi_check.elapsed() >= Duration::from_millis(500) {
-                        use crate::device::hlsmi::{get_hlsmi_manager, has_hlsmi_data};
-
-                        // Update last check time
-                        self.last_hlsmi_check = std::time::Instant::now();
-
-                        // Show pending notification if manager exists but data not ready
-                        if !self.hlsmi_pending_notified
-                            && get_hlsmi_manager().is_some()
-                            && !has_hlsmi_data()
-                        {
-                            let mut state = self.app_state.lock().await;
-                            let _ = state
-                                .notifications
-                                .info("Initializing hl-smi...".to_string());
-                            self.hlsmi_pending_notified = true;
-                        }
-
-                        // Show success notification when data is ready
-                        if !self.hlsmi_notified && has_hlsmi_data() {
-                            let mut state = self.app_state.lock().await;
-                            let _ = state.notifications.status("Intel Gaudi ready".to_string());
-                            self.hlsmi_notified = true;
-                        }
-                    }
-                }
-            }
+            self.check_hlsmi_status().await;
 
             // If nothing needs rendering, wait for the next event (fully async sleep)
             if !needs_render {
@@ -202,65 +155,98 @@ impl UiLoop {
                 continue;
             }
 
-            // Acquire state for rendering decisions
-            let mut state = self.app_state.lock().await;
+            // ------------------------------------------------------------------
+            // Critical section: acquire state, update mutable bookkeeping,
+            // capture snapshot, compute render decisions, then release the lock.
+            // All expensive work (frame composition) happens AFTER this block.
+            // ------------------------------------------------------------------
+            let (snapshot, decisions) = {
+                let mut state = self.app_state.lock().await;
 
-            // Activate animation ticks only when there are animated elements visible
-            let animations_needed = state.loading
-                || !state.device_name_scroll_offsets.is_empty()
-                || !state.is_local_mode;
-            self.event_coordinator
-                .set_animations_active(animations_needed);
+                // Activate animation ticks only when there are animated elements
+                let animations_needed = state.loading
+                    || !state.device_name_scroll_offsets.is_empty()
+                    || !state.is_local_mode;
+                self.event_coordinator
+                    .set_animations_active(animations_needed);
 
-            // Check if we need to force clear due to mode change or tab change
-            let force_clear = state.show_help != self.previous_show_help
-                || state.loading != self.previous_loading
-                || state.current_tab != self.previous_tab
-                || state.show_per_core_cpu != self.previous_show_per_core_cpu
-                || state.gpu_filter_enabled != self.previous_gpu_filter_enabled
-                || self.resize_occurred;
+                // Check if we need to force clear due to mode change or tab change
+                let force_clear = state.show_help != self.previous_show_help
+                    || state.loading != self.previous_loading
+                    || state.current_tab != self.previous_tab
+                    || state.show_per_core_cpu != self.previous_show_per_core_cpu
+                    || state.gpu_filter_enabled != self.previous_gpu_filter_enabled
+                    || self.resize_occurred;
 
-            // Check if data has changed (used for skipping expensive rendering when idle)
-            let data_changed = state.data_version != self.last_rendered_data_version;
+                // Check if data has changed
+                let data_changed = state.data_version != self.last_rendered_data_version;
 
-            // Check if scroll/selection state has changed (requires re-render)
-            let scroll_changed = state.gpu_scroll_offset != self.previous_gpu_scroll_offset
-                || state.storage_scroll_offset != self.previous_storage_scroll_offset
-                || state.selected_process_index != self.previous_selected_process_index
-                || state.process_horizontal_scroll_offset
-                    != self.previous_process_horizontal_scroll_offset
-                || state.tab_scroll_offset != self.previous_tab_scroll_offset;
+                // Check if scroll/selection state has changed
+                let scroll_changed = state.gpu_scroll_offset != self.previous_gpu_scroll_offset
+                    || state.storage_scroll_offset != self.previous_storage_scroll_offset
+                    || state.selected_process_index != self.previous_selected_process_index
+                    || state.process_horizontal_scroll_offset
+                        != self.previous_process_horizontal_scroll_offset
+                    || state.tab_scroll_offset != self.previous_tab_scroll_offset;
 
-            // Throttle rendering to prevent visual artifacts from too-frequent updates
-            let now = std::time::Instant::now();
-            let time_to_render = now.duration_since(self.last_render_time).as_millis()
-                >= AppConfig::MIN_RENDER_INTERVAL_MS as u128;
+                // Throttle rendering to prevent visual artifacts
+                let now = std::time::Instant::now();
+                let time_to_render = now.duration_since(self.last_render_time).as_millis()
+                    >= AppConfig::MIN_RENDER_INTERVAL_MS as u128;
 
-            // Only render if there is something worth rendering
-            let should_render = force_clear
-                || self.resize_occurred
-                || (time_to_render && (data_changed || scroll_changed));
+                let should_render = force_clear
+                    || self.resize_occurred
+                    || (time_to_render && (data_changed || scroll_changed));
 
-            // Update scroll offsets for long text (marquee animation)
-            if time_to_render {
-                state.frame_counter += 1;
-                #[allow(clippy::modulo_one)]
-                if state.frame_counter % AppConfig::SCROLL_UPDATE_FREQUENCY == 0 {
-                    self.update_scroll_offsets(&mut state);
+                // Update scroll offsets for long text (marquee animation)
+                if time_to_render {
+                    state.frame_counter += 1;
+                    #[allow(clippy::modulo_one)]
+                    if state.frame_counter % AppConfig::SCROLL_UPDATE_FREQUENCY == 0 {
+                        Self::update_scroll_offsets(&mut state);
+                    }
                 }
-            }
 
-            if !should_render && !time_to_render {
-                // Nothing to render yet, but we were woken up -- go back to waiting
+                if !should_render && !time_to_render {
+                    needs_render = false;
+                    // Lock is dropped here via `state` going out of scope
+                    continue;
+                }
+
+                self.last_render_time = now;
                 needs_render = false;
-                drop(state);
-                continue;
-            }
 
-            self.last_render_time = now;
-            // Mark render consumed so we go back to waiting after this iteration
-            needs_render = false;
+                // Capture snapshot while still holding the lock
+                let snapshot = RenderSnapshot::capture(&state);
 
+                // Update previous-state tracking
+                self.previous_show_help = state.show_help;
+                self.previous_loading = state.loading;
+                self.previous_tab = state.current_tab;
+                self.previous_show_per_core_cpu = state.show_per_core_cpu;
+                self.previous_gpu_filter_enabled = state.gpu_filter_enabled;
+                self.last_rendered_data_version = state.data_version;
+                self.previous_gpu_scroll_offset = state.gpu_scroll_offset;
+                self.previous_storage_scroll_offset = state.storage_scroll_offset;
+                self.previous_selected_process_index = state.selected_process_index;
+                self.previous_process_horizontal_scroll_offset =
+                    state.process_horizontal_scroll_offset;
+                self.previous_tab_scroll_offset = state.tab_scroll_offset;
+                self.resize_occurred = false;
+
+                let decisions = RenderDecisions {
+                    force_clear,
+                    should_render: true,
+                    animations_needed,
+                };
+
+                (snapshot, decisions)
+                // `state` is dropped here -- lock released before frame composition
+            };
+
+            // ------------------------------------------------------------------
+            // Frame composition: operates entirely on the snapshot, no lock held.
+            // ------------------------------------------------------------------
             let (cols, rows) = match size() {
                 Ok((c, r)) => (c, r),
                 Err(_) => return Err("Failed to get terminal size".into()),
@@ -271,18 +257,18 @@ impl UiLoop {
                 break;
             }
 
-            if force_clear && self.differential_renderer.force_clear().is_err() {
+            if decisions.force_clear && self.differential_renderer.force_clear().is_err() {
                 break;
             }
 
-            // Create content using buffer, then render differentially
-            let content = if state.show_help {
-                self.render_help_popup_content(&state, args, cols, rows)
-            } else if state.loading {
+            // Assemble frame content from the snapshot (no lock held)
+            let content = if snapshot.show_help {
+                FrameRenderer::render_help(&snapshot, args, cols, rows)
+            } else if snapshot.loading {
                 let is_remote = args.hosts.is_some() || args.hostfile.is_some();
-                self.render_loading_content(&state, is_remote, cols, rows)
+                FrameRenderer::render_loading(&snapshot, is_remote, cols, rows)
             } else {
-                self.render_main_content(&state, args, cols, rows)
+                FrameRenderer::render_main(&snapshot, args, cols, rows)
             };
 
             // Use differential rendering to update only changed lines
@@ -293,20 +279,6 @@ impl UiLoop {
             {
                 break;
             }
-
-            // Update previous state
-            self.previous_show_help = state.show_help;
-            self.previous_loading = state.loading;
-            self.previous_tab = state.current_tab;
-            self.previous_show_per_core_cpu = state.show_per_core_cpu;
-            self.previous_gpu_filter_enabled = state.gpu_filter_enabled;
-            self.last_rendered_data_version = state.data_version;
-            self.previous_gpu_scroll_offset = state.gpu_scroll_offset;
-            self.previous_storage_scroll_offset = state.storage_scroll_offset;
-            self.previous_selected_process_index = state.selected_process_index;
-            self.previous_process_horizontal_scroll_offset = state.process_horizontal_scroll_offset;
-            self.previous_tab_scroll_offset = state.tab_scroll_offset;
-            self.resize_occurred = false;
 
             if queue!(stdout, cursor::Show).is_err() {
                 break;
@@ -319,7 +291,44 @@ impl UiLoop {
         Ok(())
     }
 
-    fn update_scroll_offsets(&self, state: &mut AppState) {
+    /// Check hl-smi initialization on Linux (periodic check for performance).
+    #[cfg(target_os = "linux")]
+    async fn check_hlsmi_status(&mut self) {
+        use std::time::Duration;
+
+        // Early exit: skip all checks if both notifications have been shown
+        if self.hlsmi_notified && self.hlsmi_pending_notified {
+            return;
+        }
+
+        // Only check if enough time has passed since last check (500ms)
+        if self.last_hlsmi_check.elapsed() < Duration::from_millis(500) {
+            return;
+        }
+
+        use crate::device::hlsmi::{get_hlsmi_manager, has_hlsmi_data};
+
+        // Update last check time
+        self.last_hlsmi_check = std::time::Instant::now();
+
+        // Show pending notification if manager exists but data not ready
+        if !self.hlsmi_pending_notified && get_hlsmi_manager().is_some() && !has_hlsmi_data() {
+            let mut state = self.app_state.lock().await;
+            let _ = state
+                .notifications
+                .info("Initializing hl-smi...".to_string());
+            self.hlsmi_pending_notified = true;
+        }
+
+        // Show success notification when data is ready
+        if !self.hlsmi_notified && has_hlsmi_data() {
+            let mut state = self.app_state.lock().await;
+            let _ = state.notifications.status("Intel Gaudi ready".to_string());
+            self.hlsmi_notified = true;
+        }
+    }
+
+    fn update_scroll_offsets(state: &mut AppState) {
         let mut processed_hostnames = HashSet::new();
 
         // Collect GPU keys and lengths first to avoid borrow conflicts
@@ -389,536 +398,6 @@ impl UiLoop {
         for (key, model_len) in cpu_updates {
             let offset = state.cpu_name_scroll_offsets.entry(key).or_insert(0);
             *offset = (*offset + 1) % (model_len + 3);
-        }
-    }
-
-    fn render_help_popup_content(
-        &self,
-        state: &AppState,
-        args: &ViewArgs,
-        cols: u16,
-        rows: u16,
-    ) -> String {
-        let is_remote = args.hosts.is_some() || args.hostfile.is_some();
-        crate::ui::help::generate_help_popup_content(cols, rows, state, is_remote)
-    }
-
-    fn render_loading_content(
-        &self,
-        state: &AppState,
-        is_remote: bool,
-        cols: u16,
-        rows: u16,
-    ) -> String {
-        let mut buffer = BufferWriter::new();
-        print_function_keys(&mut buffer, cols, rows, state, is_remote);
-        print_loading_indicator(
-            &mut buffer,
-            cols,
-            rows,
-            state.frame_counter,
-            &state.startup_status_lines,
-        );
-        buffer.get_buffer().to_string()
-    }
-
-    fn render_main_content(
-        &self,
-        state: &AppState,
-        args: &ViewArgs,
-        cols: u16,
-        rows: u16,
-    ) -> String {
-        let width = cols as usize;
-        let mut buffer = BufferWriter::new();
-
-        // Write time/date header to buffer first
-        let current_time = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-        let version = env!("CARGO_PKG_VERSION");
-        let header_text = format!("all-smi - {current_time}");
-        let version_text = format!("v{version}");
-
-        // Get runtime environment info
-        let runtime_shield = if let Some((name, color)) = state.runtime_environment.display_info() {
-            // Create a shield-style badge with padding
-            let shield_content = format!(" {name} ");
-            let shield_len = shield_content.len();
-            Some((shield_content, color, shield_len))
-        } else {
-            None
-        };
-
-        // Calculate spacing to right-align version, accounting for runtime shield
-        let total_width = cols as usize;
-        let runtime_shield_len = runtime_shield
-            .as_ref()
-            .map(|(_, _, len)| len + 1)
-            .unwrap_or(0); // +1 for space before shield
-        let content_length = header_text.len() + runtime_shield_len + version_text.len();
-        let spacing = if total_width > content_length {
-            " ".repeat(total_width - content_length)
-        } else {
-            " ".to_string()
-        };
-
-        // Print header with runtime environment shield
-        print_colored_text(&mut buffer, &header_text, Color::White, None, None);
-
-        if let Some((shield_content, shield_color, _)) = runtime_shield {
-            print_colored_text(&mut buffer, " ", Color::White, None, None);
-            print_colored_text(
-                &mut buffer,
-                &shield_content,
-                Color::Black,
-                Some(shield_color),
-                None,
-            );
-        }
-
-        print_colored_text(
-            &mut buffer,
-            &format!("{spacing}{version_text}\r\n"),
-            Color::White,
-            None,
-            None,
-        );
-
-        // Write remaining header content to buffer
-        print_colored_text(&mut buffer, "Cluster Overview\r\n", Color::Cyan, None, None);
-        draw_system_view(&mut buffer, state, cols);
-
-        draw_dashboard_items(&mut buffer, state, cols);
-        draw_tabs(&mut buffer, state, cols);
-
-        let is_remote = args.hosts.is_some() || args.hostfile.is_some();
-
-        // Render chassis information (node-level metrics)
-        self.render_chassis_section(&mut buffer, state, width);
-
-        // Render GPU information
-        self.render_gpu_section(&mut buffer, state, args, cols, rows);
-
-        // Render other device information based on mode
-        if is_remote {
-            self.render_remote_devices(&mut buffer, state, width);
-        } else {
-            self.render_local_devices(&mut buffer, state, width);
-        }
-
-        // Add function keys to main content view
-        print_function_keys(&mut buffer, cols, rows, state, is_remote);
-
-        buffer.get_buffer().to_string()
-    }
-
-    fn render_gpu_section(
-        &self,
-        buffer: &mut BufferWriter,
-        state: &AppState,
-        args: &ViewArgs,
-        cols: u16,
-        rows: u16,
-    ) {
-        let mut gpu_info_to_display: Vec<_> =
-            if state.current_tab < state.tabs.len() && state.tabs[state.current_tab] == "All" {
-                state.gpu_info.iter().collect()
-            } else {
-                state
-                    .gpu_info
-                    .iter()
-                    .filter(|info| info.host_id == state.tabs[state.current_tab])
-                    .collect()
-            };
-
-        // Sort GPUs based on current sort criteria
-        gpu_info_to_display.sort_by(|a, b| state.sort_criteria.sort_gpus(a, b));
-
-        // Calculate available space and render GPUs
-        let header_lines = LayoutCalculator::calculate_header_lines(state);
-        let content_start_row = header_lines;
-        let _available_rows = rows.saturating_sub(content_start_row).saturating_sub(1) as usize;
-
-        // Calculate content area and GPU display parameters
-        let content_area = LayoutCalculator::calculate_content_area(state, cols, rows);
-        let gpu_display_params =
-            LayoutCalculator::calculate_gpu_display_params(state, args, &content_area);
-        let max_gpu_items = gpu_display_params.max_items;
-
-        // Display GPUs with scrolling
-        let start_gpu_index = state.gpu_scroll_offset;
-        let end_gpu_index = (start_gpu_index + max_gpu_items).min(gpu_info_to_display.len());
-
-        for (i, gpu_info) in gpu_info_to_display
-            .iter()
-            .enumerate()
-            .skip(start_gpu_index)
-            .take(end_gpu_index - start_gpu_index)
-        {
-            let device_name_scroll_offset = state
-                .device_name_scroll_offsets
-                .get(&gpu_info.uuid)
-                .copied()
-                .unwrap_or(0);
-            let hostname_scroll_offset = state
-                .host_id_scroll_offsets
-                .get(&gpu_info.host_id)
-                .copied()
-                .unwrap_or(0);
-
-            print_gpu_info(
-                buffer,
-                i,
-                gpu_info,
-                cols as usize,
-                device_name_scroll_offset,
-                hostname_scroll_offset,
-            );
-        }
-    }
-
-    fn render_chassis_section(&self, buffer: &mut BufferWriter, state: &AppState, width: usize) {
-        if state.chassis_info.is_empty() {
-            return;
-        }
-
-        // Filter chassis info based on mode and current tab
-        let chassis_to_display: Vec<_> = if state.is_local_mode {
-            // Local mode: show all chassis info (should be just one)
-            state.chassis_info.iter().collect()
-        } else if state.current_tab == 0 {
-            // Remote mode, "All" tab - don't show individual chassis, skip
-            return;
-        } else if state.current_tab < state.tabs.len() {
-            // Remote mode, specific node tab
-            let current_host = &state.tabs[state.current_tab];
-            state
-                .chassis_info
-                .iter()
-                .filter(|c| c.host_id == *current_host || c.hostname == *current_host)
-                .collect()
-        } else {
-            // Fallback - show all (shouldn't happen normally)
-            state.chassis_info.iter().collect()
-        };
-
-        for (i, chassis) in chassis_to_display.iter().enumerate() {
-            let hostname_scroll_offset = state
-                .host_id_scroll_offsets
-                .get(&chassis.host_id)
-                .copied()
-                .unwrap_or(0);
-
-            print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
-        }
-    }
-
-    fn render_remote_devices(&self, buffer: &mut BufferWriter, state: &AppState, width: usize) {
-        // CPU and Memory information for remote mode (only for specific host tabs, not "All" tab)
-        if state.current_tab > 0 && state.current_tab < state.tabs.len() {
-            let current_hostname = &state.tabs[state.current_tab];
-
-            // Check connection status for the current node
-            let is_connected =
-                if let Some(host_id) = state.hostname_to_host_id.get(current_hostname) {
-                    // Found in reverse lookup, get the connection status
-                    state
-                        .connection_status
-                        .get(host_id)
-                        .map(|status| status.is_connected)
-                        .unwrap_or(false)
-                } else {
-                    // Direct lookup by host_id
-                    state
-                        .connection_status
-                        .get(current_hostname)
-                        .map(|status| status.is_connected)
-                        .unwrap_or(true) // Default to connected for local mode
-                };
-
-            if !is_connected {
-                // Show elegant disconnection notification
-                self.render_disconnection_notification(buffer, current_hostname, width);
-                return;
-            }
-
-            // CPU information for specific host
-            let cpu_info_to_display: Vec<_> = state
-                .cpu_info
-                .iter()
-                .filter(|info| info.host_id == *current_hostname)
-                .collect();
-
-            for (i, cpu_info) in cpu_info_to_display.iter().enumerate() {
-                // Get scroll offsets for CPU name and hostname
-                let cpu_name_scroll_offset = state
-                    .cpu_name_scroll_offsets
-                    .get(&format!("{}-{}", cpu_info.hostname, cpu_info.cpu_model))
-                    .copied()
-                    .unwrap_or(0);
-                let hostname_scroll_offset = state
-                    .host_id_scroll_offsets
-                    .get(&cpu_info.host_id)
-                    .copied()
-                    .unwrap_or(0);
-                print_cpu_info(
-                    buffer,
-                    i,
-                    cpu_info,
-                    width,
-                    state.show_per_core_cpu,
-                    cpu_name_scroll_offset,
-                    hostname_scroll_offset,
-                );
-            }
-
-            // Memory information for specific host
-            let memory_info_to_display: Vec<_> = state
-                .memory_info
-                .iter()
-                .filter(|info| info.host_id == *current_hostname)
-                .collect();
-
-            for (i, memory_info) in memory_info_to_display.iter().enumerate() {
-                let hostname_scroll_offset = state
-                    .host_id_scroll_offsets
-                    .get(&memory_info.host_id)
-                    .copied()
-                    .unwrap_or(0);
-                print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
-            }
-
-            // Storage information for specific host
-            let storage_info_to_display: Vec<_> = state
-                .storage_info
-                .iter()
-                .filter(|info| info.host_id == *current_hostname)
-                .collect();
-
-            let visible_storage = storage_info_to_display
-                .iter()
-                .skip(state.storage_scroll_offset)
-                .take(10);
-
-            for (i, storage_info) in visible_storage.enumerate() {
-                let hostname_scroll_offset = state
-                    .host_id_scroll_offsets
-                    .get(&storage_info.host_id)
-                    .copied()
-                    .unwrap_or(0);
-                print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
-            }
-        }
-    }
-
-    fn render_disconnection_notification(
-        &self,
-        buffer: &mut BufferWriter,
-        hostname: &str,
-        width: usize,
-    ) {
-        use crate::ui::text::print_colored_text;
-        use crossterm::style::Color;
-
-        // Add some spacing
-        writeln!(buffer).unwrap();
-        writeln!(buffer).unwrap();
-
-        // Create a centered notification box
-        let box_width = (width - 4).min(60); // Leave margin and max width
-        let margin = (width - box_width) / 2;
-
-        // Top border
-        write!(buffer, "{}", " ".repeat(margin)).unwrap();
-        print_colored_text(buffer, "┌", Color::Red, None, None);
-        print_colored_text(buffer, &"─".repeat(box_width - 2), Color::Red, None, None);
-        print_colored_text(buffer, "┐", Color::Red, None, None);
-        writeln!(buffer).unwrap();
-
-        // Title line
-        let title = "CONNECTION LOST";
-        let title_padding = (box_width - 4 - title.len()) / 2;
-        write!(buffer, "{}", " ".repeat(margin)).unwrap();
-        print_colored_text(buffer, "│ ", Color::Red, None, None);
-        print_colored_text(buffer, &" ".repeat(title_padding), Color::White, None, None);
-        print_colored_text(buffer, title, Color::Red, None, None);
-        print_colored_text(
-            buffer,
-            &" ".repeat(box_width - 4 - title_padding - title.len()),
-            Color::White,
-            None,
-            None,
-        );
-        print_colored_text(buffer, " │", Color::Red, None, None);
-        writeln!(buffer).unwrap();
-
-        // Empty line
-        write!(buffer, "{}", " ".repeat(margin)).unwrap();
-        print_colored_text(buffer, "│", Color::Red, None, None);
-        print_colored_text(buffer, &" ".repeat(box_width - 2), Color::White, None, None);
-        print_colored_text(buffer, "│", Color::Red, None, None);
-        writeln!(buffer).unwrap();
-
-        // Hostname line
-        let hostname_text = format!("Node: {hostname}");
-        let hostname_padding = (box_width - 4 - hostname_text.len()) / 2;
-        write!(buffer, "{}", " ".repeat(margin)).unwrap();
-        print_colored_text(buffer, "│ ", Color::Red, None, None);
-        print_colored_text(
-            buffer,
-            &" ".repeat(hostname_padding),
-            Color::White,
-            None,
-            None,
-        );
-        print_colored_text(buffer, &hostname_text, Color::Yellow, None, None);
-        print_colored_text(
-            buffer,
-            &" ".repeat(box_width - 4 - hostname_padding - hostname_text.len()),
-            Color::White,
-            None,
-            None,
-        );
-        print_colored_text(buffer, " │", Color::Red, None, None);
-        writeln!(buffer).unwrap();
-
-        // Status line
-        let status_text = "Unable to retrieve node information";
-        let status_padding = (box_width - 4 - status_text.len()) / 2;
-        write!(buffer, "{}", " ".repeat(margin)).unwrap();
-        print_colored_text(buffer, "│ ", Color::Red, None, None);
-        print_colored_text(
-            buffer,
-            &" ".repeat(status_padding),
-            Color::White,
-            None,
-            None,
-        );
-        print_colored_text(buffer, status_text, Color::DarkGrey, None, None);
-        print_colored_text(
-            buffer,
-            &" ".repeat(box_width - 4 - status_padding - status_text.len()),
-            Color::White,
-            None,
-            None,
-        );
-        print_colored_text(buffer, " │", Color::Red, None, None);
-        writeln!(buffer).unwrap();
-
-        // Empty line
-        write!(buffer, "{}", " ".repeat(margin)).unwrap();
-        print_colored_text(buffer, "│", Color::Red, None, None);
-        print_colored_text(buffer, &" ".repeat(box_width - 2), Color::White, None, None);
-        print_colored_text(buffer, "│", Color::Red, None, None);
-        writeln!(buffer).unwrap();
-
-        // Bottom border
-        write!(buffer, "{}", " ".repeat(margin)).unwrap();
-        print_colored_text(buffer, "└", Color::Red, None, None);
-        print_colored_text(buffer, &"─".repeat(box_width - 2), Color::Red, None, None);
-        print_colored_text(buffer, "┘", Color::Red, None, None);
-        writeln!(buffer).unwrap();
-    }
-
-    fn render_local_devices(&self, buffer: &mut BufferWriter, state: &AppState, width: usize) {
-        // CPU information for local mode
-        for (i, cpu_info) in state.cpu_info.iter().enumerate() {
-            // Get scroll offsets for CPU name and hostname
-            let cpu_name_scroll_offset = state
-                .cpu_name_scroll_offsets
-                .get(&format!("{}-{}", cpu_info.hostname, cpu_info.cpu_model))
-                .copied()
-                .unwrap_or(0);
-            let hostname_scroll_offset = state
-                .host_id_scroll_offsets
-                .get(&cpu_info.host_id)
-                .copied()
-                .unwrap_or(0);
-            print_cpu_info(
-                buffer,
-                i,
-                cpu_info,
-                width,
-                state.show_per_core_cpu,
-                cpu_name_scroll_offset,
-                hostname_scroll_offset,
-            );
-        }
-
-        // Memory information for local mode
-        for (i, memory_info) in state.memory_info.iter().enumerate() {
-            let hostname_scroll_offset = state
-                .host_id_scroll_offsets
-                .get(&memory_info.host_id)
-                .copied()
-                .unwrap_or(0);
-            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
-        }
-
-        // Storage information for local mode
-        for (i, storage_info) in state.storage_info.iter().enumerate() {
-            let hostname_scroll_offset = state
-                .host_id_scroll_offsets
-                .get(&storage_info.host_id)
-                .copied()
-                .unwrap_or(0);
-            print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
-        }
-
-        // Process information for local mode (if available)
-        if !state.process_info.is_empty() {
-            // The print_process_info function expects the full process list and handles slicing internally
-            let (cols, rows) = match crossterm::terminal::size() {
-                Ok((c, r)) => (c, r),
-                Err(_) => (
-                    AppConfig::DEFAULT_TERMINAL_WIDTH,
-                    AppConfig::DEFAULT_TERMINAL_HEIGHT,
-                ),
-            };
-
-            // Calculate how many lines have been used so far
-            // Use the efficient line counter from BufferWriter
-            let lines_used = buffer.line_count();
-
-            // Add a blank line before process list
-            queue!(buffer, Print("\r\n")).unwrap();
-
-            // Reserve 1 line for function keys at the bottom
-            let function_key_rows = 1;
-
-            // Calculate available rows for process list
-            // Use all remaining space from current position to the function keys
-            // Account for the blank line we just added
-            let available_rows = rows.saturating_sub(lines_used as u16 + 1 + function_key_rows);
-
-            // Get current user for process coloring
-            let current_user = whoami::username().unwrap_or_default();
-
-            // Apply GPU filter if enabled
-            let processes_to_display: Cow<'_, [ProcessInfo]> = if state.gpu_filter_enabled {
-                Cow::Owned(
-                    state
-                        .process_info
-                        .iter()
-                        .filter(|p| p.used_memory > 0)
-                        .cloned()
-                        .collect(),
-                )
-            } else {
-                Cow::Borrowed(&state.process_info)
-            };
-
-            print_process_info(
-                buffer,
-                &processes_to_display,
-                state.selected_process_index,
-                state.start_index,
-                available_rows,
-                cols,
-                state.process_horizontal_scroll_offset,
-                &current_user,
-                &state.sort_criteria,
-                &state.sort_direction,
-            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `RenderSnapshot` struct that captures only frame-needed data from `AppState` under the mutex lock, then releases the lock immediately before expensive frame composition
- Extract all frame assembly logic into a new `FrameRenderer` module that operates purely on the immutable snapshot, never holding the `AppState` lock
- Refactor `UiLoop::run()` critical section to cover only mutable bookkeeping (scroll offsets, frame counter) and snapshot capture; all rendering, differential output, and stdout flushing happen after lock release
- `RenderSnapshot::as_app_state()` provides backward compatibility bridge with existing UI functions that accept `&AppState`
- VecDeque history data converted to Vec during snapshot capture for lighter cloning

Closes #136

## Test plan

- [x] All 204 existing unit tests pass (including UI event coordinator, app state, renderer tests)
- [x] 8 new unit tests for `RenderSnapshot`: flag preservation, tab state, scroll state, sort state, data version, VecDeque-to-Vec conversion, snapshot independence from source mutation, and roundtrip `as_app_state()` conversion
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo fmt -- --check` passes
- [ ] Manual verification: run `all-smi` in local mode and confirm identical visual output
- [ ] Manual verification: run `all-smi view` in remote mode and confirm tab switching, scrolling, and disconnection notification work correctly
- [ ] Verify responsiveness under load: background collectors should not block on render-time critical sections