### PR TITLE
feat: cache derived TUI view data to avoid per-frame sorting and cloning

### DIFF
--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -191,20 +191,25 @@ impl FrameRenderer {
             cached_indices = indices;
             cached_indices
         } else {
-            // Fallback: filter + sort inline (only reached when cache is None)
-            let is_all_tab = snapshot.current_tab < snapshot.tabs.len()
-                && snapshot.tabs[snapshot.current_tab] == "All";
-            let mut indices: Vec<usize> = if is_all_tab {
-                (0..snapshot.gpu_info.len()).collect()
-            } else {
-                snapshot
-                    .gpu_info
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, info)| info.host_id == snapshot.tabs[snapshot.current_tab])
-                    .map(|(i, _)| i)
-                    .collect()
-            };
+            // Fallback: filter + sort inline (only reached when cache is None).
+            // Use .get() to guard against out-of-bounds current_tab.
+            let mut indices: Vec<usize> =
+                if let Some(tab_name) = snapshot.tabs.get(snapshot.current_tab) {
+                    if tab_name == "All" {
+                        (0..snapshot.gpu_info.len()).collect()
+                    } else {
+                        snapshot
+                            .gpu_info
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, info)| info.host_id == *tab_name)
+                            .map(|(i, _)| i)
+                            .collect()
+                    }
+                } else {
+                    // Out-of-bounds tab index: show all (defensive)
+                    (0..snapshot.gpu_info.len()).collect()
+                };
             indices.sort_by(|&a, &b| {
                 snapshot
                     .sort_criteria

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -40,6 +40,7 @@ use crate::ui::renderer::{
 use crate::ui::tabs::draw_tabs;
 use crate::ui::text::print_colored_text;
 use crate::view::render_snapshot::RenderSnapshot;
+use crate::view::view_cache::ViewCache;
 
 /// Stateless frame renderer that operates on a `RenderSnapshot`.
 ///
@@ -76,7 +77,16 @@ impl FrameRenderer {
     }
 
     /// Render main content (the primary monitoring view) from the snapshot.
-    pub fn render_main(snapshot: &RenderSnapshot, args: &ViewArgs, cols: u16, rows: u16) -> String {
+    ///
+    /// When a `ViewCache` is provided, pre-computed sorted/filtered indices
+    /// are used instead of re-sorting and re-filtering on every frame.
+    pub fn render_main(
+        snapshot: &RenderSnapshot,
+        args: &ViewArgs,
+        cols: u16,
+        rows: u16,
+        cache: Option<&ViewCache>,
+    ) -> String {
         let width = cols as usize;
         let mut buffer = BufferWriter::new();
 
@@ -146,16 +156,16 @@ impl FrameRenderer {
         let is_remote = args.hosts.is_some() || args.hostfile.is_some();
 
         // Render chassis information (node-level metrics)
-        Self::render_chassis_section(&mut buffer, snapshot, width);
+        Self::render_chassis_section(&mut buffer, snapshot, width, cache);
 
         // Render GPU information (reuse the single view_state for layout calculation)
-        Self::render_gpu_section(&mut buffer, snapshot, &view_state, args, cols, rows);
+        Self::render_gpu_section(&mut buffer, snapshot, &view_state, args, cols, rows, cache);
 
         // Render other device information based on mode
         if is_remote {
-            Self::render_remote_devices(&mut buffer, snapshot, width);
+            Self::render_remote_devices(&mut buffer, snapshot, width, cache);
         } else {
-            Self::render_local_devices(&mut buffer, snapshot, cols, rows);
+            Self::render_local_devices(&mut buffer, snapshot, cols, rows, cache);
         }
 
         // Add function keys to main content view
@@ -171,21 +181,38 @@ impl FrameRenderer {
         args: &ViewArgs,
         cols: u16,
         rows: u16,
+        cache: Option<&ViewCache>,
     ) {
-        let mut gpu_info_to_display: Vec<_> = if snapshot.current_tab < snapshot.tabs.len()
-            && snapshot.tabs[snapshot.current_tab] == "All"
-        {
-            snapshot.gpu_info.iter().collect()
+        // Use cached sorted indices when available, otherwise fall back to
+        // the previous per-frame filter + sort path.
+        let cached_indices;
+        let fallback_indices;
+        let display_indices: &[usize] = if let Some(indices) = cache.and_then(|c| c.gpu_indices()) {
+            cached_indices = indices;
+            cached_indices
         } else {
-            snapshot
-                .gpu_info
-                .iter()
-                .filter(|info| info.host_id == snapshot.tabs[snapshot.current_tab])
-                .collect()
+            // Fallback: filter + sort inline (only reached when cache is None)
+            let is_all_tab = snapshot.current_tab < snapshot.tabs.len()
+                && snapshot.tabs[snapshot.current_tab] == "All";
+            let mut indices: Vec<usize> = if is_all_tab {
+                (0..snapshot.gpu_info.len()).collect()
+            } else {
+                snapshot
+                    .gpu_info
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, info)| info.host_id == snapshot.tabs[snapshot.current_tab])
+                    .map(|(i, _)| i)
+                    .collect()
+            };
+            indices.sort_by(|&a, &b| {
+                snapshot
+                    .sort_criteria
+                    .sort_gpus(&snapshot.gpu_info[a], &snapshot.gpu_info[b])
+            });
+            fallback_indices = indices;
+            &fallback_indices
         };
-
-        // Sort GPUs based on current sort criteria
-        gpu_info_to_display.sort_by(|a, b| snapshot.sort_criteria.sort_gpus(a, b));
 
         // Calculate content area and GPU display parameters using the shared
         // view_state from render_main, avoiding a second as_app_state() call.
@@ -196,14 +223,15 @@ impl FrameRenderer {
 
         // Display GPUs with scrolling
         let start_gpu_index = snapshot.gpu_scroll_offset;
-        let end_gpu_index = (start_gpu_index + max_gpu_items).min(gpu_info_to_display.len());
+        let end_gpu_index = (start_gpu_index + max_gpu_items).min(display_indices.len());
 
-        for (i, gpu_info) in gpu_info_to_display
+        for (i, &gpu_idx) in display_indices
             .iter()
             .enumerate()
             .skip(start_gpu_index)
-            .take(end_gpu_index - start_gpu_index)
+            .take(end_gpu_index.saturating_sub(start_gpu_index))
         {
+            let gpu_info = &snapshot.gpu_info[gpu_idx];
             let device_name_scroll_offset = snapshot
                 .device_name_scroll_offsets
                 .get(&gpu_info.uuid)
@@ -226,16 +254,37 @@ impl FrameRenderer {
         }
     }
 
-    fn render_chassis_section(buffer: &mut BufferWriter, snapshot: &RenderSnapshot, width: usize) {
+    fn render_chassis_section(
+        buffer: &mut BufferWriter,
+        snapshot: &RenderSnapshot,
+        width: usize,
+        cache: Option<&ViewCache>,
+    ) {
         if snapshot.chassis_info.is_empty() {
             return;
         }
 
-        // Filter chassis info based on mode and current tab
+        // Use cached chassis indices when available
+        if let Some(hd) = cache.and_then(|c| c.host_device_indices()) {
+            if hd.chassis_indices.is_empty() {
+                return;
+            }
+            for (i, &idx) in hd.chassis_indices.iter().enumerate() {
+                let chassis = &snapshot.chassis_info[idx];
+                let hostname_scroll_offset = snapshot
+                    .host_id_scroll_offsets
+                    .get(&chassis.host_id)
+                    .copied()
+                    .unwrap_or(0);
+                print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
+            }
+            return;
+        }
+
+        // Fallback: filter inline (only reached when cache is None)
         let chassis_to_display: Vec<_> = if snapshot.is_local_mode {
             snapshot.chassis_info.iter().collect()
         } else if snapshot.current_tab == 0 {
-            // Remote mode, "All" tab - don't show individual chassis
             return;
         } else if snapshot.current_tab < snapshot.tabs.len() {
             let current_host = &snapshot.tabs[snapshot.current_tab];
@@ -254,102 +303,130 @@ impl FrameRenderer {
                 .get(&chassis.host_id)
                 .copied()
                 .unwrap_or(0);
-
             print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
         }
     }
 
-    fn render_remote_devices(buffer: &mut BufferWriter, snapshot: &RenderSnapshot, width: usize) {
-        if snapshot.current_tab > 0 && snapshot.current_tab < snapshot.tabs.len() {
-            let current_hostname = &snapshot.tabs[snapshot.current_tab];
-
-            // Check connection status for the current node
-            let is_connected =
-                if let Some(host_id) = snapshot.hostname_to_host_id.get(current_hostname) {
-                    snapshot
-                        .connection_status
-                        .get(host_id)
-                        .map(|status| status.is_connected)
-                        .unwrap_or(false)
-                } else {
-                    snapshot
-                        .connection_status
-                        .get(current_hostname)
-                        .map(|status| status.is_connected)
-                        .unwrap_or(true)
-                };
-
-            if !is_connected {
-                Self::render_disconnection_notification(buffer, current_hostname, width);
-                return;
-            }
-
-            // CPU information for specific host
-            let cpu_info_to_display: Vec<_> = snapshot
-                .cpu_info
-                .iter()
-                .filter(|info| info.host_id == *current_hostname)
-                .collect();
-
-            for (i, cpu_info) in cpu_info_to_display.iter().enumerate() {
-                let cpu_name_scroll_offset = snapshot
-                    .cpu_name_scroll_offsets
-                    .get(&format!("{}-{}", cpu_info.hostname, cpu_info.cpu_model))
-                    .copied()
-                    .unwrap_or(0);
-                let hostname_scroll_offset = snapshot
-                    .host_id_scroll_offsets
-                    .get(&cpu_info.host_id)
-                    .copied()
-                    .unwrap_or(0);
-                print_cpu_info(
-                    buffer,
-                    i,
-                    cpu_info,
-                    width,
-                    snapshot.show_per_core_cpu,
-                    cpu_name_scroll_offset,
-                    hostname_scroll_offset,
-                );
-            }
-
-            // Memory information for specific host
-            let memory_info_to_display: Vec<_> = snapshot
-                .memory_info
-                .iter()
-                .filter(|info| info.host_id == *current_hostname)
-                .collect();
-
-            for (i, memory_info) in memory_info_to_display.iter().enumerate() {
-                let hostname_scroll_offset = snapshot
-                    .host_id_scroll_offsets
-                    .get(&memory_info.host_id)
-                    .copied()
-                    .unwrap_or(0);
-                print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
-            }
-
-            // Storage information for specific host
-            let storage_info_to_display: Vec<_> = snapshot
-                .storage_info
-                .iter()
-                .filter(|info| info.host_id == *current_hostname)
-                .collect();
-
-            let visible_storage = storage_info_to_display
-                .iter()
-                .skip(snapshot.storage_scroll_offset)
-                .take(10);
-
-            for (i, storage_info) in visible_storage.enumerate() {
-                let hostname_scroll_offset = snapshot
-                    .host_id_scroll_offsets
-                    .get(&storage_info.host_id)
-                    .copied()
-                    .unwrap_or(0);
-                print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
-            }
+    fn render_remote_devices(
+        buffer: &mut BufferWriter,
+        snapshot: &RenderSnapshot,
+        width: usize,
+        cache: Option<&ViewCache>,
+    ) {
+        if snapshot.current_tab == 0 || snapshot.current_tab >= snapshot.tabs.len() {
+            return;
         }
+
+        let current_hostname = &snapshot.tabs[snapshot.current_tab];
+
+        // Check connection status for the current node
+        let is_connected = if let Some(host_id) = snapshot.hostname_to_host_id.get(current_hostname)
+        {
+            snapshot
+                .connection_status
+                .get(host_id)
+                .map(|status| status.is_connected)
+                .unwrap_or(false)
+        } else {
+            snapshot
+                .connection_status
+                .get(current_hostname)
+                .map(|status| status.is_connected)
+                .unwrap_or(true)
+        };
+
+        if !is_connected {
+            Self::render_disconnection_notification(buffer, current_hostname, width);
+            return;
+        }
+
+        // Resolve host-device indices: use cache when available, otherwise
+        // build a temporary index list from an inline filter.
+        let fallback_cpu;
+        let fallback_mem;
+        let fallback_stor;
+        let (cpu_idx, mem_idx, stor_idx) = if let Some(hd) =
+            cache.and_then(|c| c.host_device_indices())
+        {
+            (
+                hd.cpu_indices.as_slice(),
+                hd.memory_indices.as_slice(),
+                hd.storage_indices.as_slice(),
+            )
+        } else {
+            fallback_cpu =
+                Self::filter_indices(&snapshot.cpu_info, |c| c.host_id == *current_hostname);
+            fallback_mem =
+                Self::filter_indices(&snapshot.memory_info, |m| m.host_id == *current_hostname);
+            fallback_stor =
+                Self::filter_indices(&snapshot.storage_info, |s| s.host_id == *current_hostname);
+            (
+                fallback_cpu.as_slice(),
+                fallback_mem.as_slice(),
+                fallback_stor.as_slice(),
+            )
+        };
+
+        // CPU
+        for (i, &idx) in cpu_idx.iter().enumerate() {
+            let cpu_info = &snapshot.cpu_info[idx];
+            let cpu_name_scroll_offset = snapshot
+                .cpu_name_scroll_offsets
+                .get(&format!("{}-{}", cpu_info.hostname, cpu_info.cpu_model))
+                .copied()
+                .unwrap_or(0);
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&cpu_info.host_id)
+                .copied()
+                .unwrap_or(0);
+            print_cpu_info(
+                buffer,
+                i,
+                cpu_info,
+                width,
+                snapshot.show_per_core_cpu,
+                cpu_name_scroll_offset,
+                hostname_scroll_offset,
+            );
+        }
+
+        // Memory
+        for (i, &idx) in mem_idx.iter().enumerate() {
+            let memory_info = &snapshot.memory_info[idx];
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&memory_info.host_id)
+                .copied()
+                .unwrap_or(0);
+            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
+        }
+
+        // Storage with scroll offset
+        for (i, &idx) in stor_idx
+            .iter()
+            .skip(snapshot.storage_scroll_offset)
+            .take(10)
+            .enumerate()
+        {
+            let storage_info = &snapshot.storage_info[idx];
+            let hostname_scroll_offset = snapshot
+                .host_id_scroll_offsets
+                .get(&storage_info.host_id)
+                .copied()
+                .unwrap_or(0);
+            print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
+        }
+    }
+
+    /// Collect indices of elements matching a predicate.
+    fn filter_indices<T>(items: &[T], predicate: impl Fn(&T) -> bool) -> Vec<usize> {
+        items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| predicate(item))
+            .map(|(i, _)| i)
+            .collect()
     }
 
     fn render_disconnection_notification(buffer: &mut BufferWriter, hostname: &str, width: usize) {
@@ -437,6 +514,7 @@ impl FrameRenderer {
         snapshot: &RenderSnapshot,
         cols: u16,
         rows: u16,
+        cache: Option<&ViewCache>,
     ) {
         let width = cols as usize;
 
@@ -498,19 +576,27 @@ impl FrameRenderer {
             // Get current user for process coloring
             let current_user = whoami::username().unwrap_or_default();
 
-            // Apply GPU filter if enabled
-            let processes_to_display: Cow<'_, [ProcessInfo]> = if snapshot.gpu_filter_enabled {
-                Cow::Owned(
-                    snapshot
-                        .process_info
-                        .iter()
-                        .filter(|p| p.used_memory > 0)
-                        .cloned()
-                        .collect(),
-                )
-            } else {
-                Cow::Borrowed(&snapshot.process_info)
-            };
+            // Use cached GPU-filtered process list when available, avoiding
+            // a per-frame clone of the entire process vector.
+            let processes_to_display: Cow<'_, [ProcessInfo]> =
+                if let Some(pl) = cache.and_then(|c| c.process_display_list()) {
+                    match &pl.filtered {
+                        Some(filtered) => Cow::Borrowed(filtered.as_slice()),
+                        None => Cow::Borrowed(&snapshot.process_info),
+                    }
+                } else if snapshot.gpu_filter_enabled {
+                    // Fallback: filter inline (only when cache is None)
+                    Cow::Owned(
+                        snapshot
+                            .process_info
+                            .iter()
+                            .filter(|p| p.used_memory > 0)
+                            .cloned()
+                            .collect(),
+                    )
+                } else {
+                    Cow::Borrowed(&snapshot.process_info)
+                };
 
             print_process_info(
                 buffer,
@@ -596,7 +682,7 @@ mod tests {
     fn test_render_main_does_not_panic_empty_state() {
         let snapshot = make_snapshot();
         let args = make_local_args();
-        let output = FrameRenderer::render_main(&snapshot, &args, 80, 24);
+        let output = FrameRenderer::render_main(&snapshot, &args, 80, 24, None);
         // Header must be present.
         assert!(output.contains("all-smi"));
     }
@@ -605,7 +691,7 @@ mod tests {
     fn test_render_main_contains_header_timestamp() {
         let snapshot = make_snapshot();
         let args = make_local_args();
-        let output = FrameRenderer::render_main(&snapshot, &args, 120, 40);
+        let output = FrameRenderer::render_main(&snapshot, &args, 120, 40, None);
         // The header includes the current year which is deterministic for the test run.
         assert!(output.contains("all-smi - 20"));
     }
@@ -614,7 +700,7 @@ mod tests {
     fn test_render_main_contains_version() {
         let snapshot = make_snapshot();
         let args = make_local_args();
-        let output = FrameRenderer::render_main(&snapshot, &args, 80, 24);
+        let output = FrameRenderer::render_main(&snapshot, &args, 80, 24, None);
         let version = env!("CARGO_PKG_VERSION");
         assert!(output.contains(version));
     }

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -21,5 +21,6 @@ pub mod runner;
 pub mod terminal_manager;
 pub mod ui_events;
 pub mod ui_loop;
+pub mod view_cache;
 
 pub use runner::*;

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -27,6 +27,7 @@ use crate::view::event_handler::handle_key_event;
 use crate::view::frame_renderer::FrameRenderer;
 use crate::view::render_snapshot::{RenderDecisions, RenderSnapshot};
 use crate::view::ui_events::{UiEvent, UiEventCoordinator};
+use crate::view::view_cache::ViewCache;
 
 pub struct UiLoop {
     app_state: Arc<Mutex<AppState>>,
@@ -46,6 +47,8 @@ pub struct UiLoop {
     previous_process_horizontal_scroll_offset: usize,
     previous_tab_scroll_offset: usize,
     previous_gpu_filter_enabled: bool,
+    /// Cached derived view data (sorted GPU lists, filtered host subsets, etc.)
+    view_cache: ViewCache,
     /// Event coordinator for event-driven wakeups
     event_coordinator: UiEventCoordinator,
     #[cfg(target_os = "linux")]
@@ -82,6 +85,7 @@ impl UiLoop {
             previous_process_horizontal_scroll_offset: 0,
             previous_tab_scroll_offset: 0,
             previous_gpu_filter_enabled: false,
+            view_cache: ViewCache::new(),
             event_coordinator,
             #[cfg(target_os = "linux")]
             hlsmi_notified: false,
@@ -257,9 +261,15 @@ impl UiLoop {
                 break;
             }
 
-            if decisions.force_clear && self.differential_renderer.force_clear().is_err() {
-                break;
+            if decisions.force_clear {
+                self.view_cache.invalidate_all();
+                if self.differential_renderer.force_clear().is_err() {
+                    break;
+                }
             }
+
+            // Update derived view cache (only recomputes stale entries)
+            self.view_cache.update(&snapshot);
 
             // Assemble frame content from the snapshot (no lock held)
             let content = if snapshot.show_help {
@@ -268,7 +278,7 @@ impl UiLoop {
                 let is_remote = args.hosts.is_some() || args.hostfile.is_some();
                 FrameRenderer::render_loading(&snapshot, is_remote, cols, rows)
             } else {
-                FrameRenderer::render_main(&snapshot, args, cols, rows)
+                FrameRenderer::render_main(&snapshot, args, cols, rows, Some(&self.view_cache))
             };
 
             // Use differential rendering to update only changed lines

--- a/src/view/view_cache.rs
+++ b/src/view/view_cache.rs
@@ -113,6 +113,12 @@ pub struct ViewCache {
     pub process_list: Option<CachedProcessList>,
 }
 
+impl Default for ViewCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ViewCache {
     /// Create an empty cache. All entries will be computed on the first call
     /// to `update()`.
@@ -169,22 +175,26 @@ impl ViewCache {
             return false;
         }
 
-        // Build filtered + sorted index list
-        let is_all_tab = snapshot.current_tab < snapshot.tabs.len()
-            && snapshot.tabs[snapshot.current_tab] == "All";
-
-        let mut indices: Vec<usize> = if is_all_tab {
-            (0..snapshot.gpu_info.len()).collect()
-        } else {
-            let tab_name = &snapshot.tabs[snapshot.current_tab];
-            snapshot
-                .gpu_info
-                .iter()
-                .enumerate()
-                .filter(|(_, info)| info.host_id == *tab_name)
-                .map(|(i, _)| i)
-                .collect()
-        };
+        // Build filtered + sorted index list.
+        // Guard against current_tab being out of bounds (defensive) --
+        // show all GPUs in that case rather than panicking.
+        let mut indices: Vec<usize> =
+            if let Some(tab_name) = snapshot.tabs.get(snapshot.current_tab) {
+                if tab_name == "All" {
+                    (0..snapshot.gpu_info.len()).collect()
+                } else {
+                    snapshot
+                        .gpu_info
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, info)| info.host_id == *tab_name)
+                        .map(|(i, _)| i)
+                        .collect()
+                }
+            } else {
+                // Out-of-bounds tab index: show all (defensive)
+                (0..snapshot.gpu_info.len()).collect()
+            };
 
         // Sort by the current criteria
         let criteria = snapshot.sort_criteria;

--- a/src/view/view_cache.rs
+++ b/src/view/view_cache.rs
@@ -1,0 +1,793 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Caches derived TUI view data to avoid per-frame sorting, filtering, and cloning.
+//!
+//! The cache is keyed by the inputs that affect the derived result (data version,
+//! current tab, sort criteria, GPU filter state). When any of those inputs change
+//! the relevant cache entry is invalidated and recomputed on the next render.
+//!
+//! The cache is owned by the UI loop and lives alongside the `RenderSnapshot`.
+
+use crate::app_state::SortCriteria;
+use crate::device::ProcessInfo;
+use crate::view::render_snapshot::RenderSnapshot;
+
+/// Key that determines whether the GPU display cache is still valid.
+///
+/// When any field in this key differs from the previous render, the
+/// sorted/filtered GPU list is recomputed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct GpuCacheKey {
+    data_version: u64,
+    current_tab: usize,
+    sort_criteria_ordinal: u8,
+}
+
+/// Key for host-specific device subsets (CPU, memory, storage, chassis).
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HostDeviceCacheKey {
+    data_version: u64,
+    current_tab: usize,
+    is_local_mode: bool,
+}
+
+/// Key for GPU-filtered process list.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ProcessFilterCacheKey {
+    data_version: u64,
+    gpu_filter_enabled: bool,
+}
+
+/// Map `SortCriteria` to a stable ordinal for use in cache keys.
+///
+/// Using an ordinal avoids requiring `Eq`/`Hash` on `SortCriteria` variants
+/// that only affect GPU sorting (Default, Utilization, GpuMemory, Power,
+/// Temperature) while keeping all process-sort variants collapsed to a
+/// single sentinel, since GPU sorting ignores them.
+fn sort_criteria_ordinal(criteria: SortCriteria) -> u8 {
+    match criteria {
+        SortCriteria::Default => 0,
+        SortCriteria::Utilization => 1,
+        SortCriteria::GpuMemory => 2,
+        SortCriteria::Power => 3,
+        SortCriteria::Temperature => 4,
+        // All process-only criteria map to the same Default GPU sort
+        _ => 0,
+    }
+}
+
+/// Pre-computed, sorted GPU display list for the current tab + sort criteria.
+#[derive(Clone)]
+pub struct CachedGpuList {
+    /// Sorted indices into `RenderSnapshot::gpu_info`.
+    ///
+    /// Storing indices instead of cloned `GpuInfo` avoids duplicating the
+    /// (potentially large) GPU data. The consumer reads the original snapshot
+    /// through these indices.
+    pub indices: Vec<usize>,
+}
+
+/// Pre-computed host-filtered device subsets for the current tab.
+#[derive(Clone)]
+pub struct CachedHostDevices {
+    pub chassis_indices: Vec<usize>,
+    pub cpu_indices: Vec<usize>,
+    pub memory_indices: Vec<usize>,
+    pub storage_indices: Vec<usize>,
+}
+
+/// Pre-computed GPU-filtered process list.
+#[derive(Clone)]
+pub struct CachedProcessList {
+    /// When GPU filter is disabled, this is `None` and callers should use
+    /// `snapshot.process_info` directly to avoid any clone at all.
+    /// When enabled, contains only processes with `used_memory > 0`.
+    pub filtered: Option<Vec<ProcessInfo>>,
+}
+
+/// Holds all cached derived view data with their invalidation keys.
+///
+/// The cache is designed to be created once and reused across frames.
+/// Each `update()` call checks whether the keys have changed and only
+/// recomputes the entries that are stale.
+pub struct ViewCache {
+    gpu_key: Option<GpuCacheKey>,
+    pub gpu_list: Option<CachedGpuList>,
+
+    host_key: Option<HostDeviceCacheKey>,
+    pub host_devices: Option<CachedHostDevices>,
+
+    process_key: Option<ProcessFilterCacheKey>,
+    pub process_list: Option<CachedProcessList>,
+}
+
+impl ViewCache {
+    /// Create an empty cache. All entries will be computed on the first call
+    /// to `update()`.
+    pub fn new() -> Self {
+        Self {
+            gpu_key: None,
+            gpu_list: None,
+            host_key: None,
+            host_devices: None,
+            process_key: None,
+            process_list: None,
+        }
+    }
+
+    /// Recompute any stale cache entries based on the current snapshot.
+    ///
+    /// Returns `true` if any cache entry was recomputed (useful for debugging
+    /// or metrics). Each section is checked independently so that, for
+    /// example, a tab change invalidates the GPU and host-device caches but
+    /// not the process-filter cache.
+    pub fn update(&mut self, snapshot: &RenderSnapshot) -> bool {
+        let mut recomputed = false;
+
+        recomputed |= self.update_gpu_list(snapshot);
+        recomputed |= self.update_host_devices(snapshot);
+        recomputed |= self.update_process_list(snapshot);
+
+        recomputed
+    }
+
+    /// Invalidate all cache entries, forcing recomputation on the next
+    /// `update()` call.
+    pub fn invalidate_all(&mut self) {
+        self.gpu_key = None;
+        self.gpu_list = None;
+        self.host_key = None;
+        self.host_devices = None;
+        self.process_key = None;
+        self.process_list = None;
+    }
+
+    // ------------------------------------------------------------------
+    // GPU display list
+    // ------------------------------------------------------------------
+
+    fn update_gpu_list(&mut self, snapshot: &RenderSnapshot) -> bool {
+        let new_key = GpuCacheKey {
+            data_version: snapshot.data_version,
+            current_tab: snapshot.current_tab,
+            sort_criteria_ordinal: sort_criteria_ordinal(snapshot.sort_criteria),
+        };
+
+        if self.gpu_key.as_ref() == Some(&new_key) {
+            return false;
+        }
+
+        // Build filtered + sorted index list
+        let is_all_tab = snapshot.current_tab < snapshot.tabs.len()
+            && snapshot.tabs[snapshot.current_tab] == "All";
+
+        let mut indices: Vec<usize> = if is_all_tab {
+            (0..snapshot.gpu_info.len()).collect()
+        } else {
+            let tab_name = &snapshot.tabs[snapshot.current_tab];
+            snapshot
+                .gpu_info
+                .iter()
+                .enumerate()
+                .filter(|(_, info)| info.host_id == *tab_name)
+                .map(|(i, _)| i)
+                .collect()
+        };
+
+        // Sort by the current criteria
+        let criteria = snapshot.sort_criteria;
+        indices.sort_by(|&a, &b| criteria.sort_gpus(&snapshot.gpu_info[a], &snapshot.gpu_info[b]));
+
+        self.gpu_key = Some(new_key);
+        self.gpu_list = Some(CachedGpuList { indices });
+        true
+    }
+
+    // ------------------------------------------------------------------
+    // Host device subsets
+    // ------------------------------------------------------------------
+
+    fn update_host_devices(&mut self, snapshot: &RenderSnapshot) -> bool {
+        let new_key = HostDeviceCacheKey {
+            data_version: snapshot.data_version,
+            current_tab: snapshot.current_tab,
+            is_local_mode: snapshot.is_local_mode,
+        };
+
+        if self.host_key.as_ref() == Some(&new_key) {
+            return false;
+        }
+
+        let cached = if snapshot.is_local_mode {
+            // Local mode: all devices are relevant
+            CachedHostDevices {
+                chassis_indices: (0..snapshot.chassis_info.len()).collect(),
+                cpu_indices: (0..snapshot.cpu_info.len()).collect(),
+                memory_indices: (0..snapshot.memory_info.len()).collect(),
+                storage_indices: (0..snapshot.storage_info.len()).collect(),
+            }
+        } else if snapshot.current_tab == 0 {
+            // Remote "All" tab: chassis are hidden; other devices shown on
+            // per-host tabs only, so return empty.
+            CachedHostDevices {
+                chassis_indices: Vec::new(),
+                cpu_indices: Vec::new(),
+                memory_indices: Vec::new(),
+                storage_indices: Vec::new(),
+            }
+        } else if snapshot.current_tab < snapshot.tabs.len() {
+            let hostname = &snapshot.tabs[snapshot.current_tab];
+            CachedHostDevices {
+                chassis_indices: snapshot
+                    .chassis_info
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, c)| c.host_id == *hostname || c.hostname == *hostname)
+                    .map(|(i, _)| i)
+                    .collect(),
+                cpu_indices: snapshot
+                    .cpu_info
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, c)| c.host_id == *hostname)
+                    .map(|(i, _)| i)
+                    .collect(),
+                memory_indices: snapshot
+                    .memory_info
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, m)| m.host_id == *hostname)
+                    .map(|(i, _)| i)
+                    .collect(),
+                storage_indices: snapshot
+                    .storage_info
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, s)| s.host_id == *hostname)
+                    .map(|(i, _)| i)
+                    .collect(),
+            }
+        } else {
+            // Out-of-bounds tab: show all (defensive)
+            CachedHostDevices {
+                chassis_indices: (0..snapshot.chassis_info.len()).collect(),
+                cpu_indices: (0..snapshot.cpu_info.len()).collect(),
+                memory_indices: (0..snapshot.memory_info.len()).collect(),
+                storage_indices: (0..snapshot.storage_info.len()).collect(),
+            }
+        };
+
+        self.host_key = Some(new_key);
+        self.host_devices = Some(cached);
+        true
+    }
+
+    // ------------------------------------------------------------------
+    // GPU-filtered process list
+    // ------------------------------------------------------------------
+
+    fn update_process_list(&mut self, snapshot: &RenderSnapshot) -> bool {
+        let new_key = ProcessFilterCacheKey {
+            data_version: snapshot.data_version,
+            gpu_filter_enabled: snapshot.gpu_filter_enabled,
+        };
+
+        if self.process_key.as_ref() == Some(&new_key) {
+            return false;
+        }
+
+        let filtered = if snapshot.gpu_filter_enabled {
+            Some(
+                snapshot
+                    .process_info
+                    .iter()
+                    .filter(|p| p.used_memory > 0)
+                    .cloned()
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        self.process_key = Some(new_key);
+        self.process_list = Some(CachedProcessList { filtered });
+        true
+    }
+
+    // ------------------------------------------------------------------
+    // Accessor helpers (convenience for the frame renderer)
+    // ------------------------------------------------------------------
+
+    /// Return the cached sorted GPU indices, or `None` if the cache has not
+    /// been populated yet.
+    pub fn gpu_indices(&self) -> Option<&[usize]> {
+        self.gpu_list.as_ref().map(|c| c.indices.as_slice())
+    }
+
+    /// Return the cached host-device indices, or `None` if unpopulated.
+    pub fn host_device_indices(&self) -> Option<&CachedHostDevices> {
+        self.host_devices.as_ref()
+    }
+
+    /// Return the cached process list. When the GPU filter is off the inner
+    /// `filtered` field is `None` and the caller should read directly from
+    /// the snapshot.
+    pub fn process_display_list(&self) -> Option<&CachedProcessList> {
+        self.process_list.as_ref()
+    }
+}
+
+// ======================================================================
+// Tests
+// ======================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_state::{AppState, SortCriteria};
+    use crate::device::{CpuInfo, GpuInfo, MemoryInfo};
+    use crate::storage::info::StorageInfo;
+    use crate::view::render_snapshot::RenderSnapshot;
+
+    fn make_snapshot_with_gpus(count: usize) -> RenderSnapshot {
+        let mut state = AppState::new();
+        for i in 0..count {
+            state.gpu_info.push(GpuInfo {
+                uuid: format!("gpu-{i}"),
+                time: String::new(),
+                name: format!("GPU {i}"),
+                device_type: "GPU".to_string(),
+                host_id: if i % 2 == 0 {
+                    "host-a".to_string()
+                } else {
+                    "host-b".to_string()
+                },
+                hostname: if i % 2 == 0 {
+                    "host-a".to_string()
+                } else {
+                    "host-b".to_string()
+                },
+                instance: String::new(),
+                utilization: (count - i) as f64 * 10.0,
+                ane_utilization: 0.0,
+                dla_utilization: None,
+                tensorcore_utilization: None,
+                temperature: 50 + i as u32,
+                used_memory: (i as u64 + 1) * 1024,
+                total_memory: 16384,
+                frequency: 1500,
+                power_consumption: 100.0,
+                gpu_core_count: None,
+                detail: {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("index".to_string(), i.to_string());
+                    m
+                },
+            });
+        }
+        state.tabs = vec![
+            "All".to_string(),
+            "host-a".to_string(),
+            "host-b".to_string(),
+        ];
+        state.is_local_mode = false;
+        state.mark_data_changed();
+        RenderSnapshot::capture(&state)
+    }
+
+    // ------------------------------------------------------------------
+    // Basic construction
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_new_cache_is_empty() {
+        let cache = ViewCache::new();
+        assert!(cache.gpu_indices().is_none());
+        assert!(cache.host_device_indices().is_none());
+        assert!(cache.process_display_list().is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // GPU list caching
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_gpu_cache_populated_on_first_update() {
+        let snapshot = make_snapshot_with_gpus(4);
+        let mut cache = ViewCache::new();
+
+        let recomputed = cache.update(&snapshot);
+        assert!(recomputed);
+        assert!(cache.gpu_indices().is_some());
+    }
+
+    #[test]
+    fn test_gpu_cache_reused_on_identical_snapshot() {
+        let snapshot = make_snapshot_with_gpus(4);
+        let mut cache = ViewCache::new();
+
+        cache.update(&snapshot);
+        let recomputed = cache.update(&snapshot);
+        assert!(
+            !recomputed,
+            "cache should be reused when inputs are unchanged"
+        );
+    }
+
+    #[test]
+    fn test_gpu_cache_invalidated_on_data_version_change() {
+        let mut state = AppState::new();
+        for i in 0..2 {
+            state.gpu_info.push(GpuInfo {
+                uuid: format!("gpu-{i}"),
+                time: String::new(),
+                name: format!("GPU {i}"),
+                device_type: "GPU".to_string(),
+                host_id: "host-a".to_string(),
+                hostname: "host-a".to_string(),
+                instance: String::new(),
+                utilization: 50.0,
+                ane_utilization: 0.0,
+                dla_utilization: None,
+                tensorcore_utilization: None,
+                temperature: 60,
+                used_memory: 4096,
+                total_memory: 16384,
+                frequency: 1500,
+                power_consumption: 100.0,
+                gpu_core_count: None,
+                detail: std::collections::HashMap::new(),
+            });
+        }
+        state.mark_data_changed();
+        let snap1 = RenderSnapshot::capture(&state);
+
+        let mut cache = ViewCache::new();
+        cache.update(&snap1);
+        assert!(!cache.update(&snap1));
+
+        // Bump version
+        state.mark_data_changed();
+        let snap2 = RenderSnapshot::capture(&state);
+        assert!(
+            cache.update(&snap2),
+            "cache should invalidate on data_version change"
+        );
+    }
+
+    #[test]
+    fn test_gpu_cache_invalidated_on_tab_change() {
+        let snapshot = make_snapshot_with_gpus(4);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        // Switch to host-a tab
+        let mut state = AppState::new();
+        state.gpu_info = snapshot.gpu_info.clone();
+        state.tabs = snapshot.tabs.clone();
+        state.current_tab = 1; // host-a
+        state.data_version = snapshot.data_version;
+        let snap2 = RenderSnapshot::capture(&state);
+
+        assert!(
+            cache.update(&snap2),
+            "tab change should invalidate GPU cache"
+        );
+
+        // Only host-a GPUs (even indices) should appear
+        let indices = cache.gpu_indices().unwrap();
+        for &idx in indices {
+            assert_eq!(
+                snap2.gpu_info[idx].host_id, "host-a",
+                "filtered GPU should belong to host-a"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gpu_cache_invalidated_on_sort_change() {
+        let snapshot = make_snapshot_with_gpus(4);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        let mut state = AppState::new();
+        state.gpu_info = snapshot.gpu_info.clone();
+        state.tabs = snapshot.tabs.clone();
+        state.sort_criteria = SortCriteria::Utilization;
+        state.data_version = snapshot.data_version;
+        let snap2 = RenderSnapshot::capture(&state);
+
+        assert!(
+            cache.update(&snap2),
+            "sort change should invalidate GPU cache"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Process list caching
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_process_cache_no_filter_returns_none_filtered() {
+        let mut state = AppState::new();
+        state.gpu_filter_enabled = false;
+        state.process_info.push(ProcessInfo {
+            device_id: 0,
+            device_uuid: "u".into(),
+            pid: 1,
+            used_memory: 0,
+            process_name: "test".into(),
+            user: "u".into(),
+            state: "S".into(),
+            command: "c".into(),
+            cpu_percent: 1.0,
+            memory_percent: 1.0,
+            gpu_utilization: 0.0,
+            priority: 20,
+            nice_value: 0,
+            memory_vms: 0,
+            memory_rss: 0,
+            cpu_time: 0,
+            start_time: "".into(),
+            ppid: 0,
+            threads: 1,
+            uses_gpu: false,
+        });
+        let snapshot = RenderSnapshot::capture(&state);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        let pl = cache.process_display_list().unwrap();
+        assert!(
+            pl.filtered.is_none(),
+            "when GPU filter is off, filtered should be None (use snapshot directly)"
+        );
+    }
+
+    #[test]
+    fn test_process_cache_gpu_filter_clones_only_gpu_processes() {
+        let mut state = AppState::new();
+        state.gpu_filter_enabled = true;
+        // Process with GPU memory
+        state.process_info.push(ProcessInfo {
+            device_id: 0,
+            device_uuid: "u".into(),
+            pid: 1,
+            used_memory: 4096,
+            process_name: "gpu_proc".into(),
+            user: "u".into(),
+            state: "S".into(),
+            command: "c".into(),
+            cpu_percent: 1.0,
+            memory_percent: 1.0,
+            gpu_utilization: 50.0,
+            priority: 20,
+            nice_value: 0,
+            memory_vms: 0,
+            memory_rss: 0,
+            cpu_time: 0,
+            start_time: "".into(),
+            ppid: 0,
+            threads: 1,
+            uses_gpu: true,
+        });
+        // Process without GPU memory
+        state.process_info.push(ProcessInfo {
+            device_id: 0,
+            device_uuid: "u".into(),
+            pid: 2,
+            used_memory: 0,
+            process_name: "cpu_proc".into(),
+            user: "u".into(),
+            state: "S".into(),
+            command: "c".into(),
+            cpu_percent: 50.0,
+            memory_percent: 10.0,
+            gpu_utilization: 0.0,
+            priority: 20,
+            nice_value: 0,
+            memory_vms: 0,
+            memory_rss: 0,
+            cpu_time: 0,
+            start_time: "".into(),
+            ppid: 0,
+            threads: 1,
+            uses_gpu: false,
+        });
+        let snapshot = RenderSnapshot::capture(&state);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        let pl = cache.process_display_list().unwrap();
+        let filtered = pl.filtered.as_ref().unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].pid, 1);
+    }
+
+    // ------------------------------------------------------------------
+    // Host device caching
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_host_devices_local_mode_all_indices() {
+        let mut state = AppState::new();
+        state.is_local_mode = true;
+        state.cpu_info.push(CpuInfo {
+            host_id: "local".into(),
+            hostname: "local".into(),
+            instance: "".into(),
+            cpu_model: "Test".into(),
+            architecture: "x86_64".into(),
+            platform_type: crate::device::CpuPlatformType::Intel,
+            socket_count: 1,
+            total_cores: 4,
+            total_threads: 8,
+            base_frequency_mhz: 3000,
+            max_frequency_mhz: 4000,
+            cache_size_mb: 8,
+            utilization: 10.0,
+            temperature: None,
+            power_consumption: None,
+            per_socket_info: Vec::new(),
+            apple_silicon_info: None,
+            per_core_utilization: Vec::new(),
+            time: "".into(),
+        });
+        state.memory_info.push(MemoryInfo {
+            host_id: "local".into(),
+            hostname: "local".into(),
+            instance: "".into(),
+            total_bytes: 1024,
+            used_bytes: 512,
+            available_bytes: 512,
+            free_bytes: 256,
+            buffers_bytes: 0,
+            cached_bytes: 0,
+            swap_total_bytes: 0,
+            swap_used_bytes: 0,
+            swap_free_bytes: 0,
+            utilization: 50.0,
+            time: "".into(),
+        });
+        let snapshot = RenderSnapshot::capture(&state);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        let hd = cache.host_device_indices().unwrap();
+        assert_eq!(hd.cpu_indices.len(), 1);
+        assert_eq!(hd.memory_indices.len(), 1);
+    }
+
+    #[test]
+    fn test_host_devices_remote_all_tab_empty() {
+        let mut state = AppState::new();
+        state.is_local_mode = false;
+        state.current_tab = 0; // "All" tab
+        state.cpu_info.push(CpuInfo {
+            host_id: "host-a".into(),
+            hostname: "host-a".into(),
+            instance: "".into(),
+            cpu_model: "Test".into(),
+            architecture: "x86_64".into(),
+            platform_type: crate::device::CpuPlatformType::Intel,
+            socket_count: 1,
+            total_cores: 4,
+            total_threads: 8,
+            base_frequency_mhz: 3000,
+            max_frequency_mhz: 4000,
+            cache_size_mb: 8,
+            utilization: 10.0,
+            temperature: None,
+            power_consumption: None,
+            per_socket_info: Vec::new(),
+            apple_silicon_info: None,
+            per_core_utilization: Vec::new(),
+            time: "".into(),
+        });
+        let snapshot = RenderSnapshot::capture(&state);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        let hd = cache.host_device_indices().unwrap();
+        // "All" tab in remote mode returns empty host-device indices
+        assert!(hd.cpu_indices.is_empty());
+    }
+
+    #[test]
+    fn test_host_devices_remote_host_tab_filters() {
+        let mut state = AppState::new();
+        state.is_local_mode = false;
+        state.tabs = vec![
+            "All".to_string(),
+            "host-a".to_string(),
+            "host-b".to_string(),
+        ];
+        state.current_tab = 1; // host-a
+        state.storage_info.push(StorageInfo {
+            host_id: "host-a".into(),
+            hostname: "host-a".into(),
+            mount_point: "/".into(),
+            total_bytes: 1024,
+            available_bytes: 512,
+            index: 0,
+        });
+        state.storage_info.push(StorageInfo {
+            host_id: "host-b".into(),
+            hostname: "host-b".into(),
+            mount_point: "/".into(),
+            total_bytes: 1024,
+            available_bytes: 512,
+            index: 0,
+        });
+        let snapshot = RenderSnapshot::capture(&state);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        let hd = cache.host_device_indices().unwrap();
+        assert_eq!(
+            hd.storage_indices.len(),
+            1,
+            "only host-a storage should be cached"
+        );
+        assert_eq!(
+            snapshot.storage_info[hd.storage_indices[0]].host_id,
+            "host-a"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // invalidate_all
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_invalidate_all_clears_caches() {
+        let snapshot = make_snapshot_with_gpus(2);
+        let mut cache = ViewCache::new();
+        cache.update(&snapshot);
+
+        assert!(cache.gpu_indices().is_some());
+        cache.invalidate_all();
+        assert!(cache.gpu_indices().is_none());
+        assert!(cache.host_device_indices().is_none());
+        assert!(cache.process_display_list().is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // sort_criteria_ordinal
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_sort_criteria_ordinal_distinct_for_gpu_sorts() {
+        assert_ne!(
+            sort_criteria_ordinal(SortCriteria::Default),
+            sort_criteria_ordinal(SortCriteria::Utilization)
+        );
+        assert_ne!(
+            sort_criteria_ordinal(SortCriteria::Utilization),
+            sort_criteria_ordinal(SortCriteria::GpuMemory)
+        );
+    }
+
+    #[test]
+    fn test_sort_criteria_ordinal_process_sorts_collapse() {
+        // All process-only criteria should return the same ordinal (they
+        // don't affect GPU sort order).
+        let base = sort_criteria_ordinal(SortCriteria::Default);
+        assert_eq!(sort_criteria_ordinal(SortCriteria::Pid), base);
+        assert_eq!(sort_criteria_ordinal(SortCriteria::User), base);
+        assert_eq!(sort_criteria_ordinal(SortCriteria::CpuPercent), base);
+        assert_eq!(sort_criteria_ordinal(SortCriteria::MemoryPercent), base);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ViewCache` (`src/view/view_cache.rs`) that caches sorted GPU display indices, per-host filtered device subsets (chassis/CPU/memory/storage), and GPU-filtered process lists across frames
- Integrate cache into `FrameRenderer` so rendering reads from pre-computed indices instead of re-filtering/re-sorting every frame, with inline fallback when cache is unavailable
- Wire cache into `UiLoop` with automatic invalidation on force-clear events (tab change, resize, mode switch) and lazy recomputation keyed by `data_version`, `current_tab`, `sort_criteria`, and `gpu_filter_enabled`

## Test plan

- [x] All 230 unit tests pass including 14 new cache-specific tests
- [x] All integration tests pass (container, device, library API, CPU model)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual verification: run locally with GPU(s), confirm GPU list sorted correctly after tab/sort changes
- [ ] Manual verification: run in remote mode with multiple hosts, confirm per-host filtering correct after data refreshes
- [ ] Manual verification: toggle GPU filter (f key), confirm process list filters correctly from cache
- [ ] Manual verification: confirm CPU usage reduction compared to post-#136 baseline

Closes #137