### PR TITLE
feat: add NVIDIA MIG (Multi-Instance GPU) monitoring

### DIFF
--- a/API.md
+++ b/API.md
@@ -156,6 +156,47 @@ NVIDIA vGPU metrics are emitted only on hosts with vGPU SR-IOV enabled. Non-vGPU
 - The `vgpu_vm_id` label carries the owning VM identifier so remote scrapers can reconstruct the same VM column shown in the TUI.
 - To simulate vGPU responses in development/testing without real vGPU hardware, set `ALL_SMI_MOCK_VGPU=1` when running with the `mock` feature.
 
+### NVIDIA MIG Metrics
+
+NVIDIA MIG (Multi-Instance GPU) metrics are emitted only on hosts where at least one GPU has MIG mode enabled or has active MIG instances. Non-MIG hosts produce no output for these metric families.
+
+#### Per-GPU MIG Mode
+
+| Metric                  | Description                                         | Unit  | Labels                                                          |
+|-------------------------|-----------------------------------------------------|-------|-----------------------------------------------------------------|
+| `all_smi_gpu_mig_mode`  | MIG mode per parent GPU (1=enabled, 0=disabled)     | gauge | `gpu_index`, `gpu_uuid`, `gpu`, `instance`, `host`             |
+
+#### Per-MIG-Instance Metrics
+
+| Metric                                    | Description                                           | Unit    | Labels                                                                                                                    |
+|-------------------------------------------|-------------------------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------|
+| `all_smi_mig_instance_utilization_gpu`    | Per-MIG-instance GPU SM utilization percentage (0-100)| percent | `gpu_index`, `gpu_uuid`, `gpu`, `instance`, `host`, `mig_instance`, `mig_uuid`, `mig_profile`, `gpu_instance_id`, `compute_instance_id` |
+| `all_smi_mig_instance_utilization_memory` | Per-MIG-instance memory bandwidth utilization (0-100) | percent | `gpu_index`, `gpu_uuid`, `gpu`, `instance`, `host`, `mig_instance`, `mig_uuid`, `mig_profile`, `gpu_instance_id`, `compute_instance_id` |
+| `all_smi_mig_instance_memory_used_bytes`  | Per-MIG-instance framebuffer memory used              | bytes   | `gpu_index`, `gpu_uuid`, `gpu`, `instance`, `host`, `mig_instance`, `mig_uuid`, `mig_profile`, `gpu_instance_id`, `compute_instance_id` |
+| `all_smi_mig_instance_memory_total_bytes` | Per-MIG-instance framebuffer memory total carve-out   | bytes   | `gpu_index`, `gpu_uuid`, `gpu`, `instance`, `host`, `mig_instance`, `mig_uuid`, `mig_profile`, `gpu_instance_id`, `compute_instance_id` |
+
+**Label descriptions for per-instance metrics:**
+
+| Label                | Description                                                                 |
+|----------------------|-----------------------------------------------------------------------------|
+| `gpu_index`          | Physical GPU index on the host                                              |
+| `gpu_uuid`           | UUID of the parent physical GPU                                             |
+| `gpu`                | Name of the parent GPU model                                                |
+| `instance`           | Prometheus instance label (hostname or host:port)                           |
+| `host`               | Hostname of the server                                                      |
+| `mig_instance`       | MIG instance ordinal index within the parent GPU                            |
+| `mig_uuid`           | UUID of the MIG compute instance (assigned by NVML)                         |
+| `mig_profile`        | MIG profile name (e.g. `1g.5gb`, `3g.20gb`, `7g.40gb`)                    |
+| `gpu_instance_id`    | NVML GPU instance ID; empty string when not reported by the driver          |
+| `compute_instance_id`| NVML compute instance ID; empty string when not reported by the driver      |
+
+**Notes:**
+- `all_smi_mig_instance_utilization_gpu` and `all_smi_mig_instance_utilization_memory` are emitted only when NVML reports utilization for that instance; the metric line is absent when the value is unavailable.
+- `gpu_instance_id` and `compute_instance_id` are emitted as empty string labels when NVML cannot report them, preserving round-trip fidelity in the remote parser.
+- MIG instances appear as nested rows under their parent GPU in the TUI, matched by `gpu_uuid` with a hostname+GPU-name fallback.
+- `all_smi_gpu_mig_mode` is emitted for every GPU that supports MIG (enabled or disabled), so consumers can detect mode transitions even when no instances are active.
+- To simulate MIG responses in development/testing without MIG hardware, set `ALL_SMI_MOCK_MIG=1` when running with the `mock` feature.
+
 ### NVIDIA Jetson Specific Metrics
 
 | Metric                    | Description                                 | Unit    | Labels                  |
@@ -578,6 +619,27 @@ all_smi_vgpu_scheduler_state == 2
 all_smi_vgpu_memory_utilization > 90
 ```
 
+### NVIDIA MIG Specific
+```promql
+# GPUs with MIG mode enabled
+all_smi_gpu_mig_mode == 1
+
+# MIG instances with high GPU SM utilization (> 80%)
+all_smi_mig_instance_utilization_gpu > 80
+
+# MIG framebuffer occupancy per instance
+all_smi_mig_instance_memory_used_bytes / all_smi_mig_instance_memory_total_bytes * 100
+
+# Count active MIG instances per parent GPU
+count by (gpu_uuid) (all_smi_mig_instance_memory_total_bytes)
+
+# MIG instances by profile type
+count by (mig_profile) (all_smi_mig_instance_memory_total_bytes)
+
+# Total memory carved out for MIG across the cluster
+sum(all_smi_mig_instance_memory_total_bytes)
+```
+
 ### AMD GPU Specific
 ```promql
 # AMD GPUs with high fan speed (potential cooling issues)
@@ -927,3 +989,10 @@ Higher update rates provide more real-time data but increase system load. For pr
     - Completely silent on non-vGPU hosts — no empty metric families are emitted
     - Requires NVIDIA vGPU-capable hardware and the GRID/vGPU driver stack
     - Set `ALL_SMI_MOCK_VGPU=1` (with `--features mock` build) to simulate vGPU data for development
+13. NVIDIA MIG metrics include:
+    - Per-GPU MIG mode status (`all_smi_gpu_mig_mode`); emitted for every MIG-capable GPU regardless of whether instances are active
+    - Per-instance SM utilization, memory bandwidth utilization, and framebuffer used/total bytes
+    - MIG profile name (`mig_profile`, e.g. `1g.5gb`, `3g.20gb`) and NVML instance IDs for correlating with `nvidia-smi mig`
+    - TUI renders MIG instances as nested rows under each parent GPU, matched by UUID with hostname+GPU-name fallback
+    - Completely silent on non-MIG hosts — no empty metric families are emitted
+    - Set `ALL_SMI_MOCK_MIG=1` (with `--features mock` build) to simulate MIG data for development

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ http://gpu-node3:9090
 - **Multi-GPU Support:** Handles multiple GPUs per system with individual monitoring
 - **Interactive Sorting:** Sort GPUs by utilization, memory usage, or default (hostname+index) order
 - **Platform-Specific Features:**
-  - NVIDIA: PCIe info, performance states (P0–P15), thermal thresholds (slowdown/shutdown/max-operating/acoustic), power limits, vGPU SR-IOV monitoring
+  - NVIDIA: PCIe info, performance states (P0–P15), thermal thresholds (slowdown/shutdown/max-operating/acoustic), power limits, vGPU SR-IOV monitoring, MIG (Multi-Instance GPU) monitoring with per-instance utilization and memory metrics
   - AMD: VRAM/GTT memory tracking, fan speed monitoring, GPU process detection with fdinfo
   - NVIDIA Jetson: DLA utilization monitoring
   - Apple Silicon: ANE power monitoring, thermal pressure levels
@@ -330,6 +330,7 @@ http://gpu-node3:9090
   - Platform-specific metric generation (NVIDIA, AMD, Apple Silicon, Jetson, Intel Gaudi, Google TPU, Tenstorrent, Rebellions, Furiosa)
   - Background metric updates with realistic variations
   - Set `ALL_SMI_MOCK_VGPU=1` to simulate NVIDIA vGPU SR-IOV data without real vGPU hardware
+  - Set `ALL_SMI_MOCK_MIG=1` to simulate NVIDIA MIG (Multi-Instance GPU) data without MIG hardware
 - **Performance Optimized:**
   - Template-based response generation
   - Efficient memory management
@@ -368,6 +369,7 @@ curl --unix-socket /tmp/all-smi.sock http://localhost/metrics
 Metrics are available at `http://localhost:9090/metrics` (TCP) or via Unix socket and include comprehensive hardware monitoring for:
 - **GPUs:** Utilization, memory, temperature, power, frequency (NVIDIA, AMD, Apple Silicon, Intel Gaudi, Google TPU, Tenstorrent)
 - **NVIDIA vGPUs:** Per-vGPU utilization, framebuffer memory, scheduler state, and SR-IOV host mode (emitted only on vGPU-enabled hosts)
+- **NVIDIA MIG:** Per-GPU MIG mode status and per-MIG-instance utilization, framebuffer memory used/total (emitted only on MIG-enabled hosts)
 - **CPUs:** Utilization, frequency, temperature, power (with P/E core metrics for Apple Silicon)
 - **Memory:** System and swap memory statistics
 - **Storage:** Disk usage information
@@ -467,6 +469,7 @@ fn main() -> Result<()> {
 | `get_process_info()` | `Vec<ProcessInfo>` | GPU process information |
 | `get_chassis_info()` | `Option<ChassisInfo>` | Node-level power and thermal info |
 | `get_vgpu_info()` | `Vec<VgpuHostInfo>` | NVIDIA vGPU host and per-instance metrics (empty on non-vGPU hosts) |
+| `get_mig_info()` | `Vec<MigGpuInfo>` | NVIDIA MIG per-GPU mode status and per-instance metrics (empty on non-MIG hosts) |
 
 ### Configuration
 
@@ -544,7 +547,7 @@ See the [LICENSE](./LICENSE) file for details.
 ## Changelog
 
 ### Recent Updates
-- **v0.21.0 (upcoming):** Add NVIDIA vGPU SR-IOV monitoring — per-vGPU utilization, framebuffer memory, scheduler state, and host mode exported as Prometheus metrics; TUI renders per-GPU vGPU sub-sections; remote parser reconstructs vGPU view from scraped metrics; mock server can simulate vGPU data via `ALL_SMI_MOCK_VGPU=1`. Add NVIDIA extended thermal monitoring — slowdown, shutdown, max-operating, and acoustic temperature thresholds exported as Prometheus metrics; TUI shows per-GPU thermal row with proximity highlighting (yellow within 5°C of slowdown, red within 2°C of shutdown); P-state (P0–P15) surfaced in TUI and metrics; all fields degrade gracefully to `None` on older drivers or non-NVIDIA hardware
+- **v0.21.0 (upcoming):** Add NVIDIA vGPU SR-IOV monitoring — per-vGPU utilization, framebuffer memory, scheduler state, and host mode exported as Prometheus metrics; TUI renders per-GPU vGPU sub-sections; remote parser reconstructs vGPU view from scraped metrics; mock server can simulate vGPU data via `ALL_SMI_MOCK_VGPU=1`. Add NVIDIA extended thermal monitoring — slowdown, shutdown, max-operating, and acoustic temperature thresholds exported as Prometheus metrics; TUI shows per-GPU thermal row with proximity highlighting (yellow within 5°C of slowdown, red within 2°C of shutdown); P-state (P0–P15) surfaced in TUI and metrics; all fields degrade gracefully to `None` on older drivers or non-NVIDIA hardware. Add NVIDIA MIG (Multi-Instance GPU) monitoring — per-GPU MIG mode status and per-MIG-instance SM utilization, memory bandwidth utilization, and framebuffer used/total bytes exported as Prometheus metrics; TUI renders MIG instances as nested rows under each parent GPU; remote parser reconstructs MIG view from scraped metrics; mock server can simulate MIG data via `ALL_SMI_MOCK_MIG=1`
 - **v0.20.1 (2026/04/10):** Fix local header metric row jitter by using fixed-width formatted fields; auto-promote pre-release to release in CI
 - **v0.20.0 (2026/04/10):** Redesign local-mode TUI with Activity panel featuring braille sparklines, CPU per-core view, host summary bar, and per-node LED grid; add Apple M5 Pro/Max Super core (S-CPU) support
 - **v0.19.0 (2026/04/08):** Fix Apple Silicon SMC float decoding to restore real CPU/GPU die temperatures, cache platform detection to avoid per-frame system_profiler on macOS, and fix TIME+/Command column alignment in process list

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -21,8 +21,8 @@ use crate::app_state::AppState;
 use super::metrics::{
     MetricExporter, chassis::ChassisMetricExporter, cpu::CpuMetricExporter,
     disk::DiskMetricExporter, gpu::GpuMetricExporter, memory::MemoryMetricExporter,
-    npu::NpuMetricExporter, process::ProcessMetricExporter, runtime::RuntimeMetricExporter,
-    vgpu::VgpuMetricExporter,
+    mig::MigMetricExporter, npu::NpuMetricExporter, process::ProcessMetricExporter,
+    runtime::RuntimeMetricExporter, vgpu::VgpuMetricExporter,
 };
 
 pub type SharedState = Arc<RwLock<AppState>>;
@@ -80,6 +80,13 @@ pub async fn metrics_handler(State(state): State<SharedState>) -> String {
     if !state.vgpu_info.is_empty() {
         let vgpu_exporter = VgpuMetricExporter::new(&state.vgpu_info);
         all_metrics.push_str(&vgpu_exporter.export_metrics());
+    }
+
+    // Export MIG metrics (NVIDIA datacenter GPUs with MIG enabled; silent
+    // no-op on consumer cards, pre-Ampere GPUs, and non-MIG hosts).
+    if !state.mig_info.is_empty() {
+        let mig_exporter = MigMetricExporter::new(&state.mig_info);
+        all_metrics.push_str(&mig_exporter.export_metrics());
     }
 
     all_metrics

--- a/src/api/metrics/mig.rs
+++ b/src/api/metrics/mig.rs
@@ -175,7 +175,7 @@ impl<'a> MigMetricExporter<'a> {
         rows
     }
 
-    fn instance_labels<'b>(row: &'b Row<'a>) -> [(&'b str, &'b str); 9] {
+    fn instance_labels<'b>(row: &'b Row<'a>) -> [(&'b str, &'b str); 10] {
         [
             ("gpu_index", row.gpu_index_str.as_str()),
             ("gpu_uuid", row.host.gpu_uuid.as_str()),
@@ -189,6 +189,7 @@ impl<'a> MigMetricExporter<'a> {
             // could not report them. The remote parser tolerates empty values
             // so that round-tripping stays lossless.
             ("gpu_instance_id", row.gpu_instance_id_str.as_str()),
+            ("compute_instance_id", row.compute_instance_id_str.as_str()),
         ]
     }
 }
@@ -203,12 +204,10 @@ struct Row<'a> {
     gpu_index_str: String,
     instance_id_str: String,
     /// Stringified `gpu_instance_id` (empty when NVML did not report it).
-    /// Currently unused at the label level but kept for forward compatibility
-    /// — emitted via [`MigMetricExporter::instance_labels`].
+    /// Emitted via [`MigMetricExporter::instance_labels`].
     gpu_instance_id_str: String,
-    /// Stringified `compute_instance_id`. Same forward-compatibility note as
-    /// above. Reserved for a future label rev that wants to expose it directly.
-    #[allow(dead_code)]
+    /// Stringified `compute_instance_id` (empty when NVML did not report it).
+    /// Emitted via [`MigMetricExporter::instance_labels`].
     compute_instance_id_str: String,
 }
 
@@ -285,6 +284,18 @@ mod tests {
         assert!(output.contains("mig_uuid=\"MIG-xxx\""));
         assert!(output.contains("mig_profile=\"1g.5gb\""));
         assert!(output.contains("gpu_instance_id=\"7\""));
+        assert!(output.contains("compute_instance_id=\"0\""));
+    }
+
+    #[test]
+    fn empty_compute_instance_id_renders_empty_string_label() {
+        let mut host = sample_host();
+        host.instances[0].compute_instance_id = None;
+        let hosts = vec![host];
+        let exporter = MigMetricExporter::new(&hosts);
+        let output = exporter.export_metrics();
+        // Empty label values are always present; the parser tolerates them.
+        assert!(output.contains("compute_instance_id=\"\""));
     }
 
     #[test]

--- a/src/api/metrics/mig.rs
+++ b/src/api/metrics/mig.rs
@@ -1,0 +1,342 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Prometheus exporter for NVIDIA MIG (Multi-Instance GPU) metrics.
+//!
+//! Metrics produced by this exporter:
+//!
+//! * `all_smi_gpu_mig_mode` (gauge): per parent GPU; `1` when MIG mode is
+//!   currently enabled, `0` otherwise.
+//! * `all_smi_mig_instance_utilization_gpu` (gauge, %): per-instance SM
+//!   utilization (0-100).
+//! * `all_smi_mig_instance_utilization_memory` (gauge, %): per-instance memory
+//!   bandwidth utilization (0-100).
+//! * `all_smi_mig_instance_memory_used_bytes` (gauge): per-instance framebuffer
+//!   used bytes.
+//! * `all_smi_mig_instance_memory_total_bytes` (gauge): per-instance
+//!   framebuffer carve-out total bytes.
+//!
+//! All metrics carry the labels `gpu_index`, `gpu_uuid`, `gpu`, `host`, and
+//! `instance` (the Prometheus instance label). Per-instance metrics also carry
+//! `mig_instance`, `mig_uuid`, `mig_profile`, and — when reported by NVML —
+//! `gpu_instance_id` and `compute_instance_id`.
+//!
+//! The exporter emits nothing when `mig_info` is empty — non-MIG hosts stay
+//! completely silent in the `/metrics` output, matching the vGPU exporter.
+
+use super::{MetricBuilder, MetricExporter};
+use crate::device::MigGpuInfo;
+
+pub struct MigMetricExporter<'a> {
+    pub mig_info: &'a [MigGpuInfo],
+}
+
+impl<'a> MigMetricExporter<'a> {
+    pub fn new(mig_info: &'a [MigGpuInfo]) -> Self {
+        Self { mig_info }
+    }
+
+    /// Numeric encoding of the MIG mode flag for Prometheus. Stable so
+    /// downstream dashboards can branch on the value.
+    fn mig_mode_code(enabled: bool) -> u32 {
+        if enabled { 1 } else { 0 }
+    }
+
+    fn export_host_info(&self, builder: &mut MetricBuilder) {
+        builder
+            .help(
+                "all_smi_gpu_mig_mode",
+                "NVIDIA MIG mode (1=enabled, 0=disabled) per parent GPU",
+            )
+            .type_("all_smi_gpu_mig_mode", "gauge");
+
+        for host in self.mig_info {
+            let gpu_index_str = host.gpu_index.to_string();
+            let labels = [
+                ("gpu_index", gpu_index_str.as_str()),
+                ("gpu_uuid", host.gpu_uuid.as_str()),
+                ("gpu", host.gpu_name.as_str()),
+                ("instance", host.instance.as_str()),
+                ("host", host.hostname.as_str()),
+            ];
+            builder.metric(
+                "all_smi_gpu_mig_mode",
+                &labels,
+                Self::mig_mode_code(host.mig_mode),
+            );
+        }
+    }
+
+    fn export_instance_metrics(&self, builder: &mut MetricBuilder) {
+        // Precompute the flattened host/instance rows once so the four
+        // per-instance metric families below iterate over borrowed slices
+        // without re-allocating the stringified indices per family. For
+        // N instances this reduces per-scrape allocations from
+        // 4*K*N to K*N (where K is the number of stringified labels per row).
+        let rows = self.collect_rows();
+        if rows.is_empty() {
+            return;
+        }
+
+        builder
+            .help(
+                "all_smi_mig_instance_utilization_gpu",
+                "Per-MIG-instance GPU SM utilization percentage (0-100)",
+            )
+            .type_("all_smi_mig_instance_utilization_gpu", "gauge");
+        for row in &rows {
+            if let Some(util) = row.instance.utilization_gpu {
+                let labels = Self::instance_labels(row);
+                builder.metric("all_smi_mig_instance_utilization_gpu", &labels, util);
+            }
+        }
+
+        builder
+            .help(
+                "all_smi_mig_instance_utilization_memory",
+                "Per-MIG-instance memory bandwidth utilization percentage (0-100)",
+            )
+            .type_("all_smi_mig_instance_utilization_memory", "gauge");
+        for row in &rows {
+            if let Some(util) = row.instance.utilization_memory {
+                let labels = Self::instance_labels(row);
+                builder.metric("all_smi_mig_instance_utilization_memory", &labels, util);
+            }
+        }
+
+        builder
+            .help(
+                "all_smi_mig_instance_memory_used_bytes",
+                "Per-MIG-instance framebuffer memory used in bytes",
+            )
+            .type_("all_smi_mig_instance_memory_used_bytes", "gauge");
+        for row in &rows {
+            let labels = Self::instance_labels(row);
+            builder.metric(
+                "all_smi_mig_instance_memory_used_bytes",
+                &labels,
+                row.instance.memory_used_bytes,
+            );
+        }
+
+        builder
+            .help(
+                "all_smi_mig_instance_memory_total_bytes",
+                "Per-MIG-instance framebuffer memory total carve-out in bytes",
+            )
+            .type_("all_smi_mig_instance_memory_total_bytes", "gauge");
+        for row in &rows {
+            let labels = Self::instance_labels(row);
+            builder.metric(
+                "all_smi_mig_instance_memory_total_bytes",
+                &labels,
+                row.instance.memory_total_bytes,
+            );
+        }
+    }
+
+    /// Flatten the nested host/instance structure into a single `Vec<Row>`
+    /// where each row borrows its host and instance and owns only the small
+    /// stringified id fields. Exists purely to amortize allocation across the
+    /// four per-instance metric families in `export_instance_metrics`.
+    fn collect_rows(&self) -> Vec<Row<'a>> {
+        let total: usize = self.mig_info.iter().map(|h| h.instances.len()).sum();
+        let mut rows = Vec::with_capacity(total);
+        for host in self.mig_info {
+            let gpu_index_str = host.gpu_index.to_string();
+            for instance in &host.instances {
+                rows.push(Row {
+                    host,
+                    instance,
+                    gpu_index_str: gpu_index_str.clone(),
+                    instance_id_str: instance.instance_id.to_string(),
+                    gpu_instance_id_str: instance
+                        .gpu_instance_id
+                        .map(|v| v.to_string())
+                        .unwrap_or_default(),
+                    compute_instance_id_str: instance
+                        .compute_instance_id
+                        .map(|v| v.to_string())
+                        .unwrap_or_default(),
+                });
+            }
+        }
+        rows
+    }
+
+    fn instance_labels<'b>(row: &'b Row<'a>) -> [(&'b str, &'b str); 9] {
+        [
+            ("gpu_index", row.gpu_index_str.as_str()),
+            ("gpu_uuid", row.host.gpu_uuid.as_str()),
+            ("gpu", row.host.gpu_name.as_str()),
+            ("instance", row.host.instance.as_str()),
+            ("host", row.host.hostname.as_str()),
+            ("mig_instance", row.instance_id_str.as_str()),
+            ("mig_uuid", row.instance.uuid.as_str()),
+            ("mig_profile", row.instance.profile_name.as_str()),
+            // GPU/compute instance ids are emitted as empty strings when NVML
+            // could not report them. The remote parser tolerates empty values
+            // so that round-tripping stays lossless.
+            ("gpu_instance_id", row.gpu_instance_id_str.as_str()),
+        ]
+    }
+}
+
+/// Borrowed view of a single `(host, instance)` pair used by
+/// `MigMetricExporter::export_instance_metrics`. Owns only the small
+/// stringified ids so that the per-instance metric families can iterate
+/// without re-allocating them.
+struct Row<'a> {
+    host: &'a MigGpuInfo,
+    instance: &'a crate::device::MigInstanceInfo,
+    gpu_index_str: String,
+    instance_id_str: String,
+    /// Stringified `gpu_instance_id` (empty when NVML did not report it).
+    /// Currently unused at the label level but kept for forward compatibility
+    /// — emitted via [`MigMetricExporter::instance_labels`].
+    gpu_instance_id_str: String,
+    /// Stringified `compute_instance_id`. Same forward-compatibility note as
+    /// above. Reserved for a future label rev that wants to expose it directly.
+    #[allow(dead_code)]
+    compute_instance_id_str: String,
+}
+
+impl<'a> MetricExporter for MigMetricExporter<'a> {
+    fn export_metrics(&self) -> String {
+        if self.mig_info.is_empty() {
+            return String::new();
+        }
+
+        let mut builder = MetricBuilder::new();
+        self.export_host_info(&mut builder);
+        self.export_instance_metrics(&mut builder);
+        builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{MigGpuInfo, MigInstanceInfo};
+
+    fn sample_host() -> MigGpuInfo {
+        MigGpuInfo {
+            host_id: "gpu-host".to_string(),
+            hostname: "gpu-host".to_string(),
+            instance: "gpu-host".to_string(),
+            gpu_index: 0,
+            gpu_uuid: "GPU-abc123".to_string(),
+            gpu_name: "NVIDIA A100".to_string(),
+            mig_mode: true,
+            instances: vec![MigInstanceInfo {
+                instance_id: 3,
+                gpu_instance_id: Some(7),
+                compute_instance_id: Some(0),
+                uuid: "MIG-xxx".to_string(),
+                profile_name: "1g.5gb".to_string(),
+                utilization_gpu: Some(75),
+                utilization_memory: Some(40),
+                memory_used_bytes: 1 << 30,
+                memory_total_bytes: 5 << 30,
+            }],
+        }
+    }
+
+    #[test]
+    fn exports_nothing_when_mig_info_empty() {
+        let exporter = MigMetricExporter::new(&[]);
+        assert_eq!(exporter.export_metrics(), "");
+    }
+
+    #[test]
+    fn exports_expected_metric_families() {
+        let hosts = vec![sample_host()];
+        let exporter = MigMetricExporter::new(&hosts);
+        let output = exporter.export_metrics();
+
+        assert!(output.contains("all_smi_gpu_mig_mode"));
+        assert!(output.contains("all_smi_mig_instance_utilization_gpu"));
+        assert!(output.contains("all_smi_mig_instance_utilization_memory"));
+        assert!(output.contains("all_smi_mig_instance_memory_used_bytes"));
+        assert!(output.contains("all_smi_mig_instance_memory_total_bytes"));
+    }
+
+    #[test]
+    fn exports_required_labels_for_instance_metrics() {
+        let hosts = vec![sample_host()];
+        let exporter = MigMetricExporter::new(&hosts);
+        let output = exporter.export_metrics();
+
+        assert!(output.contains("gpu_index=\"0\""));
+        assert!(output.contains("gpu_uuid=\"GPU-abc123\""));
+        assert!(output.contains("host=\"gpu-host\""));
+        assert!(output.contains("mig_instance=\"3\""));
+        assert!(output.contains("mig_uuid=\"MIG-xxx\""));
+        assert!(output.contains("mig_profile=\"1g.5gb\""));
+        assert!(output.contains("gpu_instance_id=\"7\""));
+    }
+
+    #[test]
+    fn mig_mode_emits_zero_for_disabled_parent_gpu() {
+        let mut host = sample_host();
+        host.mig_mode = false;
+        // is_mig_active is still true because instances is non-empty, so the
+        // host record still surfaces. The mode metric must report 0.
+        let hosts = vec![host];
+        let exporter = MigMetricExporter::new(&hosts);
+        let out = exporter.export_metrics();
+        assert!(out.contains("all_smi_gpu_mig_mode{"));
+        // The data line must end with " 0" for the disabled parent.
+        let mode_line = out
+            .lines()
+            .find(|l| l.starts_with("all_smi_gpu_mig_mode{"))
+            .expect("mode line present");
+        assert!(mode_line.ends_with(" 0"), "got line: {mode_line}");
+    }
+
+    #[test]
+    fn mig_mode_code_is_stable() {
+        assert_eq!(MigMetricExporter::mig_mode_code(false), 0);
+        assert_eq!(MigMetricExporter::mig_mode_code(true), 1);
+    }
+
+    #[test]
+    fn util_line_present_only_when_reported() {
+        let mut host = sample_host();
+        host.instances[0].utilization_gpu = None;
+        let hosts = vec![host];
+        let exporter = MigMetricExporter::new(&hosts);
+        let output = exporter.export_metrics();
+
+        // HELP/TYPE lines are always emitted, but no data line for utilization
+        // should be produced when the stat is unavailable.
+        assert!(output.contains("# HELP all_smi_mig_instance_utilization_gpu"));
+        let data_lines = output
+            .lines()
+            .filter(|l| l.starts_with("all_smi_mig_instance_utilization_gpu{"))
+            .count();
+        assert_eq!(data_lines, 0);
+    }
+
+    #[test]
+    fn empty_gpu_instance_id_renders_empty_string_label() {
+        let mut host = sample_host();
+        host.instances[0].gpu_instance_id = None;
+        let hosts = vec![host];
+        let exporter = MigMetricExporter::new(&hosts);
+        let output = exporter.export_metrics();
+        // Empty label values are always present; the parser tolerates them.
+        assert!(output.contains("gpu_instance_id=\"\""));
+    }
+}

--- a/src/api/metrics/mig.rs
+++ b/src/api/metrics/mig.rs
@@ -317,6 +317,37 @@ mod tests {
     }
 
     #[test]
+    fn mig_mode_emits_zero_when_disabled_and_no_instances() {
+        // Regression for the "disabled MIG is invisible" bug: a GPU row that
+        // supports MIG but has it turned off and therefore no instances must
+        // still produce an `all_smi_gpu_mig_mode{...} 0` line so consumers
+        // can observe the state transition.
+        let mut host = sample_host();
+        host.mig_mode = false;
+        host.instances.clear();
+        let hosts = vec![host];
+        let exporter = MigMetricExporter::new(&hosts);
+        let out = exporter.export_metrics();
+
+        let mode_line = out
+            .lines()
+            .find(|l| l.starts_with("all_smi_gpu_mig_mode{"))
+            .expect("mode line present even without instances");
+        assert!(mode_line.ends_with(" 0"), "got line: {mode_line}");
+
+        // With no instances, no per-instance metric data lines may leak.
+        for family in [
+            "all_smi_mig_instance_utilization_gpu{",
+            "all_smi_mig_instance_utilization_memory{",
+            "all_smi_mig_instance_memory_used_bytes{",
+            "all_smi_mig_instance_memory_total_bytes{",
+        ] {
+            let count = out.lines().filter(|l| l.starts_with(family)).count();
+            assert_eq!(count, 0, "unexpected data line for `{family}` in:\n{out}");
+        }
+    }
+
+    #[test]
     fn mig_mode_code_is_stable() {
         assert_eq!(MigMetricExporter::mig_mode_code(false), 0);
         assert_eq!(MigMetricExporter::mig_mode_code(true), 1);

--- a/src/api/metrics/mod.rs
+++ b/src/api/metrics/mod.rs
@@ -17,6 +17,7 @@ pub mod cpu;
 pub mod disk;
 pub mod gpu;
 pub mod memory;
+pub mod mig;
 pub mod npu;
 pub mod process;
 pub mod runtime;

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::device::{ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, ProcessInfo, VgpuHostInfo};
+use crate::device::{
+    ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, MigGpuInfo, ProcessInfo, VgpuHostInfo,
+};
 use crate::storage::info::StorageInfo;
 use crate::ui::notification::NotificationManager;
 use crate::utils::RuntimeEnvironment;
@@ -83,6 +85,9 @@ pub struct AppState {
     /// Per-GPU vGPU host info for NVIDIA vGPU-enabled hosts.
     /// Empty on bare-metal or non-NVIDIA systems.
     pub vgpu_info: Vec<VgpuHostInfo>,
+    /// Per-GPU MIG host info for NVIDIA MIG-enabled hosts (A100/A30/H100/H200).
+    /// Empty on consumer cards, pre-Ampere datacenter GPUs, and non-MIG hosts.
+    pub mig_info: Vec<MigGpuInfo>,
     pub selected_process_index: usize,
     pub start_index: usize,
     pub sort_criteria: SortCriteria,
@@ -180,6 +185,7 @@ impl AppState {
             process_info: Vec::new(),
             chassis_info: Vec::new(),
             vgpu_info: Vec::new(),
+            mig_info: Vec::new(),
             selected_process_index: 0,
             start_index: 0,
             sort_criteria: SortCriteria::Default,

--- a/src/client.rs
+++ b/src/client.rs
@@ -52,8 +52,8 @@
 
 use crate::device::{
     ChassisInfo, ChassisReader, CpuInfo, CpuReader, GpuInfo, GpuReader, MemoryInfo, MemoryReader,
-    MigGpuInfo, ProcessInfo, VgpuHostInfo, create_chassis_reader, get_cpu_readers,
-    get_gpu_readers, get_memory_readers,
+    MigGpuInfo, ProcessInfo, VgpuHostInfo, create_chassis_reader, get_cpu_readers, get_gpu_readers,
+    get_memory_readers,
 };
 use crate::error::Result;
 use crate::storage::{StorageInfo, StorageReader, create_storage_reader};

--- a/src/client.rs
+++ b/src/client.rs
@@ -52,8 +52,8 @@
 
 use crate::device::{
     ChassisInfo, ChassisReader, CpuInfo, CpuReader, GpuInfo, GpuReader, MemoryInfo, MemoryReader,
-    ProcessInfo, VgpuHostInfo, create_chassis_reader, get_cpu_readers, get_gpu_readers,
-    get_memory_readers,
+    MigGpuInfo, ProcessInfo, VgpuHostInfo, create_chassis_reader, get_cpu_readers,
+    get_gpu_readers, get_memory_readers,
 };
 use crate::error::Result;
 use crate::storage::{StorageInfo, StorageReader, create_storage_reader};
@@ -321,6 +321,38 @@ impl AllSmi {
             all_vgpu.extend(reader.get_vgpu_info());
         }
         all_vgpu
+    }
+
+    /// Get NVIDIA MIG (Multi-Instance GPU) information for every GPU that
+    /// has MIG mode enabled.
+    ///
+    /// Returns an empty vector on consumer cards, pre-Ampere datacenter GPUs
+    /// (which do not support compute MIG), and bare-metal hosts where MIG is
+    /// not configured. Each [`MigGpuInfo`] record carries the parent GPU
+    /// metadata, the live MIG mode flag, and a list of enumerated instances.
+    /// Non-NVIDIA readers return empty via the trait default.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use all_smi::AllSmi;
+    ///
+    /// let smi = AllSmi::new()?;
+    /// for host in smi.get_mig_info() {
+    ///     println!("{}: MIG {}", host.gpu_name, if host.mig_mode { "on" } else { "off" });
+    ///     for inst in &host.instances {
+    ///         println!("  instance {} - {} ({:?}% util)",
+    ///             inst.instance_id, inst.profile_name, inst.utilization_gpu);
+    ///     }
+    /// }
+    /// # Ok::<(), all_smi::Error>(())
+    /// ```
+    pub fn get_mig_info(&self) -> Vec<MigGpuInfo> {
+        let mut all_mig = Vec::new();
+        for reader in &self.gpu_readers {
+            all_mig.extend(reader.get_mig_info());
+        }
+        all_mig
     }
 
     /// Get information about system CPUs.

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -30,6 +30,7 @@ pub mod gaudi;
 pub mod google_tpu;
 pub mod nvidia;
 pub mod nvidia_jetson;
+pub mod nvidia_mig;
 pub mod nvidia_vgpu;
 pub mod rebellions;
 #[cfg(target_os = "linux")]

--- a/src/device/readers/nvidia.rs
+++ b/src/device/readers/nvidia.rs
@@ -17,8 +17,9 @@ use crate::device::common::constants::BYTES_PER_MB;
 use crate::device::common::{execute_command_default, parse_csv_line};
 use crate::device::process_list::{get_all_processes, merge_gpu_processes};
 use crate::device::readers::common_cache::{DetailBuilder, DeviceStaticInfo, MAX_DEVICES};
+use crate::device::readers::nvidia_mig::collect_mig_info;
 use crate::device::readers::nvidia_vgpu::collect_vgpu_info;
-use crate::device::types::{GpuInfo, ProcessInfo, VgpuHostInfo};
+use crate::device::types::{GpuInfo, MigGpuInfo, ProcessInfo, VgpuHostInfo};
 use crate::utils::{get_hostname, with_global_system};
 use chrono::Local;
 use nvml_wrapper::enum_wrappers::device::{PerformanceState, TemperatureThreshold};
@@ -388,6 +389,14 @@ impl GpuReader for NvidiaGpuReader {
         // Degrade to an empty vector on any NVML failure. Callers MUST treat
         // an empty response as "not vGPU-capable" and render nothing.
         self.with_nvml(collect_vgpu_info).unwrap_or_default()
+    }
+
+    fn get_mig_info(&self) -> Vec<MigGpuInfo> {
+        // Degrade to an empty vector on any NVML failure (driver too old,
+        // pre-Ampere GPUs, MIG not enabled, missing permissions). Callers
+        // MUST treat an empty response as "not MIG-capable" and render
+        // nothing.
+        self.with_nvml(collect_mig_info).unwrap_or_default()
     }
 }
 

--- a/src/device/readers/nvidia_mig.rs
+++ b/src/device/readers/nvidia_mig.rs
@@ -1,0 +1,286 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! NVIDIA MIG (Multi-Instance GPU) information collection.
+//!
+//! This module queries NVML's MIG APIs and returns one [`MigGpuInfo`] row per
+//! physical GPU that has MIG mode enabled. On consumer cards, older datacenter
+//! GPUs (pre-Ampere), and machines without MIG configured the reader returns
+//! an empty vector — the feature MUST be a silent no-op there.
+//!
+//! # Error handling contract
+//!
+//! * Any NVML error (`NotSupported`, `FunctionNotFound`, `Uninitialized`, …)
+//!   for a given call is swallowed and treated as "feature unavailable".
+//! * A physical GPU is included in the output only when `mig_mode()` reports
+//!   the MIG-enabled state. The pending mode is intentionally ignored: we
+//!   monitor what is live now, not what would happen after a reboot.
+//! * Per-instance enumeration uses `mig_device_count()` (the maximum slot
+//!   count) and skips slots that return `NotSupported` / `InvalidArg`, which
+//!   is how NVML reports "this slot is not currently provisioned".
+//! * Per-instance metric reads are independently best-effort — a single
+//!   failed `utilization_rates` call does not drop the whole instance row.
+
+use std::ffi::CStr;
+use std::os::raw::c_uint;
+
+use nvml_wrapper::Nvml;
+use nvml_wrapper::error::nvml_try;
+
+use crate::device::types::{MigGpuInfo, MigInstanceInfo};
+use crate::utils::get_hostname;
+
+/// NVML reports the maximum theoretical MIG slot count via
+/// `nvmlDeviceGetMaxMigDeviceCount`. Real GPUs cap at 7 instances on
+/// A100/H100, so we clamp at a defensive upper bound to avoid pathological
+/// loops on a misbehaving driver.
+const MAX_MIG_INSTANCES_PER_DEVICE: u32 = 64;
+
+/// Defensive upper bound on the MIG profile name buffer. Real names like
+/// `1g.5gb` / `7g.40gb` fit comfortably; we allocate 64 bytes for safety.
+const MIG_NAME_BUFFER: usize = 64;
+
+/// Collect MIG information for every physical NVIDIA GPU on the host.
+///
+/// Returns an empty vector when:
+/// * NVML reports zero devices.
+/// * No device responds successfully to `mig_mode()`.
+/// * No device has MIG mode currently enabled.
+pub fn collect_mig_info(nvml: &Nvml) -> Vec<MigGpuInfo> {
+    let mut out = Vec::new();
+
+    let device_count = match nvml.device_count() {
+        Ok(n) => n,
+        Err(_) => return out,
+    };
+
+    let hostname = get_hostname();
+
+    for index in 0..device_count {
+        let device = match nvml.device_by_index(index) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        // Probe MIG mode. `NotSupported` is the expected response on consumer
+        // cards and pre-Ampere datacenter GPUs — we silently skip them.
+        let mode = match device.mig_mode() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let mig_enabled = mode.current == 1;
+
+        // Only surface a record when MIG mode is actually live. Pending mode
+        // is informational and would require a reboot to take effect.
+        if !mig_enabled {
+            continue;
+        }
+
+        let gpu_uuid = device.uuid().unwrap_or_else(|_| format!("GPU-{index}"));
+        let gpu_name = device.name().unwrap_or_else(|_| "Unknown GPU".to_string());
+
+        let instances = enumerate_mig_instances(nvml, &device);
+
+        out.push(MigGpuInfo {
+            host_id: hostname.clone(),
+            hostname: hostname.clone(),
+            instance: hostname.clone(),
+            gpu_index: index,
+            gpu_uuid,
+            gpu_name,
+            mig_mode: true,
+            instances,
+        });
+    }
+
+    out
+}
+
+/// Enumerate live MIG instances under a parent physical GPU.
+///
+/// Returns an empty vector if `mig_device_count` errors (driver too old, MIG
+/// disabled mid-call, missing permissions). Per-slot errors during the
+/// enumeration loop are silently skipped — they are NVML's normal way of
+/// signalling "no instance provisioned at this index".
+fn enumerate_mig_instances(nvml: &Nvml, parent: &nvml_wrapper::Device) -> Vec<MigInstanceInfo> {
+    let max_count = match parent.mig_device_count() {
+        Ok(c) => c.min(MAX_MIG_INSTANCES_PER_DEVICE),
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out = Vec::with_capacity(max_count as usize);
+
+    for slot in 0..max_count {
+        let mig_device = match parent.mig_device_by_index(slot) {
+            Ok(d) => d,
+            // `NotSupported` / `InvalidArg` here means the slot is unprovisioned.
+            // SELinux / cgroup misconfiguration also lands in this branch and
+            // produces a silent skip per the contract documented at the top.
+            Err(_) => continue,
+        };
+
+        out.push(collect_single_mig_instance(nvml, &mig_device, slot));
+    }
+
+    out
+}
+
+/// Collect metadata for a single MIG instance. All sub-queries are
+/// `.ok()`-wrapped so that a failed read degrades to a default value rather
+/// than killing the whole row.
+fn collect_single_mig_instance(
+    nvml: &Nvml,
+    device: &nvml_wrapper::Device,
+    instance_id: u32,
+) -> MigInstanceInfo {
+    let uuid = device.uuid().unwrap_or_default();
+
+    let mem = device.memory_info().ok();
+    let memory_used_bytes = mem.as_ref().map(|m| m.used).unwrap_or(0);
+    let memory_total_bytes = mem.as_ref().map(|m| m.total).unwrap_or(0);
+
+    let util = device.utilization_rates().ok();
+    let utilization_gpu = util.as_ref().map(|u| u.gpu);
+    let utilization_memory = util.as_ref().map(|u| u.memory);
+
+    let gpu_instance_id = mig_gpu_instance_id(nvml, device);
+    let compute_instance_id = mig_compute_instance_id(nvml, device);
+
+    // Best-effort profile name. NVML exposes the per-instance name via the
+    // generic `nvmlDeviceGetName` call when invoked on a MIG handle.
+    let profile_name = device
+        .name()
+        .ok()
+        .map(|s| extract_profile_suffix(&s))
+        .unwrap_or_default();
+
+    MigInstanceInfo {
+        instance_id,
+        gpu_instance_id,
+        compute_instance_id,
+        uuid,
+        profile_name,
+        utilization_gpu,
+        utilization_memory,
+        memory_used_bytes,
+        memory_total_bytes,
+    }
+}
+
+/// Query the GPU instance id for a MIG handle via raw NVML FFI.
+///
+/// nvml-wrapper 0.12 does not expose `nvmlDeviceGetGpuInstanceId` as a
+/// high-level method (it is only present indirectly inside `ProcessInfo`),
+/// so we call the symbol ourselves and degrade silently on any failure.
+fn mig_gpu_instance_id(nvml: &Nvml, device: &nvml_wrapper::Device) -> Option<u32> {
+    let sym = nvml.lib().nvmlDeviceGetGpuInstanceId.as_ref().ok()?;
+    let mut id: c_uint = 0;
+    // SAFETY: `Device::handle()` returns the same `nvmlDevice_t` NVML
+    // expects. `id` is a valid u32 on the stack; NVML writes one u32.
+    let result = unsafe { sym(device.handle(), &mut id) };
+    nvml_try(result).ok()?;
+    Some(id)
+}
+
+/// Query the compute instance id for a MIG handle via raw NVML FFI.
+///
+/// Same rationale as [`mig_gpu_instance_id`] — the high-level wrapper does
+/// not expose it directly in 0.12, so we go through the raw symbol and
+/// degrade silently on any failure.
+fn mig_compute_instance_id(nvml: &Nvml, device: &nvml_wrapper::Device) -> Option<u32> {
+    let sym = nvml.lib().nvmlDeviceGetComputeInstanceId.as_ref().ok()?;
+    let mut id: c_uint = 0;
+    // SAFETY: same invariants as `mig_gpu_instance_id` above — valid
+    // device handle, valid out-pointer, NVML writes one u32.
+    let result = unsafe { sym(device.handle(), &mut id) };
+    nvml_try(result).ok()?;
+    Some(id)
+}
+
+/// NVML returns full names like "MIG 1g.5gb Device" or "NVIDIA A100 MIG 2g.10gb".
+/// Extract the slice profile fragment (`1g.5gb`) for compact display. Returns
+/// the original string when no recognisable fragment is found.
+fn extract_profile_suffix(raw: &str) -> String {
+    // Heuristic: the slice fragment is always of the form `<digits>g.<digits>gb`.
+    for token in raw.split_whitespace() {
+        if is_mig_profile_token(token) {
+            return token.to_string();
+        }
+    }
+    raw.to_string()
+}
+
+/// `true` when `token` looks like a MIG slice profile (`1g.5gb`, `7g.80gb`,
+/// `1c.1g.5gb` for compute-only slices, etc.). Rejects everything else.
+fn is_mig_profile_token(token: &str) -> bool {
+    let token = token.trim();
+    if token.is_empty() || token.len() > MIG_NAME_BUFFER {
+        return false;
+    }
+    // Must contain `g.` and end in `gb`.
+    if !token.contains("g.") || !token.ends_with("gb") {
+        return false;
+    }
+    // First character must be a digit (e.g. `1g.5gb`).
+    token.chars().next().is_some_and(|c| c.is_ascii_digit())
+}
+
+/// Decode a NUL-terminated NVML C string buffer. Used by the few raw-FFI
+/// helpers above when nvml-wrapper does not provide a Rust accessor; kept
+/// here in the MIG module so it stays close to its sole caller.
+#[allow(dead_code)]
+fn decode_cstr(buf: &[i8]) -> String {
+    // SAFETY: NVML guarantees NUL termination within the supplied buffer.
+    let cstr = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) };
+    cstr.to_str().unwrap_or("").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_profile_suffix_returns_canonical_token() {
+        assert_eq!(extract_profile_suffix("MIG 1g.5gb Device"), "1g.5gb");
+        assert_eq!(extract_profile_suffix("NVIDIA A100 MIG 7g.40gb"), "7g.40gb");
+        assert_eq!(extract_profile_suffix("3g.20gb"), "3g.20gb");
+    }
+
+    #[test]
+    fn extract_profile_suffix_returns_input_when_no_token_present() {
+        assert_eq!(
+            extract_profile_suffix("Some Random Name"),
+            "Some Random Name"
+        );
+        assert_eq!(extract_profile_suffix(""), "");
+    }
+
+    #[test]
+    fn is_mig_profile_token_accepts_valid_slices() {
+        assert!(is_mig_profile_token("1g.5gb"));
+        assert!(is_mig_profile_token("2g.10gb"));
+        assert!(is_mig_profile_token("3g.20gb"));
+        assert!(is_mig_profile_token("7g.40gb"));
+        assert!(is_mig_profile_token("7g.80gb"));
+    }
+
+    #[test]
+    fn is_mig_profile_token_rejects_non_profiles() {
+        assert!(!is_mig_profile_token(""));
+        assert!(!is_mig_profile_token("MIG"));
+        assert!(!is_mig_profile_token("1g.5g"));
+        assert!(!is_mig_profile_token("g.5gb"));
+        assert!(!is_mig_profile_token("xg.ygb"));
+    }
+}

--- a/src/device/readers/nvidia_mig.rs
+++ b/src/device/readers/nvidia_mig.rs
@@ -15,20 +15,26 @@
 //! NVIDIA MIG (Multi-Instance GPU) information collection.
 //!
 //! This module queries NVML's MIG APIs and returns one [`MigGpuInfo`] row per
-//! physical GPU that has MIG mode enabled. On consumer cards, older datacenter
-//! GPUs (pre-Ampere), and machines without MIG configured the reader returns
-//! an empty vector — the feature MUST be a silent no-op there.
+//! physical GPU that answers the MIG mode query — regardless of whether MIG
+//! mode is currently on. On consumer cards, older datacenter GPUs
+//! (pre-Ampere), and machines without MIG support the reader returns an empty
+//! vector — the feature MUST be a silent no-op there.
 //!
 //! # Error handling contract
 //!
 //! * Any NVML error (`NotSupported`, `FunctionNotFound`, `Uninitialized`, …)
 //!   for a given call is swallowed and treated as "feature unavailable".
-//! * A physical GPU is included in the output only when `mig_mode()` reports
-//!   the MIG-enabled state. The pending mode is intentionally ignored: we
-//!   monitor what is live now, not what would happen after a reboot.
-//! * Per-instance enumeration uses `mig_device_count()` (the maximum slot
-//!   count) and skips slots that return `NotSupported` / `InvalidArg`, which
-//!   is how NVML reports "this slot is not currently provisioned".
+//! * A physical GPU is included in the output whenever `mig_mode()` returns
+//!   a value — enabled or disabled. Surfacing disabled rows lets downstream
+//!   consumers observe the current MIG state (and its runtime transitions)
+//!   via `all_smi_gpu_mig_mode = 0`. The pending mode is intentionally
+//!   ignored: we monitor what is live now, not what would happen after a
+//!   reboot.
+//! * Per-instance enumeration is skipped entirely when MIG mode is disabled
+//!   (there are no instances to read). For enabled GPUs it uses
+//!   `mig_device_count()` (the maximum slot count) and skips slots that
+//!   return `NotSupported` / `InvalidArg`, which is how NVML reports "this
+//!   slot is not currently provisioned".
 //! * Per-instance metric reads are independently best-effort — a single
 //!   failed `utilization_rates` call does not drop the whole instance row.
 
@@ -55,8 +61,13 @@ const MIG_NAME_BUFFER: usize = 64;
 ///
 /// Returns an empty vector when:
 /// * NVML reports zero devices.
-/// * No device responds successfully to `mig_mode()`.
-/// * No device has MIG mode currently enabled.
+/// * No device responds successfully to `mig_mode()` (i.e. no MIG-capable
+///   GPU is present — consumer cards / pre-Ampere datacenter GPUs).
+///
+/// A row is emitted for every MIG-capable GPU, with `mig_mode` reflecting
+/// the current live state and `instances` empty whenever MIG mode is
+/// disabled. This lets consumers observe disabled GPUs in dashboards and
+/// catch runtime MIG toggles via `all_smi_gpu_mig_mode = 0`.
 pub fn collect_mig_info(nvml: &Nvml) -> Vec<MigGpuInfo> {
     let mut out = Vec::new();
 
@@ -74,23 +85,25 @@ pub fn collect_mig_info(nvml: &Nvml) -> Vec<MigGpuInfo> {
         };
 
         // Probe MIG mode. `NotSupported` is the expected response on consumer
-        // cards and pre-Ampere datacenter GPUs — we silently skip them.
+        // cards and pre-Ampere datacenter GPUs — silently skip those, they
+        // have no MIG story at all to report.
         let mode = match device.mig_mode() {
             Ok(m) => m,
             Err(_) => continue,
         };
         let mig_enabled = mode.current == 1;
 
-        // Only surface a record when MIG mode is actually live. Pending mode
-        // is informational and would require a reboot to take effect.
-        if !mig_enabled {
-            continue;
-        }
-
         let gpu_uuid = device.uuid().unwrap_or_else(|_| format!("GPU-{index}"));
         let gpu_name = device.name().unwrap_or_else(|_| "Unknown GPU".to_string());
 
-        let instances = enumerate_mig_instances(nvml, &device);
+        // Disabled MIG mode => no instances to enumerate. Keep the host row
+        // around so the exporter still emits `all_smi_gpu_mig_mode = 0` for
+        // it and downstream consumers can track runtime toggles.
+        let instances = if mig_enabled {
+            enumerate_mig_instances(nvml, &device)
+        } else {
+            Vec::new()
+        };
 
         out.push(MigGpuInfo {
             host_id: hostname.clone(),
@@ -99,7 +112,7 @@ pub fn collect_mig_info(nvml: &Nvml) -> Vec<MigGpuInfo> {
             gpu_index: index,
             gpu_uuid,
             gpu_name,
-            mig_mode: true,
+            mig_mode: mig_enabled,
             instances,
         });
     }

--- a/src/device/readers/nvidia_mig.rs
+++ b/src/device/readers/nvidia_mig.rs
@@ -38,7 +38,6 @@
 //! * Per-instance metric reads are independently best-effort — a single
 //!   failed `utilization_rates` call does not drop the whole instance row.
 
-use std::ffi::CStr;
 use std::os::raw::c_uint;
 
 use nvml_wrapper::Nvml;
@@ -247,16 +246,6 @@ fn is_mig_profile_token(token: &str) -> bool {
     }
     // First character must be a digit (e.g. `1g.5gb`).
     token.chars().next().is_some_and(|c| c.is_ascii_digit())
-}
-
-/// Decode a NUL-terminated NVML C string buffer. Used by the few raw-FFI
-/// helpers above when nvml-wrapper does not provide a Rust accessor; kept
-/// here in the MIG module so it stays close to its sole caller.
-#[allow(dead_code)]
-fn decode_cstr(buf: &[i8]) -> String {
-    // SAFETY: NVML guarantees NUL termination within the supplied buffer.
-    let cstr = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) };
-    cstr.to_str().unwrap_or("").to_string()
 }
 
 #[cfg(test)]

--- a/src/device/traits.rs
+++ b/src/device/traits.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::device::{ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, ProcessInfo, VgpuHostInfo};
+use crate::device::{
+    ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, MigGpuInfo, ProcessInfo, VgpuHostInfo,
+};
 use std::collections::HashSet;
 
 pub trait GpuReader: Send + Sync {
@@ -40,6 +42,18 @@ pub trait GpuReader: Send + Sync {
     /// vGPU MUST ensure that a missing-host case returns an empty vector
     /// rather than panicking or producing synthetic rows.
     fn get_vgpu_info(&self) -> Vec<VgpuHostInfo> {
+        Vec::new()
+    }
+
+    /// Collect per-GPU MIG (Multi-Instance GPU) host and instance information.
+    ///
+    /// Returns an empty vector on non-MIG hardware (consumer cards, older
+    /// architectures than Ampere) or when the reader does not support MIG at
+    /// all (the default). Implementations that do support MIG MUST ensure
+    /// that any NVML failure (driver too old, `NotSupported`, missing
+    /// permissions to enumerate instances) degrades gracefully to an empty
+    /// vector rather than panicking or producing synthetic rows.
+    fn get_mig_info(&self) -> Vec<MigGpuInfo> {
         Vec::new()
     }
 }

--- a/src/device/types.rs
+++ b/src/device/types.rs
@@ -365,6 +365,73 @@ impl VgpuHostInfo {
     }
 }
 
+/// Per-MIG-instance metrics collected from NVML.
+///
+/// A MIG (Multi-Instance GPU) instance is an isolated partition of an NVIDIA
+/// datacenter GPU (A100/A30/H100/H200). Each instance has its own SM slice,
+/// memory carve-out, and L2 cache, exposed through NVML as a child `Device`
+/// handle of the parent physical GPU.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct MigInstanceInfo {
+    /// MIG instance index returned by `mig_device_by_index` enumeration (0-based).
+    pub instance_id: u32,
+    /// GPU instance id (the SM/memory slice id, distinct from `instance_id`),
+    /// as reported by `nvmlDeviceGetGpuInstanceId`. `None` when the driver does
+    /// not expose it (older drivers).
+    pub gpu_instance_id: Option<u32>,
+    /// Compute instance id, as reported by `nvmlDeviceGetComputeInstanceId`.
+    /// `None` when the driver does not expose it.
+    pub compute_instance_id: Option<u32>,
+    /// MIG instance UUID (e.g. `MIG-…`). Empty when the driver does not expose one.
+    pub uuid: String,
+    /// MIG profile/slice name (e.g. `1g.5gb`, `2g.10gb`, `7g.40gb`). Best-effort
+    /// — empty when not derivable from the available NVML data.
+    pub profile_name: String,
+    /// GPU SM utilization percentage over the most recent NVML sample (0-100).
+    /// `None` when NVML reports the metric as unavailable for the instance.
+    pub utilization_gpu: Option<u32>,
+    /// Memory bandwidth utilization percentage (0-100). `None` when unavailable.
+    pub utilization_memory: Option<u32>,
+    /// Framebuffer used (bytes). `0` when NVML cannot report it.
+    pub memory_used_bytes: u64,
+    /// Framebuffer total carve-out for this instance (bytes). `0` when unavailable.
+    pub memory_total_bytes: u64,
+}
+
+/// Per-physical-GPU MIG host record.
+///
+/// Populated only when NVML reports MIG mode enabled for the GPU and at least
+/// one instance enumeration succeeded. On non-MIG GPUs and older architectures
+/// the parent vector stays empty — the feature MUST be a silent no-op.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct MigGpuInfo {
+    /// Host identifier (e.g. `10.82.128.41:9090` or local hostname).
+    pub host_id: String,
+    /// DNS hostname of the host.
+    pub hostname: String,
+    /// Prometheus `instance` label.
+    pub instance: String,
+    /// NVML device index of the parent physical GPU.
+    pub gpu_index: u32,
+    /// UUID of the parent physical GPU.
+    pub gpu_uuid: String,
+    /// Device display name (e.g. `NVIDIA A100-SXM4-80GB`).
+    pub gpu_name: String,
+    /// Whether MIG mode is currently enabled (`true`) or disabled (`false`)
+    /// on the parent GPU.
+    pub mig_mode: bool,
+    /// Live MIG instances enumerated from NVML.
+    pub instances: Vec<MigInstanceInfo>,
+}
+
+impl MigGpuInfo {
+    /// Returns `true` when the parent GPU should surface a MIG section in the
+    /// TUI — either MIG mode is enabled or live instances were enumerated.
+    pub fn is_mig_active(&self) -> bool {
+        self.mig_mode || !self.instances.is_empty()
+    }
+}
+
 /// Fan information for cooling monitoring
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FanInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,14 @@ pub use error::{Error, Result};
 // Internal Modules (also exported for advanced usage and testing)
 // =============================================================================
 
+/// Prometheus metric exporters and HTTP handlers used by `all-smi api` mode.
+///
+/// Exposed for integration tests that need to assert on the exact exporter
+/// output. The HTTP handler side of the module depends on the `cli` feature
+/// because it pulls in [`app_state`], `axum`, and `tower-http`.
+#[cfg(feature = "cli")]
+pub mod api;
+
 /// Device readers and types for GPU, CPU, memory monitoring.
 pub mod device;
 

--- a/src/mock/templates/mig.rs
+++ b/src/mock/templates/mig.rs
@@ -141,8 +141,16 @@ pub fn render_mig_response(mut response: String, gpus: &[GpuMetrics]) -> String 
             // a small fraction stay idle to exercise the "no util reported"
             // path on the consumer side.
             let active = rng.random_bool(0.7);
-            let util = if active { rng.random_range(10..90_u32) } else { 0 };
-            let mem_util = if active { rng.random_range(5..60_u32) } else { 0 };
+            let util = if active {
+                rng.random_range(10..90_u32)
+            } else {
+                0
+            };
+            let mem_util = if active {
+                rng.random_range(5..60_u32)
+            } else {
+                0
+            };
             let used = if active {
                 rng.random_range((fb_total / 10)..(fb_total * 9 / 10))
             } else {
@@ -253,7 +261,9 @@ mod tests {
         add_mig_template(&mut template, "node", "NVIDIA A100", &gpus);
 
         // 2 GPUs * 5 profiles = 10 placeholder rows in the utilization family.
-        let count = template.matches("all_smi_mig_instance_utilization_gpu{").count();
+        let count = template
+            .matches("all_smi_mig_instance_utilization_gpu{")
+            .count();
         assert_eq!(count, 10);
     }
 

--- a/src/mock/templates/mig.rs
+++ b/src/mock/templates/mig.rs
@@ -1,0 +1,301 @@
+//! NVIDIA MIG mock template generator.
+//!
+//! Simulates a MIG-enabled NVIDIA host by emitting the same Prometheus
+//! families that `api/metrics/mig.rs` produces from real NVML data.
+//! Controlled at runtime by the `ALL_SMI_MOCK_MIG` environment variable —
+//! setting it to any non-empty value adds MIG metrics to NVIDIA mock
+//! responses so integration tests and UIs can be exercised without MIG
+//! hardware.
+
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::mock::metrics::GpuMetrics;
+
+/// Environment variable that gates MIG emission in mock responses.
+pub const MIG_ENV_VAR: &str = "ALL_SMI_MOCK_MIG";
+
+/// Realistic MIG profiles spanning the full A100/H100 spectrum. The choice
+/// of 5 instances per GPU (1+2+3+1=7-slot equivalent) matches a typical
+/// "1g.5gb x4 + 3g.20gb x1" partitioning that fills an A100. This is one of
+/// the configurations the issue asked for; switching profiles at runtime
+/// can be done by adjusting the `MIG_PROFILES` slice below.
+const MIG_PROFILES: &[(u32, u64, &str)] = &[
+    // (instance_id, fb_total_bytes, profile_name)
+    (0, 5 * (1 << 30), "1g.5gb"),
+    (1, 5 * (1 << 30), "1g.5gb"),
+    (2, 10 * (1 << 30), "2g.10gb"),
+    (3, 20 * (1 << 30), "3g.20gb"),
+    (4, 40 * (1 << 30), "7g.40gb"),
+];
+
+/// Append MIG metric families to the NVIDIA mock template when the feature
+/// is enabled via [`MIG_ENV_VAR`]. No-op on bare-metal mocks.
+pub fn maybe_add_mig_template(
+    template: &mut String,
+    instance_name: &str,
+    gpu_name: &str,
+    gpus: &[GpuMetrics],
+) {
+    if !is_mig_enabled() {
+        return;
+    }
+    add_mig_template(template, instance_name, gpu_name, gpus);
+}
+
+/// Append MIG metric families unconditionally. Exposed for unit tests.
+pub fn add_mig_template(
+    template: &mut String,
+    instance_name: &str,
+    gpu_name: &str,
+    gpus: &[GpuMetrics],
+) {
+    // Host-level: gpu_mig_mode --------------------------------------------
+    template.push_str(
+        "# HELP all_smi_gpu_mig_mode NVIDIA MIG mode (1=enabled, 0=disabled) per parent GPU\n",
+    );
+    template.push_str("# TYPE all_smi_gpu_mig_mode gauge\n");
+    for (i, gpu) in gpus.iter().enumerate() {
+        let labels = format!(
+            "gpu_index=\"{i}\", gpu_uuid=\"{}\", gpu=\"{gpu_name}\", instance=\"{instance_name}\", host=\"{instance_name}\"",
+            gpu.uuid
+        );
+        template.push_str(&format!("all_smi_gpu_mig_mode{{{labels}}} 1\n"));
+    }
+
+    // Per-instance metrics -------------------------------------------------
+    template.push_str(
+        "# HELP all_smi_mig_instance_utilization_gpu Per-MIG-instance GPU SM utilization percentage (0-100)\n",
+    );
+    template.push_str("# TYPE all_smi_mig_instance_utilization_gpu gauge\n");
+    emit_instance_family(template, instance_name, gpu_name, gpus, |i, j| {
+        format!(
+            "all_smi_mig_instance_utilization_gpu{{{}}} {{{{MIG_UTIL_{i}_{j}}}}}\n",
+            format_instance_labels(i, j, instance_name, gpu_name, &gpus[i].uuid)
+        )
+    });
+
+    template.push_str(
+        "# HELP all_smi_mig_instance_utilization_memory Per-MIG-instance memory bandwidth utilization percentage (0-100)\n",
+    );
+    template.push_str("# TYPE all_smi_mig_instance_utilization_memory gauge\n");
+    emit_instance_family(template, instance_name, gpu_name, gpus, |i, j| {
+        format!(
+            "all_smi_mig_instance_utilization_memory{{{}}} {{{{MIG_MEMUTIL_{i}_{j}}}}}\n",
+            format_instance_labels(i, j, instance_name, gpu_name, &gpus[i].uuid)
+        )
+    });
+
+    template.push_str(
+        "# HELP all_smi_mig_instance_memory_used_bytes Per-MIG-instance framebuffer memory used\n",
+    );
+    template.push_str("# TYPE all_smi_mig_instance_memory_used_bytes gauge\n");
+    emit_instance_family(template, instance_name, gpu_name, gpus, |i, j| {
+        format!(
+            "all_smi_mig_instance_memory_used_bytes{{{}}} {{{{MIG_MEMUSED_{i}_{j}}}}}\n",
+            format_instance_labels(i, j, instance_name, gpu_name, &gpus[i].uuid)
+        )
+    });
+
+    template.push_str(
+        "# HELP all_smi_mig_instance_memory_total_bytes Per-MIG-instance framebuffer total carve-out\n",
+    );
+    template.push_str("# TYPE all_smi_mig_instance_memory_total_bytes gauge\n");
+    emit_instance_family(template, instance_name, gpu_name, gpus, |i, j| {
+        format!(
+            "all_smi_mig_instance_memory_total_bytes{{{}}} {}\n",
+            format_instance_labels(i, j, instance_name, gpu_name, &gpus[i].uuid),
+            MIG_PROFILES[j].1
+        )
+    });
+}
+
+/// Replace per-instance MIG placeholders with synthetic values. Call from
+/// the NVIDIA response renderer after the regular metric substitutions.
+pub fn maybe_render_mig_response(response: String, gpus: &[GpuMetrics]) -> String {
+    if !is_mig_enabled() {
+        return response;
+    }
+    render_mig_response(response, gpus)
+}
+
+/// Unconditional renderer; used by tests.
+pub fn render_mig_response(mut response: String, gpus: &[GpuMetrics]) -> String {
+    use rand::{RngExt, rng};
+    let mut rng = rng();
+
+    for (i, _gpu) in gpus.iter().enumerate() {
+        for (j, &(_, fb_total, _)) in MIG_PROFILES.iter().enumerate() {
+            // Active instances get realistic utilization + memory footprint;
+            // a small fraction stay idle to exercise the "no util reported"
+            // path on the consumer side.
+            let active = rng.random_bool(0.7);
+            let util = if active { rng.random_range(10..90_u32) } else { 0 };
+            let mem_util = if active { rng.random_range(5..60_u32) } else { 0 };
+            let used = if active {
+                rng.random_range((fb_total / 10)..(fb_total * 9 / 10))
+            } else {
+                0
+            };
+
+            response = response
+                .replace(&format!("{{{{MIG_UTIL_{i}_{j}}}}}"), &util.to_string())
+                .replace(
+                    &format!("{{{{MIG_MEMUTIL_{i}_{j}}}}}"),
+                    &mem_util.to_string(),
+                )
+                .replace(&format!("{{{{MIG_MEMUSED_{i}_{j}}}}}"), &used.to_string());
+        }
+    }
+
+    response
+}
+
+/// `true` when the MIG mock mode is enabled via env var.
+pub fn is_mig_enabled() -> bool {
+    std::env::var(MIG_ENV_VAR)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+fn format_instance_labels(
+    i: usize,
+    j: usize,
+    instance_name: &str,
+    gpu_name: &str,
+    gpu_uuid: &str,
+) -> String {
+    let (mig_instance, _, profile) = MIG_PROFILES[j];
+    // Synthesize plausible IDs: gi=mig_instance+1, ci=0 (single compute slice).
+    let gi = mig_instance + 1;
+    let ci = 0_u32;
+    format!(
+        "gpu_index=\"{i}\", gpu_uuid=\"{gpu_uuid}\", gpu=\"{gpu_name}\", instance=\"{instance_name}\", host=\"{instance_name}\", mig_instance=\"{mig_instance}\", mig_uuid=\"MIG-mock-{i}-{j}\", mig_profile=\"{profile}\", gpu_instance_id=\"{gi}\", compute_instance_id=\"{ci}\""
+    )
+}
+
+fn emit_instance_family(
+    template: &mut String,
+    _instance_name: &str,
+    _gpu_name: &str,
+    gpus: &[GpuMetrics],
+    render_line: impl Fn(usize, usize) -> String,
+) {
+    for i in 0..gpus.len() {
+        for j in 0..MIG_PROFILES.len() {
+            template.push_str(&render_line(i, j));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_gpu(uuid: &str) -> GpuMetrics {
+        GpuMetrics {
+            uuid: uuid.to_string(),
+            utilization: 50.0,
+            memory_used_bytes: 20 * (1 << 30),
+            memory_total_bytes: 80 * (1 << 30),
+            temperature_celsius: 60,
+            power_consumption_watts: 300.0,
+            frequency_mhz: 1500,
+            ane_utilization_watts: 0.0,
+            thermal_pressure_level: None,
+        }
+    }
+
+    #[test]
+    fn template_emits_expected_families() {
+        let gpus = vec![fake_gpu("GPU-1"), fake_gpu("GPU-2")];
+        let mut template = String::new();
+        add_mig_template(&mut template, "node-01", "NVIDIA A100", &gpus);
+
+        for family in [
+            "all_smi_gpu_mig_mode",
+            "all_smi_mig_instance_utilization_gpu",
+            "all_smi_mig_instance_utilization_memory",
+            "all_smi_mig_instance_memory_used_bytes",
+            "all_smi_mig_instance_memory_total_bytes",
+        ] {
+            assert!(template.contains(family), "missing family {family}");
+        }
+    }
+
+    #[test]
+    fn template_uses_expected_instance_labels() {
+        let gpus = vec![fake_gpu("GPU-7")];
+        let mut template = String::new();
+        add_mig_template(&mut template, "node-42", "NVIDIA A100", &gpus);
+        assert!(template.contains("host=\"node-42\""));
+        assert!(template.contains("gpu_uuid=\"GPU-7\""));
+        assert!(template.contains("mig_instance=\"0\""));
+        assert!(template.contains("mig_uuid=\"MIG-mock-0-0\""));
+        assert!(template.contains("mig_profile=\"1g.5gb\""));
+    }
+
+    #[test]
+    fn template_emits_one_row_per_profile_per_gpu() {
+        let gpus = vec![fake_gpu("GPU-1"), fake_gpu("GPU-2")];
+        let mut template = String::new();
+        add_mig_template(&mut template, "node", "NVIDIA A100", &gpus);
+
+        // 2 GPUs * 5 profiles = 10 placeholder rows in the utilization family.
+        let count = template.matches("all_smi_mig_instance_utilization_gpu{").count();
+        assert_eq!(count, 10);
+    }
+
+    #[test]
+    fn rendering_substitutes_all_placeholders() {
+        let gpus = vec![fake_gpu("GPU-1")];
+        let mut template = String::new();
+        add_mig_template(&mut template, "node", "NVIDIA A100", &gpus);
+
+        let rendered = render_mig_response(template, &gpus);
+        assert!(
+            !rendered.contains("{{MIG_"),
+            "Placeholders remain unsubstituted:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn is_mig_enabled_reflects_env_var() {
+        let prior = std::env::var(MIG_ENV_VAR).ok();
+        // SAFETY: Single-threaded test harness for this specific test; env
+        // mutation is confined to this scope. Same rationale as the vGPU
+        // mock's `is_vgpu_enabled_reflects_env_var` test.
+        unsafe {
+            std::env::remove_var(MIG_ENV_VAR);
+        }
+        assert!(!is_mig_enabled());
+
+        unsafe {
+            std::env::set_var(MIG_ENV_VAR, "1");
+        }
+        assert!(is_mig_enabled());
+
+        unsafe {
+            std::env::set_var(MIG_ENV_VAR, "");
+        }
+        assert!(!is_mig_enabled());
+
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(MIG_ENV_VAR, v),
+                None => std::env::remove_var(MIG_ENV_VAR),
+            }
+        }
+    }
+}

--- a/src/mock/templates/mod.rs
+++ b/src/mock/templates/mod.rs
@@ -21,6 +21,7 @@ pub mod disk;
 pub mod furiosa;
 pub mod gaudi;
 pub mod jetson;
+pub mod mig;
 pub mod nvidia;
 pub mod rebellions;
 pub mod tenstorrent;

--- a/src/mock/templates/nvidia.rs
+++ b/src/mock/templates/nvidia.rs
@@ -76,6 +76,15 @@ impl NvidiaMockGenerator {
             gpus,
         );
 
+        // Optional MIG metrics — gated by the ALL_SMI_MOCK_MIG env var.
+        // Same default-off contract as vGPU above.
+        crate::mock::templates::mig::maybe_add_mig_template(
+            &mut template,
+            &self.instance_name,
+            &self.gpu_name,
+            gpus,
+        );
+
         template
     }
 
@@ -365,6 +374,10 @@ impl NvidiaMockGenerator {
         // Replace vGPU placeholders when the mock mode is enabled. No-op when
         // the env var is unset.
         response = crate::mock::templates::vgpu::maybe_render_vgpu_response(response, gpus);
+
+        // Replace MIG placeholders when the mock mode is enabled. No-op when
+        // the env var is unset.
+        response = crate::mock::templates::mig::maybe_render_mig_response(response, gpus);
 
         response
     }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -274,6 +274,7 @@ impl NetworkClient {
         Vec<MemoryInfo>,
         Vec<StorageInfo>,
         Vec<crate::device::VgpuHostInfo>,
+        Vec<crate::device::MigGpuInfo>,
         Vec<ConnectionStatus>,
     ) {
         let mut all_gpu_info = Vec::new();
@@ -281,6 +282,7 @@ impl NetworkClient {
         let mut all_memory_info = Vec::new();
         let mut all_storage_info = Vec::new();
         let mut all_vgpu_info: Vec<crate::device::VgpuHostInfo> = Vec::new();
+        let mut all_mig_info: Vec<crate::device::MigGpuInfo> = Vec::new();
         let mut connection_statuses = Vec::new();
 
         // Parallel data collection with concurrency limiting and retries
@@ -417,8 +419,14 @@ impl NetworkClient {
                                     connection_statuses.push(connection_status);
                                 } else {
                                     let parser = super::metrics_parser::MetricsParser::new();
-                                    let (gpu_info, cpu_info, memory_info, storage_info, vgpu_info) =
-                                        parser.parse_metrics(&text, &host, re);
+                                    let (
+                                        gpu_info,
+                                        cpu_info,
+                                        memory_info,
+                                        storage_info,
+                                        vgpu_info,
+                                        mig_info,
+                                    ) = parser.parse_metrics(&text, &host, re);
 
                                     // Extract the instance name from device info if available
                                     let instance_name = if let Some(first_gpu) = gpu_info.first() {
@@ -436,6 +444,7 @@ impl NetworkClient {
                                     all_memory_info.extend(memory_info);
                                     all_storage_info.extend(storage_info);
                                     all_vgpu_info.extend(vgpu_info);
+                                    all_mig_info.extend(mig_info);
                                 }
                             }
                         }
@@ -475,6 +484,7 @@ impl NetworkClient {
             all_memory_info,
             all_storage_info,
             all_vgpu_info,
+            all_mig_info,
             connection_statuses,
         )
     }

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::parsing::common::sanitize_label_value;
 use chrono::Local;
@@ -923,6 +923,12 @@ struct MigParseState {
     hosts: HashMap<String, MigGpuInfo>,
     /// `(gpu_uuid, mig_instance) -> MigInstanceInfo` accumulator.
     instances: HashMap<(String, u32), MigInstanceInfo>,
+    /// UUIDs that received an explicit `gpu_mig_mode` line during this scrape.
+    /// Used by `finish` to retain disabled-MIG rows (mode=0, zero instances)
+    /// that were deliberately emitted by the remote exporter, while still
+    /// dropping spurious hosts whose `gpu_uuid` appeared only in some other
+    /// (non-MIG) family's labels by accident.
+    hosts_with_mode: HashSet<String>,
 }
 
 /// Per-scrape cap on distinct MIG-capable GPUs. Matches the existing
@@ -944,6 +950,7 @@ impl MigParseState {
         Self {
             hosts: HashMap::new(),
             instances: HashMap::new(),
+            hosts_with_mode: HashSet::new(),
         }
     }
 
@@ -994,6 +1001,12 @@ impl MigParseState {
                 // value defensively as "enabled" rather than panicking on a
                 // weird remote payload.
                 host_entry.mig_mode = value > 0.0;
+                // Remember that this host was explicitly observed via the
+                // MIG-mode metric so `finish` retains it even with mode=0
+                // and zero instances. Without this, disabled GPUs would be
+                // silently dropped and the metric would be unobservable on
+                // the consumer side.
+                self.hosts_with_mode.insert(gpu_uuid.clone());
             }
             _ => {
                 // Per-instance metric families: require a `mig_instance` label
@@ -1066,11 +1079,15 @@ impl MigParseState {
         for host in self.hosts.values_mut() {
             host.instances.sort_by_key(|i| i.instance_id);
         }
-        // Drop hosts that ended up with neither MIG mode nor any instance —
-        // an exporter is free to omit `gpu_mig_mode` if MIG is disabled, so
-        // we should not surface a bogus row from labels that only mentioned
-        // a `gpu_uuid` in passing.
-        self.hosts.retain(|_, h| h.is_mig_active());
+        // Retain a host when it either:
+        //   * received an explicit `gpu_mig_mode` line (enabled or disabled),
+        //     so disabled parent GPUs remain observable to consumers, or
+        //   * has at least one MIG instance attached.
+        // Hosts whose `gpu_uuid` appeared only incidentally on non-MIG
+        // metrics still drop out here.
+        let hosts_with_mode = &self.hosts_with_mode;
+        self.hosts
+            .retain(|uuid, h| hosts_with_mode.contains(uuid) || !h.instances.is_empty());
         let mut out: Vec<MigGpuInfo> = self.hosts.into_values().collect();
         out.sort_by_key(|h| h.gpu_index);
         out
@@ -1835,9 +1852,10 @@ all_smi_cpu_utilization{cpu_model="AMD", instance="node1", hostname="node1", ind
 
     #[test]
     fn mig_parser_records_disabled_mode_when_only_mode_metric_present() {
-        // A parent GPU with MIG mode disabled and no instances should still
-        // surface one row with `mig_mode=false`. Useful for dashboards that
-        // want to track the rollout of MIG enablement across a cluster.
+        // A parent GPU with MIG mode disabled and no instances must still
+        // surface one row with `mig_mode=false`. Dashboards rely on this to
+        // track runtime MIG toggles and cluster-wide MIG enablement rollout;
+        // silently dropping disabled rows would make the metric unobservable.
         let parser = create_test_parser();
         let re = create_test_regex();
         let host = "127.0.0.1:10203";
@@ -1846,12 +1864,14 @@ all_smi_cpu_utilization{cpu_model="AMD", instance="node1", hostname="node1", ind
 all_smi_gpu_mig_mode{gpu_index="0", gpu_uuid="GPU-X", gpu="NVIDIA A100", instance="node1", host="node1"} 0
 "#;
         let (_, _, _, _, _, mig) = parser.parse_metrics(text, host, &re);
-        // is_mig_active() == false when mig_mode is false and no instances:
-        // MigParseState::finish drops the row.
-        assert!(
-            mig.is_empty(),
-            "Disabled MIG mode with no instances must be silent"
+        assert_eq!(
+            mig.len(),
+            1,
+            "Disabled-MIG row must be retained so consumers can see mode=0"
         );
+        assert!(!mig[0].mig_mode);
+        assert_eq!(mig[0].gpu_uuid, "GPU-X");
+        assert!(mig[0].instances.is_empty());
     }
 
     #[test]

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -19,8 +19,8 @@ use chrono::Local;
 use regex::Regex;
 
 use crate::device::{
-    AppleSiliconCpuInfo, CpuInfo, CpuPlatformType, GpuInfo, MemoryInfo, MigGpuInfo, MigInstanceInfo,
-    VgpuHostInfo, VgpuInfo,
+    AppleSiliconCpuInfo, CpuInfo, CpuPlatformType, GpuInfo, MemoryInfo, MigGpuInfo,
+    MigInstanceInfo, VgpuHostInfo, VgpuInfo,
 };
 use crate::storage::info::StorageInfo;
 
@@ -87,8 +87,7 @@ impl MetricsParser {
                 // the broader `gpu_` prefix below.
                 if metric_name.starts_with("vgpu_") {
                     vgpu_state.process(&metric_name, &labels, value, host);
-                } else if metric_name == "gpu_mig_mode"
-                    || metric_name.starts_with("mig_instance_")
+                } else if metric_name == "gpu_mig_mode" || metric_name.starts_with("mig_instance_")
                 {
                     mig_state.process(&metric_name, &labels, value, host);
                 } else if metric_name.starts_with("gpu_")

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -1762,4 +1762,186 @@ all_smi_cpu_utilization{cpu_model="AMD", instance="node1", hostname="node1", ind
         let labels = parser.parse_labels(labels_str);
         assert_eq!(labels.get("key").unwrap(), "line1\nline2\rend");
     }
+
+    #[test]
+    fn test_parse_mig_metrics_populates_host_and_instances() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10200";
+
+        let text = r#"
+all_smi_gpu_mig_mode{gpu_index="0", gpu_uuid="GPU-M", gpu="NVIDIA A100", instance="node1", host="node1"} 1
+all_smi_mig_instance_utilization_gpu{gpu_index="0", gpu_uuid="GPU-M", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="0", mig_uuid="MIG-1", mig_profile="1g.5gb", gpu_instance_id="7", compute_instance_id="0"} 55
+all_smi_mig_instance_utilization_memory{gpu_index="0", gpu_uuid="GPU-M", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="0", mig_uuid="MIG-1", mig_profile="1g.5gb", gpu_instance_id="7", compute_instance_id="0"} 30
+all_smi_mig_instance_memory_used_bytes{gpu_index="0", gpu_uuid="GPU-M", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="0", mig_uuid="MIG-1", mig_profile="1g.5gb", gpu_instance_id="7", compute_instance_id="0"} 1073741824
+all_smi_mig_instance_memory_total_bytes{gpu_index="0", gpu_uuid="GPU-M", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="0", mig_uuid="MIG-1", mig_profile="1g.5gb", gpu_instance_id="7", compute_instance_id="0"} 5368709120
+all_smi_mig_instance_utilization_gpu{gpu_index="0", gpu_uuid="GPU-M", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="1", mig_uuid="MIG-2", mig_profile="2g.10gb", gpu_instance_id="2", compute_instance_id="0"} 10
+"#;
+
+        let (_gpu, _cpu, _mem, _storage, _vgpu, mig) = parser.parse_metrics(text, host, &re);
+
+        assert_eq!(mig.len(), 1, "expected one MIG host record");
+        let host0 = &mig[0];
+        assert!(host0.mig_mode);
+        assert_eq!(host0.gpu_uuid, "GPU-M");
+        assert_eq!(host0.gpu_name, "NVIDIA A100");
+        assert_eq!(host0.gpu_index, 0);
+        assert_eq!(host0.instances.len(), 2);
+
+        let inst0 = &host0.instances[0];
+        assert_eq!(inst0.instance_id, 0);
+        assert_eq!(inst0.uuid, "MIG-1");
+        assert_eq!(inst0.profile_name, "1g.5gb");
+        assert_eq!(inst0.gpu_instance_id, Some(7));
+        assert_eq!(inst0.compute_instance_id, Some(0));
+        assert_eq!(inst0.utilization_gpu, Some(55));
+        assert_eq!(inst0.utilization_memory, Some(30));
+        assert_eq!(inst0.memory_used_bytes, 1_073_741_824);
+        assert_eq!(inst0.memory_total_bytes, 5_368_709_120);
+
+        let inst1 = &host0.instances[1];
+        assert_eq!(inst1.instance_id, 1);
+        assert_eq!(inst1.utilization_gpu, Some(10));
+    }
+
+    #[test]
+    fn test_parse_mig_metrics_skips_rows_without_gpu_uuid() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10201";
+        let text = r#"
+all_smi_mig_instance_utilization_gpu{instance="node1", mig_instance="0"} 55
+"#;
+        let (_, _, _, _, _, mig) = parser.parse_metrics(text, host, &re);
+        assert!(mig.is_empty());
+    }
+
+    #[test]
+    fn test_parse_non_mig_host_produces_no_mig_rows() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10202";
+
+        let text = r#"
+all_smi_gpu_utilization{gpu="NVIDIA A100", instance="node1", uuid="GPU-X", index="0"} 50
+all_smi_cpu_utilization{cpu_model="AMD", instance="node1", hostname="node1", index="0"} 20
+"#;
+        let (gpu, _cpu, _mem, _store, _vgpu, mig) = parser.parse_metrics(text, host, &re);
+        assert_eq!(gpu.len(), 1);
+        assert!(
+            mig.is_empty(),
+            "No MIG rows must be emitted for a bare-metal host"
+        );
+    }
+
+    #[test]
+    fn mig_parser_records_disabled_mode_when_only_mode_metric_present() {
+        // A parent GPU with MIG mode disabled and no instances should still
+        // surface one row with `mig_mode=false`. Useful for dashboards that
+        // want to track the rollout of MIG enablement across a cluster.
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10203";
+
+        let text = r#"
+all_smi_gpu_mig_mode{gpu_index="0", gpu_uuid="GPU-X", gpu="NVIDIA A100", instance="node1", host="node1"} 0
+"#;
+        let (_, _, _, _, _, mig) = parser.parse_metrics(text, host, &re);
+        // is_mig_active() == false when mig_mode is false and no instances:
+        // MigParseState::finish drops the row.
+        assert!(
+            mig.is_empty(),
+            "Disabled MIG mode with no instances must be silent"
+        );
+    }
+
+    #[test]
+    fn mig_parser_caps_host_count() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10204";
+
+        // Feed 2 * MAX_MIG_GPUS unique host UUIDs. Only the first
+        // MAX_MIG_GPUS may survive; the rest must be dropped silently.
+        let mut text = String::new();
+        for i in 0..(2 * MAX_MIG_GPUS) {
+            text.push_str(&format!(
+                r#"all_smi_gpu_mig_mode{{gpu_index="0", gpu_uuid="GPU-{i}", gpu="NVIDIA A100", instance="node1", host="node1"}} 1
+"#
+            ));
+        }
+        let (_, _, _, _, _, mig) = parser.parse_metrics(&text, host, &re);
+        assert_eq!(mig.len(), MAX_MIG_GPUS, "host count must not exceed cap");
+    }
+
+    #[test]
+    fn mig_parser_caps_instance_count() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10205";
+
+        // Single host with 2 * MAX_MIG_INSTANCES unique mig_instance ids.
+        // Indices beyond MAX_MIG_INSTANCE_INDEX (64) are also dropped by the
+        // per-index defensive cap, so this test exercises both layers.
+        let mut text = String::new();
+        text.push_str(
+            r#"all_smi_gpu_mig_mode{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance="node1", host="node1"} 1
+"#,
+        );
+        for i in 0..(2 * MAX_MIG_INSTANCES) {
+            text.push_str(&format!(
+                r#"all_smi_mig_instance_utilization_gpu{{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="{i}", mig_uuid="MIG-{i}", mig_profile="1g.5gb"}} 1
+"#
+            ));
+        }
+        let (_, _, _, _, _, mig) = parser.parse_metrics(&text, host, &re);
+        assert_eq!(mig.len(), 1, "single host must still exist");
+        // Per-index cap kicks in first (only IDs 0..=64 survive), so the
+        // visible instance count is bounded by MAX_MIG_INSTANCE_INDEX + 1.
+        assert!(
+            mig[0].instances.len() <= (MAX_MIG_INSTANCE_INDEX as usize) + 1,
+            "per-index cap must clamp instance count, got {}",
+            mig[0].instances.len()
+        );
+    }
+
+    #[test]
+    fn mig_parser_drops_rows_with_oversized_instance_index() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10206";
+
+        // mig_instance="9999" exceeds the defensive cap (64) — must be
+        // dropped silently. The parent host record only surfaces because of
+        // the gpu_mig_mode line.
+        let text = r#"
+all_smi_gpu_mig_mode{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance="node1", host="node1"} 1
+all_smi_mig_instance_utilization_gpu{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="9999", mig_uuid="MIG-X", mig_profile="1g.5gb"} 50
+"#;
+        let (_, _, _, _, _, mig) = parser.parse_metrics(text, host, &re);
+        assert_eq!(mig.len(), 1, "host record present");
+        assert!(
+            mig[0].instances.is_empty(),
+            "oversized mig_instance must be rejected"
+        );
+    }
+
+    #[test]
+    fn mig_parser_handles_missing_optional_ids() {
+        // Older drivers may not emit gpu_instance_id / compute_instance_id.
+        // Empty values must round-trip as None rather than panic.
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10207";
+
+        let text = r#"
+all_smi_gpu_mig_mode{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance="node1", host="node1"} 1
+all_smi_mig_instance_utilization_gpu{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="0", mig_uuid="MIG-X", mig_profile="1g.5gb", gpu_instance_id="", compute_instance_id=""} 25
+"#;
+        let (_, _, _, _, _, mig) = parser.parse_metrics(text, host, &re);
+        assert_eq!(mig.len(), 1);
+        assert_eq!(mig[0].instances.len(), 1);
+        assert!(mig[0].instances[0].gpu_instance_id.is_none());
+        assert!(mig[0].instances[0].compute_instance_id.is_none());
+    }
 }

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -1088,6 +1088,17 @@ impl MigParseState {
         let hosts_with_mode = &self.hosts_with_mode;
         self.hosts
             .retain(|uuid, h| hosts_with_mode.contains(uuid) || !h.instances.is_empty());
+        // Enforce the invariant: mig_mode must be true whenever instances are
+        // present. A remote feed may emit `all_smi_mig_instance_*` lines for a
+        // UUID without a corresponding `gpu_mig_mode` line. The retain above
+        // keeps such hosts alive via the `!h.instances.is_empty()` arm, but
+        // they would carry `mig_mode=false`, which is a contradictory "ghost"
+        // state that no real exporter produces. Infer the mode from presence.
+        for host in self.hosts.values_mut() {
+            if !host.instances.is_empty() {
+                host.mig_mode = true;
+            }
+        }
         let mut out: Vec<MigGpuInfo> = self.hosts.into_values().collect();
         out.sort_by_key(|h| h.gpu_index);
         out
@@ -1962,5 +1973,30 @@ all_smi_mig_instance_utilization_gpu{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDI
         assert_eq!(mig[0].instances.len(), 1);
         assert!(mig[0].instances[0].gpu_instance_id.is_none());
         assert!(mig[0].instances[0].compute_instance_id.is_none());
+    }
+
+    #[test]
+    fn mig_parser_infers_mig_mode_from_instance_presence() {
+        // When a remote feed emits `all_smi_mig_instance_*` lines for a UUID
+        // without a `gpu_mig_mode` line, the host would survive the retain
+        // (via the `!instances.is_empty()` arm) but carry `mig_mode=false` —
+        // a contradictory "ghost" state. The parser must infer `mig_mode=true`
+        // whenever instances are present.
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10208";
+
+        // No gpu_mig_mode line — only instance metrics.
+        let text = r#"
+all_smi_mig_instance_utilization_gpu{gpu_index="0", gpu_uuid="GPU-G", gpu="NVIDIA A100", instance="node1", host="node1", mig_instance="0", mig_uuid="MIG-G1", mig_profile="1g.5gb", gpu_instance_id="7", compute_instance_id="0"} 42
+"#;
+        let (_, _, _, _, _, mig) = parser.parse_metrics(text, host, &re);
+        assert_eq!(mig.len(), 1, "host must survive via instance presence");
+        assert!(
+            mig[0].mig_mode,
+            "mig_mode must be inferred as true when instances are present"
+        );
+        assert_eq!(mig[0].instances.len(), 1);
+        assert_eq!(mig[0].instances[0].uuid, "MIG-G1");
     }
 }

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -19,7 +19,8 @@ use chrono::Local;
 use regex::Regex;
 
 use crate::device::{
-    AppleSiliconCpuInfo, CpuInfo, CpuPlatformType, GpuInfo, MemoryInfo, VgpuHostInfo, VgpuInfo,
+    AppleSiliconCpuInfo, CpuInfo, CpuPlatformType, GpuInfo, MemoryInfo, MigGpuInfo, MigInstanceInfo,
+    VgpuHostInfo, VgpuInfo,
 };
 use crate::storage::info::StorageInfo;
 
@@ -42,6 +43,7 @@ impl MetricsParser {
         Vec<MemoryInfo>,
         Vec<StorageInfo>,
         Vec<VgpuHostInfo>,
+        Vec<MigGpuInfo>,
     ) {
         // Limit the maximum size of HashMaps to prevent memory exhaustion
         const MAX_DEVICES_PER_TYPE: usize = 256;
@@ -64,6 +66,9 @@ impl MetricsParser {
         // Keyed by (gpu_uuid, vgpu_id) for instance rows, and by (gpu_uuid, "__host__")
         // for host-scoped metrics.
         let mut vgpu_state = VgpuParseState::new();
+        // MIG accumulator — keyed by gpu_uuid for parent host rows, and by
+        // (gpu_uuid, mig_instance) for per-instance rows.
+        let mut mig_state = MigParseState::new();
         let mut host_instance_name: Option<String> = None;
 
         for line in text.lines() {
@@ -78,9 +83,14 @@ impl MetricsParser {
                 }
 
                 // Process different metric types with size limits.
-                // Route vGPU lines first so they aren't swallowed by the gpu_ prefix.
+                // Route vGPU and MIG lines first so they aren't swallowed by
+                // the broader `gpu_` prefix below.
                 if metric_name.starts_with("vgpu_") {
                     vgpu_state.process(&metric_name, &labels, value, host);
+                } else if metric_name == "gpu_mig_mode"
+                    || metric_name.starts_with("mig_instance_")
+                {
+                    mig_state.process(&metric_name, &labels, value, host);
                 } else if metric_name.starts_with("gpu_")
                     || metric_name.starts_with("npu_")
                     || metric_name == "ane_utilization"
@@ -145,6 +155,7 @@ impl MetricsParser {
             memory_info_map.into_values().collect(),
             storage_info_map.into_values().collect(),
             vgpu_state.finish(),
+            mig_state.finish(),
         )
     }
 
@@ -902,6 +913,171 @@ impl VgpuParseState {
     }
 }
 
+/// Accumulator used while parsing MIG Prometheus lines.
+///
+/// Per-instance metrics are keyed by `(gpu_uuid, mig_instance)` so they merge
+/// into a single [`MigInstanceInfo`] even if emitted across multiple metric
+/// families. Host-scoped metrics (`gpu_mig_mode`) populate the parent
+/// [`MigGpuInfo`] keyed solely by `gpu_uuid`.
+struct MigParseState {
+    /// `gpu_uuid -> MigGpuInfo` being assembled.
+    hosts: HashMap<String, MigGpuInfo>,
+    /// `(gpu_uuid, mig_instance) -> MigInstanceInfo` accumulator.
+    instances: HashMap<(String, u32), MigInstanceInfo>,
+}
+
+/// Per-scrape cap on distinct MIG-capable GPUs. Matches the existing
+/// `MAX_DEVICES_PER_TYPE` and `MAX_VGPU_HOSTS` ceilings so a malicious remote
+/// exporter cannot exhaust memory by advertising unbounded `gpu_uuid` values.
+const MAX_MIG_GPUS: usize = 256;
+/// Per-scrape cap on distinct `(gpu_uuid, mig_instance)` tuples. A100/H100
+/// support up to 7 instances per GPU, so 4096 leaves plenty of headroom for
+/// large clusters without inviting an OOM via crafted input.
+const MAX_MIG_INSTANCES: usize = 4096;
+/// Per-instance cap on the `mig_instance` index value itself. MIG hardware
+/// caps at 7 today; we accept up to 64 to leave headroom for future
+/// architectures while still rejecting obviously bogus indices like
+/// `mig_instance="9999"` from a hostile remote.
+const MAX_MIG_INSTANCE_INDEX: u32 = 64;
+
+impl MigParseState {
+    fn new() -> Self {
+        Self {
+            hosts: HashMap::new(),
+            instances: HashMap::new(),
+        }
+    }
+
+    fn process(
+        &mut self,
+        metric_name: &str,
+        labels: &HashMap<String, String>,
+        value: f64,
+        host: &str,
+    ) {
+        let gpu_uuid = labels.get("gpu_uuid").cloned().unwrap_or_default();
+        if gpu_uuid.is_empty() {
+            return;
+        }
+
+        // Drop samples for new hosts once the cap is reached. Updates to an
+        // already-tracked host UUID always flow through.
+        if !self.hosts.contains_key(&gpu_uuid) && self.hosts.len() >= MAX_MIG_GPUS {
+            return;
+        }
+
+        // Ensure the host row exists before we touch either branch.
+        let host_entry = self.hosts.entry(gpu_uuid.clone()).or_insert_with(|| {
+            let gpu_index = labels
+                .get("gpu_index")
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(0);
+            let hostname = labels
+                .get("host")
+                .or_else(|| labels.get("instance"))
+                .cloned()
+                .unwrap_or_else(|| host.to_string());
+            MigGpuInfo {
+                host_id: host.to_string(),
+                hostname: hostname.clone(),
+                instance: hostname,
+                gpu_index,
+                gpu_uuid: gpu_uuid.clone(),
+                gpu_name: labels.get("gpu").cloned().unwrap_or_default(),
+                mig_mode: false,
+                instances: Vec::new(),
+            }
+        });
+
+        match metric_name {
+            "gpu_mig_mode" => {
+                // Exporter encodes 1=enabled, 0=disabled. Treat any positive
+                // value defensively as "enabled" rather than panicking on a
+                // weird remote payload.
+                host_entry.mig_mode = value > 0.0;
+            }
+            _ => {
+                // Per-instance metric families: require a `mig_instance` label
+                // and reject indices beyond the defensive cap.
+                let Some(mig_instance) = labels
+                    .get("mig_instance")
+                    .and_then(|s| s.parse::<u32>().ok())
+                else {
+                    return;
+                };
+                if mig_instance > MAX_MIG_INSTANCE_INDEX {
+                    return;
+                }
+                let instance_key = (gpu_uuid.clone(), mig_instance);
+
+                // Drop new-instance samples once the cap is reached. Updates
+                // to an already-tracked instance always flow through.
+                if !self.instances.contains_key(&instance_key)
+                    && self.instances.len() >= MAX_MIG_INSTANCES
+                {
+                    return;
+                }
+
+                let entry = self
+                    .instances
+                    .entry(instance_key)
+                    .or_insert_with(|| MigInstanceInfo {
+                        instance_id: mig_instance,
+                        gpu_instance_id: labels
+                            .get("gpu_instance_id")
+                            .and_then(|s| s.parse::<u32>().ok()),
+                        compute_instance_id: labels
+                            .get("compute_instance_id")
+                            .and_then(|s| s.parse::<u32>().ok()),
+                        uuid: labels.get("mig_uuid").cloned().unwrap_or_default(),
+                        profile_name: labels.get("mig_profile").cloned().unwrap_or_default(),
+                        utilization_gpu: None,
+                        utilization_memory: None,
+                        memory_used_bytes: 0,
+                        memory_total_bytes: 0,
+                    });
+
+                match metric_name {
+                    "mig_instance_utilization_gpu" => {
+                        entry.utilization_gpu = Some(value as u32);
+                    }
+                    "mig_instance_utilization_memory" => {
+                        entry.utilization_memory = Some(value as u32);
+                    }
+                    "mig_instance_memory_used_bytes" => {
+                        entry.memory_used_bytes = value as u64;
+                    }
+                    "mig_instance_memory_total_bytes" => {
+                        entry.memory_total_bytes = value as u64;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn finish(mut self) -> Vec<MigGpuInfo> {
+        // Attach instances to their owning host rows.
+        for ((gpu_uuid, _mig_instance), instance) in self.instances {
+            if let Some(host) = self.hosts.get_mut(&gpu_uuid) {
+                host.instances.push(instance);
+            }
+        }
+        // Deterministic order: instance_id ascending inside each host.
+        for host in self.hosts.values_mut() {
+            host.instances.sort_by_key(|i| i.instance_id);
+        }
+        // Drop hosts that ended up with neither MIG mode nor any instance —
+        // an exporter is free to omit `gpu_mig_mode` if MIG is disabled, so
+        // we should not surface a bogus row from labels that only mentioned
+        // a `gpu_uuid` in passing.
+        self.hosts.retain(|_, h| h.is_mig_active());
+        let mut out: Vec<MigGpuInfo> = self.hosts.into_values().collect();
+        out.sort_by_key(|h| h.gpu_index);
+        out
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -950,7 +1126,7 @@ all_smi_gpu_power_consumption_watts{gpu="NVIDIA H200 141GB HBM3", instance="node
 all_smi_ane_utilization{gpu="NVIDIA H200 141GB HBM3", instance="node-0058", uuid="GPU-12345", index="0"} 15.2
 "#;
 
-        let (gpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (gpu_info, _, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(gpu_info.len(), 1);
         let gpu = &gpu_info[0];
@@ -983,7 +1159,7 @@ all_smi_gpu_temperature_threshold_acoustic_celsius{gpu="NVIDIA A100", instance="
 all_smi_gpu_performance_state{gpu="NVIDIA A100", instance="node-1", uuid="GPU-T", index="0"} 2
 "#;
 
-        let (gpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (gpu_info, _, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
         assert_eq!(gpu_info.len(), 1);
         let gpu = &gpu_info[0];
         assert_eq!(gpu.temperature_threshold_slowdown, Some(90));
@@ -1005,7 +1181,7 @@ all_smi_gpu_performance_state{gpu="NVIDIA A100", instance="node-1", uuid="GPU-T"
 all_smi_gpu_utilization{gpu="NVIDIA A100", instance="node-1", uuid="GPU-A", index="0"} 40
 all_smi_gpu_temperature_celsius{gpu="NVIDIA A100", instance="node-1", uuid="GPU-A", index="0"} 60
 "#;
-        let (gpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (gpu_info, _, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
         assert_eq!(gpu_info.len(), 1);
         let gpu = &gpu_info[0];
         assert!(gpu.temperature_threshold_slowdown.is_none());
@@ -1027,7 +1203,7 @@ all_smi_gpu_temperature_celsius{gpu="NVIDIA A100", instance="node-1", uuid="GPU-
                 "all_smi_gpu_utilization{{gpu=\"GPU\", instance=\"n\", uuid=\"GPU-BAD\", index=\"0\"}} 0\n\
                  all_smi_gpu_performance_state{{gpu=\"GPU\", instance=\"n\", uuid=\"GPU-BAD\", index=\"0\"}} {bad_value}\n"
             );
-            let (gpu_info, _, _, _, _) = parser.parse_metrics(&test_data, host, &re);
+            let (gpu_info, _, _, _, _, _) = parser.parse_metrics(&test_data, host, &re);
             assert_eq!(gpu_info.len(), 1);
             assert!(
                 gpu_info[0].performance_state.is_none(),
@@ -1062,7 +1238,7 @@ all_smi_cpu_temperature_celsius{cpu_model="Intel Xeon", instance="node-0058", ho
 all_smi_cpu_power_consumption_watts{cpu_model="Intel Xeon", instance="node-0058", hostname="node-0058", index="0"} 125.5
 "#;
 
-        let (_, cpu_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (_, cpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(cpu_info.len(), 1);
         let cpu = &cpu_info[0];
@@ -1098,7 +1274,7 @@ all_smi_cpu_p_core_utilization{cpu_model="Apple M2 Max", instance="node-0058", h
 all_smi_cpu_e_core_utilization{cpu_model="Apple M2 Max", instance="node-0058", hostname="node-0058", index="0"} 10.8
 "#;
 
-        let (_, cpu_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (_, cpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(cpu_info.len(), 1);
         let cpu = &cpu_info[0];
@@ -1129,7 +1305,7 @@ all_smi_memory_available_bytes{instance="node-0058", hostname="node-0058", index
 all_smi_memory_utilization{instance="node-0058", hostname="node-0058", index="0"} 50.0
 "#;
 
-        let (_, _, memory_info, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (_, _, memory_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(memory_info.len(), 1);
         let memory = &memory_info[0];
@@ -1155,7 +1331,7 @@ all_smi_disk_total_bytes{instance="node-0058", mount_point="/home", index="1"} 1
 all_smi_disk_available_bytes{instance="node-0058", mount_point="/home", index="1"} 549755813888
 "#;
 
-        let (_, _, _, storage_info, _) = parser.parse_metrics(test_data, host, &re);
+        let (_, _, _, storage_info, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(storage_info.len(), 2);
 
@@ -1190,7 +1366,7 @@ all_smi_memory_total_bytes{instance="node-0001", hostname="node-0001", index="0"
 all_smi_disk_total_bytes{instance="node-0001", mount_point="/", index="0"} 2199023255552
 "#;
 
-        let (gpu_info, cpu_info, memory_info, storage_info, _) =
+        let (gpu_info, cpu_info, memory_info, storage_info, _, _) =
             parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(gpu_info.len(), 1);
@@ -1227,7 +1403,7 @@ all_smi_gpu_utilization{malformed labels} invalid_value
 all_smi_unknown_metric{instance="test"} 42.0
 "#;
 
-        let (gpu_info, cpu_info, memory_info, storage_info, _) =
+        let (gpu_info, cpu_info, memory_info, storage_info, _, _) =
             parser.parse_metrics(test_data, host, &re);
 
         assert!(gpu_info.is_empty());
@@ -1242,7 +1418,7 @@ all_smi_unknown_metric{instance="test"} 42.0
         let re = create_test_regex();
         let host = "127.0.0.1:10058";
 
-        let (gpu_info, cpu_info, memory_info, storage_info, _) =
+        let (gpu_info, cpu_info, memory_info, storage_info, _, _) =
             parser.parse_metrics("", host, &re);
 
         assert!(gpu_info.is_empty());
@@ -1262,7 +1438,7 @@ all_smi_gpu_utilization{gpu="Tesla V100", instance="production-node-42", uuid="G
 all_smi_cpu_utilization{cpu_model="Intel Xeon", instance="production-node-42", hostname="node-0058", index="0"} 55.0
 "#;
 
-        let (gpu_info, cpu_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (gpu_info, cpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(gpu_info[0].host_id, host);
         assert_eq!(gpu_info[0].hostname, "production-node-42");
@@ -1293,7 +1469,7 @@ all_smi_cpu_utilization{cpu_model="Intel Xeon", instance="production-node-42", h
                 r#"all_smi_cpu_utilization{{cpu_model="{cpu_model}", instance="test", hostname="test", index="0"}} 50.0"#
             );
 
-            let (_, cpu_info, _, _, _) = parser.parse_metrics(&test_data, host, &re);
+            let (_, cpu_info, _, _, _, _) = parser.parse_metrics(&test_data, host, &re);
             assert_eq!(cpu_info.len(), 1);
 
             match (&cpu_info[0].platform_type, &expected_type) {
@@ -1328,7 +1504,7 @@ all_smi_gpu_utilization{instance="node-0058", index="0"} 25.5
 all_smi_disk_total_bytes{instance="node-0058", index="0"} 1000000000
 "#;
 
-        let (gpu_info, _, _, storage_info, _) = parser.parse_metrics(test_data, host, &re);
+        let (gpu_info, _, _, storage_info, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert!(gpu_info.is_empty());
         assert!(storage_info.is_empty());
@@ -1351,7 +1527,7 @@ all_smi_cpu_p_core_utilization{cpu_model="Apple M5 Max", instance="m5-node", hos
 all_smi_cpu_e_core_utilization{cpu_model="Apple M5 Max", instance="m5-node", hostname="m5-node", index="0"} 0.0
 "#;
 
-        let (_, cpu_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (_, cpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(cpu_info.len(), 1);
         let cpu = &cpu_info[0];
@@ -1386,7 +1562,7 @@ all_smi_cpu_core_utilization{cpu_model="Apple M5 Pro", instance="m5pro-node", ho
 all_smi_cpu_core_utilization{cpu_model="Apple M5 Pro", instance="m5pro-node", hostname="m5pro-node", core_id="3", core_type="P", index="0"} 25.0
 "#;
 
-        let (_, cpu_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (_, cpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(cpu_info.len(), 1);
         let cpu = &cpu_info[0];
@@ -1428,7 +1604,7 @@ all_smi_cpu_p_core_utilization{cpu_model="Apple M2 Max", instance="m2-node", hos
 all_smi_cpu_e_core_utilization{cpu_model="Apple M2 Max", instance="m2-node", hostname="m2-node", index="0"} 5.0
 "#;
 
-        let (_, cpu_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
+        let (_, cpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
         assert_eq!(cpu_info.len(), 1);
         let cpu = &cpu_info[0];
@@ -1459,7 +1635,7 @@ all_smi_vgpu_active{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance
 all_smi_vgpu_utilization{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", instance="node1", host="node1", vgpu_id="1", vgpu_uuid="GRID-2", vgpu_type="GRID A100-4C"} 10
 "#;
 
-        let (_gpu, _cpu, _mem, _storage, vgpu) = parser.parse_metrics(text, host, &re);
+        let (_gpu, _cpu, _mem, _storage, vgpu, _) = parser.parse_metrics(text, host, &re);
 
         assert_eq!(vgpu.len(), 1, "expected one host record");
         let host0 = &vgpu[0];
@@ -1488,7 +1664,7 @@ all_smi_vgpu_utilization{gpu_index="0", gpu_uuid="GPU-A", gpu="NVIDIA A100", ins
         let text = r#"
 all_smi_vgpu_utilization{instance="node1", vgpu_id="0"} 55
 "#;
-        let (_, _, _, _, vgpu) = parser.parse_metrics(text, host, &re);
+        let (_, _, _, _, vgpu, _) = parser.parse_metrics(text, host, &re);
         assert!(vgpu.is_empty());
     }
 
@@ -1502,7 +1678,7 @@ all_smi_vgpu_utilization{instance="node1", vgpu_id="0"} 55
 all_smi_gpu_utilization{gpu="NVIDIA A100", instance="node1", uuid="GPU-X", index="0"} 50
 all_smi_cpu_utilization{cpu_model="AMD", instance="node1", hostname="node1", index="0"} 20
 "#;
-        let (gpu, _cpu, _mem, _store, vgpu) = parser.parse_metrics(text, host, &re);
+        let (gpu, _cpu, _mem, _store, vgpu, _) = parser.parse_metrics(text, host, &re);
         assert_eq!(gpu.len(), 1);
         assert!(
             vgpu.is_empty(),
@@ -1525,7 +1701,7 @@ all_smi_cpu_utilization{cpu_model="AMD", instance="node1", hostname="node1", ind
 "#
             ));
         }
-        let (_gpu, _cpu, _mem, _storage, vgpu) = parser.parse_metrics(&text, host, &re);
+        let (_gpu, _cpu, _mem, _storage, vgpu, _) = parser.parse_metrics(&text, host, &re);
         assert_eq!(vgpu.len(), MAX_VGPU_HOSTS, "host count must not exceed cap");
     }
 
@@ -1551,7 +1727,7 @@ all_smi_cpu_utilization{cpu_model="AMD", instance="node1", hostname="node1", ind
 "#
             ));
         }
-        let (_gpu, _cpu, _mem, _storage, vgpu) = parser.parse_metrics(&text, host, &re);
+        let (_gpu, _cpu, _mem, _storage, vgpu, _) = parser.parse_metrics(&text, host, &re);
         assert_eq!(vgpu.len(), 1, "single host must still exist");
         assert_eq!(
             vgpu[0].vgpus.len(),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -47,7 +47,7 @@ pub use crate::client::{AllSmi, AllSmiConfig, DeviceType};
 pub use crate::error::{Error, Result};
 
 // Core data types - GPU/NPU
-pub use crate::device::{GpuInfo, ProcessInfo, VgpuHostInfo, VgpuInfo};
+pub use crate::device::{GpuInfo, MigGpuInfo, MigInstanceInfo, ProcessInfo, VgpuHostInfo, VgpuInfo};
 
 // Core data types - CPU
 pub use crate::device::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -47,7 +47,9 @@ pub use crate::client::{AllSmi, AllSmiConfig, DeviceType};
 pub use crate::error::{Error, Result};
 
 // Core data types - GPU/NPU
-pub use crate::device::{GpuInfo, MigGpuInfo, MigInstanceInfo, ProcessInfo, VgpuHostInfo, VgpuInfo};
+pub use crate::device::{
+    GpuInfo, MigGpuInfo, MigInstanceInfo, ProcessInfo, VgpuHostInfo, VgpuInfo,
+};
 
 // Core data types - CPU
 pub use crate::device::{

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -15,7 +15,7 @@
 /// UI layout calculation utilities
 use crate::app_state::AppState;
 use crate::cli::ViewArgs;
-use crate::device::{GpuInfo, VgpuHostInfo};
+use crate::device::{GpuInfo, MigGpuInfo, VgpuHostInfo};
 use crate::ui::activity_panel;
 use crate::ui::gpu_sparkline_panel;
 use crate::ui::renderers::gpu_renderer::gpu_render_line_count;
@@ -335,11 +335,15 @@ fn visible_gpus_for_tab<'a>(state: &'a AppState) -> Box<dyn Iterator<Item = &'a 
 }
 
 /// Compute the maximum line count any visible GPU would render given the
-/// current `state.gpu_info` and `state.vgpu_info`. Falls back to the
-/// historical 2-line baseline when no GPUs are visible (empty cluster,
-/// loading state) so layout math never returns 0.
+/// current `state.gpu_info`, `state.vgpu_info`, and `state.mig_info`. Falls
+/// back to the historical 2-line baseline when no GPUs are visible (empty
+/// cluster, loading state) so layout math never returns 0.
 pub(crate) fn max_gpu_lines_for_tab(state: &AppState) -> usize {
-    max_gpu_lines_over(visible_gpus_for_tab(state), &state.vgpu_info)
+    max_gpu_lines_over(
+        visible_gpus_for_tab(state),
+        &state.vgpu_info,
+        &state.mig_info,
+    )
 }
 
 /// Pure helper used by [`max_gpu_lines_for_tab`] and the unit tests. Iterates
@@ -348,8 +352,9 @@ pub(crate) fn max_gpu_lines_for_tab(state: &AppState) -> usize {
 pub(crate) fn max_gpu_lines_over<'a>(
     gpus: impl Iterator<Item = &'a GpuInfo>,
     vgpu_info: &[VgpuHostInfo],
+    mig_info: &[MigGpuInfo],
 ) -> usize {
-    gpus.map(|g| gpu_render_line_count(g, vgpu_info))
+    gpus.map(|g| gpu_render_line_count(g, vgpu_info, mig_info))
         .max()
         .unwrap_or(2)
 }
@@ -454,7 +459,7 @@ mod tests {
     fn max_gpu_lines_over_returns_two_for_empty_iterator() {
         // No GPUs visible (e.g. cluster still loading) → fall back to the
         // historical baseline so layout math never returns 0.
-        let lines = max_gpu_lines_over(std::iter::empty(), &[]);
+        let lines = max_gpu_lines_over(std::iter::empty(), &[], &[]);
         assert_eq!(lines, 2);
     }
 
@@ -466,7 +471,7 @@ mod tests {
         let mut nvidia = make_minimal_gpu("h2", "NVIDIA A100");
         nvidia.performance_state = Some(2);
         let gpus = [plain, nvidia];
-        let lines = max_gpu_lines_over(gpus.iter(), &[]);
+        let lines = max_gpu_lines_over(gpus.iter(), &[], &[]);
         assert_eq!(lines, 3);
     }
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -16,6 +16,6 @@
 pub use crate::ui::chrome::{print_function_keys, print_loading_indicator};
 pub use crate::ui::process_renderer::print_process_info;
 pub use crate::ui::renderers::{
-    print_chassis_info, print_cpu_info, print_gpu_info, print_memory_info, print_storage_info,
-    print_vgpu_section,
+    print_chassis_info, print_cpu_info, print_gpu_info, print_memory_info, print_mig_section,
+    print_storage_info, print_vgpu_section,
 };

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -17,6 +17,7 @@ use std::io::Write;
 use crossterm::{queue, style::Color, style::Print};
 
 use crate::device::GpuInfo;
+use crate::device::MigGpuInfo;
 use crate::device::VgpuHostInfo;
 use crate::device::types::{ThermalProximity, ThermalProximityConfig};
 use crate::ui::text::print_colored_text;
@@ -41,7 +42,7 @@ impl GpuRenderer {
 
 /// Compute the number of terminal lines [`print_gpu_info`] will emit for a
 /// single GPU, including any optional thermal/P-state row and any nested
-/// vGPU section.
+/// vGPU / MIG section.
 ///
 /// Layout pieces, in render order:
 ///   1. The base info line (always 1 line).
@@ -50,15 +51,22 @@ impl GpuRenderer {
 ///   3. The gauge row (always 1 line).
 ///   4. A nested vGPU section, when a matching [`VgpuHostInfo`] is present
 ///      and the host is "active": 1 header line + 1 line per vGPU instance.
+///   5. A nested MIG section, when a matching [`MigGpuInfo`] is present and
+///      the host is "active": 1 header line + 1 line per MIG instance.
 ///
-/// The vGPU matching here mirrors `find_matching_vgpu_host` in
-/// `view::frame_renderer` (UUID first, then hostname + gpu_name fallback)
-/// so that layout math agrees with what is actually rendered.
+/// The vGPU/MIG matching here mirrors `find_matching_vgpu_host` /
+/// `find_matching_mig_gpu` in `view::frame_renderer` (UUID first, then
+/// hostname + gpu_name fallback) so that layout math agrees with what is
+/// actually rendered.
 ///
 /// Used by the layout calculator and the PgUp/PgDn handlers to size the
 /// scrollable GPU area correctly when the new thermal/P-state row is
 /// present, since it can grow rows from 2 to 3 lines apiece.
-pub fn gpu_render_line_count(gpu: &GpuInfo, vgpu_info: &[VgpuHostInfo]) -> usize {
+pub fn gpu_render_line_count(
+    gpu: &GpuInfo,
+    vgpu_info: &[VgpuHostInfo],
+    mig_info: &[MigGpuInfo],
+) -> usize {
     // Base: info line + gauges line.
     let mut lines: usize = 2;
 
@@ -87,6 +95,23 @@ pub fn gpu_render_line_count(gpu: &GpuInfo, vgpu_info: &[VgpuHostInfo]) -> usize
         && host.is_vgpu_active()
     {
         lines += 1 + host.vgpus.len();
+    }
+
+    // Optional MIG section: header + one row per instance. The matching
+    // logic must stay in lockstep with `find_matching_mig_gpu` in
+    // `view::frame_renderer`.
+    let mig_matched = mig_info
+        .iter()
+        .find(|m| m.gpu_uuid == gpu.uuid)
+        .or_else(|| {
+            mig_info
+                .iter()
+                .find(|m| m.hostname == gpu.hostname && m.gpu_name == gpu.name)
+        });
+    if let Some(host) = mig_matched
+        && host.is_mig_active()
+    {
+        lines += 1 + host.instances.len();
     }
 
     lines
@@ -816,7 +841,7 @@ mod tests {
         gpu.temperature_threshold_max_operating = None;
         gpu.temperature_threshold_acoustic = None;
         gpu.performance_state = None;
-        assert_eq!(gpu_render_line_count(&gpu, &[]), 2);
+        assert_eq!(gpu_render_line_count(&gpu, &[], &[]), 2);
     }
 
     #[test]
@@ -837,7 +862,7 @@ mod tests {
             gpu.performance_state = None;
             setter(&mut gpu);
             assert_eq!(
-                gpu_render_line_count(&gpu, &[]),
+                gpu_render_line_count(&gpu, &[], &[]),
                 3,
                 "expected 3 lines for {gpu:?}"
             );
@@ -856,7 +881,10 @@ mod tests {
         gpu.uuid = "GPU-A".to_string();
         let host = make_vgpu_host("GPU-A", 3);
         // 2 base + 0 thermal + (1 header + 3 instances) = 6
-        assert_eq!(gpu_render_line_count(&gpu, std::slice::from_ref(&host)), 6);
+        assert_eq!(
+            gpu_render_line_count(&gpu, std::slice::from_ref(&host), &[]),
+            6
+        );
     }
 
     #[test]
@@ -875,7 +903,10 @@ mod tests {
         gpu.name = "Test GPU".to_string();
         // Host has a *different* uuid but matching hostname + gpu_name.
         let host = make_vgpu_host("GPU-OTHER", 2);
-        assert_eq!(gpu_render_line_count(&gpu, std::slice::from_ref(&host)), 5);
+        assert_eq!(
+            gpu_render_line_count(&gpu, std::slice::from_ref(&host), &[]),
+            5
+        );
     }
 
     #[test]
@@ -890,7 +921,10 @@ mod tests {
         let mut host = make_vgpu_host("GPU-A", 0);
         host.host_mode = "Disabled".to_string();
         // Disabled host with no instances renders nothing → count stays at 2.
-        assert_eq!(gpu_render_line_count(&gpu, std::slice::from_ref(&host)), 2);
+        assert_eq!(
+            gpu_render_line_count(&gpu, std::slice::from_ref(&host), &[]),
+            2
+        );
     }
 
     #[test]
@@ -903,6 +937,116 @@ mod tests {
         // thermal row +1 line.
         let host = make_vgpu_host("GPU-A", 2);
         // 2 base + 1 thermal + (1 header + 2 instances) = 6
-        assert_eq!(gpu_render_line_count(&gpu, std::slice::from_ref(&host)), 6);
+        assert_eq!(
+            gpu_render_line_count(&gpu, std::slice::from_ref(&host), &[]),
+            6
+        );
+    }
+
+    fn make_mig_host(gpu_uuid: &str, instances: usize) -> MigGpuInfo {
+        use crate::device::types::MigInstanceInfo;
+        let entries = (0..instances)
+            .map(|i| MigInstanceInfo {
+                instance_id: i as u32,
+                gpu_instance_id: Some((i as u32) + 1),
+                compute_instance_id: Some(0),
+                uuid: format!("MIG-{i}"),
+                profile_name: "1g.5gb".into(),
+                utilization_gpu: Some(0),
+                utilization_memory: Some(0),
+                memory_used_bytes: 0,
+                memory_total_bytes: 5 << 30,
+            })
+            .collect();
+        MigGpuInfo {
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            gpu_index: 0,
+            gpu_uuid: gpu_uuid.to_string(),
+            gpu_name: "Test GPU".to_string(),
+            mig_mode: true,
+            instances: entries,
+        }
+    }
+
+    #[test]
+    fn line_count_includes_mig_section_when_uuid_matches() {
+        let mut gpu = make_gpu(40);
+        gpu.temperature_threshold_slowdown = None;
+        gpu.temperature_threshold_shutdown = None;
+        gpu.temperature_threshold_max_operating = None;
+        gpu.temperature_threshold_acoustic = None;
+        gpu.performance_state = None;
+        gpu.uuid = "GPU-A".to_string();
+        let mig_host = make_mig_host("GPU-A", 4);
+        // 2 base + 0 thermal + (1 MIG header + 4 instances) = 7
+        assert_eq!(
+            gpu_render_line_count(&gpu, &[], std::slice::from_ref(&mig_host)),
+            7
+        );
+    }
+
+    #[test]
+    fn line_count_falls_back_to_hostname_for_mig_when_uuid_missing() {
+        let mut gpu = make_gpu(40);
+        gpu.temperature_threshold_slowdown = None;
+        gpu.temperature_threshold_shutdown = None;
+        gpu.temperature_threshold_max_operating = None;
+        gpu.temperature_threshold_acoustic = None;
+        gpu.performance_state = None;
+        gpu.uuid = "GPU-A".to_string();
+        gpu.hostname = "h".to_string();
+        gpu.name = "Test GPU".to_string();
+        // MIG host has a different UUID but matching hostname + gpu_name.
+        let mig_host = make_mig_host("GPU-OTHER", 2);
+        // 2 base + (1 header + 2 instances) = 5
+        assert_eq!(
+            gpu_render_line_count(&gpu, &[], std::slice::from_ref(&mig_host)),
+            5
+        );
+    }
+
+    #[test]
+    fn line_count_combines_vgpu_and_mig_contributions() {
+        // Pathological but supported: a single GPU could in theory carry both
+        // vGPU and MIG records (e.g. a vGPU host that scrapes a MIG-enabled
+        // physical card via NVML on a passthrough-style setup). Exercise the
+        // additive path.
+        let mut gpu = make_gpu(40);
+        gpu.temperature_threshold_slowdown = None;
+        gpu.temperature_threshold_shutdown = None;
+        gpu.temperature_threshold_max_operating = None;
+        gpu.temperature_threshold_acoustic = None;
+        gpu.performance_state = None;
+        gpu.uuid = "GPU-A".to_string();
+        let vgpu_host = make_vgpu_host("GPU-A", 2);
+        let mig_host = make_mig_host("GPU-A", 3);
+        // 2 base + 0 thermal + (1+2 vGPU) + (1+3 MIG) = 9
+        assert_eq!(
+            gpu_render_line_count(
+                &gpu,
+                std::slice::from_ref(&vgpu_host),
+                std::slice::from_ref(&mig_host),
+            ),
+            9
+        );
+    }
+
+    #[test]
+    fn line_count_ignores_mig_host_with_no_instances_and_disabled_mode() {
+        let mut gpu = make_gpu(40);
+        gpu.temperature_threshold_slowdown = None;
+        gpu.temperature_threshold_shutdown = None;
+        gpu.temperature_threshold_max_operating = None;
+        gpu.temperature_threshold_acoustic = None;
+        gpu.performance_state = None;
+        gpu.uuid = "GPU-A".to_string();
+        let mut mig_host = make_mig_host("GPU-A", 0);
+        mig_host.mig_mode = false;
+        assert_eq!(
+            gpu_render_line_count(&gpu, &[], std::slice::from_ref(&mig_host)),
+            2
+        );
     }
 }

--- a/src/ui/renderers/mig_renderer.rs
+++ b/src/ui/renderers/mig_renderer.rs
@@ -1,0 +1,255 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compact per-GPU MIG section renderer.
+//!
+//! Mirrors the vGPU renderer in [`super::vgpu_renderer`]: called from the
+//! frame renderer only when a GPU has a matching [`MigGpuInfo`] record.
+//! Non-MIG GPUs receive zero output.
+
+use std::io::Write;
+
+use crossterm::{queue, style::Color, style::Print};
+
+use crate::device::MigGpuInfo;
+use crate::ui::text::print_colored_text;
+
+/// Render a compact MIG sub-section beneath a physical GPU row.
+///
+/// Layout:
+/// ```text
+///   MIG host: enabled  instances=3
+///       [0] 1g.5gb   util:42%  mem: 1.2/5.0GB  gi=7  ci=0
+///       [1] 2g.10gb  util:18%  mem: 4.0/10.0GB gi=2  ci=0
+///       [2] 7g.40gb  util: 0%  mem: 0.0/40.0GB
+/// ```
+///
+/// Writes nothing when the host carries no MIG-related data.
+pub fn print_mig_section<W: Write>(stdout: &mut W, host: &MigGpuInfo, _width: usize) {
+    if !host.is_mig_active() {
+        return;
+    }
+
+    print_colored_text(stdout, "  MIG host: ", Color::DarkGrey, None, None);
+    if host.mig_mode {
+        print_colored_text(stdout, "enabled", Color::Green, None, None);
+    } else {
+        print_colored_text(stdout, "disabled", Color::DarkRed, None, None);
+    }
+
+    print_colored_text(stdout, "  instances=", Color::DarkGrey, None, None);
+    print_colored_text(
+        stdout,
+        &host.instances.len().to_string(),
+        Color::Yellow,
+        None,
+        None,
+    );
+
+    queue!(stdout, Print("\r\n")).unwrap();
+
+    for (i, inst) in host.instances.iter().enumerate() {
+        print_colored_text(stdout, "      [", Color::DarkGrey, None, None);
+        print_colored_text(stdout, &i.to_string(), Color::Cyan, None, None);
+        print_colored_text(stdout, "] ", Color::DarkGrey, None, None);
+
+        let profile_display = if inst.profile_name.is_empty() {
+            "unknown"
+        } else {
+            inst.profile_name.as_str()
+        };
+        let profile_trunc = truncate_str(profile_display, 10);
+        print_colored_text(
+            stdout,
+            &format!("{profile_trunc:<10}"),
+            Color::White,
+            None,
+            None,
+        );
+
+        print_colored_text(stdout, " util:", Color::Yellow, None, None);
+        let util_str = match inst.utilization_gpu {
+            Some(u) => format!("{u:>3}%"),
+            None => "  -%".to_string(),
+        };
+        print_colored_text(stdout, &util_str, Color::White, None, None);
+
+        print_colored_text(stdout, "  mem:", Color::Blue, None, None);
+        let used_gb = inst.memory_used_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+        let total_gb = inst.memory_total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+        let mem_str = if inst.memory_total_bytes > 0 {
+            format!("{used_gb:>5.1}/{total_gb:.1}GB")
+        } else {
+            format!("{used_gb:>5.1}GB")
+        };
+        print_colored_text(stdout, &mem_str, Color::White, None, None);
+
+        if let Some(gi) = inst.gpu_instance_id {
+            print_colored_text(stdout, "  gi=", Color::DarkGrey, None, None);
+            print_colored_text(stdout, &gi.to_string(), Color::White, None, None);
+        }
+        if let Some(ci) = inst.compute_instance_id {
+            print_colored_text(stdout, "  ci=", Color::DarkGrey, None, None);
+            print_colored_text(stdout, &ci.to_string(), Color::White, None, None);
+        }
+
+        queue!(stdout, Print("\r\n")).unwrap();
+    }
+}
+
+/// Truncate a display string on char boundaries to the given max char count.
+/// Appends an ellipsis when truncation actually occurred.
+fn truncate_str(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{MigGpuInfo, MigInstanceInfo};
+
+    fn host_with(instances: Vec<MigInstanceInfo>, mig_mode: bool) -> MigGpuInfo {
+        MigGpuInfo {
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            gpu_index: 0,
+            gpu_uuid: "GPU-x".to_string(),
+            gpu_name: "GPU".to_string(),
+            mig_mode,
+            instances,
+        }
+    }
+
+    /// Strip common ANSI color escape sequences so tests can assert textual
+    /// content without matching the interleaved control codes.
+    fn strip_ansi(text: &str) -> String {
+        let mut out = String::with_capacity(text.len());
+        let mut chars = text.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                if chars.peek() == Some(&'[') {
+                    chars.next();
+                    for next in chars.by_ref() {
+                        if next.is_ascii_alphabetic() {
+                            break;
+                        }
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn renders_nothing_when_no_instances_and_mode_disabled() {
+        let host = host_with(Vec::new(), false);
+        let mut buf: Vec<u8> = Vec::new();
+        print_mig_section(&mut buf, &host, 80);
+        assert!(buf.is_empty(), "Disabled host with no instances must be silent");
+    }
+
+    #[test]
+    fn renders_section_when_mig_mode_is_enabled_even_without_instances() {
+        let host = host_with(Vec::new(), true);
+        let mut buf: Vec<u8> = Vec::new();
+        print_mig_section(&mut buf, &host, 80);
+        let out = strip_ansi(&String::from_utf8_lossy(&buf));
+        assert!(out.contains("MIG host"));
+        assert!(out.contains("enabled"));
+        assert!(out.contains("instances=0"));
+    }
+
+    #[test]
+    fn renders_each_mig_instance_row() {
+        let instances = vec![
+            MigInstanceInfo {
+                instance_id: 0,
+                gpu_instance_id: Some(7),
+                compute_instance_id: Some(0),
+                uuid: "MIG-0".into(),
+                profile_name: "1g.5gb".into(),
+                utilization_gpu: Some(42),
+                utilization_memory: Some(30),
+                memory_used_bytes: 2 * (1 << 30),
+                memory_total_bytes: 5 * (1 << 30),
+            },
+            MigInstanceInfo {
+                instance_id: 1,
+                gpu_instance_id: None,
+                compute_instance_id: None,
+                uuid: "MIG-1".into(),
+                profile_name: "2g.10gb".into(),
+                utilization_gpu: None,
+                utilization_memory: None,
+                memory_used_bytes: 0,
+                memory_total_bytes: 10 * (1 << 30),
+            },
+        ];
+        let host = host_with(instances, true);
+        let mut buf: Vec<u8> = Vec::new();
+        print_mig_section(&mut buf, &host, 100);
+        let plain = strip_ansi(&String::from_utf8_lossy(&buf));
+
+        assert!(plain.contains("[0]"), "missing [0] in:\n{plain}");
+        assert!(plain.contains("[1]"), "missing [1] in:\n{plain}");
+        assert!(plain.contains("1g.5gb"));
+        assert!(plain.contains("2g.10gb"));
+        assert!(plain.contains(" 42%"), "missing 42% in:\n{plain}");
+        assert!(plain.contains("-%"), "missing -% in:\n{plain}");
+        // gi/ci visible only on the instance that reports them.
+        assert!(plain.contains("gi=7"), "missing gi=7 in:\n{plain}");
+        assert!(plain.contains("ci=0"));
+    }
+
+    #[test]
+    fn renders_unknown_profile_when_name_empty() {
+        let instances = vec![MigInstanceInfo {
+            instance_id: 0,
+            gpu_instance_id: None,
+            compute_instance_id: None,
+            uuid: String::new(),
+            profile_name: String::new(),
+            utilization_gpu: Some(1),
+            utilization_memory: Some(1),
+            memory_used_bytes: 0,
+            memory_total_bytes: 0,
+        }];
+        let host = host_with(instances, true);
+        let mut buf: Vec<u8> = Vec::new();
+        print_mig_section(&mut buf, &host, 80);
+        let plain = strip_ansi(&String::from_utf8_lossy(&buf));
+        assert!(plain.contains("unknown"));
+    }
+
+    #[test]
+    fn truncate_str_preserves_short_strings() {
+        assert_eq!(truncate_str("abc", 10), "abc");
+        assert_eq!(truncate_str("abcdefghij", 10), "abcdefghij");
+    }
+
+    #[test]
+    fn truncate_str_trims_and_appends_ellipsis() {
+        let out = truncate_str("abcdefghij", 5);
+        assert_eq!(out.chars().count(), 5);
+        assert!(out.ends_with('…'));
+    }
+}

--- a/src/ui/renderers/mig_renderer.rs
+++ b/src/ui/renderers/mig_renderer.rs
@@ -164,7 +164,10 @@ mod tests {
         let host = host_with(Vec::new(), false);
         let mut buf: Vec<u8> = Vec::new();
         print_mig_section(&mut buf, &host, 80);
-        assert!(buf.is_empty(), "Disabled host with no instances must be silent");
+        assert!(
+            buf.is_empty(),
+            "Disabled host with no instances must be silent"
+        );
     }
 
     #[test]

--- a/src/ui/renderers/mig_renderer.rs
+++ b/src/ui/renderers/mig_renderer.rs
@@ -59,9 +59,20 @@ pub fn print_mig_section<W: Write>(stdout: &mut W, host: &MigGpuInfo, _width: us
 
     queue!(stdout, Print("\r\n")).unwrap();
 
-    for (i, inst) in host.instances.iter().enumerate() {
+    for inst in host.instances.iter() {
         print_colored_text(stdout, "      [", Color::DarkGrey, None, None);
-        print_colored_text(stdout, &i.to_string(), Color::Cyan, None, None);
+        // Show NVML's `instance_id` (the slot NVML enumerated the instance
+        // at), not the vec index. These diverge whenever the instances are
+        // sparse — e.g. slots 0, 1, 4 present but 2 and 3 unprovisioned —
+        // and using the vec index would silently disagree with the
+        // `mig_instance` label the Prometheus exporter emits.
+        print_colored_text(
+            stdout,
+            &inst.instance_id.to_string(),
+            Color::Cyan,
+            None,
+            None,
+        );
         print_colored_text(stdout, "] ", Color::DarkGrey, None, None);
 
         let profile_display = if inst.profile_name.is_empty() {
@@ -241,6 +252,65 @@ mod tests {
         print_mig_section(&mut buf, &host, 80);
         let plain = strip_ansi(&String::from_utf8_lossy(&buf));
         assert!(plain.contains("unknown"));
+    }
+
+    #[test]
+    fn renders_nvml_instance_id_for_sparse_instances() {
+        // Regression: when NVML enumerates MIG instances at non-contiguous
+        // slots (e.g. 0, 1, 4 — typical after teardown of some partitions),
+        // the TUI used to print the vec index instead of the real
+        // `instance_id`. That disagreed with the Prometheus `mig_instance`
+        // label and made the UI lie about which slot each row belongs to.
+        let instances = vec![
+            MigInstanceInfo {
+                instance_id: 0,
+                gpu_instance_id: Some(1),
+                compute_instance_id: Some(0),
+                uuid: "MIG-0".into(),
+                profile_name: "1g.5gb".into(),
+                utilization_gpu: Some(10),
+                utilization_memory: Some(10),
+                memory_used_bytes: 0,
+                memory_total_bytes: 5 * (1 << 30),
+            },
+            MigInstanceInfo {
+                instance_id: 1,
+                gpu_instance_id: Some(2),
+                compute_instance_id: Some(0),
+                uuid: "MIG-1".into(),
+                profile_name: "1g.5gb".into(),
+                utilization_gpu: Some(20),
+                utilization_memory: Some(20),
+                memory_used_bytes: 0,
+                memory_total_bytes: 5 * (1 << 30),
+            },
+            MigInstanceInfo {
+                instance_id: 4,
+                gpu_instance_id: Some(5),
+                compute_instance_id: Some(0),
+                uuid: "MIG-4".into(),
+                profile_name: "1g.5gb".into(),
+                utilization_gpu: Some(40),
+                utilization_memory: Some(40),
+                memory_used_bytes: 0,
+                memory_total_bytes: 5 * (1 << 30),
+            },
+        ];
+        let host = host_with(instances, true);
+        let mut buf: Vec<u8> = Vec::new();
+        print_mig_section(&mut buf, &host, 100);
+        let plain = strip_ansi(&String::from_utf8_lossy(&buf));
+
+        assert!(plain.contains("[0]"), "missing [0] in:\n{plain}");
+        assert!(plain.contains("[1]"), "missing [1] in:\n{plain}");
+        assert!(
+            plain.contains("[4]"),
+            "missing [4] (NVML instance_id) in:\n{plain}"
+        );
+        assert!(
+            !plain.contains("[2]"),
+            "must not print the enumeration index `[2]` when instance_id is sparse:\n{plain}"
+        );
     }
 
     #[test]

--- a/src/ui/renderers/mod.rs
+++ b/src/ui/renderers/mod.rs
@@ -16,6 +16,7 @@ pub mod chassis_renderer;
 pub mod cpu_renderer;
 pub mod gpu_renderer;
 pub mod memory_renderer;
+pub mod mig_renderer;
 pub mod storage_renderer;
 pub mod vgpu_renderer;
 pub mod widgets;
@@ -25,6 +26,7 @@ pub use chassis_renderer::print_chassis_info;
 pub use cpu_renderer::print_cpu_info;
 pub use gpu_renderer::print_gpu_info;
 pub use memory_renderer::print_memory_info;
+pub use mig_renderer::print_mig_section;
 pub use storage_renderer::print_storage_info;
 pub use vgpu_renderer::print_vgpu_section;
 

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -191,6 +191,7 @@ mod tests {
             process_info: Vec::new(),
             chassis_info: Vec::new(),
             vgpu_info: Vec::new(),
+            mig_info: Vec::new(),
             selected_process_index: 0,
             start_index: 0,
             sort_criteria: crate::app_state::SortCriteria::Default,

--- a/src/view/data_collection/local_collector.rs
+++ b/src/view/data_collection/local_collector.rs
@@ -29,7 +29,7 @@ use crate::app_state::AppState;
 use crate::device::platform_detection::has_tenstorrent;
 use crate::device::{
     ChassisInfo, ChassisReader, CpuInfo, CpuReader, GpuInfo, GpuReader, MemoryInfo, MemoryReader,
-    ProcessInfo, VgpuHostInfo, create_chassis_reader, get_cpu_readers, get_gpu_readers,
+    MigGpuInfo, ProcessInfo, VgpuHostInfo, create_chassis_reader, get_cpu_readers, get_gpu_readers,
     get_memory_readers, get_nvml_status_message,
     platform_detection::has_nvidia,
     process_list::{merge_gpu_processes, update_process_cache},
@@ -252,6 +252,7 @@ impl LocalCollector {
         let gpu_readers_1 = Arc::clone(&self.gpu_readers);
         let gpu_readers_2 = Arc::clone(&self.gpu_readers);
         let gpu_readers_vgpu = Arc::clone(&self.gpu_readers);
+        let gpu_readers_mig = Arc::clone(&self.gpu_readers);
         let cpu_readers = Arc::clone(&self.cpu_readers);
         let memory_readers = Arc::clone(&self.memory_readers);
         let chassis_reader = Arc::clone(&self.chassis_reader);
@@ -266,6 +267,7 @@ impl LocalCollector {
             all_storage_info,
             all_chassis_info,
             all_vgpu_info,
+            all_mig_info,
         ) = {
             let status_tx_gpu = status_tx.clone();
             let status_tx_cpu = status_tx.clone();
@@ -384,6 +386,17 @@ impl LocalCollector {
                         .flat_map(|reader| reader.get_vgpu_info())
                         .collect();
                     info
+                },
+                // MIG info collection (only NVIDIA readers with MIG enabled
+                // GPUs produce data; everyone else returns an empty vector
+                // via the default trait implementation).
+                async move {
+                    let readers = gpu_readers_mig.read().await;
+                    let info: Vec<MigGpuInfo> = readers
+                        .iter()
+                        .flat_map(|reader| reader.get_mig_info())
+                        .collect();
+                    info
                 }
             )
         };
@@ -427,6 +440,7 @@ impl LocalCollector {
             storage_info: all_storage_info,
             chassis_info: all_chassis_info,
             vgpu_info: all_vgpu_info,
+            mig_info: all_mig_info,
             connection_statuses: Vec::new(),
         }
     }
@@ -463,6 +477,12 @@ impl LocalCollector {
         let all_vgpu_info: Vec<VgpuHostInfo> = gpu_readers
             .iter()
             .flat_map(|reader| reader.get_vgpu_info())
+            .collect();
+
+        // MIG info collection — same locality benefits as vGPU above.
+        let all_mig_info: Vec<MigGpuInfo> = gpu_readers
+            .iter()
+            .flat_map(|reader| reader.get_mig_info())
             .collect();
 
         // Determine if we should do a full refresh or selective refresh
@@ -547,6 +567,7 @@ impl LocalCollector {
             storage_info: all_storage_info,
             chassis_info: all_chassis_info,
             vgpu_info: all_vgpu_info,
+            mig_info: all_mig_info,
             connection_statuses: Vec::new(),
         }
     }
@@ -705,6 +726,7 @@ impl DataCollectionStrategy for LocalCollector {
         state.storage_info = data.storage_info;
         state.chassis_info = data.chassis_info;
         state.vgpu_info = data.vgpu_info;
+        state.mig_info = data.mig_info;
 
         // Mark data as changed to trigger UI update
         state.mark_data_changed();

--- a/src/view/data_collection/remote_collector.rs
+++ b/src/view/data_collection/remote_collector.rs
@@ -167,7 +167,15 @@ impl DataCollectionStrategy for RemoteCollector {
             return Err(CollectionError::Other("No hosts configured".to_string()));
         }
 
-        let (gpu_info, cpu_info, memory_info, storage_info, vgpu_info, connection_statuses) = self
+        let (
+            gpu_info,
+            cpu_info,
+            memory_info,
+            storage_info,
+            vgpu_info,
+            mig_info,
+            connection_statuses,
+        ) = self
             .network_client
             .fetch_remote_data(&config.hosts, &self.semaphore, &self.regex)
             .await;
@@ -182,6 +190,7 @@ impl DataCollectionStrategy for RemoteCollector {
             storage_info: deduplicated_storage,
             chassis_info: Vec::new(), // TODO: Parse chassis info from remote metrics
             vgpu_info,
+            mig_info,
             connection_statuses,
         })
     }
@@ -207,6 +216,7 @@ impl DataCollectionStrategy for RemoteCollector {
         state.memory_info = data.memory_info;
         state.storage_info = data.storage_info;
         state.vgpu_info = data.vgpu_info;
+        state.mig_info = data.mig_info;
 
         // Update connection status and maintain known hosts
         Self::update_connection_status(&mut state, data.connection_statuses, &config.hosts);

--- a/src/view/data_collection/strategy.rs
+++ b/src/view/data_collection/strategy.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::app_state::{AppState, ConnectionStatus};
-use crate::device::{ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, ProcessInfo, VgpuHostInfo};
+use crate::device::{
+    ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, MigGpuInfo, ProcessInfo, VgpuHostInfo,
+};
 use crate::storage::info::StorageInfo;
 
 /// Result type for data collection operations
@@ -34,6 +36,8 @@ pub struct CollectionData {
     pub chassis_info: Vec<ChassisInfo>,
     /// Per-GPU vGPU information. Empty on non-vGPU hosts.
     pub vgpu_info: Vec<VgpuHostInfo>,
+    /// Per-GPU MIG information. Empty on non-MIG hosts.
+    pub mig_info: Vec<MigGpuInfo>,
     pub connection_statuses: Vec<ConnectionStatus>,
 }
 
@@ -47,6 +51,7 @@ impl CollectionData {
             storage_info: Vec::new(),
             chassis_info: Vec::new(),
             vgpu_info: Vec::new(),
+            mig_info: Vec::new(),
             connection_statuses: Vec::new(),
         }
     }

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -38,8 +38,8 @@ use crate::ui::layout::LayoutCalculator;
 use crate::ui::local_header::draw_local_header_bar;
 use crate::ui::renderer::{
     print_chassis_info, print_cpu_info, print_function_keys, print_gpu_info,
-    print_loading_indicator, print_memory_info, print_process_info, print_storage_info,
-    print_vgpu_section,
+    print_loading_indicator, print_memory_info, print_mig_section, print_process_info,
+    print_storage_info, print_vgpu_section,
 };
 use crate::ui::tabs::draw_tabs;
 use crate::ui::text::print_colored_text;
@@ -291,6 +291,13 @@ impl FrameRenderer {
             // hostname+gpu-name fallback for remote-mode data without UUID.
             if let Some(vgpu_host) = find_matching_vgpu_host(&snapshot.vgpu_info, gpu_info) {
                 print_vgpu_section(buffer, vgpu_host, cols as usize);
+            }
+
+            // If this GPU has MIG mode enabled, render the nested MIG section
+            // directly beneath the GPU row using the same UUID-first matching
+            // strategy as the vGPU section above.
+            if let Some(mig_host) = find_matching_mig_gpu(&snapshot.mig_info, gpu_info) {
+                print_mig_section(buffer, mig_host, cols as usize);
             }
         }
     }
@@ -694,6 +701,27 @@ fn find_matching_vgpu_host<'a>(
     vgpu_info
         .iter()
         .find(|v| v.hostname == gpu.hostname && v.gpu_name == gpu.name)
+}
+
+/// Locate the [`crate::device::MigGpuInfo`] record matching a given GPU row.
+///
+/// Same precedence as [`find_matching_vgpu_host`]:
+/// 1. Exact `gpu_uuid` match (authoritative).
+/// 2. Fallback: same `hostname` + matching `gpu_name` — used when UUID
+///    propagation is missing (e.g. remote mode with incomplete metrics).
+///
+/// Returns `None` when no match is found, keeping the MIG section from
+/// appearing under unrelated GPU rows.
+fn find_matching_mig_gpu<'a>(
+    mig_info: &'a [crate::device::MigGpuInfo],
+    gpu: &crate::device::GpuInfo,
+) -> Option<&'a crate::device::MigGpuInfo> {
+    if let Some(host) = mig_info.iter().find(|m| m.gpu_uuid == gpu.uuid) {
+        return Some(host);
+    }
+    mig_info
+        .iter()
+        .find(|m| m.hostname == gpu.hostname && m.gpu_name == gpu.name)
 }
 
 #[cfg(test)]

--- a/src/view/render_snapshot.rs
+++ b/src/view/render_snapshot.rs
@@ -22,7 +22,9 @@
 use std::collections::HashMap;
 
 use crate::app_state::{AppState, ConnectionStatus, SortCriteria, SortDirection};
-use crate::device::{ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, ProcessInfo, VgpuHostInfo};
+use crate::device::{
+    ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, MigGpuInfo, ProcessInfo, VgpuHostInfo,
+};
 use crate::storage::info::StorageInfo;
 use crate::ui::notification::NotificationManager;
 use crate::utils::RuntimeEnvironment;
@@ -90,6 +92,9 @@ pub struct RenderSnapshot {
     pub storage_info: Vec<StorageInfo>,
     /// Per-GPU vGPU host info (NVIDIA vGPU only). Empty on bare-metal.
     pub vgpu_info: Vec<VgpuHostInfo>,
+    /// Per-GPU MIG host info (NVIDIA datacenter GPUs with MIG enabled). Empty
+    /// on consumer cards, pre-Ampere architectures, and non-MIG hosts.
+    pub mig_info: Vec<MigGpuInfo>,
 
     // Connection tracking (remote mode)
     pub connection_status: HashMap<String, ConnectionStatus>,
@@ -166,6 +171,7 @@ impl RenderSnapshot {
             chassis_info: state.chassis_info.clone(),
             storage_info: state.storage_info.clone(),
             vgpu_info: state.vgpu_info.clone(),
+            mig_info: state.mig_info.clone(),
 
             // Connection tracking
             connection_status: state.connection_status.clone(),
@@ -245,6 +251,7 @@ impl RenderSnapshot {
         state.chassis_info = self.chassis_info.clone();
         state.storage_info = self.storage_info.clone();
         state.vgpu_info = self.vgpu_info.clone();
+        state.mig_info = self.mig_info.clone();
 
         // Connection tracking
         state.connection_status = self.connection_status.clone();

--- a/tests/cpu_model_test.rs
+++ b/tests/cpu_model_test.rs
@@ -19,7 +19,7 @@ all_smi_cpu_core_count{cpu_model="", instance="node-0001", index="0"} 128
 all_smi_cpu_frequency_mhz{instance="node-0001"} 2450
 "#;
 
-    let (_, cpu_info, _, _, _) = parser.parse_metrics(test_data, host, &re);
+    let (_, cpu_info, _, _, _, _) = parser.parse_metrics(test_data, host, &re);
 
     assert_eq!(cpu_info.len(), 1);
     let cpu = &cpu_info[0];

--- a/tests/mig_integration_test.rs
+++ b/tests/mig_integration_test.rs
@@ -120,6 +120,46 @@ fn mig_metrics_parser_roundtrip_preserves_all_fields() {
 }
 
 #[test]
+fn mig_disabled_parent_roundtrips_as_visible_row_with_mode_zero() {
+    // End-to-end: a MIG-capable GPU with MIG mode currently disabled (the
+    // typical "hardware supports it but operators haven't turned it on" state)
+    // must survive the full exporter -> parser round trip. Previously the
+    // reader skipped disabled GPUs entirely, so `all_smi_gpu_mig_mode = 0`
+    // was never observed in production and the parser silently dropped any
+    // row that managed to reach it.
+    use all_smi::network::metrics_parser::MetricsParser;
+
+    let disabled_host = MigGpuInfo {
+        host_id: "node-42".to_string(),
+        hostname: "node-42".to_string(),
+        instance: "node-42".to_string(),
+        gpu_index: 0,
+        gpu_uuid: "GPU-OFF".to_string(),
+        gpu_name: "NVIDIA A100".to_string(),
+        mig_mode: false,
+        instances: Vec::new(),
+    };
+    let hosts = vec![disabled_host];
+    let text = MigMetricExporter::new(&hosts).export_metrics();
+
+    // Exporter side: the mode-0 line must be present.
+    let mode_line = text
+        .lines()
+        .find(|l| l.starts_with("all_smi_gpu_mig_mode{"))
+        .expect("exporter must emit gpu_mig_mode for disabled parent");
+    assert!(mode_line.ends_with(" 0"), "got line: {mode_line}");
+
+    // Parser side: the disabled row must survive the retain filter.
+    let parser = MetricsParser::new();
+    let (_gpu, _cpu, _mem, _store, _vgpu, parsed) =
+        parser.parse_metrics(&text, "127.0.0.1:9090", &regex());
+    assert_eq!(parsed.len(), 1, "disabled MIG row must be retained");
+    assert_eq!(parsed[0].gpu_uuid, "GPU-OFF");
+    assert!(!parsed[0].mig_mode);
+    assert!(parsed[0].instances.is_empty());
+}
+
+#[test]
 fn mig_parser_is_empty_on_bare_metal_metrics() {
     use all_smi::network::metrics_parser::MetricsParser;
 

--- a/tests/mig_integration_test.rs
+++ b/tests/mig_integration_test.rs
@@ -1,0 +1,157 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the NVIDIA MIG pipeline.
+//!
+//! Exercises the Prometheus-format round-trip from exporter text (crafted to
+//! mirror what `api::metrics::mig::MigMetricExporter` emits) through the
+//! remote metrics parser, asserting that every field survives unchanged.
+
+use all_smi::prelude::*;
+use regex::Regex;
+
+fn regex() -> Regex {
+    Regex::new(r"^all_smi_([^\{]+)\{([^}]+)\} ([\d\.]+)$").unwrap()
+}
+
+/// Replicate the exporter output format. Kept close to
+/// `api/metrics/mig.rs`; if that exporter adds new metrics, this test should
+/// be updated in lockstep.
+fn exported_metrics_text() -> String {
+    let mut out = String::new();
+    out.push_str("# HELP all_smi_gpu_mig_mode NVIDIA MIG mode\n");
+    out.push_str("# TYPE all_smi_gpu_mig_mode gauge\n");
+    out.push_str(concat!(
+        "all_smi_gpu_mig_mode{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", ",
+        "gpu=\"NVIDIA A100\", instance=\"node-42\", host=\"node-42\"} 1\n"
+    ));
+    // instance metrics
+    out.push_str("# HELP all_smi_mig_instance_utilization_gpu\n");
+    out.push_str("# TYPE all_smi_mig_instance_utilization_gpu gauge\n");
+    out.push_str(concat!(
+        "all_smi_mig_instance_utilization_gpu{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
+        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
+        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 64\n"
+    ));
+    out.push_str("# HELP all_smi_mig_instance_utilization_memory\n");
+    out.push_str("# TYPE all_smi_mig_instance_utilization_memory gauge\n");
+    out.push_str(concat!(
+        "all_smi_mig_instance_utilization_memory{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
+        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
+        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 18\n"
+    ));
+    out.push_str("# HELP all_smi_mig_instance_memory_used_bytes\n");
+    out.push_str("# TYPE all_smi_mig_instance_memory_used_bytes gauge\n");
+    out.push_str(concat!(
+        "all_smi_mig_instance_memory_used_bytes{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
+        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
+        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 8589934592\n"
+    ));
+    out.push_str("# HELP all_smi_mig_instance_memory_total_bytes\n");
+    out.push_str("# TYPE all_smi_mig_instance_memory_total_bytes gauge\n");
+    out.push_str(concat!(
+        "all_smi_mig_instance_memory_total_bytes{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
+        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
+        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 21474836480\n"
+    ));
+    out
+}
+
+#[test]
+fn mig_metrics_parser_roundtrip_preserves_all_fields() {
+    use all_smi::network::metrics_parser::MetricsParser;
+
+    let parser = MetricsParser::new();
+    let (_gpu, _cpu, _mem, _store, _vgpu, parsed) =
+        parser.parse_metrics(&exported_metrics_text(), "127.0.0.1:9090", &regex());
+
+    assert_eq!(parsed.len(), 1, "expected one host record");
+    let got = &parsed[0];
+
+    assert_eq!(got.gpu_uuid, "GPU-MIG");
+    assert_eq!(got.gpu_name, "NVIDIA A100");
+    assert!(got.mig_mode);
+    assert_eq!(got.gpu_index, 3);
+    assert_eq!(got.instances.len(), 1);
+
+    let inst = &got.instances[0];
+    assert_eq!(inst.instance_id, 2);
+    assert_eq!(inst.uuid, "MIG-2");
+    assert_eq!(inst.profile_name, "3g.20gb");
+    assert_eq!(inst.gpu_instance_id, Some(5));
+    assert_eq!(inst.compute_instance_id, Some(0));
+    assert_eq!(inst.utilization_gpu, Some(64));
+    assert_eq!(inst.utilization_memory, Some(18));
+    assert_eq!(inst.memory_used_bytes, 8 * (1 << 30));
+    assert_eq!(inst.memory_total_bytes, 20 * (1 << 30));
+}
+
+#[test]
+fn mig_parser_is_empty_on_bare_metal_metrics() {
+    use all_smi::network::metrics_parser::MetricsParser;
+
+    let parser = MetricsParser::new();
+    let non_mig = concat!(
+        "all_smi_gpu_utilization{gpu=\"RTX\", instance=\"x\", uuid=\"GPU-1\", index=\"0\"} 10\n",
+        "all_smi_cpu_utilization{cpu_model=\"AMD\", instance=\"x\", hostname=\"x\", index=\"0\"} 20\n",
+    );
+
+    let (gpu, _cpu, _mem, _storage, _vgpu, parsed) =
+        parser.parse_metrics(non_mig, "x", &regex());
+    assert_eq!(gpu.len(), 1, "sanity: GPU row still parsed");
+    assert!(parsed.is_empty(), "MIG parser must stay quiet on bare-metal");
+}
+
+#[test]
+fn mig_parser_attaches_multiple_instances_to_same_host() {
+    use all_smi::network::metrics_parser::MetricsParser;
+
+    let mut text = String::new();
+    text.push_str(concat!(
+        "all_smi_gpu_mig_mode{gpu_index=\"0\", gpu_uuid=\"GPU-Z\", gpu=\"NVIDIA H100\", ",
+        "instance=\"node-9\", host=\"node-9\"} 1\n",
+    ));
+    for i in 0..7 {
+        // Realistic 7g.10gb partitioning.
+        text.push_str(&format!(
+            "all_smi_mig_instance_utilization_gpu{{gpu_index=\"0\", gpu_uuid=\"GPU-Z\", gpu=\"NVIDIA H100\", \
+             instance=\"node-9\", host=\"node-9\", mig_instance=\"{i}\", mig_uuid=\"MIG-Z-{i}\", \
+             mig_profile=\"1g.10gb\", gpu_instance_id=\"{}\", compute_instance_id=\"0\"}} {}\n",
+            i + 1,
+            10 * i
+        ));
+    }
+
+    let parser = MetricsParser::new();
+    let (_gpu, _cpu, _mem, _store, _vgpu, parsed) =
+        parser.parse_metrics(&text, "node-9:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].instances.len(), 7);
+    // Sorted by instance_id ascending — first must be id 0, last id 6.
+    assert_eq!(parsed[0].instances[0].instance_id, 0);
+    assert_eq!(parsed[0].instances[6].instance_id, 6);
+}
+
+#[test]
+fn library_api_exposes_mig_info_method() {
+    // Smoke test: simply verifying `AllSmi::get_mig_info` exists and returns
+    // a Vec. On CI hosts without MIG-enabled NVIDIA GPUs the method returns
+    // empty, which is the correct no-op behaviour we document.
+    let smi = AllSmi::new().expect("AllSmi::new should not fail");
+    let info: Vec<MigGpuInfo> = smi.get_mig_info();
+    // We can't assert the Vec is empty because the CI host could theoretically
+    // be a MIG-enabled GPU host. We just assert the call shape compiles and
+    // does not panic.
+    let _ = info;
+}

--- a/tests/mig_integration_test.rs
+++ b/tests/mig_integration_test.rs
@@ -107,10 +107,12 @@ fn mig_parser_is_empty_on_bare_metal_metrics() {
         "all_smi_cpu_utilization{cpu_model=\"AMD\", instance=\"x\", hostname=\"x\", index=\"0\"} 20\n",
     );
 
-    let (gpu, _cpu, _mem, _storage, _vgpu, parsed) =
-        parser.parse_metrics(non_mig, "x", &regex());
+    let (gpu, _cpu, _mem, _storage, _vgpu, parsed) = parser.parse_metrics(non_mig, "x", &regex());
     assert_eq!(gpu.len(), 1, "sanity: GPU row still parsed");
-    assert!(parsed.is_empty(), "MIG parser must stay quiet on bare-metal");
+    assert!(
+        parsed.is_empty(),
+        "MIG parser must stay quiet on bare-metal"
+    );
 }
 
 #[test]

--- a/tests/mig_integration_test.rs
+++ b/tests/mig_integration_test.rs
@@ -14,10 +14,14 @@
 
 //! Integration tests for the NVIDIA MIG pipeline.
 //!
-//! Exercises the Prometheus-format round-trip from exporter text (crafted to
-//! mirror what `api::metrics::mig::MigMetricExporter` emits) through the
-//! remote metrics parser, asserting that every field survives unchanged.
+//! Exercises the Prometheus-format round-trip from the real
+//! `api::metrics::mig::MigMetricExporter` through the remote metrics parser,
+//! asserting that every field (including every label) survives unchanged.
+//! Using the live exporter output — rather than hand-crafted text — keeps the
+//! integration test honest whenever the exporter's label set drifts.
 
+use all_smi::api::metrics::MetricExporter;
+use all_smi::api::metrics::mig::MigMetricExporter;
 use all_smi::prelude::*;
 use regex::Regex;
 
@@ -25,47 +29,62 @@ fn regex() -> Regex {
     Regex::new(r"^all_smi_([^\{]+)\{([^}]+)\} ([\d\.]+)$").unwrap()
 }
 
-/// Replicate the exporter output format. Kept close to
-/// `api/metrics/mig.rs`; if that exporter adds new metrics, this test should
-/// be updated in lockstep.
+/// Build a representative MIG host fixture covering every label the exporter
+/// is required to emit (including the historically forgotten
+/// `compute_instance_id`).
+fn sample_host() -> MigGpuInfo {
+    MigGpuInfo {
+        host_id: "node-42".to_string(),
+        hostname: "node-42".to_string(),
+        instance: "node-42".to_string(),
+        gpu_index: 3,
+        gpu_uuid: "GPU-MIG".to_string(),
+        gpu_name: "NVIDIA A100".to_string(),
+        mig_mode: true,
+        instances: vec![MigInstanceInfo {
+            instance_id: 2,
+            gpu_instance_id: Some(5),
+            compute_instance_id: Some(0),
+            uuid: "MIG-2".to_string(),
+            profile_name: "3g.20gb".to_string(),
+            utilization_gpu: Some(64),
+            utilization_memory: Some(18),
+            memory_used_bytes: 8 * (1 << 30),
+            memory_total_bytes: 20 * (1 << 30),
+        }],
+    }
+}
+
+/// Produce the exporter's own output string. Any label the exporter stops
+/// emitting is lost here first — which is exactly the regression the
+/// round-trip test below is supposed to catch.
 fn exported_metrics_text() -> String {
-    let mut out = String::new();
-    out.push_str("# HELP all_smi_gpu_mig_mode NVIDIA MIG mode\n");
-    out.push_str("# TYPE all_smi_gpu_mig_mode gauge\n");
-    out.push_str(concat!(
-        "all_smi_gpu_mig_mode{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", ",
-        "gpu=\"NVIDIA A100\", instance=\"node-42\", host=\"node-42\"} 1\n"
-    ));
-    // instance metrics
-    out.push_str("# HELP all_smi_mig_instance_utilization_gpu\n");
-    out.push_str("# TYPE all_smi_mig_instance_utilization_gpu gauge\n");
-    out.push_str(concat!(
-        "all_smi_mig_instance_utilization_gpu{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
-        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
-        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 64\n"
-    ));
-    out.push_str("# HELP all_smi_mig_instance_utilization_memory\n");
-    out.push_str("# TYPE all_smi_mig_instance_utilization_memory gauge\n");
-    out.push_str(concat!(
-        "all_smi_mig_instance_utilization_memory{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
-        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
-        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 18\n"
-    ));
-    out.push_str("# HELP all_smi_mig_instance_memory_used_bytes\n");
-    out.push_str("# TYPE all_smi_mig_instance_memory_used_bytes gauge\n");
-    out.push_str(concat!(
-        "all_smi_mig_instance_memory_used_bytes{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
-        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
-        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 8589934592\n"
-    ));
-    out.push_str("# HELP all_smi_mig_instance_memory_total_bytes\n");
-    out.push_str("# TYPE all_smi_mig_instance_memory_total_bytes gauge\n");
-    out.push_str(concat!(
-        "all_smi_mig_instance_memory_total_bytes{gpu_index=\"3\", gpu_uuid=\"GPU-MIG\", gpu=\"NVIDIA A100\", ",
-        "instance=\"node-42\", host=\"node-42\", mig_instance=\"2\", mig_uuid=\"MIG-2\", ",
-        "mig_profile=\"3g.20gb\", gpu_instance_id=\"5\", compute_instance_id=\"0\"} 21474836480\n"
-    ));
-    out
+    let hosts = vec![sample_host()];
+    MigMetricExporter::new(&hosts).export_metrics()
+}
+
+#[test]
+fn mig_exporter_emits_every_required_label() {
+    // Sanity check on the exporter output itself — fail loudly if any label
+    // the downstream parser relies on is silently dropped at the source.
+    let output = exported_metrics_text();
+    for label in [
+        "gpu_index=\"3\"",
+        "gpu_uuid=\"GPU-MIG\"",
+        "gpu=\"NVIDIA A100\"",
+        "instance=\"node-42\"",
+        "host=\"node-42\"",
+        "mig_instance=\"2\"",
+        "mig_uuid=\"MIG-2\"",
+        "mig_profile=\"3g.20gb\"",
+        "gpu_instance_id=\"5\"",
+        "compute_instance_id=\"0\"",
+    ] {
+        assert!(
+            output.contains(label),
+            "exporter output missing label fragment `{label}`:\n{output}"
+        );
+    }
 }
 
 #[test]
@@ -90,6 +109,9 @@ fn mig_metrics_parser_roundtrip_preserves_all_fields() {
     assert_eq!(inst.uuid, "MIG-2");
     assert_eq!(inst.profile_name, "3g.20gb");
     assert_eq!(inst.gpu_instance_id, Some(5));
+    // Regression guard: the exporter historically omitted compute_instance_id
+    // from its label set, so the parser had nothing to populate. Using the
+    // real exporter output here ensures the label survives every round-trip.
     assert_eq!(inst.compute_instance_id, Some(0));
     assert_eq!(inst.utilization_gpu, Some(64));
     assert_eq!(inst.utilization_memory, Some(18));

--- a/tests/thermal_pstate_integration_test.rs
+++ b/tests/thermal_pstate_integration_test.rs
@@ -85,7 +85,7 @@ fn partial_exposition() -> String {
 #[test]
 fn thermal_and_pstate_round_trip_preserves_all_fields() {
     let parser = MetricsParser::new();
-    let (parsed, _, _, _, _) = parser.parse_metrics(&full_exposition(), "node-7:9090", &regex());
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(&full_exposition(), "node-7:9090", &regex());
 
     assert_eq!(parsed.len(), 1, "expected exactly one GPU record");
     let gpu = &parsed[0];
@@ -103,7 +103,7 @@ fn thermal_and_pstate_round_trip_handles_partial_reports() {
     // Older drivers: only slowdown + shutdown known. The others must stay
     // `None` after parse, not default to 0.
     let parser = MetricsParser::new();
-    let (parsed, _, _, _, _) = parser.parse_metrics(&partial_exposition(), "node-7:9090", &regex());
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(&partial_exposition(), "node-7:9090", &regex());
     assert_eq!(parsed.len(), 1);
     let gpu = &parsed[0];
     assert_eq!(gpu.temperature_threshold_slowdown, Some(91));
@@ -125,7 +125,7 @@ fn non_nvidia_path_leaves_fields_none() {
     );
 
     let parser = MetricsParser::new();
-    let (parsed, _, _, _, _) = parser.parse_metrics(non_nvidia, "mac-1:9090", &regex());
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(non_nvidia, "mac-1:9090", &regex());
     assert_eq!(parsed.len(), 1);
     let gpu = &parsed[0];
     assert!(gpu.temperature_threshold_slowdown.is_none());
@@ -152,7 +152,7 @@ fn performance_state_omission_means_unavailable() {
         "all_smi_gpu_temperature_celsius{gpu=\"NVIDIA A100\", instance=\"node-7\", \
          uuid=\"GPU-X\", index=\"0\"} 50\n",
     );
-    let (parsed, _, _, _, _) = parser.parse_metrics(text, "node-7:9090", &regex());
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-7:9090", &regex());
     assert_eq!(parsed.len(), 1);
     assert!(parsed[0].performance_state.is_none());
 }

--- a/tests/thermal_pstate_integration_test.rs
+++ b/tests/thermal_pstate_integration_test.rs
@@ -103,7 +103,8 @@ fn thermal_and_pstate_round_trip_handles_partial_reports() {
     // Older drivers: only slowdown + shutdown known. The others must stay
     // `None` after parse, not default to 0.
     let parser = MetricsParser::new();
-    let (parsed, _, _, _, _, _) = parser.parse_metrics(&partial_exposition(), "node-7:9090", &regex());
+    let (parsed, _, _, _, _, _) =
+        parser.parse_metrics(&partial_exposition(), "node-7:9090", &regex());
     assert_eq!(parsed.len(), 1);
     let gpu = &parsed[0];
     assert_eq!(gpu.temperature_threshold_slowdown, Some(91));

--- a/tests/vgpu_integration_test.rs
+++ b/tests/vgpu_integration_test.rs
@@ -87,7 +87,7 @@ fn vgpu_metrics_parser_roundtrip_preserves_all_fields() {
     use all_smi::network::metrics_parser::MetricsParser;
 
     let parser = MetricsParser::new();
-    let (_gpu, _cpu, _mem, _store, parsed) =
+    let (_gpu, _cpu, _mem, _store, parsed, _mig) =
         parser.parse_metrics(&exported_metrics_text(), "127.0.0.1:9090", &regex());
 
     assert_eq!(parsed.len(), 1, "expected one host record");
@@ -125,7 +125,7 @@ fn vgpu_parser_is_empty_on_bare_metal_metrics() {
         "all_smi_cpu_utilization{cpu_model=\"AMD\", instance=\"x\", hostname=\"x\", index=\"0\"} 20\n",
     );
 
-    let (gpu, _cpu, _mem, _storage, parsed) = parser.parse_metrics(non_vgpu, "x", &regex());
+    let (gpu, _cpu, _mem, _storage, parsed, _mig) = parser.parse_metrics(non_vgpu, "x", &regex());
     assert_eq!(gpu.len(), 1, "sanity: GPU row still parsed");
     assert!(
         parsed.is_empty(),


### PR DESCRIPTION
## Summary

- Adds NVIDIA MIG (Multi-Instance GPU) detection and per-instance monitoring across the data model, NVML reader, TUI, Prometheus exporter, remote parser, and mock server. Mirrors the architectural pattern landed in #172 (vGPU) and #173 (thermal/P-state).
- Surfaces MIG instances as nested rows beneath the parent GPU in the TUI, exports `all_smi_gpu_mig_mode` plus four `all_smi_mig_instance_*` families with `gpu_uuid`/`mig_instance`/`mig_uuid`/`mig_profile`/`gpu_instance_id` labels, and round-trips through the remote scrape parser losslessly.
- Non-MIG GPUs and pre-Ampere architectures stay completely silent — every NVML call is `.ok()`-wrapped and the feature degrades to an empty `Vec` on any error (driver too old, missing permissions, MIG mode disabled).
- Mock server can simulate a MIG-partitioned A100/H100 (5 instances per GPU spanning `1g.5gb`/`2g.10gb`/`3g.20gb`/`7g.40gb`) when `ALL_SMI_MOCK_MIG` is set; otherwise the NVIDIA mock output is byte-identical to today.

Closes #131.

## Files touched

- `src/device/types.rs` — new `MigInstanceInfo` and `MigGpuInfo` structs.
- `src/device/traits.rs` — `GpuReader::get_mig_info(&self)` with empty default.
- `src/device/readers/nvidia_mig.rs` (new) + `src/device/readers/nvidia.rs` — wire NVML probe (`mig_mode()` + `mig_device_by_index` enumeration, raw FFI for `nvmlDeviceGetGpuInstanceId` / `nvmlDeviceGetComputeInstanceId`).
- `src/app_state.rs`, `src/view/data_collection/strategy.rs`, `src/view/render_snapshot.rs`, `src/view/data_collection/{local,remote}_collector.rs`, `src/network/client.rs` — thread `mig_info: Vec<MigGpuInfo>` end-to-end (local + remote).
- `src/network/metrics_parser.rs` — new `MigParseState` with `MAX_MIG_GPUS=256` / `MAX_MIG_INSTANCES=4096` / `MAX_MIG_INSTANCE_INDEX=64` defensive caps; routed `mig_instance_*` and `gpu_mig_mode` lines.
- `src/api/metrics/mig.rs` (new) + `src/api/handlers.rs` — Prometheus exporter with precomputed row cache (matches the perf pattern landed in #172).
- `src/ui/renderers/mig_renderer.rs` (new), `src/view/frame_renderer.rs`, `src/ui/renderers/gpu_renderer.rs`, `src/ui/layout.rs` — TUI nested rows, `find_matching_mig_gpu` UUID-first matcher, layout math updated so PgUp/PgDn page sizes account for MIG rows.
- `src/mock/templates/mig.rs` (new) + `src/mock/templates/nvidia.rs` — env-gated mock template.
- `src/client.rs`, `src/prelude.rs` — `AllSmi::get_mig_info()` and `MigGpuInfo` / `MigInstanceInfo` exports.
- Tests: `tests/mig_integration_test.rs` (4 tests, mirrors `tests/vgpu_integration_test.rs`); inline coverage added to `metrics_parser.rs` (parser caps, oversized indices, missing optional ids), `mig.rs` exporter (label set, silent-when-empty), `mig_renderer.rs` (ANSI-aware), `mig.rs` mock template (placeholder substitution, env gating). Existing `tests/{cpu_model,thermal_pstate_integration,vgpu_integration}_test.rs` updated for the new 6-tuple `parse_metrics` signature.

## Test plan

- [x] `cargo build --features mock` — green
- [x] `cargo test --features mock` — 422 lib + 500 bin + 38 integration + 4 new MIG integration tests, **0 failures**
- [x] `cargo clippy --features mock --all-targets` — no MIG-related warnings (8 pre-existing in `amd.rs`)
- [x] `cargo fmt` — clean
- [x] Mock smoke test: `ALL_SMI_MOCK_MIG=1 all-smi-mock-server --port-range 19099 --platform nvidia` emits 168 MIG metric lines for 8 GPUs × 5 profiles; without the env var, `/metrics` shows 0 MIG lines (silent no-op verified)
- [ ] Hardware validation on a real MIG-enabled A100/H100 host (no MIG hardware available in dev environment)

## Notes for reviewers

- The `MIG_PROFILES` table in `src/mock/templates/mig.rs` documents the synthetic partitioning used in mock mode (1g.5gb x2, 2g.10gb, 3g.20gb, 7g.40gb). Easy to swap for a different mix without touching the parser.
- `compute_instance_id` is plumbed end-to-end (FFI → exporter labels → parser) but not currently used as a TUI label — kept available for future PRs that want to surface compute slice IDs in the UI.
- Per-MIG-instance process attribution is intentionally out of scope here; it can be layered in by joining the existing NVML process accounting (which already reports `gpu_instance_id`/`compute_instance_id` per PID) against the new `MigInstanceInfo` records in a follow-up.