### PR TITLE
fix: cache platform detection results to avoid per-frame system_profiler

### DIFF
--- a/src/device/cpu_macos.rs
+++ b/src/device/cpu_macos.rs
@@ -363,10 +363,10 @@ impl MacOsCpuReader {
                 if let Some(value) = line.split(':').nth(1) {
                     p_core_count = value.trim().parse().unwrap_or(0);
                 }
-            } else if line.starts_with("hw.perflevel1.physicalcpu:") {
-                if let Some(value) = line.split(':').nth(1) {
-                    e_core_count = value.trim().parse().unwrap_or(0);
-                }
+            } else if line.starts_with("hw.perflevel1.physicalcpu:")
+                && let Some(value) = line.split(':').nth(1)
+            {
+                e_core_count = value.trim().parse().unwrap_or(0);
             }
         }
 
@@ -421,10 +421,10 @@ impl MacOsCpuReader {
             if line.contains("\"gpu-core-count\"") {
                 // Format: "gpu-core-count" = 10
                 let parts: Vec<&str> = line.split('=').collect();
-                if parts.len() >= 2 {
-                    if let Ok(count) = parts[1].trim().parse::<u32>() {
-                        return Ok(count);
-                    }
+                if parts.len() >= 2
+                    && let Ok(count) = parts[1].trim().parse::<u32>()
+                {
+                    return Ok(count);
                 }
             }
         }
@@ -516,15 +516,13 @@ impl MacOsCpuReader {
         for line in output_str.lines() {
             if line.contains("sppci_cores") {
                 // Extract the value between quotes after the colon
-                if let Some(value_part) = line.split(':').nth(1) {
-                    if let Some(start_quote) = value_part.find('"') {
-                        if let Some(end_quote) = value_part[start_quote + 1..].find('"') {
-                            let core_str =
-                                &value_part[start_quote + 1..start_quote + 1 + end_quote];
-                            if let Ok(count) = core_str.parse::<u32>() {
-                                return Ok(count);
-                            }
-                        }
+                if let Some(value_part) = line.split(':').nth(1)
+                    && let Some(start_quote) = value_part.find('"')
+                    && let Some(end_quote) = value_part[start_quote + 1..].find('"')
+                {
+                    let core_str = &value_part[start_quote + 1..start_quote + 1 + end_quote];
+                    if let Ok(count) = core_str.parse::<u32>() {
+                        return Ok(count);
                     }
                 }
             }
@@ -609,10 +607,10 @@ impl MacOsCpuReader {
                     total_cores = cores;
                     total_threads = cores * 2; // Assume hyperthreading
                 }
-            } else if line.starts_with("L3 Cache:") {
-                if let Some(size) = crate::parse_colon_value!(line, u32) {
-                    cache_size = size;
-                }
+            } else if line.starts_with("L3 Cache:")
+                && let Some(size) = crate::parse_colon_value!(line, u32)
+            {
+                cache_size = size;
             }
         }
 
@@ -698,21 +696,21 @@ impl MacOsCpuReader {
         let total_cpu_util = self.system.read().unwrap().global_cpu_usage() as f64;
 
         // Use native metrics manager for cluster residency (cached, no extra collection)
-        if let Some(manager) = get_native_metrics_manager() {
-            if let Ok(data) = manager.collect_once() {
-                // Use cluster residency from native metrics
-                let p_residency = data.p_cluster_active_residency.clamp(0.0, 100.0);
-                let e_residency = data.e_cluster_active_residency.clamp(0.0, 100.0);
-                let total_residency = p_residency + e_residency;
+        if let Some(manager) = get_native_metrics_manager()
+            && let Ok(data) = manager.collect_once()
+        {
+            // Use cluster residency from native metrics
+            let p_residency = data.p_cluster_active_residency.clamp(0.0, 100.0);
+            let e_residency = data.e_cluster_active_residency.clamp(0.0, 100.0);
+            let total_residency = p_residency + e_residency;
 
-                if total_residency > 0.0 {
-                    let p_ratio = p_residency / total_residency;
-                    let e_ratio = e_residency / total_residency;
-                    return Ok((
-                        (total_cpu_util * p_ratio * 1.2).clamp(0.0, 100.0),
-                        (total_cpu_util * e_ratio * 0.8).clamp(0.0, 100.0),
-                    ));
-                }
+            if total_residency > 0.0 {
+                let p_ratio = p_residency / total_residency;
+                let e_ratio = e_residency / total_residency;
+                return Ok((
+                    (total_cpu_util * p_ratio * 1.2).clamp(0.0, 100.0),
+                    (total_cpu_util * e_ratio * 0.8).clamp(0.0, 100.0),
+                ));
             }
         }
 
@@ -750,10 +748,10 @@ impl MacOsCpuReader {
     #[allow(dead_code)] // OPTIMIZATION: Now using cached native_data instead
     fn get_cpu_power_consumption(&self) -> Option<f64> {
         // Use native metrics manager
-        if let Some(manager) = get_native_metrics_manager() {
-            if let Ok(data) = manager.collect_once() {
-                return Some(data.cpu_power_mw / 1000.0); // Convert mW to W
-            }
+        if let Some(manager) = get_native_metrics_manager()
+            && let Ok(data) = manager.collect_once()
+        {
+            return Some(data.cpu_power_mw / 1000.0); // Convert mW to W
         }
 
         None

--- a/src/device/macos_native/ioreport.rs
+++ b/src/device/macos_native/ioreport.rs
@@ -662,10 +662,10 @@ impl IOReport {
 impl Drop for IOReport {
     fn drop(&mut self) {
         unsafe {
-            if let Some((prev, _)) = self.prev_sample.take() {
-                if !prev.is_null() {
-                    CFRelease(prev as *const c_void);
-                }
+            if let Some((prev, _)) = self.prev_sample.take()
+                && !prev.is_null()
+            {
+                CFRelease(prev as *const c_void);
             }
             if !self.channels.is_null() {
                 CFRelease(self.channels as *const c_void);

--- a/src/device/macos_native/manager.rs
+++ b/src/device/macos_native/manager.rs
@@ -302,12 +302,10 @@ impl NativeMetricsManager {
         // First check: quick read-only cache check (no lock)
         if let (Ok(time_guard), Ok(data_guard)) =
             (self.last_collection_time.read(), self.latest_data.read())
+            && let (Some(last_time), Some(data)) = (*time_guard, data_guard.clone())
+            && last_time.elapsed().as_millis() < cache_duration_ms
         {
-            if let (Some(last_time), Some(data)) = (*time_guard, data_guard.clone()) {
-                if last_time.elapsed().as_millis() < cache_duration_ms {
-                    return Ok(data);
-                }
-            }
+            return Ok(data);
         }
 
         // Acquire collection lock to prevent concurrent collections
@@ -319,12 +317,10 @@ impl NativeMetricsManager {
         // Second check: re-check cache after acquiring lock (another thread may have collected)
         if let (Ok(time_guard), Ok(data_guard)) =
             (self.last_collection_time.read(), self.latest_data.read())
+            && let (Some(last_time), Some(data)) = (*time_guard, data_guard.clone())
+            && last_time.elapsed().as_millis() < cache_duration_ms
         {
-            if let (Some(last_time), Some(data)) = (*time_guard, data_guard.clone()) {
-                if last_time.elapsed().as_millis() < cache_duration_ms {
-                    return Ok(data);
-                }
-            }
+            return Ok(data);
         }
 
         // OPTIMIZATION: Reuse the existing IOReport instance instead of creating a new one
@@ -379,10 +375,10 @@ impl NativeMetricsManager {
         self.is_running.store(false, Ordering::Release);
 
         // Wait for collector thread to finish
-        if let Ok(mut guard) = self.collector_handle.lock() {
-            if let Some(handle) = guard.take() {
-                let _ = handle.join();
-            }
+        if let Ok(mut guard) = self.collector_handle.lock()
+            && let Some(handle) = guard.take()
+        {
+            let _ = handle.join();
         }
 
         FIRST_DATA_RECEIVED.store(false, Ordering::Relaxed);
@@ -435,10 +431,10 @@ pub fn get_native_metrics_manager() -> Option<Arc<NativeMetricsManager>> {
 /// Shutdown and cleanup the native metrics manager
 #[allow(dead_code)]
 pub fn shutdown_native_metrics_manager() {
-    if let Ok(mut guard) = NATIVE_METRICS_MANAGER.lock() {
-        if let Some(manager) = guard.take() {
-            manager.shutdown();
-        }
+    if let Ok(mut guard) = NATIVE_METRICS_MANAGER.lock()
+        && let Some(manager) = guard.take()
+    {
+        manager.shutdown();
     }
     FIRST_DATA_RECEIVED.store(false, Ordering::Relaxed);
 }

--- a/src/device/macos_native/smc.rs
+++ b/src/device/macos_native/smc.rs
@@ -454,10 +454,10 @@ impl SMC {
         ];
 
         for key in static_keys {
-            if let Ok(value) = self.read_value(key) {
-                if (10.0..=120.0).contains(&value) {
-                    temps.push(value);
-                }
+            if let Ok(value) = self.read_value(key)
+                && (10.0..=120.0).contains(&value)
+            {
+                temps.push(value);
             }
         }
 
@@ -469,10 +469,10 @@ impl SMC {
             });
 
             for key in &discovered.cpu_keys {
-                if let Ok(value) = self.read_value(key) {
-                    if (10.0..=120.0).contains(&value) {
-                        temps.push(value);
-                    }
+                if let Ok(value) = self.read_value(key)
+                    && (10.0..=120.0).contains(&value)
+                {
+                    temps.push(value);
                 }
             }
         }
@@ -495,10 +495,10 @@ impl SMC {
         let static_keys = ["Tg0f", "Tg0j", "TG0P", "TG0D"];
 
         for key in static_keys {
-            if let Ok(value) = self.read_value(key) {
-                if (10.0..=120.0).contains(&value) {
-                    temps.push(value);
-                }
+            if let Ok(value) = self.read_value(key)
+                && (10.0..=120.0).contains(&value)
+            {
+                temps.push(value);
             }
         }
 
@@ -510,10 +510,10 @@ impl SMC {
             });
 
             for key in &discovered.gpu_keys {
-                if let Ok(value) = self.read_value(key) {
-                    if (10.0..=120.0).contains(&value) {
-                        temps.push(value);
-                    }
+                if let Ok(value) = self.read_value(key)
+                    && (10.0..=120.0).contains(&value)
+                {
+                    temps.push(value);
                 }
             }
         }

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -12,11 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::OnceLock;
+
 #[cfg(target_os = "linux")]
 use crate::device::common::constants::google_tpu::is_libtpu_available;
 use crate::device::common::execute_command_default;
 
+// Platform detection results are immutable for the lifetime of the process:
+// hardware doesn't appear or disappear at runtime. Cache each detection call
+// in a process-global OnceLock so expensive probes (e.g. `system_profiler
+// SPPCIDataType` on macOS, `lspci` on Linux, `nvidia-smi -L` everywhere) run
+// at most once, instead of being re-executed on every view refresh cycle.
+
 pub fn has_nvidia() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_nvidia)
+}
+
+fn detect_nvidia() -> bool {
     // On macOS, use system_profiler to check for NVIDIA devices
     if std::env::consts::OS == "macos" {
         // First check system_profiler for NVIDIA PCI devices
@@ -102,6 +115,12 @@ pub fn has_nvidia() -> bool {
 
 #[cfg(all(target_os = "linux", not(target_env = "musl")))]
 pub fn has_amd() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_amd)
+}
+
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+fn detect_amd() -> bool {
     // On Linux, check for AMD GPUs
     if std::env::consts::OS == "linux" {
         // Check lspci for AMD devices (Vendor ID 1002)
@@ -131,6 +150,11 @@ pub fn has_amd() -> bool {
 }
 
 pub fn is_jetson() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_jetson)
+}
+
+fn detect_jetson() -> bool {
     if let Ok(compatible) = std::fs::read_to_string("/proc/device-tree/compatible") {
         return compatible.contains("tegra");
     }
@@ -138,6 +162,11 @@ pub fn is_jetson() -> bool {
 }
 
 pub fn is_apple_silicon() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_apple_silicon)
+}
+
+fn detect_apple_silicon() -> bool {
     // Only check on macOS
     if std::env::consts::OS != "macos" {
         return false;
@@ -150,6 +179,11 @@ pub fn is_apple_silicon() -> bool {
 }
 
 pub fn has_furiosa() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_furiosa)
+}
+
+fn detect_furiosa() -> bool {
     // Check if devices are visible under the /sys/class/rngd_mgmt directory
     let rngd_mgmt_path = std::path::Path::new("/sys/class/rngd_mgmt");
     if !rngd_mgmt_path.exists() {
@@ -175,6 +209,12 @@ pub fn has_furiosa() -> bool {
 
 #[cfg(target_os = "linux")]
 pub fn has_tenstorrent() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_tenstorrent)
+}
+
+#[cfg(target_os = "linux")]
+fn detect_tenstorrent() -> bool {
     // First check if device directory exists
     if std::path::Path::new("/dev/tenstorrent").exists() {
         return true;
@@ -212,6 +252,11 @@ pub fn has_tenstorrent() -> bool {
 }
 
 pub fn has_rebellions() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_rebellions)
+}
+
+fn detect_rebellions() -> bool {
     // First check if device files exist (rbln0, rbln1, etc.)
     if std::path::Path::new("/dev/rbln0").exists() {
         return true;
@@ -264,6 +309,12 @@ pub fn has_rebellions() -> bool {
 /// IMPORTANT: No external commands are executed to prevent process accumulation.
 #[cfg(target_os = "linux")]
 pub fn has_google_tpu() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_google_tpu)
+}
+
+#[cfg(target_os = "linux")]
+fn detect_google_tpu() -> bool {
     // Method 1: Check if /dev/accel* devices exist with Google vendor ID
     // This works for on-premise TPU nodes and some TPU versions
     if let Ok(entries) = std::fs::read_dir("/dev") {
@@ -315,6 +366,11 @@ pub fn has_google_tpu() -> bool {
 }
 
 pub fn has_gaudi() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_gaudi)
+}
+
+fn detect_gaudi() -> bool {
     // First check if device files exist (typical Gaudi device paths)
     // Intel Gaudi uses /dev/accel/accel* device files
     if std::path::Path::new("/dev/accel/accel0").exists() {

--- a/src/device/readers/apple_silicon_native.rs
+++ b/src/device/readers/apple_silicon_native.rs
@@ -198,14 +198,14 @@ impl GpuReader for AppleSiliconNativeGpuReader {
 
         // Add unified AI acceleration library labels
         detail.insert("lib_name".to_string(), "Metal".to_string());
-        if let Some(driver_ver) = static_info.detail.get("driver_version") {
-            if driver_ver != "Unknown" {
-                let lib_ver = driver_ver
-                    .strip_prefix("Metal ")
-                    .unwrap_or(driver_ver)
-                    .to_string();
-                detail.insert("lib_version".to_string(), lib_ver);
-            }
+        if let Some(driver_ver) = static_info.detail.get("driver_version")
+            && driver_ver != "Unknown"
+        {
+            let lib_ver = driver_ver
+                .strip_prefix("Metal ")
+                .unwrap_or(driver_ver)
+                .to_string();
+            detail.insert("lib_version".to_string(), lib_ver);
         }
 
         // Use GPU temperature if available, otherwise default to 0
@@ -264,12 +264,12 @@ fn get_gpu_name_and_version() -> (String, Option<String>) {
                 if part.starts_with("M") && part.chars().nth(1).is_some_and(|c| c.is_numeric()) {
                     let mut gpu_name = format!("Apple {part} GPU");
                     let parts: Vec<&str> = cpu_brand.split_whitespace().collect();
-                    if let Some(pos) = parts.iter().position(|&x| x == part) {
-                        if pos + 1 < parts.len() {
-                            let suffix = parts[pos + 1];
-                            if suffix == "Pro" || suffix == "Max" || suffix == "Ultra" {
-                                gpu_name = format!("Apple {part} {suffix} GPU");
-                            }
+                    if let Some(pos) = parts.iter().position(|&x| x == part)
+                        && pos + 1 < parts.len()
+                    {
+                        let suffix = parts[pos + 1];
+                        if suffix == "Pro" || suffix == "Max" || suffix == "Ultra" {
+                            gpu_name = format!("Apple {part} {suffix} GPU");
                         }
                     }
                     name = Some(gpu_name);
@@ -293,19 +293,19 @@ fn get_gpu_name_and_version() -> (String, Option<String>) {
 fn get_metal_version_from_framework() -> Option<String> {
     if let Ok(output) = execute_command_default("sw_vers", &["-productVersion"]) {
         let version_str = output.stdout.trim();
-        if let Some(major_version) = version_str.split('.').next() {
-            if let Ok(major) = major_version.parse::<u32>() {
-                let metal_version = match major {
-                    26.. => "Metal 4",
-                    15..=25 => "Metal 3",
-                    14 => "Metal 3",
-                    13 => "Metal 3",
-                    12 => "Metal 2.4",
-                    11 => "Metal 2.3",
-                    _ => "Metal 2",
-                };
-                return Some(metal_version.to_string());
-            }
+        if let Some(major_version) = version_str.split('.').next()
+            && let Ok(major) = major_version.parse::<u32>()
+        {
+            let metal_version = match major {
+                26.. => "Metal 4",
+                15..=25 => "Metal 3",
+                14 => "Metal 3",
+                13 => "Metal 3",
+                12 => "Metal 2.4",
+                11 => "Metal 2.3",
+                _ => "Metal 2",
+            };
+            return Some(metal_version.to_string());
         }
     }
     Some("Metal 3".to_string())
@@ -361,10 +361,10 @@ fn parse_ioreg_gpu_cores(output_str: &str) -> Option<u32> {
     for line in output_str.lines() {
         if line.contains("\"gpu-core-count\"") {
             let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() >= 3 {
-                if let Ok(core_count) = parts[2].parse::<u32>() {
-                    return Some(core_count);
-                }
+            if parts.len() >= 3
+                && let Ok(core_count) = parts[2].parse::<u32>()
+            {
+                return Some(core_count);
             }
         }
     }


### PR DESCRIPTION
## Summary

Platform detection functions (`has_nvidia`, `has_gaudi`, `has_tenstorrent`, etc.) in `src/device/platform_detection.rs` were re-evaluated on every view refresh cycle. On macOS this meant `system_profiler SPPCIDataType` — a probe that takes hundreds of milliseconds and spawns a fresh process — was running once per frame in local view mode.

## Root Cause

In `src/view/data_collection/local_collector.rs:565`, `update_notifications` is called from every data collection cycle and evaluates `has_nvidia()` first in a short-circuit chain:

```rust
if has_nvidia()
    && let Some(nvml_message) = get_nvml_status_message()
    && !state.nvml_notification_shown
```

Because `has_nvidia()` is the first term, the `nvml_notification_shown` guard never short-circuits the probe. On macOS the function shells out to `system_profiler SPPCIDataType` on every call.

## Fix

Wrap each platform detection function in a process-global `OnceLock`, so the underlying probe runs at most once per process:

- `has_nvidia`, `has_amd`, `has_furiosa`, `has_tenstorrent`, `has_rebellions`, `has_google_tpu`, `has_gaudi`
- `is_jetson`, `is_apple_silicon`

Hardware presence does not change at runtime, so caching is semantically correct. All call sites in `reader_factory`, `local_collector`, `main`, and `client` automatically benefit without modification.

Also collapses nested `if` blocks flagged by `clippy::collapsible_if` in macOS-specific device readers (`cpu_macos.rs`, `macos_native/*.rs`, `apple_silicon_native.rs`).

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo clippy` clean
- [x] `cargo test` passes (5 + 17 + 19 tests)
- [ ] Manual verification on macOS that `system_profiler` is no longer spawned on every view refresh cycle