### PR TITLE
fix(ui): local mode Activity panel polish — border off-by-one, P/E gauge alignment, @hostname suppression, ANE row always-on, and Processes header restyle

### DIFF
--- a/src/ui/activity_panel.rs
+++ b/src/ui/activity_panel.rs
@@ -211,7 +211,7 @@ fn draw_panel_bottom_border<W: Write>(stdout: &mut W, panel_width: usize, _full_
     let inner_width = panel_width.saturating_sub(4); // 2 margin + 2 corners
     print_colored_text(stdout, "  ", Color::White, None, None);
     print_colored_text(stdout, "\u{2570}", Color::Cyan, None, None);
-    for _ in 0..(inner_width + 1) {
+    for _ in 0..inner_width {
         print_colored_text(stdout, "\u{2500}", Color::Cyan, None, None);
     }
     print_colored_text(stdout, "\u{256f}", Color::Cyan, None, None);
@@ -371,13 +371,19 @@ fn draw_pe_cluster_bars<W: Write>(
         .filter(|c| c.core_type == CoreType::Efficiency)
         .collect();
 
+    // Compute one shared bar_width using the larger block section so that
+    // P-CPU and E-CPU gauges end at the same column.
+    let p_block_width = p_cores.len() + (p_cores.len() / 4);
+    let e_block_width = e_cores.len() + (e_cores.len() / 4);
+    let shared_bar_width = content_width.saturating_sub(p_block_width.max(e_block_width) + 2);
+
     // P-cluster line: bar + utilization blocks
     draw_cluster_line(
         stdout,
         "P-CPU",
         apple.p_core_utilization,
         &p_cores,
-        content_width,
+        shared_bar_width,
         panel_width,
     );
 
@@ -387,7 +393,7 @@ fn draw_pe_cluster_bars<W: Write>(
         "E-CPU",
         apple.e_core_utilization,
         &e_cores,
-        content_width,
+        shared_bar_width,
         panel_width,
     );
 }
@@ -397,17 +403,13 @@ fn draw_cluster_line<W: Write>(
     label: &str,
     utilization: f64,
     cores: &[&CoreUtilization],
-    content_width: usize,
+    bar_width: usize,
     panel_width: usize,
 ) {
     print_colored_text(stdout, "  ", Color::White, None, None);
     print_colored_text(stdout, "\u{2502} ", Color::Cyan, None, None);
 
-    // Calculate how much space the utilization blocks need
-    let block_section_width = cores.len() + (cores.len() / 4); // blocks + group separators
-    let bar_width = content_width.saturating_sub(block_section_width + 2); // 2 for spacing
-
-    // Draw the progress bar
+    // Draw the progress bar using the pre-computed shared bar_width
     draw_bar(stdout, label, utilization, 100.0, bar_width, None);
     print_colored_text(stdout, " ", Color::White, None, None);
 

--- a/src/ui/gpu_sparkline_panel.rs
+++ b/src/ui/gpu_sparkline_panel.rs
@@ -409,7 +409,6 @@ fn show_ane_row(state: &AppState) -> bool {
 /// Currently returns `false` -- no Intel/Windows NPU reader exists yet.
 /// When an NPU telemetry reader is added (Meteor Lake / Core Ultra),
 /// flip this to check for NPU presence via `src/api/metrics/npu/common.rs`.
-#[allow(clippy::unnecessary_wraps)]
 fn show_npu_row(_state: &AppState) -> bool {
     false
 }

--- a/src/ui/gpu_sparkline_panel.rs
+++ b/src/ui/gpu_sparkline_panel.rs
@@ -70,10 +70,10 @@ pub fn gpu_content_rows(state: &AppState) -> usize {
     if state.gpu_info.is_empty() {
         return 0;
     }
-    let is_apple = detect_apple_silicon(state);
-    let has_ane = is_apple && has_ane_data(state);
-    // GPU Util + GPU Mem + GPU Temp + (ANE?) + Pkg Power
-    3 + usize::from(has_ane) + 1
+    let ane = show_ane_row(state);
+    let npu = show_npu_row(state);
+    // GPU Util + GPU Mem + GPU Temp + (ANE?) + (NPU?) + Pkg Power
+    3 + usize::from(ane) + usize::from(npu) + 1
 }
 
 /// Render the combined Activity panel (CPU left half + GPU right half).
@@ -156,8 +156,9 @@ fn render_gpu_lines(state: &AppState, panel_width: usize) -> Vec<String> {
     }
 
     let is_apple = detect_apple_silicon(state);
-    let has_ane = is_apple && has_ane_data(state);
-    let rows = build_rows(state, is_apple, has_ane);
+    let ane = show_ane_row(state);
+    let npu = show_npu_row(state);
+    let rows = build_rows(state, is_apple, ane, npu);
 
     let mut lines: Vec<String> = Vec::with_capacity(rows.len() + 2);
 
@@ -210,8 +211,8 @@ struct SparklineRow {
 // Row construction
 // ---------------------------------------------------------------------------
 
-fn build_rows(state: &AppState, is_apple: bool, has_ane: bool) -> Vec<SparklineRow> {
-    let mut rows = Vec::with_capacity(5);
+fn build_rows(state: &AppState, is_apple: bool, has_ane: bool, has_npu: bool) -> Vec<SparklineRow> {
+    let mut rows = Vec::with_capacity(6);
 
     // 1. GPU Utilization
     // Collect once; clone for power-proxy row to avoid a second VecDeque iteration.
@@ -254,7 +255,7 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool) -> Vec<SparklineR
         badge: None,
     });
 
-    // 4. ANE (Apple Silicon only, when data is present)
+    // 4. ANE (Apple Silicon -- always shown regardless of current power)
     if has_ane {
         let ane_mw = state
             .gpu_info
@@ -270,6 +271,19 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool) -> Vec<SparklineR
             latest_str: format!("{ane_w:.1}W"),
             min_max_str: String::new(),
             history: ane_history,
+            range: None,
+            badge: None,
+        });
+    }
+
+    // 4b. NPU (Intel/Windows -- scaffolding for future NPU reader)
+    if has_npu {
+        rows.push(SparklineRow {
+            label: "NPU",
+            color: Color::Yellow,
+            latest_str: "0.0W".to_string(),
+            min_max_str: String::new(),
+            history: vec![0.0],
             range: None,
             badge: None,
         });
@@ -380,12 +394,24 @@ fn detect_apple_silicon(state: &AppState) -> bool {
     })
 }
 
-fn has_ane_data(state: &AppState) -> bool {
-    state
-        .gpu_info
-        .first()
-        .map(|g| g.ane_utilization > 0.0)
-        .unwrap_or(false)
+/// Whether the ANE row should be shown in the GPU Metrics panel.
+///
+/// Returns `true` on Apple Silicon regardless of current ANE power.
+/// An ANE at 0 W is a meaningful "idle" reading and the row is
+/// load-bearing for platform identity even when the Neural Engine
+/// is completely idle.
+fn show_ane_row(state: &AppState) -> bool {
+    detect_apple_silicon(state)
+}
+
+/// Whether an NPU row should be shown in the GPU Metrics panel.
+///
+/// Currently returns `false` -- no Intel/Windows NPU reader exists yet.
+/// When an NPU telemetry reader is added (Meteor Lake / Core Ultra),
+/// flip this to check for NPU presence via `src/api/metrics/npu/common.rs`.
+#[allow(clippy::unnecessary_wraps)]
+fn show_npu_row(_state: &AppState) -> bool {
+    false
 }
 
 fn package_power(state: &AppState, is_apple: bool) -> (f64, &'static str) {
@@ -631,9 +657,31 @@ mod tests {
     }
 
     #[test]
-    fn test_has_ane_data() {
-        assert!(!has_ane_data(&make_nvidia_state()));
-        assert!(has_ane_data(&make_apple_silicon_state()));
+    fn test_show_ane_row() {
+        assert!(!show_ane_row(&make_nvidia_state()));
+        assert!(show_ane_row(&make_apple_silicon_state()));
+    }
+
+    #[test]
+    fn test_show_ane_row_even_when_ane_idle() {
+        // ANE row should be shown even when ane_utilization is 0
+        let mut state = make_apple_silicon_state();
+        state.gpu_info[0].ane_utilization = 0.0;
+        assert!(show_ane_row(&state));
+    }
+
+    #[test]
+    fn test_show_npu_row_returns_false() {
+        assert!(!show_npu_row(&make_nvidia_state()));
+        assert!(!show_npu_row(&make_apple_silicon_state()));
+    }
+
+    #[test]
+    fn test_gpu_content_rows_apple_with_zero_ane_still_shows_row() {
+        let mut state = make_apple_silicon_state();
+        state.gpu_info[0].ane_utilization = 0.0;
+        // GPU Util + GPU Mem + GPU Temp + ANE (always-on) + Pkg Power = 5
+        assert_eq!(gpu_content_rows(&state), 5);
     }
 
     #[test]
@@ -667,7 +715,7 @@ mod tests {
     #[test]
     fn test_build_rows_nvidia() {
         let state = make_nvidia_state();
-        let rows = build_rows(&state, false, false);
+        let rows = build_rows(&state, false, false, false);
         assert_eq!(rows.len(), 4);
         assert_eq!(rows[0].label, "GPU Util");
         assert_eq!(rows[1].label, "GPU Mem");
@@ -679,12 +727,21 @@ mod tests {
     #[test]
     fn test_build_rows_apple_silicon() {
         let state = make_apple_silicon_state();
-        let rows = build_rows(&state, true, true);
+        let rows = build_rows(&state, true, true, false);
         assert_eq!(rows.len(), 5);
         assert_eq!(rows[0].label, "GPU Util");
         assert_eq!(rows[3].label, "ANE");
         assert_eq!(rows[4].label, "Pkg Power");
         assert!(rows[2].badge.is_none());
+    }
+
+    #[test]
+    fn test_build_rows_with_npu_scaffolding() {
+        let state = make_nvidia_state();
+        let rows = build_rows(&state, false, false, true);
+        assert_eq!(rows.len(), 5);
+        assert_eq!(rows[3].label, "NPU");
+        assert_eq!(rows[4].label, "GPU Power");
     }
 
     #[test]

--- a/src/ui/gpu_sparkline_panel.rs
+++ b/src/ui/gpu_sparkline_panel.rs
@@ -31,9 +31,7 @@
 //! | ANE       | `gpu.ane_utilization` (mW)     | Yellow  |
 //! | Pkg Power | `combined_power_mw` / board pwr| Red     |
 //!
-//! The ANE row is only shown on Apple Silicon when `ane_utilization > 0`.
-//! The thermal pressure badge is appended to the GPU Temp row on Apple
-//! Silicon when the `thermal_pressure` detail key is present.
+//! The ANE row is shown on Apple Silicon regardless of current ANE power.
 //!
 //! ## Rendering model
 //!
@@ -246,11 +244,6 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool) -> Vec<SparklineR
     // 3. GPU Temperature
     let gpu_temp: Vec<f64> = state.temperature_history.iter().copied().collect();
     let latest_temp = gpu_temp.last().copied().unwrap_or(0.0);
-    let thermal_badge = if is_apple {
-        thermal_pressure_badge(state)
-    } else {
-        None
-    };
     rows.push(SparklineRow {
         label: "GPU Temp",
         color: Color::Magenta,
@@ -258,7 +251,7 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool) -> Vec<SparklineR
         min_max_str: min_max_badge(&gpu_temp),
         history: gpu_temp,
         range: None, // auto-range: temperature varies
-        badge: thermal_badge,
+        badge: None,
     });
 
     // 4. ANE (Apple Silicon only, when data is present)
@@ -395,23 +388,6 @@ fn has_ane_data(state: &AppState) -> bool {
         .unwrap_or(false)
 }
 
-fn thermal_pressure_badge(state: &AppState) -> Option<(String, Color)> {
-    state
-        .gpu_info
-        .first()
-        .and_then(|gpu| gpu.detail.get("thermal_pressure"))
-        .map(|level| {
-            let color = match level.as_str() {
-                "Nominal" => Color::Green,
-                "Fair" => Color::Yellow,
-                "Serious" => Color::Red,
-                "Critical" => Color::DarkRed,
-                _ => Color::DarkGrey,
-            };
-            (level.clone(), color)
-        })
-}
-
 fn package_power(state: &AppState, is_apple: bool) -> (f64, &'static str) {
     if is_apple {
         // Apple Silicon: combined CPU+GPU+ANE power from native metrics
@@ -515,7 +491,6 @@ mod tests {
 
         let mut detail = HashMap::new();
         detail.insert("architecture".to_string(), "Apple Silicon".to_string());
-        detail.insert("thermal_pressure".to_string(), "Nominal".to_string());
         detail.insert("combined_power_mw".to_string(), "12500".to_string());
 
         state.gpu_info.push(GpuInfo {
@@ -662,21 +637,6 @@ mod tests {
     }
 
     #[test]
-    fn test_thermal_pressure_badge_nominal() {
-        let state = make_apple_silicon_state();
-        let badge = thermal_pressure_badge(&state);
-        assert!(badge.is_some());
-        let (text, color) = badge.unwrap();
-        assert_eq!(text, "Nominal");
-        assert_eq!(color, Color::Green);
-    }
-
-    #[test]
-    fn test_thermal_pressure_badge_none_on_nvidia() {
-        assert!(thermal_pressure_badge(&make_nvidia_state()).is_none());
-    }
-
-    #[test]
     fn test_package_power_apple_silicon() {
         let state = make_apple_silicon_state();
         let (watts, label) = package_power(&state, true);
@@ -724,7 +684,7 @@ mod tests {
         assert_eq!(rows[0].label, "GPU Util");
         assert_eq!(rows[3].label, "ANE");
         assert_eq!(rows[4].label, "Pkg Power");
-        assert!(rows[2].badge.is_some());
+        assert!(rows[2].badge.is_none());
     }
 
     #[test]

--- a/src/ui/process_renderer.rs
+++ b/src/ui/process_renderer.rs
@@ -56,9 +56,22 @@ pub fn print_process_info<W: Write>(
     sort_direction: &crate::app_state::SortDirection,
 ) {
     // Don't add extra newlines at the start - the caller should handle positioning
-    queue!(stdout, Print("Processes:\r\n")).unwrap();
-
     let width = cols as usize;
+
+    // Styled title line: "── Processes ───────────────────────"
+    print_colored_text(stdout, "\u{2500}\u{2500} ", Color::Cyan, None, None);
+    print_colored_text(stdout, "Processes", Color::Cyan, None, None);
+    print_colored_text(stdout, " ", Color::DarkGrey, None, None);
+    let title_prefix_cols = 3 + "Processes".len() + 1; // "── Processes "
+    let dashes = width.saturating_sub(title_prefix_cols);
+    print_colored_text(
+        stdout,
+        &"\u{2500}".repeat(dashes),
+        Color::DarkGrey,
+        None,
+        None,
+    );
+    queue!(stdout, Print("\r\n")).unwrap();
 
     // Fixed column widths based on actual data sizes
     // PID: 7 (up to 9999999), USER: 12, PRI: 3, NI: 3, VIRT: 6, RES: 6, S: 1,

--- a/src/ui/process_renderer.rs
+++ b/src/ui/process_renderer.rs
@@ -191,7 +191,7 @@ pub fn print_process_info<W: Write>(
     let footer_rows = 2usize; // "Showing..." line + "Active..." stats line
 
     // Calculate how many processes we can display
-    // Reserve rows for header section: 1 for "Processes:" title, 1 for header, 1 for separator, 1 for blank line
+    // Reserve rows for header section: 1 for styled title rule, 1 for header, 1 for separator, 1 for blank line
     const RESERVED_HEADER_ROWS: usize = 4;
     let available_rows_for_processes =
         (available_rows as usize).saturating_sub(RESERVED_HEADER_ROWS + footer_rows);

--- a/src/ui/renderers/cpu_renderer.rs
+++ b/src/ui/renderers/cpu_renderer.rs
@@ -229,6 +229,7 @@ fn render_cpu_visualization<W: Write>(
 }
 
 /// Render CPU information including model, cores, frequency, and utilization
+#[allow(clippy::too_many_arguments)]
 pub fn print_cpu_info<W: Write>(
     stdout: &mut W,
     _index: usize,
@@ -237,6 +238,7 @@ pub fn print_cpu_info<W: Write>(
     show_per_core: bool,
     cpu_name_scroll_offset: usize,
     hostname_scroll_offset: usize,
+    show_hostname: bool,
 ) {
     // Format CPU name with scrolling if needed (same as GPU: 15 chars)
     let cpu_name = if info.cpu_model.len() > 15 {
@@ -253,14 +255,14 @@ pub fn print_cpu_info<W: Write>(
         format!("{:<15}", info.cpu_model)
     };
 
-    // Format hostname with scrolling if needed (same as GPU: 9 chars)
-    let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
-
     // Print CPU info line
     print_colored_text(stdout, "CPU  ", Color::Cyan, None, None);
     print_colored_text(stdout, &cpu_name, Color::White, None, None);
-    print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
-    print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    if show_hostname {
+        let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
+        print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
+        print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    }
     print_colored_text(stdout, " Arch:", Color::Yellow, None, None);
     print_colored_text(stdout, &info.architecture, Color::White, None, None);
     print_colored_text(stdout, " Sockets:", Color::Yellow, None, None);

--- a/src/ui/renderers/cpu_renderer.rs
+++ b/src/ui/renderers/cpu_renderer.rs
@@ -608,3 +608,166 @@ pub fn print_cpu_info<W: Write>(
         queue!(stdout, Print("\r\n")).unwrap();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{AppleSiliconCpuInfo, CoreType, CoreUtilization, CpuPlatformType};
+
+    fn make_standard_cpu(hostname: &str, core_count: usize) -> CpuInfo {
+        let per_core: Vec<CoreUtilization> = (0..core_count)
+            .map(|i| CoreUtilization {
+                core_id: i as u32,
+                core_type: CoreType::Standard,
+                utilization: (i as f64 * 10.0) % 100.0,
+            })
+            .collect();
+
+        CpuInfo {
+            host_id: "localhost".to_string(),
+            hostname: hostname.to_string(),
+            instance: String::new(),
+            cpu_model: "Test CPU".to_string(),
+            architecture: "x86_64".to_string(),
+            platform_type: CpuPlatformType::Intel,
+            socket_count: 1,
+            total_cores: core_count as u32,
+            total_threads: core_count as u32 * 2,
+            base_frequency_mhz: 3000,
+            max_frequency_mhz: 4000,
+            cache_size_mb: 16,
+            utilization: 50.0,
+            temperature: Some(65),
+            power_consumption: Some(95.0),
+            per_socket_info: Vec::new(),
+            apple_silicon_info: None,
+            per_core_utilization: per_core,
+            time: String::new(),
+        }
+    }
+
+    fn make_apple_silicon_cpu(hostname: &str) -> CpuInfo {
+        let mut per_core = Vec::new();
+        for i in 0..4 {
+            per_core.push(CoreUtilization {
+                core_id: i as u32,
+                core_type: CoreType::Efficiency,
+                utilization: 20.0 + i as f64 * 5.0,
+            });
+        }
+        for i in 0..8 {
+            per_core.push(CoreUtilization {
+                core_id: (4 + i) as u32,
+                core_type: CoreType::Performance,
+                utilization: 40.0 + i as f64 * 5.0,
+            });
+        }
+        CpuInfo {
+            host_id: "localhost".to_string(),
+            hostname: hostname.to_string(),
+            instance: String::new(),
+            cpu_model: "Apple M2 Pro".to_string(),
+            architecture: "arm64".to_string(),
+            platform_type: CpuPlatformType::AppleSilicon,
+            socket_count: 1,
+            total_cores: 12,
+            total_threads: 12,
+            base_frequency_mhz: 3490,
+            max_frequency_mhz: 3490,
+            cache_size_mb: 16,
+            utilization: 35.0,
+            temperature: None,
+            power_consumption: None,
+            per_socket_info: Vec::new(),
+            apple_silicon_info: Some(AppleSiliconCpuInfo {
+                p_core_count: 8,
+                e_core_count: 4,
+                gpu_core_count: 16,
+                p_core_utilization: 55.0,
+                e_core_utilization: 25.0,
+                ane_ops_per_second: None,
+                p_cluster_frequency_mhz: Some(3490),
+                e_cluster_frequency_mhz: Some(2420),
+                p_core_l2_cache_mb: Some(16),
+                e_core_l2_cache_mb: Some(4),
+            }),
+            per_core_utilization: per_core,
+            time: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_print_cpu_info_with_hostname() {
+        let info = make_standard_cpu("myhost", 8);
+        let mut buf: Vec<u8> = Vec::new();
+        print_cpu_info(&mut buf, 0, &info, 120, false, 0, 0, true);
+        let output = String::from_utf8_lossy(&buf);
+        assert!(output.contains("myhost"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_cpu_info_without_hostname() {
+        let info = make_standard_cpu("myhost", 8);
+        let mut buf: Vec<u8> = Vec::new();
+        print_cpu_info(&mut buf, 0, &info, 120, false, 0, 0, false);
+        let output = String::from_utf8_lossy(&buf);
+        // hostname is suppressed in local mode
+        assert!(!output.contains("@ myhost"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_cpu_info_apple_silicon_with_hostname() {
+        let info = make_apple_silicon_cpu("mac-host");
+        let mut buf: Vec<u8> = Vec::new();
+        print_cpu_info(&mut buf, 0, &info, 120, false, 0, 0, true);
+        let output = String::from_utf8_lossy(&buf);
+        assert!(output.contains("mac-host"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_cpu_info_apple_silicon_without_hostname() {
+        let info = make_apple_silicon_cpu("mac-host");
+        let mut buf: Vec<u8> = Vec::new();
+        print_cpu_info(&mut buf, 0, &info, 120, false, 0, 0, false);
+        let output = String::from_utf8_lossy(&buf);
+        assert!(!output.contains("@ mac-host"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_cpu_info_long_hostname_scrolls() {
+        let info = make_standard_cpu("very-long-hostname-value", 4);
+        let mut buf: Vec<u8> = Vec::new();
+        print_cpu_info(&mut buf, 0, &info, 120, false, 0, 5, true);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_format_hostname_with_scroll_short() {
+        assert_eq!(format_hostname_with_scroll("host", 0), "host     ");
+        assert_eq!(format_hostname_with_scroll("host", 99), "host     ");
+    }
+
+    #[test]
+    fn test_format_hostname_with_scroll_exact_nine() {
+        assert_eq!(format_hostname_with_scroll("localhost", 0), "localhost");
+    }
+
+    #[test]
+    fn test_format_hostname_with_scroll_long() {
+        let long = "very-long-hostname";
+        let result = format_hostname_with_scroll(long, 0);
+        assert_eq!(result.len(), 9);
+        assert_eq!(result, "very-long");
+
+        // After scrolling by the full cycle length, it wraps back
+        let scroll_len = long.len() + 3;
+        assert_eq!(
+            format_hostname_with_scroll(long, scroll_len),
+            format_hostname_with_scroll(long, 0)
+        );
+    }
+}

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -93,6 +93,7 @@ pub fn print_gpu_info<W: Write>(
     width: usize,
     device_name_scroll_offset: usize,
     hostname_scroll_offset: usize,
+    show_hostname: bool,
 ) {
     // Format device name with scrolling if needed
     let device_name = if info.name.len() > 15 {
@@ -109,9 +110,6 @@ pub fn print_gpu_info<W: Write>(
         format!("{:<15}", info.name)
     };
 
-    // Format hostname with scrolling if needed
-    let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
-
     // Calculate values
     let memory_gb = info.used_memory as f64 / (1024.0 * 1024.0 * 1024.0);
     let total_memory_gb = info.total_memory as f64 / (1024.0 * 1024.0 * 1024.0);
@@ -121,7 +119,7 @@ pub fn print_gpu_info<W: Write>(
         0.0
     };
 
-    // Print info line: <device_type> <name> @ <hostname> Util:4.0% Mem:25.2/128GB Temp:0°C Pwr:0.0W
+    // Print info line: <device_type> <name> [@ <hostname>] Util:4.0% Mem:25.2/128GB Temp:0°C Pwr:0.0W
     print_colored_text(
         stdout,
         &format!("{:<5}", info.device_type),
@@ -130,8 +128,11 @@ pub fn print_gpu_info<W: Write>(
         None,
     );
     print_colored_text(stdout, &device_name, Color::White, None, None);
-    print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
-    print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    if show_hostname {
+        let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
+        print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
+        print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    }
     print_colored_text(stdout, " Util:", Color::Yellow, None, None);
     let util_display = if info.utilization < 0.0 {
         format!("{:>6}", "N/A")

--- a/src/ui/renderers/memory_renderer.rs
+++ b/src/ui/renderers/memory_renderer.rs
@@ -61,19 +61,20 @@ pub fn print_memory_info<W: Write>(
     info: &MemoryInfo,
     width: usize,
     hostname_scroll_offset: usize,
+    show_hostname: bool,
 ) {
     // Convert bytes to GB for display
     let total_gb = info.total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
     let used_gb = info.used_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
     let available_gb = info.available_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
 
-    // Format hostname with scrolling if needed (same as GPU/CPU: 9 chars)
-    let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
-
     // Print Memory info line
     print_colored_text(stdout, "Host Memory         ", Color::Cyan, None, None);
-    print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
-    print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    if show_hostname {
+        let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
+        print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
+        print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    }
     print_colored_text(stdout, " Total:", Color::Green, None, None);
     print_colored_text(
         stdout,

--- a/src/ui/renderers/memory_renderer.rs
+++ b/src/ui/renderers/memory_renderer.rs
@@ -163,3 +163,66 @@ pub fn print_memory_info<W: Write>(
     print_colored_text(stdout, &" ".repeat(right_padding), Color::White, None, None);
     queue!(stdout, Print("\r\n")).unwrap();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::MemoryInfo;
+
+    fn make_memory_info(hostname: &str) -> MemoryInfo {
+        MemoryInfo {
+            host_id: "localhost".to_string(),
+            hostname: hostname.to_string(),
+            instance: String::new(),
+            total_bytes: 16 * 1024 * 1024 * 1024,
+            used_bytes: 8 * 1024 * 1024 * 1024,
+            available_bytes: 8 * 1024 * 1024 * 1024,
+            free_bytes: 4 * 1024 * 1024 * 1024,
+            buffers_bytes: 1 * 1024 * 1024 * 1024,
+            cached_bytes: 3 * 1024 * 1024 * 1024,
+            swap_total_bytes: 4 * 1024 * 1024 * 1024,
+            swap_used_bytes: 512 * 1024 * 1024,
+            swap_free_bytes: 3584 * 1024 * 1024,
+            utilization: 50.0,
+            time: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_print_memory_info_with_hostname() {
+        let info = make_memory_info("myhost");
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 120, 0, true);
+        let output = String::from_utf8_lossy(&buf);
+        assert!(output.contains("myhost"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_memory_info_without_hostname() {
+        let info = make_memory_info("myhost");
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 120, 0, false);
+        let output = String::from_utf8_lossy(&buf);
+        // hostname is suppressed in local mode
+        assert!(!output.contains("@ myhost"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_memory_info_long_hostname_scrolls() {
+        let info = make_memory_info("very-long-hostname-value");
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 120, 3, true);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_memory_info_narrow_width() {
+        let info = make_memory_info("host");
+        let mut buf: Vec<u8> = Vec::new();
+        // Should not panic with a narrow terminal width
+        print_memory_info(&mut buf, 0, &info, 30, 0, false);
+        assert!(!buf.is_empty());
+    }
+}

--- a/src/ui/renderers/storage_renderer.rs
+++ b/src/ui/renderers/storage_renderer.rs
@@ -61,6 +61,7 @@ pub fn print_storage_info<W: Write>(
     info: &StorageInfo,
     width: usize,
     hostname_scroll_offset: usize,
+    show_hostname: bool,
 ) {
     // Convert bytes to appropriate units
     let total_gb = info.total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
@@ -92,9 +93,11 @@ pub fn print_storage_info<W: Write>(
         None,
         None,
     );
-    print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
-    let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
-    print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    if show_hostname {
+        let hostname_display = format_hostname_with_scroll(&info.hostname, hostname_scroll_offset);
+        print_colored_text(stdout, " @ ", Color::DarkGreen, None, None);
+        print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    }
     print_colored_text(stdout, " Total:", Color::Green, None, None);
     print_colored_text(
         stdout,

--- a/src/ui/renderers/storage_renderer.rs
+++ b/src/ui/renderers/storage_renderer.rs
@@ -149,3 +149,86 @@ pub fn print_storage_info<W: Write>(
     print_colored_text(stdout, &" ".repeat(right_padding), Color::White, None, None); // dynamic right padding
     queue!(stdout, Print("\r\n")).unwrap();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::info::StorageInfo;
+
+    fn make_storage_info(hostname: &str, mount_point: &str) -> StorageInfo {
+        StorageInfo {
+            mount_point: mount_point.to_string(),
+            total_bytes: 500 * 1024 * 1024 * 1024,
+            available_bytes: 200 * 1024 * 1024 * 1024,
+            host_id: "localhost".to_string(),
+            hostname: hostname.to_string(),
+            index: 0,
+        }
+    }
+
+    #[test]
+    fn test_print_storage_info_with_hostname() {
+        let info = make_storage_info("myhost", "/");
+        let mut buf: Vec<u8> = Vec::new();
+        print_storage_info(&mut buf, 0, &info, 120, 0, true);
+        let output = String::from_utf8_lossy(&buf);
+        assert!(output.contains("myhost"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_storage_info_without_hostname() {
+        let info = make_storage_info("myhost", "/");
+        let mut buf: Vec<u8> = Vec::new();
+        print_storage_info(&mut buf, 0, &info, 120, 0, false);
+        let output = String::from_utf8_lossy(&buf);
+        // hostname is suppressed in local mode
+        assert!(!output.contains("@ myhost"));
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_storage_info_long_mount_point_truncated() {
+        let info = make_storage_info("host", "/very/long/mount/point/path/here");
+        let mut buf: Vec<u8> = Vec::new();
+        print_storage_info(&mut buf, 0, &info, 120, 0, false);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_storage_info_long_hostname_scrolls() {
+        let info = make_storage_info("very-long-hostname-value", "/data");
+        let mut buf: Vec<u8> = Vec::new();
+        print_storage_info(&mut buf, 0, &info, 120, 5, true);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_storage_info_does_not_panic_zero_total() {
+        let mut info = make_storage_info("host", "/");
+        info.total_bytes = 0;
+        info.available_bytes = 0;
+        let mut buf: Vec<u8> = Vec::new();
+        // Should not panic even when total_bytes is zero
+        print_storage_info(&mut buf, 0, &info, 80, 0, false);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_print_storage_info_terabyte_display() {
+        let info = StorageInfo {
+            mount_point: "/data".to_string(),
+            total_bytes: 2 * 1024 * 1024 * 1024 * 1024, // 2 TB
+            available_bytes: 1 * 1024 * 1024 * 1024 * 1024, // 1 TB available
+            host_id: "localhost".to_string(),
+            hostname: "host".to_string(),
+            index: 0,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        print_storage_info(&mut buf, 0, &info, 120, 0, false);
+        let output = String::from_utf8_lossy(&buf);
+        // Should render TB units
+        assert!(output.contains("TB") || output.contains("GB"));
+        assert!(!buf.is_empty());
+    }
+}

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -282,6 +282,7 @@ impl FrameRenderer {
                 cols as usize,
                 device_name_scroll_offset,
                 hostname_scroll_offset,
+                !view_state.is_local_mode,
             );
         }
     }
@@ -420,6 +421,7 @@ impl FrameRenderer {
                 false,
                 cpu_name_scroll_offset,
                 hostname_scroll_offset,
+                true,
             );
         }
 
@@ -431,7 +433,7 @@ impl FrameRenderer {
                 .get(&memory_info.host_id)
                 .copied()
                 .unwrap_or(0);
-            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
+            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset, true);
         }
 
         // Storage with scroll offset
@@ -447,7 +449,7 @@ impl FrameRenderer {
                 .get(&storage_info.host_id)
                 .copied()
                 .unwrap_or(0);
-            print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
+            print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset, true);
         }
     }
 
@@ -573,6 +575,7 @@ impl FrameRenderer {
                 false,
                 cpu_name_scroll_offset,
                 hostname_scroll_offset,
+                false,
             );
         }
 
@@ -583,7 +586,7 @@ impl FrameRenderer {
                 .get(&memory_info.host_id)
                 .copied()
                 .unwrap_or(0);
-            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset);
+            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset, false);
         }
 
         // Storage information for local mode
@@ -593,7 +596,14 @@ impl FrameRenderer {
                 .get(&storage_info.host_id)
                 .copied()
                 .unwrap_or(0);
-            print_storage_info(buffer, i, storage_info, width, hostname_scroll_offset);
+            print_storage_info(
+                buffer,
+                i,
+                storage_info,
+                width,
+                hostname_scroll_offset,
+                false,
+            );
         }
 
         // Process information for local mode (if available)

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -408,17 +408,24 @@ impl UiLoop {
             })
             .collect();
 
-        let gpu_hostname_updates: Vec<_> = state
-            .gpu_info
-            .iter()
-            .filter_map(|gpu| {
-                if gpu.hostname.len() > 9 && processed_hostnames.insert(gpu.host_id.clone()) {
-                    Some((gpu.host_id.clone(), gpu.hostname.len()))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        // Skip hostname scroll animation in local mode -- the hostname is
+        // not rendered on any device row, so advancing the offset would
+        // just burn CPU for no visible effect.
+        let gpu_hostname_updates: Vec<_> = if state.is_local_mode {
+            Vec::new()
+        } else {
+            state
+                .gpu_info
+                .iter()
+                .filter_map(|gpu| {
+                    if gpu.hostname.len() > 9 && processed_hostnames.insert(gpu.host_id.clone()) {
+                        Some((gpu.host_id.clone(), gpu.hostname.len()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
 
         // Collect CPU keys and lengths
         let cpu_updates: Vec<_> = state
@@ -434,17 +441,21 @@ impl UiLoop {
             })
             .collect();
 
-        let cpu_hostname_updates: Vec<_> = state
-            .cpu_info
-            .iter()
-            .filter_map(|cpu| {
-                if cpu.hostname.len() > 9 && processed_hostnames.insert(cpu.host_id.clone()) {
-                    Some((cpu.host_id.clone(), cpu.hostname.len()))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let cpu_hostname_updates: Vec<_> = if state.is_local_mode {
+            Vec::new()
+        } else {
+            state
+                .cpu_info
+                .iter()
+                .filter_map(|cpu| {
+                    if cpu.hostname.len() > 9 && processed_hostnames.insert(cpu.host_id.clone()) {
+                        Some((cpu.host_id.clone(), cpu.hostname.len()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
 
         // Apply GPU device name scroll updates in-place
         for (key, name_len) in gpu_updates {


### PR DESCRIPTION
## Summary

Fixes #165 — seven small but visible issues in the local-mode Activity panel and device list rendering on Apple Silicon.

- **Border off-by-one**: Fix CPU Cores panel bottom border emitting `panel_width + 1` columns instead of `panel_width`, which also broke the GPU Metrics panel alignment on the same row.
- **P/E gauge alignment**: Compute one shared `bar_width` in `draw_pe_cluster_bars` using the larger block section so P-CPU and E-CPU gauges end at the same column.
- **Thermal badge removal**: Drop the "Nominal" thermal pressure badge from the GPU Temp sparkline row. This also fixes the GPU Temp sparkline being shorter than the rows above it.
- **Hostname suppression**: Add `show_hostname: bool` parameter to `print_gpu_info`, `print_cpu_info`, `print_memory_info`, and `print_storage_info`. Skip `@ hostname` in local mode. Also skip hostname scroll animation in local mode.
- **ANE always-on**: Replace `has_ane_data` (gated on `ane_utilization > 0`) with `show_ane_row` returning true whenever Apple Silicon is detected. Add `show_npu_row` scaffolding for future Intel NPU support.
- **Processes header restyle**: Replace bare `Processes:` with styled title rule `── Processes ──────────`.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes (325 tests, 0 failures)
- [ ] Visual check: CPU Cores panel borders align top to bottom
- [ ] Visual check: P-CPU and E-CPU gauges end at the same column
- [ ] Visual check: GPU Temp sparkline same length as GPU Util/GPU Mem rows
- [ ] Visual check: `@ hostname` not shown on GPU/CPU/Memory/Disk rows in local mode
- [ ] Visual check: ANE row present in GPU Metrics panel even when idle
- [ ] Visual check: Processes section opens with styled title rule