### PR TITLE
fix: decode SMC float sensors as little-endian on Apple Silicon

### DIFF
--- a/src/device/cpu_macos.rs
+++ b/src/device/cpu_macos.rs
@@ -162,8 +162,12 @@ impl MacOsCpuReader {
         let per_core_utilization =
             self.get_per_core_utilization_no_refresh(e_core_count as usize, p_core_count as usize);
 
-        // Get CPU temperature (may not be available)
-        let temperature = self.get_cpu_temperature();
+        // Get CPU temperature from cached native metrics (SMC sensor reading).
+        // Falls back to None if SMC didn't return a usable value.
+        let temperature = native_data
+            .as_ref()
+            .and_then(|d| d.cpu_temperature)
+            .map(|t| t.round() as u32);
 
         // Power consumption from cached native metrics
         let power_consumption = native_data.as_ref().map(|d| d.cpu_power_mw / 1000.0);

--- a/src/device/macos_native/smc.rs
+++ b/src/device/macos_native/smc.rs
@@ -370,7 +370,13 @@ impl SMC {
             SMC_TYPE_UI8 => bytes[0] as f64,
             SMC_TYPE_UI16 => u16::from_be_bytes([bytes[0], bytes[1]]) as f64,
             SMC_TYPE_UI32 => u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as f64,
-            SMC_TYPE_FLT => f32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as f64,
+            // Apple Silicon SMC stores `flt ` (IEEE 754 single-precision)
+            // values in little-endian byte order, unlike the legacy fixed-point
+            // types (SP78, FP*) which remain big-endian. This matches what
+            // mactop and asitop do; using `from_be_bytes` here yields random
+            // garbage that varies between calls because the bit pattern is
+            // misinterpreted as a wildly different float.
+            SMC_TYPE_FLT => f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as f64,
             SMC_TYPE_SP78 => {
                 // Signed 7.8 fixed point
                 let raw = i16::from_be_bytes([bytes[0], bytes[1]]);
@@ -614,5 +620,22 @@ mod tests {
     fn test_hash_key_fourcc() {
         // Test the #KEY special key used for key count
         assert_eq!(str_to_fourcc("#KEY"), u32::from_be_bytes(*b"#KEY"));
+    }
+
+    /// Sanity-check little-endian decoding of the `flt ` SMC type. Apple
+    /// Silicon stores temperature sensor floats as little-endian; if this
+    /// regresses we get garbage values like 1e-32 or 3e36 instead of real
+    /// temperatures (the symptom that motivated this conversion).
+    #[test]
+    fn test_flt_little_endian_decoding() {
+        let smc = SMC { conn: 0 }; // convert_value doesn't touch the connection
+        let mut bytes = [0u8; 32];
+        // 51.2°C as IEEE 754 single = 0x424ccccd
+        bytes[0..4].copy_from_slice(&0x424ccccd_u32.to_le_bytes());
+        let value = smc.convert_value(&bytes, SMC_TYPE_FLT, 4);
+        assert!(
+            (value - 51.2).abs() < 0.01,
+            "expected ~51.2, got {value} — float endianness may have regressed"
+        );
     }
 }

--- a/src/device/readers/apple_silicon_native.rs
+++ b/src/device/readers/apple_silicon_native.rs
@@ -208,8 +208,12 @@ impl GpuReader for AppleSiliconNativeGpuReader {
             detail.insert("lib_version".to_string(), lib_ver);
         }
 
-        // Use GPU temperature if available, otherwise default to 0
-        let temperature = gpu_temp.map(|t| t as u32).unwrap_or(0);
+        // GPU temperature: Apple Silicon's per-die GPU thermistor keys (Tg*) are
+        // not always exposed reliably across chip generations. When SMC didn't
+        // return a usable value, fall back to the CPU die temperature — CPU and
+        // GPU share the same SoC package so the readings are tightly correlated
+        // and this is far more meaningful than reporting 0 °C.
+        let temperature = gpu_temp.or(cpu_temp).map(|t| t.round() as u32).unwrap_or(0);
 
         vec![GpuInfo {
             uuid: static_info

--- a/src/device/readers/nvidia.rs
+++ b/src/device/readers/nvidia.rs
@@ -499,7 +499,7 @@ fn create_device_detail(
     // Add all device details using helper macros
     let mut detail = builder.build();
     add_detail!(detail, device.brand(), "Brand");
-    add_detail!(detail, device.architecture(), "Architecture");
+    add_detail!(detail, device.architecture(), "architecture");
 
     let mem_total = device.memory_info().map(|m| m.total).unwrap_or(0);
     let uma = is_uma_device_with_mem(device, mem_total);

--- a/src/device/readers/nvidia_jetson.rs
+++ b/src/device/readers/nvidia_jetson.rs
@@ -99,7 +99,7 @@ impl NvidiaJetsonGpuReader {
 
             // Static hardware info
             detail.insert("GPU Type".to_string(), "Integrated".to_string());
-            detail.insert("Architecture".to_string(), "Tegra".to_string());
+            detail.insert("architecture".to_string(), "Tegra".to_string());
 
             DeviceStaticInfo::with_details(name, None, detail)
         })

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -42,10 +42,14 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
     };
     let total_gpus = state.gpu_info.len();
 
-    // Check if we're on Apple Silicon
+    // Check if we're on Apple Silicon. The native reader writes the
+    // architecture detail under the lowercase "architecture" key
+    // (see device/readers/apple_silicon_native.rs); previously this lookup
+    // used "Architecture" and never matched, so the special-case path
+    // (thermal pressure display, unified memory totals, etc.) was dead.
     let is_apple_silicon = state.gpu_info.iter().any(|gpu| {
         gpu.detail
-            .get("Architecture")
+            .get("architecture")
             .map(|arch| arch == "Apple Silicon")
             .unwrap_or(false)
     });
@@ -158,30 +162,36 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
         0.0
     };
 
-    // For Apple Silicon, get thermal pressure text; for others, calculate numeric temperature
-    let (avg_temperature_display, temp_std_dev_display) = if is_apple_silicon && total_gpus > 0 {
-        // Get the thermal pressure text from the first GPU (they should all be the same on a single machine)
+    // Average GPU temperature in °C — shown identically on every platform.
+    // On Apple Silicon, gpu.temperature is sourced from the SMC CPU die sensor
+    // (CPU/GPU share the same SoC die), so this is a real die temperature
+    // rather than the qualitative thermal-pressure text we used to show.
+    let avg_temperature = if total_gpus > 0 {
+        state
+            .gpu_info
+            .iter()
+            .map(|gpu| gpu.temperature as f64)
+            .sum::<f64>()
+            / total_gpus as f64
+    } else {
+        0.0
+    };
+    let avg_temperature_display = format!("{avg_temperature:.0}°C");
+
+    // The second-row temperature cell is platform-dependent:
+    // - On Apple Silicon (single SoC die) standard deviation is meaningless,
+    //   so we surface NSProcessInfo's thermal pressure level instead — that
+    //   qualitative reading is the only OS-blessed thermal hint Apple exposes.
+    // - On multi-GPU platforms we keep the cross-GPU temperature spread.
+    let (temp_secondary_label, temp_secondary_display) = if is_apple_silicon && total_gpus > 0 {
         let thermal_pressure = state
             .gpu_info
             .first()
             .and_then(|gpu| gpu.detail.get("thermal_pressure"))
             .cloned()
             .unwrap_or_else(|| "Unknown".to_string());
-        (thermal_pressure, "N/A".to_string())
+        ("Thermal", thermal_pressure)
     } else {
-        // Calculate numeric temperature for non-Apple Silicon
-        let avg_temperature = if total_gpus > 0 {
-            state
-                .gpu_info
-                .iter()
-                .map(|gpu| gpu.temperature as f64)
-                .sum::<f64>()
-                / total_gpus as f64
-        } else {
-            0.0
-        };
-
-        // Calculate temperature standard deviation
         let temp_std_dev = if total_gpus > 1 {
             let temp_variance = state
                 .gpu_info
@@ -196,11 +206,7 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
         } else {
             0.0
         };
-
-        (
-            format!("{avg_temperature:.0}°C"),
-            format!("±{temp_std_dev:.1}°C"),
-        )
+        ("Temp. Stdev", format!("±{temp_std_dev:.1}°C"))
     };
 
     let avg_power = if total_gpus > 0 {
@@ -270,7 +276,7 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
                 format_ram_value(used_gpu_memory_gb),
                 Color::Blue,
             ),
-            ("Temp. Stdev", temp_std_dev_display, Color::Magenta),
+            (temp_secondary_label, temp_secondary_display, Color::Magenta),
             ("Avg. Power", format!("{avg_power:.1}W"), Color::Red),
         ],
         box_width,

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -154,14 +154,16 @@ pub fn print_gpu_info<W: Write>(
     print_colored_text(stdout, &vram_display, Color::White, None, None);
     print_colored_text(stdout, " Temp:", Color::Magenta, None, None);
 
-    // For Apple Silicon, display thermal pressure level instead of numeric temperature
-    let temp_display = if info.name.contains("Apple") || info.name.contains("Metal") {
-        if let Some(thermal_level) = info.detail.get("thermal_pressure") {
-            format!("{thermal_level:>7}")
-        } else {
-            format!("{:>7}", "Unknown")
-        }
-    } else if info.detail.get("metrics_available") == Some(&"false".to_string()) {
+    // Display real GPU die temperature on every platform. Apple Silicon used
+    // to fall back to the qualitative thermal pressure text because SMC float
+    // decoding was broken; with the SMC `flt ` little-endian fix in place the
+    // Tg* sensors return real die temperatures (~50 °C idle), so the numeric
+    // reading is now meaningful and consistent with other platforms.
+    let temp_display = if info.detail.get("metrics_available") == Some(&"false".to_string()) {
+        format!("{:>7}", "N/A")
+    } else if info.temperature == 0 {
+        // SMC didn't yield a usable reading and we have no fallback — show N/A
+        // rather than a misleading "0 °C".
         format!("{:>7}", "N/A")
     } else {
         format!("{:>4}°C", info.temperature)

--- a/src/view/data_collection/aggregator.rs
+++ b/src/view/data_collection/aggregator.rs
@@ -94,7 +94,7 @@ impl DataAggregator {
         let has_gpu_data = !state.gpu_info.is_empty();
         let is_apple_silicon = state.gpu_info.iter().any(|gpu| {
             gpu.detail
-                .get("Architecture")
+                .get("architecture")
                 .map(|arch| arch == "Apple Silicon")
                 .unwrap_or(false)
         });


### PR DESCRIPTION
## Summary

Fixes broken temperature readings on macOS local mode. Apple Silicon's SMC stores ``flt `` (IEEE 754 single-precision) sensor values in **little-endian** byte order, but ``convert_value()`` was decoding them as big-endian. Every Tg*/Tp*/Te* read returned a randomly varying garbage float, the (10..=120) sanity filter rejected almost everything, and downstream the dashboard showed 0 °C / 6 °C / "Nominal" depending on which fallback path triggered.

Switching ``SMC_TYPE_FLT`` to ``f32::from_le_bytes()`` restores real die temperatures (~50–60 °C idle on M1 Ultra). Verified by dumping the raw SMC response buffer: bytes always landed at offset 48 with consistent LE-encoded floats matching expected die temps.

## Root Cause

``src/device/macos_native/smc.rs:373`` decoded ``SMC_TYPE_FLT`` with ``f32::from_be_bytes()``. Apple Silicon SMC actually stores floats little-endian (mactop, asitop, macmon all do this). The legacy fixed-point types (SP78, FP*) remain big-endian, so the bug only affects the ``flt `` variant — but on Apple Silicon every modern temperature/voltage/current sensor uses ``flt ``.

Symptoms:
- ``all_smi_gpu_temperature_celsius`` = 0 in API mode
- ``all_smi_cpu_temperature_celsius`` not exported (because ``cpu.temperature`` was always None)
- View mode "GPU Temp." gauge oscillating between 0 and ~7 °C
- Dashboard "Avg. Temp" cell showing thermal pressure text only because the numeric path produced nonsense

## Additional Fixes

While investigating the temperature display, several related correctness issues were uncovered and fixed in the same PR:

1. **``architecture`` detail key case mismatch.** ``apple_silicon_native`` and the prometheus exporter wrote the GPU detail key as lowercase ``"architecture"``, but ``ui/dashboard.rs`` and ``view/data_collection/aggregator.rs`` looked it up as ``"Architecture"``. The mismatch silently disabled the entire ``is_apple_silicon`` special-case path. Standardised on the lowercase form everywhere, including the NVIDIA and Jetson readers.

2. **``cpu_macos::get_cpu_temperature`` was a stub.** Always returned ``None``, so the live "CPU Temp." gauge was permanently 0 °C even though SMC was already collecting the value. Wired it through the cached ``NativeMetricsData`` already fetched in ``get_apple_silicon_cpu_info``.

3. **GPU temperature fallback.** ``apple_silicon_native`` now falls back to the SMC CPU die temperature when the GPU sensor is unavailable. CPU and GPU share the same SoC die so the readings track each other closely; far more meaningful than reporting 0 °C.

4. **Unified dashboard temperature display.** "Avg. Temp" cell now shows numeric °C on every platform. On Apple Silicon the second-row "Temp. Stdev" cell becomes a "Thermal" cell carrying the qualitative thermal pressure level (single-die std dev is meaningless), so both numeric and qualitative information remain visible.

5. **Per-GPU list view.** Used to display thermal pressure text on Apple Silicon for the same reason; now shows the real numeric die temp, consistent with every other platform.

## Verification (M1 Ultra)

Before:
```
all_smi_gpu_temperature_celsius{...} 0
# (no all_smi_cpu_temperature_celsius metric exported)
```

After:
```
all_smi_gpu_temperature_celsius{...} 51
all_smi_cpu_temperature_celsius{...} 60
gpu_info{cpu_temperature="60.0", gpu_temperature="50.7", thermal_pressure="Nominal", ...}
```

Added ``test_flt_little_endian_decoding`` regression unit test so the endianness can't silently flip back.

## Test plan

- [x] ``cargo build`` succeeds
- [x] ``cargo clippy`` clean
- [x] ``cargo test`` passes (5 + 17 + 19 tests, including new endianness test)
- [x] M1 Ultra: API mode exports real die temperatures
- [x] M1 Ultra: View mode dashboard shows consistent numeric °C across top row, live stats, and per-GPU list