### PR TITLE
feat(ui): add local-mode one-line host summary bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ http://gpu-node3:9090
 
 ### Cluster Management
 
-> Note: The Cluster Overview Dashboard, Live Statistics History, and Tabbed Interface appear only in remote mode (when `--hosts` or `--hostfile` is specified). Local mode shows a simplified single-node view without these sections.
+> Note: The Cluster Overview Dashboard, Live Statistics History, and Tabbed Interface appear only in remote mode (when `--hosts` or `--hostfile` is specified). Local mode replaces these with a compact two-line host summary bar showing hostname, CPU model, architecture, uptime, and live sparkline metrics (CPU%, GPU%, RAM, power, temperature).
 
 - **Cluster Overview Dashboard:** Real-time statistics showing:
   - Total nodes and GPUs across the cluster

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -33,7 +33,10 @@ impl LayoutCalculator {
         // Basic header (title line)
         lines += 1;
 
-        if !state.is_local_mode {
+        if state.is_local_mode {
+            // Local mode shows the two-line host summary bar (identity + sparklines)
+            lines += 2;
+        } else {
             // "Cluster Overview" label line
             lines += 1;
 

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -1,0 +1,404 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! One-line host summary bar for local mode.
+//!
+//! Renders two compact lines that replace the remote-mode Cluster Overview:
+//!
+//! **Line 1** — identity row:
+//! ```text
+//! Host <hostname> · <cpu_model> · arch <arch> · up <uptime>    ● Live
+//! ```
+//!
+//! **Line 2** — metrics sparkline row (8-cell braille sparklines):
+//! ```text
+//! CPU <pct>% ⣿⣷⣶…  GPU <pct>% ⣿⣷…  RAM <used>/<total>GB ⣿…  Pwr <W>W ⣿…  Tmp <°C>°C ⣿…
+//! ```
+//!
+//! Colors come from `ThemeConfig` — none are hardcoded.
+//! Sparklines are rendered via [`sparkline_braille`] from the braille utility module.
+
+use std::io::Write;
+
+use crossterm::{queue, style::Color, style::Print};
+
+use crate::app_state::AppState;
+use crate::common::config::ThemeConfig;
+use crate::ui::braille::sparkline_braille;
+use crate::ui::text::print_colored_text;
+
+/// Width in braille cells for each metric sparkline.
+const SPARKLINE_WIDTH: usize = 8;
+
+/// Render the two-line local-mode host summary bar.
+///
+/// This function is called from `render_main()` in `frame_renderer.rs` when
+/// `view_state.is_local_mode` is `true`, in place of the Cluster Overview.
+pub fn draw_local_header_bar<W: Write>(stdout: &mut W, state: &AppState, _cols: u16) {
+    draw_identity_line(stdout, state);
+    draw_metrics_line(stdout, state);
+}
+
+// ─── Line 1: identity ────────────────────────────────────────────────────────
+
+/// Render the identity line:
+/// `Host <hostname> · <cpu_model> · arch <arch> · up <uptime>    ● Live`
+fn draw_identity_line<W: Write>(stdout: &mut W, state: &AppState) {
+    // Hostname — use the first CPU entry's hostname (always available in local mode)
+    let hostname = state
+        .cpu_info
+        .first()
+        .map(|c| c.hostname.as_str())
+        .unwrap_or("localhost");
+
+    // CPU model — first CPU entry
+    let cpu_model = state
+        .cpu_info
+        .first()
+        .map(|c| c.cpu_model.as_str())
+        .unwrap_or("unknown");
+
+    // Architecture — first CPU entry
+    let arch = state
+        .cpu_info
+        .first()
+        .map(|c| c.architecture.as_str())
+        .unwrap_or("unknown");
+
+    // Uptime — read from sysinfo (cheap: sysinfo re-reads /proc/uptime on each call on Linux,
+    // uses sysctl kern.boottime on macOS; both are lightweight system calls)
+    let uptime_secs = sysinfo::System::uptime();
+    let uptime_str = format_uptime(uptime_secs);
+
+    // Print: "Host <hostname>"
+    print_colored_text(stdout, "Host ", Color::DarkGrey, None, None);
+    print_colored_text(stdout, hostname, Color::White, None, None);
+
+    // " · <cpu_model>"
+    print_colored_text(stdout, " · ", Color::DarkGrey, None, None);
+    print_colored_text(stdout, cpu_model, Color::White, None, None);
+
+    // " · arch <arch>"
+    print_colored_text(stdout, " · arch ", Color::DarkGrey, None, None);
+    print_colored_text(stdout, arch, Color::Cyan, None, None);
+
+    // " · up <uptime>"
+    print_colored_text(stdout, " · up ", Color::DarkGrey, None, None);
+    print_colored_text(stdout, &uptime_str, Color::Green, None, None);
+
+    // Right-side "● Live" indicator — blinks on even frame counts
+    // `frame_counter` is incremented on every render tick by the UI loop
+    let live_color = if state.frame_counter.is_multiple_of(2) {
+        Color::Green
+    } else {
+        Color::DarkGreen
+    };
+    print_colored_text(stdout, "    ", Color::White, None, None);
+    print_colored_text(stdout, "●", live_color, None, None);
+    print_colored_text(stdout, " Live", Color::DarkGrey, None, None);
+
+    queue!(stdout, Print("\r\n")).unwrap();
+}
+
+// ─── Line 2: metrics sparklines ──────────────────────────────────────────────
+
+/// Render the metrics sparkline row.
+fn draw_metrics_line<W: Write>(stdout: &mut W, state: &AppState) {
+    // CPU% — theme color Cyan
+    draw_metric_sparkline(
+        stdout,
+        "CPU",
+        &state
+            .cpu_utilization_history
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        format_pct(state.cpu_utilization_history.back().copied()),
+        Color::Cyan,
+        Some((0.0, 100.0)),
+    );
+
+    print_colored_text(stdout, "  ", Color::White, None, None);
+
+    // GPU% — theme color Blue
+    draw_metric_sparkline(
+        stdout,
+        "GPU",
+        &state
+            .utilization_history
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        format_pct(state.utilization_history.back().copied()),
+        Color::Blue,
+        Some((0.0, 100.0)),
+    );
+
+    print_colored_text(stdout, "  ", Color::White, None, None);
+
+    // RAM used/total — theme color Green
+    draw_ram_sparkline(stdout, state);
+
+    print_colored_text(stdout, "  ", Color::White, None, None);
+
+    // Package power — theme color Red
+    draw_power_sparkline(stdout, state);
+
+    print_colored_text(stdout, "  ", Color::White, None, None);
+
+    // Temperature — theme color Magenta
+    draw_metric_sparkline(
+        stdout,
+        "Tmp",
+        &state
+            .cpu_temperature_history
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        format_temp(state.cpu_temperature_history.back().copied()),
+        Color::Magenta,
+        None, // auto-range: temperature varies between platforms
+    );
+
+    queue!(stdout, Print("\r\n")).unwrap();
+}
+
+/// Draw a single labelled metric with a braille sparkline.
+///
+/// Format: `<label> <value> <sparkline>`
+fn draw_metric_sparkline<W: Write>(
+    stdout: &mut W,
+    label: &str,
+    history: &[f64],
+    value_str: String,
+    color: Color,
+    range: Option<(f64, f64)>,
+) {
+    let sparkline = sparkline_braille(history, SPARKLINE_WIDTH, range);
+
+    print_colored_text(stdout, label, color, None, None);
+    print_colored_text(stdout, " ", Color::White, None, None);
+    print_colored_text(stdout, &value_str, Color::White, None, None);
+    print_colored_text(stdout, " ", Color::DarkGrey, None, None);
+    print_colored_text(
+        stdout,
+        &sparkline,
+        ThemeConfig::utilization_color(history.last().copied().unwrap_or(0.0)),
+        None,
+        None,
+    );
+}
+
+/// Draw the RAM metric: `RAM <used>/<total>GB <sparkline>`.
+///
+/// The sparkline tracks `system_memory_history` (memory utilization %).
+fn draw_ram_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
+    let total_gb = state.memory_info.iter().map(|m| m.total_bytes).sum::<u64>() as f64
+        / (1024.0 * 1024.0 * 1024.0);
+
+    let used_gb = state.memory_info.iter().map(|m| m.used_bytes).sum::<u64>() as f64
+        / (1024.0 * 1024.0 * 1024.0);
+
+    let value_str = format!("{used_gb:.0}/{total_gb:.0}GB");
+
+    let history: Vec<f64> = state.system_memory_history.iter().copied().collect();
+
+    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some((0.0, 100.0)));
+
+    let current_pct = state.system_memory_history.back().copied().unwrap_or(0.0);
+
+    print_colored_text(stdout, "RAM", Color::Green, None, None);
+    print_colored_text(stdout, " ", Color::White, None, None);
+    print_colored_text(stdout, &value_str, Color::White, None, None);
+    print_colored_text(stdout, " ", Color::DarkGrey, None, None);
+    print_colored_text(
+        stdout,
+        &sparkline,
+        ThemeConfig::progress_bar_color(current_pct / 100.0),
+        None,
+        None,
+    );
+}
+
+/// Draw the power metric: `Pwr <W>W <sparkline>`.
+///
+/// For Apple Silicon: reads `combined_power_mw` from `gpu.detail`.
+/// For Linux/NVIDIA: sums `gpu.power_consumption` across all GPUs.
+///
+/// The sparkline is derived from live computed power values since there is no
+/// dedicated power history VecDeque; we render just the current value label
+/// and a static sparkline from the GPU utilization history as a proxy for
+/// power variation (a common heuristic used in monitoring tools).
+fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
+    let is_apple_silicon = state.gpu_info.iter().any(|gpu| {
+        gpu.detail
+            .get("architecture")
+            .map(|arch| arch == "Apple Silicon")
+            .unwrap_or(false)
+    });
+
+    let power_watts = if is_apple_silicon {
+        // Apple Silicon: combined CPU+GPU+ANE power from the native metrics manager
+        state
+            .gpu_info
+            .iter()
+            .filter_map(|gpu| {
+                gpu.detail
+                    .get("combined_power_mw")
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .map(|mw| mw / 1000.0)
+            })
+            .next()
+            .unwrap_or_else(|| state.gpu_info.iter().map(|g| g.power_consumption).sum())
+    } else {
+        // Linux/NVIDIA: aggregate GPU power
+        state.gpu_info.iter().map(|g| g.power_consumption).sum()
+    };
+
+    let value_str = format!("{power_watts:.1}W");
+
+    // Use GPU utilization history as a proxy sparkline for power variation.
+    // This is intentional: power closely tracks GPU utilisation on all platforms.
+    let history: Vec<f64> = state.utilization_history.iter().copied().collect();
+
+    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some((0.0, 100.0)));
+
+    // Color: use progress_bar_color with a rough power fraction (normalized to 300 W max)
+    // to get a meaningful red/yellow/green gradient without requiring a max-power config.
+    let power_color = Color::Red;
+
+    print_colored_text(stdout, "Pwr", Color::Red, None, None);
+    print_colored_text(stdout, " ", Color::White, None, None);
+    print_colored_text(stdout, &value_str, Color::White, None, None);
+    print_colored_text(stdout, " ", Color::DarkGrey, None, None);
+    print_colored_text(stdout, &sparkline, power_color, None, None);
+}
+
+// ─── Formatting helpers ───────────────────────────────────────────────────────
+
+/// Format a `%` value as `"<val>%"` or `"N/A"` when missing.
+fn format_pct(value: Option<f64>) -> String {
+    match value {
+        Some(v) => format!("{v:.1}%"),
+        None => "N/A".to_string(),
+    }
+}
+
+/// Format a temperature value as `"<val>°C"` or `"N/A"`.
+fn format_temp(value: Option<f64>) -> String {
+    match value {
+        Some(v) => format!("{v:.0}°C"),
+        None => "N/A".to_string(),
+    }
+}
+
+/// Convert uptime seconds into a human-readable string.
+///
+/// Format: `"Xd Xh Xm"` for multi-day, `"Xh Xm"` for multi-hour, `"Xm Xs"` otherwise.
+fn format_uptime(secs: u64) -> String {
+    let days = secs / 86400;
+    let hours = (secs % 86400) / 3600;
+    let mins = (secs % 3600) / 60;
+    let remaining_secs = secs % 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h {mins}m")
+    } else if hours > 0 {
+        format!("{hours}h {mins}m")
+    } else {
+        format!("{mins}m {remaining_secs}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_uptime_seconds_only() {
+        assert_eq!(format_uptime(45), "0m 45s");
+        assert_eq!(format_uptime(0), "0m 0s");
+    }
+
+    #[test]
+    fn test_format_uptime_minutes() {
+        assert_eq!(format_uptime(90), "1m 30s");
+        assert_eq!(format_uptime(3599), "59m 59s");
+    }
+
+    #[test]
+    fn test_format_uptime_hours() {
+        assert_eq!(format_uptime(3600), "1h 0m");
+        assert_eq!(format_uptime(7384), "2h 3m");
+        assert_eq!(format_uptime(86399), "23h 59m");
+    }
+
+    #[test]
+    fn test_format_uptime_days() {
+        assert_eq!(format_uptime(86400), "1d 0h 0m");
+        assert_eq!(format_uptime(172861), "2d 0h 1m");
+        assert_eq!(format_uptime(263845), "3d 1h 17m");
+    }
+
+    #[test]
+    fn test_format_pct_some() {
+        assert_eq!(format_pct(Some(0.0)), "0.0%");
+        assert_eq!(format_pct(Some(75.5)), "75.5%");
+        assert_eq!(format_pct(Some(100.0)), "100.0%");
+    }
+
+    #[test]
+    fn test_format_pct_none() {
+        assert_eq!(format_pct(None), "N/A");
+    }
+
+    #[test]
+    fn test_format_temp_some() {
+        assert_eq!(format_temp(Some(72.0)), "72°C");
+        assert_eq!(format_temp(Some(72.9)), "73°C"); // rounds
+    }
+
+    #[test]
+    fn test_format_temp_none() {
+        assert_eq!(format_temp(None), "N/A");
+    }
+
+    #[test]
+    fn test_draw_local_header_bar_does_not_panic_empty_state() {
+        use crate::app_state::AppState;
+        let state = AppState::new();
+        let mut buf: Vec<u8> = Vec::new();
+        // Should complete without panic even when all history is empty
+        draw_local_header_bar(&mut buf, &state, 80);
+    }
+
+    #[test]
+    fn test_draw_local_header_bar_with_history() {
+        use crate::app_state::AppState;
+        let mut state = AppState::new();
+        // Populate some history to exercise the sparkline path
+        for i in 0..10 {
+            state.cpu_utilization_history.push_back(i as f64 * 10.0);
+            state.utilization_history.push_back(i as f64 * 8.0);
+            state.system_memory_history.push_back(i as f64 * 5.0);
+            state
+                .cpu_temperature_history
+                .push_back(40.0 + i as f64 * 3.0);
+        }
+        let mut buf: Vec<u8> = Vec::new();
+        draw_local_header_bar(&mut buf, &state, 120);
+        // Buffer must be non-empty
+        assert!(!buf.is_empty());
+    }
+}

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -274,9 +274,9 @@ fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
 
     let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some((0.0, 100.0)));
 
-    // Color: use progress_bar_color with a rough power fraction (normalized to 300 W max)
-    // to get a meaningful red/yellow/green gradient without requiring a max-power config.
-    let power_color = Color::Red;
+    // Sparkline color: use ThemeConfig::utilization_color on the proxy GPU
+    // utilization value, consistent with how CPU/GPU/Temp sparklines are colored.
+    let power_color = ThemeConfig::utilization_color(history.last().copied().unwrap_or(0.0));
 
     print_colored_text(stdout, "Pwr", Color::Red, None, None);
     print_colored_text(stdout, " ", Color::White, None, None);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,6 +19,7 @@ pub mod constants;
 pub mod dashboard;
 pub mod help;
 pub mod layout;
+pub mod local_header;
 pub mod notification;
 pub mod process_renderer;
 pub mod renderer;

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -33,6 +33,7 @@ use crate::device::ProcessInfo;
 use crate::ui::buffer::BufferWriter;
 use crate::ui::dashboard::{draw_dashboard_items, draw_system_view};
 use crate::ui::layout::LayoutCalculator;
+use crate::ui::local_header::draw_local_header_bar;
 use crate::ui::renderer::{
     print_chassis_info, print_cpu_info, print_function_keys, print_gpu_info,
     print_loading_indicator, print_memory_info, print_process_info, print_storage_info,
@@ -155,7 +156,11 @@ impl FrameRenderer {
         // any --hosts / --hostfile argument is supplied (see the assignment sites in
         // `src/view/runner.rs::run_view_mode` / `run_local_mode`), so a single remote
         // host still shows these widgets.
-        if !view_state.is_local_mode {
+        //
+        // In local mode we show the compact two-line host summary bar instead.
+        if view_state.is_local_mode {
+            draw_local_header_bar(&mut buffer, &view_state, cols);
+        } else {
             // Write remaining header content to buffer
             print_colored_text(&mut buffer, "Cluster Overview\r\n", Color::Cyan, None, None);
             draw_system_view(&mut buffer, &view_state, cols);


### PR DESCRIPTION
## Summary

- Add `src/ui/local_header.rs` with `draw_local_header_bar()` that renders in local mode in place of Cluster Overview
- Line 1: `Host <hostname> · <cpu_model> · arch <arch> · up <uptime>    ● Live` with blinking indicator based on `frame_counter`
- Line 2: `CPU <pct>%`, `GPU <pct>%`, `RAM <used>/<total>GB`, `Pwr <W>W`, `Tmp <°C>°C` — each with 8-cell braille sparklines from `sparkline_braille()`
- Colors come from `ThemeConfig` (Cyan for CPU, Blue for GPU, Green for RAM, Red for Power, Magenta for Temp) — not hardcoded
- Apple Silicon: reads `combined_power_mw` from `gpu.detail`; Linux/NVIDIA: sums `gpu.power_consumption`
- Layout header line count updated (+2) so content area remains correctly sized
- Uptime uses `sysinfo::System::uptime()` (already a dependency, cross-platform)

Closes #155
Part of #152

## Test plan

- [ ] Build passes (`cargo build`)
- [ ] Tests pass (`cargo test`) — 10 new unit tests in `local_header.rs`
- [ ] Clippy clean (`cargo clippy`)
- [ ] Local mode shows host summary bar (identity + sparklines) instead of Cluster Overview
- [ ] Sparklines render correctly for all 5 metrics
- [ ] Colors come from ThemeConfig, not hardcoded
- [ ] Live indicator blinks (alternates between bright/dark green)
- [ ] Uptime formatted correctly (Xd Xh Xm / Xh Xm / Xm Xs)
- [ ] Layout content area not clipped (process list and GPU rows still fit)