### PR TITLE
fix(ui): stabilize local header metric row width to prevent jitter (#170)

### DIFF
--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -439,8 +439,9 @@ mod tests {
         for total in totals {
             let total_str = format!("{total:.0}");
             let w = total_str.len();
-            let len_0 = format!("{:>w$.0}/{total_str}GB", 0.0_f64).len();
-            let len_total = format!("{:>w$.0}/{total_str}GB", total).len();
+            let zero = 0.0_f64;
+            let len_0 = format!("{zero:>w$.0}/{total_str}GB").len();
+            let len_total = format!("{total:>w$.0}/{total_str}GB").len();
             assert_eq!(
                 len_0, len_total,
                 "RAM format width should be stable for total={total}"

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -204,7 +204,8 @@ fn draw_ram_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
     let used_gb = state.memory_info.iter().map(|m| m.used_bytes).sum::<u64>() as f64
         / (1024.0 * 1024.0 * 1024.0);
 
-    let value_str = format!("{used_gb:.0}/{total_gb:.0}GB");
+    let total_str = format!("{total_gb:.0}");
+    let value_str = format!("{used_gb:>width$.0}/{total_str}GB", width = total_str.len());
 
     let history: Vec<f64> = state.system_memory_history.iter().copied().collect();
 
@@ -250,7 +251,7 @@ fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
         state.gpu_info.iter().map(|g| g.power_consumption).sum()
     };
 
-    let value_str = format!("{power_watts:.1}W");
+    let value_str = format!("{power_watts:>5.1}W");
 
     let history: Vec<f64> = state.package_power_history.iter().copied().collect();
     let range = if history.is_empty() {
@@ -273,18 +274,24 @@ fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
 // ─── Formatting helpers ───────────────────────────────────────────────────────
 
 /// Format a `%` value as `"<val>%"` or `"N/A"` when missing.
+///
+/// The numeric part is right-aligned in a 5-char field, producing a
+/// consistent 6-display-column string: `"  0.0%"` through `"100.0%"`.
 fn format_pct(value: Option<f64>) -> String {
     match value {
-        Some(v) => format!("{v:.1}%"),
-        None => "N/A".to_string(),
+        Some(v) => format!("{v:>5.1}%"),
+        None => format!("{:>6}", "N/A"),
     }
 }
 
 /// Format a temperature value as `"<val>°C"` or `"N/A"`.
+///
+/// The numeric part is right-aligned in a 3-char field, producing a
+/// consistent 5-display-column string: `"  0°C"` through `"999°C"`.
 fn format_temp(value: Option<f64>) -> String {
     match value {
-        Some(v) => format!("{v:.0}°C"),
-        None => "N/A".to_string(),
+        Some(v) => format!("{v:>3.0}°C"),
+        None => format!("{:>5}", "N/A"),
     }
 }
 
@@ -338,25 +345,46 @@ mod tests {
 
     #[test]
     fn test_format_pct_some() {
-        assert_eq!(format_pct(Some(0.0)), "0.0%");
-        assert_eq!(format_pct(Some(75.5)), "75.5%");
+        assert_eq!(format_pct(Some(0.0)), "  0.0%");
+        assert_eq!(format_pct(Some(75.5)), " 75.5%");
         assert_eq!(format_pct(Some(100.0)), "100.0%");
     }
 
     #[test]
     fn test_format_pct_none() {
-        assert_eq!(format_pct(None), "N/A");
+        assert_eq!(format_pct(None), "   N/A");
     }
 
     #[test]
     fn test_format_temp_some() {
-        assert_eq!(format_temp(Some(72.0)), "72°C");
-        assert_eq!(format_temp(Some(72.9)), "73°C"); // rounds
+        assert_eq!(format_temp(Some(72.0)), " 72°C");
+        assert_eq!(format_temp(Some(72.9)), " 73°C"); // rounds
     }
 
     #[test]
     fn test_format_temp_none() {
-        assert_eq!(format_temp(None), "N/A");
+        assert_eq!(format_temp(None), "  N/A");
+    }
+
+    #[test]
+    fn test_format_pct_fixed_width() {
+        // All formatted percentages must have the same display width (6 chars)
+        let values = [0.0, 9.9, 10.0, 50.0, 99.9, 100.0];
+        let widths: Vec<usize> = values.iter().map(|&v| format_pct(Some(v)).len()).collect();
+        assert!(
+            widths.windows(2).all(|w| w[0] == w[1]),
+            "all pct widths should be equal: {widths:?}"
+        );
+    }
+
+    #[test]
+    fn test_format_temp_fixed_display_width() {
+        // Verify digit boundaries don't change width
+        // "°" is multi-byte UTF-8, so check specific expected values
+        assert_eq!(format_temp(Some(9.0)), "  9°C");
+        assert_eq!(format_temp(Some(10.0)), " 10°C");
+        assert_eq!(format_temp(Some(99.0)), " 99°C");
+        assert_eq!(format_temp(Some(100.0)), "100°C");
     }
 
     #[test]

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -387,6 +387,67 @@ mod tests {
         assert_eq!(format_temp(Some(100.0)), "100°C");
     }
 
+    /// Replicate the inline power formatting from [`draw_power_sparkline`] and
+    /// assert that all values produce a string of exactly 6 characters.
+    #[test]
+    fn test_format_power_fixed_width() {
+        // The inline formula is: format!("{power_watts:>5.1}W")
+        // 5-char numeric field + "W" = 6 chars total for 0.0 through 999.9 W.
+        let values = [0.0_f64, 9.9, 10.0, 99.9, 100.0, 999.9];
+        for &w in &values {
+            let s = format!("{w:>5.1}W");
+            assert_eq!(
+                s.len(),
+                6,
+                "power format for {w} should be 6 chars, got {s:?}"
+            );
+        }
+        // Spot-check specific expected strings
+        assert_eq!(format!("{:>5.1}W", 0.0_f64), "  0.0W");
+        assert_eq!(format!("{:>5.1}W", 10.5_f64), " 10.5W");
+        assert_eq!(format!("{:>5.1}W", 999.9_f64), "999.9W");
+    }
+
+    /// Replicate the inline RAM formatting from [`draw_ram_sparkline`] and
+    /// assert that the `used` field is always padded to the same width as
+    /// `total`, keeping the `/` separator in a fixed column.
+    #[test]
+    fn test_format_ram_fixed_separator_position() {
+        // The inline formula:
+        //   let total_str = format!("{total_gb:.0}");
+        //   format!("{used_gb:>width$.0}/{total_str}GB", width = total_str.len())
+        let cases: &[(f64, f64, &str)] = &[
+            // total=16 → 2-digit field → used is padded to width 2
+            (0.0, 16.0, " 0/16GB"),
+            (8.0, 16.0, " 8/16GB"),
+            (16.0, 16.0, "16/16GB"),
+            // total=128 → 3-digit field → used is padded to width 3
+            (0.0, 128.0, "  0/128GB"),
+            (64.0, 128.0, " 64/128GB"),
+            (128.0, 128.0, "128/128GB"),
+        ];
+        for &(used, total, expected) in cases {
+            let total_str = format!("{total:.0}");
+            let value_str = format!("{used:>width$.0}/{total_str}GB", width = total_str.len());
+            assert_eq!(
+                value_str, expected,
+                "RAM format for {used}/{total} GB should be {expected:?}, got {value_str:?}"
+            );
+        }
+        // All strings for a given total_gb must have the same byte length
+        let totals = [16.0_f64, 128.0];
+        for total in totals {
+            let total_str = format!("{total:.0}");
+            let w = total_str.len();
+            let len_0 = format!("{:>w$.0}/{total_str}GB", 0.0_f64).len();
+            let len_total = format!("{:>w$.0}/{total_str}GB", total).len();
+            assert_eq!(
+                len_0, len_total,
+                "RAM format width should be stable for total={total}"
+            );
+        }
+    }
+
     #[test]
     fn test_draw_local_header_bar_does_not_panic_empty_state() {
         use crate::app_state::AppState;


### PR DESCRIPTION
## Summary

- Right-align CPU/GPU percentage values in a 5-char numeric field → consistent 6-column string (`"  0.0%"` through `"100.0%"`)
- Right-align temperature values in a 3-char numeric field → consistent 5-column string (`"  0°C"` through `"999°C"`)
- Right-align power values in a 5-char numeric field → consistent 6-char string (`"  0.0W"` through `"999.9W"`)
- Pad the RAM `used` portion to the same digit-width as `total` so the separator `/` stays in a fixed column (e.g. always `" 0/16GB"` through `"16/16GB"`)

## Test plan

- [ ] `cargo test -p all-smi` passes — updated existing assertions and added `test_format_pct_fixed_width` and `test_format_temp_fixed_display_width` to assert stable byte-lengths across digit boundaries
- [ ] `cargo clippy` clean — no warnings
- [ ] `cargo fmt --check` clean — formatting unchanged
- [ ] Visual verification: run `./target/release/all-smi view` in local mode and confirm the metrics row does not shift left/right as values cross 9→10 or 99→100 boundaries

Closes #170