### PR TITLE
docs: add protobuf-devel to Fedora/RHEL build prerequisites

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -34,7 +34,7 @@ This guide provides comprehensive information for developers and contributors wo
 sudo apt-get install pkg-config libssl-dev protobuf-compiler
 
 # Fedora/RHEL
-sudo dnf install pkg-config openssl-devel protobuf-compiler
+sudo dnf install pkg-config openssl-devel protobuf-compiler protobuf-devel
 
 # Arch Linux
 sudo pacman -S pkg-config openssl protobuf

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Install all-smi through Cargo:
 cargo install all-smi
 ```
 
+On Linux, you need build dependencies installed first:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install pkg-config libssl-dev protobuf-compiler
+
+# Fedora/RHEL
+sudo dnf install pkg-config openssl-devel protobuf-compiler protobuf-devel
+```
+
 After installation, the binary will be available in your `$PATH` as `all-smi`.
 
 ### Option 6: Build from Source


### PR DESCRIPTION
## Summary
- Add missing `protobuf-devel` package to Fedora/RHEL dnf install command in DEVELOPERS.md (provides well-known proto types like `google/protobuf/timestamp.proto`)
- Add Linux build dependency instructions to the `cargo install` section in README.md

Closes #134