### PR TITLE
feat: enrich chassis info with DMI data, thermal zones, and GPU power

### DIFF
--- a/src/api/metrics/chassis.rs
+++ b/src/api/metrics/chassis.rs
@@ -377,4 +377,99 @@ mod tests {
         assert!(metrics.contains("all_smi_chassis_thermal_pressure_info"));
         assert!(metrics.contains("level=\"Nominal\""));
     }
+
+    #[test]
+    fn test_chassis_info_dmi_labels_metric() {
+        let mut detail = std::collections::HashMap::new();
+        detail.insert("Product Name".to_string(), "DGX H100".to_string());
+        detail.insert("Vendor".to_string(), "NVIDIA".to_string());
+        detail.insert("Board".to_string(), "H100-BOARD".to_string());
+        detail.insert("BIOS Version".to_string(), "1.0.0".to_string());
+        detail.insert("platform".to_string(), "Linux".to_string());
+
+        let chassis = ChassisInfo {
+            hostname: "dgx-host".to_string(),
+            instance: "dgx-instance".to_string(),
+            detail,
+            ..Default::default()
+        };
+
+        let chassis_vec = vec![chassis];
+        let exporter = ChassisMetricExporter::new(&chassis_vec);
+        let metrics = exporter.export_metrics();
+
+        assert!(metrics.contains("all_smi_chassis_info"));
+        assert!(metrics.contains("product_name=\"DGX H100\""));
+        assert!(metrics.contains("vendor=\"NVIDIA\""));
+        assert!(metrics.contains("board=\"H100-BOARD\""));
+        assert!(metrics.contains("bios_version=\"1.0.0\""));
+        assert!(metrics.contains("platform=\"Linux\""));
+        assert!(metrics.contains("hostname=\"dgx-host\""));
+        // The metric value should be 1
+        assert!(metrics.contains("} 1\n"));
+    }
+
+    #[test]
+    fn test_chassis_inlet_outlet_temperature_metrics() {
+        let chassis = ChassisInfo {
+            hostname: "server1".to_string(),
+            instance: "server1".to_string(),
+            inlet_temperature: Some(22.5),
+            outlet_temperature: Some(35.0),
+            ..Default::default()
+        };
+
+        let chassis_vec = vec![chassis];
+        let exporter = ChassisMetricExporter::new(&chassis_vec);
+        let metrics = exporter.export_metrics();
+
+        assert!(metrics.contains("all_smi_chassis_inlet_temperature_celsius"));
+        assert!(metrics.contains("22.5"));
+        assert!(metrics.contains("all_smi_chassis_outlet_temperature_celsius"));
+        assert!(metrics.contains("35.0"));
+    }
+
+    #[test]
+    fn test_chassis_info_no_dmi_details_skips_info_metric() {
+        // A chassis with no recognized detail keys should not emit all_smi_chassis_info
+        let chassis = ChassisInfo {
+            hostname: "bare-host".to_string(),
+            instance: "bare-instance".to_string(),
+            ..Default::default()
+        };
+
+        let chassis_vec = vec![chassis];
+        let exporter = ChassisMetricExporter::new(&chassis_vec);
+        let metrics = exporter.export_metrics();
+
+        assert!(!metrics.contains("all_smi_chassis_info"));
+    }
+
+    #[test]
+    fn test_metric_presence_flags_all_present() {
+        let mut detail = std::collections::HashMap::new();
+        detail.insert("cpu_power_watts".to_string(), "15.0".to_string());
+        detail.insert("gpu_power_watts".to_string(), "200.0".to_string());
+        detail.insert("ane_power_watts".to_string(), "5.0".to_string());
+
+        let chassis = ChassisInfo {
+            hostname: "full-host".to_string(),
+            instance: "full-instance".to_string(),
+            total_power_watts: Some(220.0),
+            thermal_pressure: Some("Nominal".to_string()),
+            inlet_temperature: Some(20.0),
+            outlet_temperature: Some(30.0),
+            fan_speeds: vec![crate::device::FanInfo {
+                id: 0,
+                name: "Fan0".to_string(),
+                speed_rpm: 1200,
+                max_rpm: 3000,
+            }],
+            detail,
+            ..Default::default()
+        };
+
+        let flags = MetricPresenceFlags::from_chassis_info(&[chassis]);
+        assert!(flags.all_present());
+    }
 }

--- a/src/api/metrics/chassis.rs
+++ b/src/api/metrics/chassis.rs
@@ -101,6 +101,46 @@ impl<'a> MetricExporter for ChassisMetricExporter<'a> {
         // Single pass to determine which metrics are present
         let flags = MetricPresenceFlags::from_chassis_info(self.chassis_info);
 
+        // Export chassis info metric with DMI/platform details as labels
+        {
+            // Known detail keys to promote to Prometheus labels (display_key, label_name)
+            let detail_keys: &[(&str, &str)] = &[
+                ("Product Name", "product_name"),
+                ("Vendor", "vendor"),
+                ("Board", "board"),
+                ("Version", "version"),
+                ("BIOS Version", "bios_version"),
+                ("platform", "platform"),
+            ];
+            let has_details = self
+                .chassis_info
+                .iter()
+                .any(|c| detail_keys.iter().any(|(k, _)| c.detail.contains_key(*k)));
+
+            if has_details {
+                builder
+                    .help(
+                        "all_smi_chassis_info",
+                        "Chassis/node identification information",
+                    )
+                    .type_("all_smi_chassis_info", "gauge");
+
+                for chassis in self.chassis_info {
+                    // Collect label values that are present
+                    let mut label_values: Vec<(&str, &str)> = vec![
+                        ("hostname", &chassis.hostname),
+                        ("instance", &chassis.instance),
+                    ];
+                    for &(display_key, label_name) in detail_keys {
+                        if let Some(val) = chassis.detail.get(display_key) {
+                            label_values.push((label_name, val));
+                        }
+                    }
+                    builder.metric("all_smi_chassis_info", &label_values, "1");
+                }
+            }
+        }
+
         // Export chassis power metrics
         if flags.has_power {
             builder

--- a/src/api/metrics/mod.rs
+++ b/src/api/metrics/mod.rs
@@ -105,3 +105,53 @@ impl Default for MetricBuilder {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metric_builder_label_escaping_backslash() {
+        let mut builder = MetricBuilder::new();
+        builder.metric("test_metric", &[("path", "C:\\Windows\\System32")], "1");
+        let output = builder.build();
+        assert!(output.contains(r#"path="C:\\Windows\\System32""#));
+    }
+
+    #[test]
+    fn test_metric_builder_label_escaping_double_quote() {
+        let mut builder = MetricBuilder::new();
+        builder.metric("test_metric", &[("label", r#"say "hello""#)], "1");
+        let output = builder.build();
+        assert!(output.contains(r#"label="say \"hello\"""#));
+    }
+
+    #[test]
+    fn test_metric_builder_label_escaping_newline() {
+        let mut builder = MetricBuilder::new();
+        builder.metric("test_metric", &[("value", "line1\nline2")], "1");
+        let output = builder.build();
+        assert!(output.contains(r#"value="line1\nline2""#));
+    }
+
+    #[test]
+    fn test_metric_builder_no_labels() {
+        let mut builder = MetricBuilder::new();
+        builder.metric("test_metric", &[], "42.5");
+        let output = builder.build();
+        assert_eq!(output, "test_metric 42.5\n");
+    }
+
+    #[test]
+    fn test_metric_builder_help_and_type() {
+        let mut builder = MetricBuilder::new();
+        builder
+            .help("my_metric", "A test metric")
+            .type_("my_metric", "gauge")
+            .metric("my_metric", &[("host", "server1")], "99");
+        let output = builder.build();
+        assert!(output.contains("# HELP my_metric A test metric\n"));
+        assert!(output.contains("# TYPE my_metric gauge\n"));
+        assert!(output.contains("my_metric{host=\"server1\"} 99\n"));
+    }
+}

--- a/src/api/metrics/mod.rs
+++ b/src/api/metrics/mod.rs
@@ -77,8 +77,12 @@ impl MetricBuilder {
                 if i > 0 {
                     self.metrics.push_str(", ");
                 }
-                // Escape quotes in values for Prometheus format
-                let escaped_value = value.replace('"', "\\\"");
+                // Escape per Prometheus exposition format spec:
+                // backslash, double-quote, and newline must be escaped
+                let escaped_value = value
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+                    .replace('\n', "\\n");
                 self.metrics.push_str(&format!("{key}=\"{escaped_value}\""));
             }
             self.metrics.push('}');

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -29,7 +29,7 @@ use tokio::net::UnixListener;
 use crate::api::handlers::{SharedState, metrics_handler};
 use crate::app_state::AppState;
 use crate::cli::ApiArgs;
-use crate::device::{get_cpu_readers, get_gpu_readers, get_memory_readers};
+use crate::device::{create_chassis_reader, get_cpu_readers, get_gpu_readers, get_memory_readers};
 use crate::storage::info::StorageInfo;
 use crate::utils::{filter_docker_aware_disks, get_hostname};
 
@@ -115,9 +115,10 @@ pub async fn run_api_mode(args: &ApiArgs) {
         let gpu_readers = get_gpu_readers();
         let cpu_readers = get_cpu_readers();
         let memory_readers = get_memory_readers();
+        let chassis_reader = create_chassis_reader();
         let mut disks = Disks::new_with_refreshed_list();
         loop {
-            let all_gpu_info = gpu_readers
+            let all_gpu_info: Vec<_> = gpu_readers
                 .iter()
                 .flat_map(|reader| reader.get_gpu_info())
                 .collect();
@@ -141,6 +142,23 @@ pub async fn run_api_mode(args: &ApiArgs) {
                 Vec::new()
             };
 
+            // Collect chassis-level info (DMI, thermals, power)
+            let chassis_info: Vec<_> = chassis_reader
+                .get_chassis_info()
+                .into_iter()
+                .map(|mut ci| {
+                    // Aggregate GPU power into chassis total if not already set
+                    if ci.total_power_watts.is_none() {
+                        let total_gpu_power: f64 =
+                            all_gpu_info.iter().map(|g| g.power_consumption).sum();
+                        if total_gpu_power > 0.0 {
+                            ci.total_power_watts = Some(total_gpu_power);
+                        }
+                    }
+                    ci
+                })
+                .collect();
+
             // Refresh disk info in-place instead of creating a new Disks instance
             disks.refresh(true);
             let storage_info = collect_storage_info_from(&disks);
@@ -150,6 +168,7 @@ pub async fn run_api_mode(args: &ApiArgs) {
             state.cpu_info = all_cpu_info;
             state.memory_info = all_memory_info;
             state.process_info = all_processes;
+            state.chassis_info = chassis_info;
             state.storage_info = storage_info;
             if state.loading {
                 state.loading = false;

--- a/src/device/readers/chassis/generic.rs
+++ b/src/device/readers/chassis/generic.rs
@@ -31,6 +31,8 @@ pub struct GenericChassisReader {
     hostname: String,
     /// Cached total GPU power (updated externally)
     cached_gpu_power: Arc<RwLock<Option<f64>>>,
+    /// Static DMI detail cached at construction (never changes at runtime)
+    dmi_detail: HashMap<String, String>,
 }
 
 impl Default for GenericChassisReader {
@@ -42,9 +44,13 @@ impl Default for GenericChassisReader {
 #[allow(dead_code)]
 impl GenericChassisReader {
     pub fn new() -> Self {
+        let mut dmi_detail = HashMap::new();
+        #[cfg(target_os = "linux")]
+        collect_dmi_info(&mut dmi_detail);
         Self {
             hostname: get_hostname(),
             cached_gpu_power: Arc::new(RwLock::new(None)),
+            dmi_detail,
         }
     }
 
@@ -151,17 +157,14 @@ fn read_thermal_zones_from(base_path: &str) -> (Option<f64>, Option<f64>) {
 
 impl ChassisReader for GenericChassisReader {
     fn get_chassis_info(&self) -> Option<ChassisInfo> {
-        let mut detail = HashMap::new();
+        // Start with cached DMI detail (read once at construction)
+        let mut detail = self.dmi_detail.clone();
 
         // Platform identifier
         #[cfg(target_os = "linux")]
         detail.insert("platform".to_string(), "Linux".to_string());
         #[cfg(target_os = "windows")]
         detail.insert("platform".to_string(), "Windows".to_string());
-
-        // Collect DMI information (Linux only, no sudo required)
-        #[cfg(target_os = "linux")]
-        collect_dmi_info(&mut detail);
 
         // Read thermal zones (Linux only)
         #[cfg(target_os = "linux")]

--- a/src/device/readers/chassis/generic.rs
+++ b/src/device/readers/chassis/generic.rs
@@ -14,8 +14,10 @@
 
 //! Generic chassis reader for non-Apple Silicon platforms
 //!
-//! This reader aggregates GPU power consumption to provide chassis-level
-//! power metrics. It serves as a foundation for future BMC/IPMI integration.
+//! This reader collects chassis-level metrics from:
+//! - DMI data (`/sys/class/dmi/id/`) for system identification
+//! - Thermal zones (`/sys/class/thermal/`) for board temperatures
+//! - Cached GPU power for total power consumption
 
 use crate::device::{ChassisInfo, ChassisReader};
 use crate::utils::get_hostname;
@@ -23,7 +25,7 @@ use chrono::Local;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-/// Generic chassis reader that aggregates device power
+/// Generic chassis reader that collects DMI info, thermal zones, and GPU power
 #[allow(dead_code)]
 pub struct GenericChassisReader {
     hostname: String,
@@ -60,37 +62,127 @@ impl GenericChassisReader {
     }
 }
 
+/// Read a single DMI field from `/sys/class/dmi/id/`.
+/// Returns `None` if the file doesn't exist or is unreadable (e.g., permission denied).
+fn read_dmi_field(field: &str) -> Option<String> {
+    let path = format!("/sys/class/dmi/id/{field}");
+    std::fs::read_to_string(&path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Collect DMI information into the detail map.
+fn collect_dmi_info(detail: &mut HashMap<String, String>) {
+    if let Some(v) = read_dmi_field("product_name") {
+        detail.insert("Product Name".to_string(), v);
+    }
+    if let Some(v) = read_dmi_field("sys_vendor") {
+        detail.insert("Vendor".to_string(), v);
+    }
+    if let Some(v) = read_dmi_field("board_name") {
+        detail.insert("Board".to_string(), v);
+    }
+    if let Some(v) = read_dmi_field("product_version") {
+        detail.insert("Version".to_string(), v);
+    }
+    if let Some(v) = read_dmi_field("bios_version") {
+        detail.insert("BIOS Version".to_string(), v);
+    }
+}
+
+/// Read thermal zones from `/sys/class/thermal/` and return (inlet, outlet) temperatures.
+///
+/// On systems like DGX Spark, ACPI thermal zones provide board-level temperatures.
+/// We use the minimum temperature as "inlet" and maximum as "outlet" — a reasonable
+/// approximation when specific zone roles aren't labeled.
+fn read_thermal_zones() -> (Option<f64>, Option<f64>) {
+    read_thermal_zones_from("/sys/class/thermal")
+}
+
+/// Testable version that accepts a base path.
+fn read_thermal_zones_from(base_path: &str) -> (Option<f64>, Option<f64>) {
+    let entries = match std::fs::read_dir(base_path) {
+        Ok(e) => e,
+        Err(_) => return (None, None),
+    };
+
+    let mut temps: Vec<f64> = Vec::new();
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if !name_str.starts_with("thermal_zone") {
+            continue;
+        }
+
+        let zone_path = entry.path();
+
+        // Only use ACPI thermal zones (most reliable for board-level temps)
+        let type_path = zone_path.join("type");
+        if let Ok(zone_type) = std::fs::read_to_string(&type_path) {
+            let zone_type = zone_type.trim();
+            if zone_type != "acpitz" {
+                continue;
+            }
+        }
+
+        let temp_path = zone_path.join("temp");
+        if let Ok(temp_str) = std::fs::read_to_string(&temp_path)
+            && let Ok(millidegrees) = temp_str.trim().parse::<i64>()
+        {
+            // Kernel reports in millidegrees Celsius
+            let celsius = millidegrees as f64 / 1000.0;
+            // Sanity check: ignore obviously wrong readings
+            if celsius > -40.0 && celsius < 150.0 {
+                temps.push(celsius);
+            }
+        }
+    }
+
+    if temps.is_empty() {
+        return (None, None);
+    }
+
+    let min = temps.iter().cloned().reduce(f64::min);
+    let max = temps.iter().cloned().reduce(f64::max);
+    (min, max)
+}
+
 impl ChassisReader for GenericChassisReader {
     fn get_chassis_info(&self) -> Option<ChassisInfo> {
-        // Build platform detail
-        let detail = {
-            #[allow(unused_mut)]
-            let mut d = HashMap::new();
-            #[cfg(target_os = "linux")]
-            d.insert("platform".to_string(), "Linux".to_string());
-            #[cfg(target_os = "windows")]
-            d.insert("platform".to_string(), "Windows".to_string());
-            d
-        };
+        let mut detail = HashMap::new();
+
+        // Platform identifier
+        #[cfg(target_os = "linux")]
+        detail.insert("platform".to_string(), "Linux".to_string());
+        #[cfg(target_os = "windows")]
+        detail.insert("platform".to_string(), "Windows".to_string());
+
+        // Collect DMI information (Linux only, no sudo required)
+        #[cfg(target_os = "linux")]
+        collect_dmi_info(&mut detail);
+
+        // Read thermal zones (Linux only)
+        #[cfg(target_os = "linux")]
+        let (inlet_temperature, outlet_temperature) = read_thermal_zones();
+        #[cfg(not(target_os = "linux"))]
+        let (inlet_temperature, outlet_temperature) = (None, None);
 
         // Get total power from cached GPU power
-        // In the future, this can be enhanced with IPMI/BMC data
         let total_power_watts = self.get_cached_gpu_power();
 
-        // Only return chassis info if we have some data
-        // For now, we always return at least the hostname info
-        // Clone hostname once and use for all identifier fields
         let hostname = self.hostname.clone();
         Some(ChassisInfo {
             host_id: hostname.clone(),
             hostname: hostname.clone(),
             instance: hostname,
             total_power_watts,
-            inlet_temperature: None,  // Future: IPMI integration
-            outlet_temperature: None, // Future: IPMI integration
-            thermal_pressure: None,   // Not applicable for non-Apple platforms
-            fan_speeds: Vec::new(),   // Future: IPMI integration
-            psu_status: Vec::new(),   // Future: IPMI integration
+            inlet_temperature,
+            outlet_temperature,
+            thermal_pressure: None, // Not applicable for non-Apple platforms
+            fan_speeds: Vec::new(),
+            psu_status: Vec::new(),
             detail,
             time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
         })
@@ -128,5 +220,83 @@ mod tests {
         let info = chassis_info.unwrap();
         assert!(info.total_power_watts.is_none());
         assert!(!info.hostname.is_empty());
+    }
+
+    #[test]
+    fn test_read_dmi_field_nonexistent() {
+        // A non-existent DMI field should return None
+        assert!(read_dmi_field("nonexistent_field_xyz").is_none());
+    }
+
+    #[test]
+    fn test_read_thermal_zones_from_nonexistent_path() {
+        let (inlet, outlet) = read_thermal_zones_from("/nonexistent/thermal/path");
+        assert!(inlet.is_none());
+        assert!(outlet.is_none());
+    }
+
+    #[test]
+    fn test_read_thermal_zones_from_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let (inlet, outlet) = read_thermal_zones_from(dir.path().to_str().unwrap());
+        assert!(inlet.is_none());
+        assert!(outlet.is_none());
+    }
+
+    #[test]
+    fn test_read_thermal_zones_from_mock_zones() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        // Create two mock thermal zones
+        for (i, temp) in [(0, 39700), (1, 42300)] {
+            let zone = base.join(format!("thermal_zone{i}"));
+            std::fs::create_dir_all(&zone).unwrap();
+            std::fs::write(zone.join("type"), "acpitz\n").unwrap();
+            std::fs::write(zone.join("temp"), format!("{temp}\n")).unwrap();
+        }
+
+        // Create a non-ACPI zone that should be ignored
+        let zone_other = base.join("thermal_zone2");
+        std::fs::create_dir_all(&zone_other).unwrap();
+        std::fs::write(zone_other.join("type"), "x86_pkg_temp\n").unwrap();
+        std::fs::write(zone_other.join("temp"), "99000\n").unwrap();
+
+        let (inlet, outlet) = read_thermal_zones_from(base.to_str().unwrap());
+        assert!((inlet.unwrap() - 39.7).abs() < 0.01);
+        assert!((outlet.unwrap() - 42.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_read_thermal_zones_from_single_zone() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        let zone = base.join("thermal_zone0");
+        std::fs::create_dir_all(&zone).unwrap();
+        std::fs::write(zone.join("type"), "acpitz\n").unwrap();
+        std::fs::write(zone.join("temp"), "40500\n").unwrap();
+
+        let (inlet, outlet) = read_thermal_zones_from(base.to_str().unwrap());
+        // With a single zone, inlet == outlet
+        assert!((inlet.unwrap() - 40.5).abs() < 0.01);
+        assert!((outlet.unwrap() - 40.5).abs() < 0.01);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_chassis_info_has_dmi_on_linux() {
+        let reader = GenericChassisReader::new();
+        let info = reader.get_chassis_info().unwrap();
+        // On a real Linux system, at least one DMI field should be present
+        // (product_name is almost always available)
+        let has_any_dmi = info.detail.contains_key("Product Name")
+            || info.detail.contains_key("Vendor")
+            || info.detail.contains_key("Board");
+        assert!(
+            has_any_dmi,
+            "Expected at least one DMI field on Linux, got detail: {:?}",
+            info.detail
+        );
     }
 }

--- a/src/view/data_collection/local_collector.rs
+++ b/src/view/data_collection/local_collector.rs
@@ -58,6 +58,22 @@ const MAX_DISPLAY_PROCESSES: usize = 500;
 /// Every N cycles, we refresh all processes; otherwise, we only refresh tracked PIDs.
 const FULL_REFRESH_INTERVAL: u32 = 5;
 
+/// Inject aggregated GPU power into chassis info when not already set.
+fn inject_gpu_power(chassis_info: Vec<ChassisInfo>, gpu_info: &[GpuInfo]) -> Vec<ChassisInfo> {
+    chassis_info
+        .into_iter()
+        .map(|mut ci| {
+            if ci.total_power_watts.is_none() {
+                let total: f64 = gpu_info.iter().map(|g| g.power_consumption).sum();
+                if total > 0.0 {
+                    ci.total_power_watts = Some(total);
+                }
+            }
+            ci
+        })
+        .collect()
+}
+
 pub struct LocalCollector {
     gpu_readers: Arc<RwLock<Vec<Box<dyn GpuReader>>>>,
     cpu_readers: Arc<RwLock<Vec<Box<dyn CpuReader>>>>,
@@ -388,6 +404,9 @@ impl LocalCollector {
         // Reset refresh cycle counter (first iteration counts as cycle 0)
         self.refresh_cycle.store(1, Ordering::Relaxed);
 
+        // Inject aggregated GPU power into chassis info
+        let all_chassis_info = inject_gpu_power(all_chassis_info, &all_gpu_info);
+
         CollectionData {
             gpu_info: all_gpu_info,
             cpu_info: all_cpu_info,
@@ -496,6 +515,9 @@ impl LocalCollector {
             .and_then(|r| r.get_chassis_info())
             .into_iter()
             .collect();
+
+        // Inject aggregated GPU power into chassis info
+        let all_chassis_info = inject_gpu_power(all_chassis_info, &all_gpu_info);
 
         CollectionData {
             gpu_info: all_gpu_info,


### PR DESCRIPTION
## Summary
- Read DMI fields (product name, vendor, board, version, BIOS) from `/sys/class/dmi/id/` on Linux (no sudo required)
- Read ACPI thermal zones for inlet/outlet board temperatures from `/sys/class/thermal/`
- Wire up chassis reader in API server data collection loop (was missing)
- Aggregate GPU power into chassis `total_power_watts` for both TUI and API paths
- Add `all_smi_chassis_info` Prometheus metric exposing DMI details as labels

## Verified on DGX Spark (GB10)

Before: `Pwr: N/A` (no other chassis data)

After:
```
all_smi_chassis_info{hostname="spark-0c5a", product_name="NVIDIA_DGX_Spark", vendor="NVIDIA", board="P4242", version="A.7", bios_version="5.36_0ACUM018", platform="Linux"} 1
all_smi_chassis_power_watts{hostname="spark-0c5a"} 4.05
all_smi_chassis_inlet_temperature_celsius{hostname="spark-0c5a"} 39.7
all_smi_chassis_outlet_temperature_celsius{hostname="spark-0c5a"} 41.8
```

Closes #147

## Test plan
- [x] Build passes on GB10 (aarch64)
- [x] All 601 tests pass
- [x] Chassis metrics include DMI data, thermal zones, and GPU power
- [x] No sudo required for new data collection
- [x] Graceful fallback when DMI/thermal data unavailable (tested with nonexistent paths)
- [ ] No regression on macOS (Apple Silicon chassis reader untouched)