### PR TITLE
feat(ui): gate Cluster Overview + tabs behind remote mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ http://gpu-node3:9090
   - Server systems: BMC sensor integration for comprehensive thermal monitoring
 
 ### Cluster Management
+
+> Note: The Cluster Overview Dashboard, Live Statistics History, and Tabbed Interface appear only in remote mode (when `--hosts` or `--hostfile` is specified). Local mode shows a simplified single-node view without these sections.
+
 - **Cluster Overview Dashboard:** Real-time statistics showing:
   - Total nodes and GPUs across the cluster
   - Average utilization and memory usage

--- a/src/ui/braille.rs
+++ b/src/ui/braille.rs
@@ -31,6 +31,7 @@
 
 /// Row bit masks for the left sub-column, ordered bottom→top.
 /// level=0 fills only the bottom row; level=3 fills all four rows.
+#[allow(dead_code)] // Used by sparkline_braille; integration into callers lands in a later sub-issue
 const LEFT_BITS: [u32; 4] = [
     0x40, // dot7 – bottom row
     0x04, // dot3 – lower-mid row
@@ -39,6 +40,7 @@ const LEFT_BITS: [u32; 4] = [
 ];
 
 /// Row bit masks for the right sub-column, ordered bottom→top.
+#[allow(dead_code)] // Used by sparkline_braille; integration into callers lands in a later sub-issue
 const RIGHT_BITS: [u32; 4] = [
     0x80, // dot8 – bottom row
     0x20, // dot6 – lower-mid row
@@ -64,6 +66,7 @@ const RIGHT_BITS: [u32; 4] = [
 /// - Degenerate explicit range `(lo, hi)` where `hi <= lo` → treated as constant;
 ///   all cells rendered at the bottom row.
 #[must_use]
+#[allow(dead_code)] // Integration into callers lands in a later sub-issue
 pub fn sparkline_braille(data: &[f64], width: usize, range: Option<(f64, f64)>) -> String {
     if data.is_empty() {
         return " ".repeat(width);

--- a/src/ui/braille.rs
+++ b/src/ui/braille.rs
@@ -31,7 +31,7 @@
 
 /// Row bit masks for the left sub-column, ordered bottom→top.
 /// level=0 fills only the bottom row; level=3 fills all four rows.
-#[allow(dead_code)] // Used by sparkline_braille; integration into callers lands in a later sub-issue
+#[allow(dead_code)] // Used by sparkline_braille; call-site integration lands in sub-issues #155/#157/#158 of #152
 const LEFT_BITS: [u32; 4] = [
     0x40, // dot7 – bottom row
     0x04, // dot3 – lower-mid row
@@ -40,7 +40,7 @@ const LEFT_BITS: [u32; 4] = [
 ];
 
 /// Row bit masks for the right sub-column, ordered bottom→top.
-#[allow(dead_code)] // Used by sparkline_braille; integration into callers lands in a later sub-issue
+#[allow(dead_code)] // Used by sparkline_braille; call-site integration lands in sub-issues #155/#157/#158 of #152
 const RIGHT_BITS: [u32; 4] = [
     0x80, // dot8 – bottom row
     0x20, // dot6 – lower-mid row
@@ -66,7 +66,7 @@ const RIGHT_BITS: [u32; 4] = [
 /// - Degenerate explicit range `(lo, hi)` where `hi <= lo` → treated as constant;
 ///   all cells rendered at the bottom row.
 #[must_use]
-#[allow(dead_code)] // Integration into callers lands in a later sub-issue
+#[allow(dead_code)] // Call-site integration lands in sub-issues #155/#157/#158 of #152
 pub fn sparkline_braille(data: &[f64], width: usize, range: Option<(f64, f64)>) -> String {
     if data.is_empty() {
         return " ".repeat(width);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -315,4 +315,38 @@ mod tests {
         assert_eq!(widths[1], 25); // 15 + 10
         assert_eq!(widths[2], 7); // 5 + 2
     }
+
+    #[test]
+    fn test_calculate_header_lines_local_vs_remote() {
+        use crate::app_state::AppState;
+
+        // Local mode: only the basic title line, no cluster/tab widgets.
+        let local_state = AppState {
+            is_local_mode: true,
+            ..AppState::default()
+        };
+        let local_lines = LayoutCalculator::calculate_header_lines(&local_state);
+
+        // Remote mode without history: title + "Cluster Overview" label +
+        // dashboard card rows + tabs row.
+        let mut remote_state = AppState {
+            is_local_mode: false,
+            ..AppState::default()
+        };
+        let remote_lines_no_history = LayoutCalculator::calculate_header_lines(&remote_state);
+
+        assert!(
+            local_lines < remote_lines_no_history,
+            "local mode ({local_lines}) should use fewer header lines than remote mode ({remote_lines_no_history})"
+        );
+
+        // Remote mode with non-empty utilization history adds more lines.
+        remote_state.utilization_history.push_back(42.0);
+        let remote_lines_with_history = LayoutCalculator::calculate_header_lines(&remote_state);
+
+        assert!(
+            remote_lines_no_history < remote_lines_with_history,
+            "remote mode with history ({remote_lines_with_history}) should use more header lines than without ({remote_lines_no_history})"
+        );
+    }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -20,23 +20,34 @@ use crate::cli::ViewArgs;
 pub struct LayoutCalculator;
 
 impl LayoutCalculator {
-    /// Calculate the number of header lines for dynamic layout
+    /// Calculate the number of header lines for dynamic layout.
+    ///
+    /// In local mode (`state.is_local_mode == true`) the Cluster Overview card,
+    /// dashboard items, and the tabs row are all suppressed by `render_main()`,
+    /// so their line contributions are excluded here.  This keeps the content
+    /// area (process list, GPU rows) from being unnecessarily clipped and
+    /// preserves the "reserved space for function keys" regression fix.
     pub fn calculate_header_lines(state: &AppState) -> u16 {
         let mut lines = 0u16;
 
-        // Basic header (title, cluster overview)
-        lines += 3;
+        // Basic header (title line)
+        lines += 1;
 
-        // System overview dashboard (2 rows)
-        lines += 4;
+        if !state.is_local_mode {
+            // "Cluster Overview" label line
+            lines += 1;
 
-        // Live statistics section
-        if !state.utilization_history.is_empty() {
-            lines += 5; // Header + 3 history lines + separator
+            // System overview dashboard card (2 rows) + label separator row
+            lines += 4;
+
+            // Live statistics section
+            if !state.utilization_history.is_empty() {
+                lines += 5; // Header + 3 history lines + separator
+            }
+
+            // Tabs section
+            lines += 2; // Tabs line + separator
         }
-
-        // Tabs section
-        lines += 2; // Tabs line + separator
 
         lines
     }

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -152,8 +152,9 @@ impl FrameRenderer {
 
         // Cluster Overview, dashboard items, and the tabs row are only meaningful
         // when monitoring multiple remote hosts. `is_local_mode` is false the moment
-        // any --hosts / --hostfile argument is supplied (see src/ui/layout.rs build
-        // site near line 68), so a single remote host still shows these widgets.
+        // any --hosts / --hostfile argument is supplied (see the assignment sites in
+        // `src/view/runner.rs::run_view_mode` / `run_local_mode`), so a single remote
+        // host still shows these widgets.
         if !view_state.is_local_mode {
             // Write remaining header content to buffer
             print_colored_text(&mut buffer, "Cluster Overview\r\n", Color::Cyan, None, None);

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -148,14 +148,20 @@ impl FrameRenderer {
             None,
         );
 
-        // Write remaining header content to buffer
-        print_colored_text(&mut buffer, "Cluster Overview\r\n", Color::Cyan, None, None);
-        draw_system_view(&mut buffer, &view_state, cols);
-
-        draw_dashboard_items(&mut buffer, &view_state, cols);
-        draw_tabs(&mut buffer, &view_state, cols);
-
         let is_remote = args.hosts.is_some() || args.hostfile.is_some();
+
+        // Cluster Overview, dashboard items, and the tabs row are only meaningful
+        // when monitoring multiple remote hosts. `is_local_mode` is false the moment
+        // any --hosts / --hostfile argument is supplied (see src/ui/layout.rs build
+        // site near line 68), so a single remote host still shows these widgets.
+        if !view_state.is_local_mode {
+            // Write remaining header content to buffer
+            print_colored_text(&mut buffer, "Cluster Overview\r\n", Color::Cyan, None, None);
+            draw_system_view(&mut buffer, &view_state, cols);
+
+            draw_dashboard_items(&mut buffer, &view_state, cols);
+            draw_tabs(&mut buffer, &view_state, cols);
+        }
 
         // Render chassis information (node-level metrics)
         Self::render_chassis_section(&mut buffer, snapshot, width, cache);

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -26,7 +26,10 @@ pub async fn run_local_mode(args: &LocalArgs) {
     let mut startup_profiler = crate::utils::StartupProfiler::new();
     startup_profiler.checkpoint("Starting run_local_mode");
 
-    // Initialize application state for local mode
+    // Initialize application state for local mode.
+    // `is_local_mode = true` means no --hosts / --hostfile were supplied.
+    // The UI gates the Cluster Overview card, dashboard items, and tabs row
+    // behind `!is_local_mode` (see src/view/frame_renderer.rs render_main).
     let mut initial_state = AppState::new();
     initial_state.is_local_mode = true;
     let app_state = Arc::new(Mutex::new(initial_state));
@@ -83,7 +86,11 @@ pub async fn run_local_mode(args: &LocalArgs) {
 }
 
 pub async fn run_view_mode(args: &ViewArgs) {
-    // Initialize application state for remote mode
+    // Initialize application state for remote mode.
+    // `is_local_mode = false` whenever any --hosts / --hostfile argument is
+    // supplied, including a single remote host.  The UI renders Cluster
+    // Overview, dashboard items, and the tabs row only when this is false
+    // (see src/view/frame_renderer.rs render_main).
     let mut initial_state = AppState::new();
     initial_state.is_local_mode = false;
     let app_state = Arc::new(Mutex::new(initial_state));

--- a/src/view/ui_events.rs
+++ b/src/view/ui_events.rs
@@ -379,15 +379,15 @@ mod tests {
     #[test]
     fn test_animation_tick_ms_reasonable() {
         // Must be positive and not unreasonably large.
-        assert!(AppConfig::ANIMATION_TICK_MS > 0);
-        assert!(AppConfig::ANIMATION_TICK_MS <= 500);
+        const { assert!(AppConfig::ANIMATION_TICK_MS > 0) };
+        const { assert!(AppConfig::ANIMATION_TICK_MS <= 500) };
     }
 
     #[test]
     fn test_terminal_reader_poll_ms_reasonable() {
         // Must be positive and not so large that shutdown detection is sluggish.
-        assert!(AppConfig::TERMINAL_READER_POLL_MS > 0);
-        assert!(AppConfig::TERMINAL_READER_POLL_MS <= 200);
+        const { assert!(AppConfig::TERMINAL_READER_POLL_MS > 0) };
+        const { assert!(AppConfig::TERMINAL_READER_POLL_MS <= 200) };
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- In local mode (no `--hosts` / `--hostfile`), suppress three widgets that show meaningless data: the Cluster Overview card, dashboard items, and the tabs row.
- A single `if !view_state.is_local_mode { … }` guard in `render_main()` wraps all three `draw_*` calls.
- `calculate_header_lines()` in `src/ui/layout.rs` now excludes the suppressed rows from its count, keeping the content area (GPU rows, process list) correctly sized and preventing function-key-row clipping.
- Comments added at both `is_local_mode` assignment sites in `runner.rs` to anchor the invariant explicitly.
- Fixed pre-existing clippy failures (`dead_code` on `braille.rs` symbols, `assertions_on_constants` in `ui_events.rs`) that blocked the acceptance gate on `main`.

**Note**: The empty top band in local mode between the all-smi header and the `NODE │ …` row is intentional as an intermediate state. It will be filled by the new local-mode header landing in sub-issues #155 and #157.

## Regression safety

| Scenario | Expected behaviour | Guard result |
|---|---|---|
| Pure local mode (no flags) | No Cluster Overview, dashboard items, or tabs | `is_local_mode = true` → widgets skipped |
| `--hosts http://host:9090` (single remote) | All three widgets render | `is_local_mode = false` → widgets shown |
| `--hostfile hosts.csv` (10+ nodes) | All three widgets render | `is_local_mode = false` → widgets shown |

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — passes (0 warnings)
- [x] `cargo test` — 220 + 280 unit tests, 0 failed
- [x] `cargo build --release` — compiles cleanly

Closes #154
Part of #152