### PR TITLE
feat: add extended NVIDIA hardware details (NUMA, GSP firmware, NvLink, GPM)

### DIFF
--- a/API.md
+++ b/API.md
@@ -128,6 +128,32 @@ count by (lib_name, lib_version) (all_smi_gpu_info) > 1
 - `performance_state` maps NVML `PerformanceState` variants: P0 (maximum performance) = 0 through P15 = 15. The `Unknown` sentinel is suppressed (`None`) rather than emitted.
 - The acoustic threshold is available on newer drivers and some GPU SKUs; older drivers leave it absent.
 
+### NVIDIA Hardware Details Metrics
+
+Extended NVIDIA hardware detail metrics (NUMA topology, GSP firmware, NvLink topology, and GPU Performance Monitoring). All metrics in this group share the same four-label base set as other NVIDIA-specific metrics (`gpu`, `instance`, `uuid`, `index`) and are omitted entirely for non-NVIDIA devices, on older drivers that do not expose the underlying NVML APIs, or when the field value is unavailable.
+
+| Metric                                    | Description                                                                                                      | Unit  | Labels                                                               |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------------------|-------|----------------------------------------------------------------------|
+| `all_smi_gpu_numa_node_id`                | NUMA node the GPU is attached to; omitted when the host has no NUMA topology or the driver does not report one   | gauge | `gpu`, `instance`, `uuid`, `index`                                   |
+| `all_smi_gpu_gsp_firmware_mode`           | GSP firmware mode: `0`=disabled, `1`=enabled, `2`=default; omitted on pre-R525 drivers or non-datacenter SKUs  | gauge | `gpu`, `instance`, `uuid`, `index`                                   |
+| `all_smi_gpu_gsp_firmware_version_info`   | Info-style metric (value always 1) carrying the GSP firmware version string in a `version` label                | gauge | `gpu`, `instance`, `uuid`, `index`, `version`                        |
+| `all_smi_nvlink_remote_device_type`       | Info-style metric (value always 1) per active NvLink; classification in `remote_type` label                     | gauge | `gpu`, `instance`, `uuid`, `index`, `link_index`, `remote_type`      |
+| `all_smi_gpu_sm_occupancy`                | GPM-reported SM occupancy fraction (0.0–1.0); omitted on pre-Hopper GPUs or when GPM has not yet sampled        | gauge | `gpu`, `instance`, `uuid`, `index`                                   |
+| `all_smi_gpu_memory_bandwidth_utilization`| GPM-reported DRAM bandwidth utilization fraction (0.0–1.0); omitted when GPM is unsupported or unsampled        | gauge | `gpu`, `instance`, `uuid`, `index`                                   |
+
+**Label values for `all_smi_nvlink_remote_device_type`:**
+
+| Label        | Values                                   | Description                                       |
+|--------------|------------------------------------------|---------------------------------------------------|
+| `link_index` | `"0"`, `"1"`, …                         | NvLink port index on the GPU                      |
+| `remote_type`| `"gpu"`, `"switch"`, `"ibmnpu"`, `"unknown"` | Classification of the remote endpoint        |
+
+**Notes:**
+- `all_smi_gpu_numa_node_id`: NVML reports `-1` for GPUs without a NUMA attachment; this value is canonicalised to `None` and the metric is omitted rather than emitting a negative number.
+- `all_smi_gpu_gsp_firmware_version_info`: the `version` label carries a string such as `"550.54.15"`. Because the version is static for the lifetime of the driver, it is cached after the first successful NVML call.
+- `all_smi_nvlink_remote_device_type`: one metric row is emitted per active NvLink. A GPU with no active links produces no rows for this metric family.
+- `all_smi_gpu_sm_occupancy` and `all_smi_gpu_memory_bandwidth_utilization`: GPM requires a two-sample handshake before values are available. Until the handshake completes the exporter holds `None` for both fields and emits nothing, preventing spurious zero readings. These metrics are currently plumbing only — values are populated on Hopper and later hardware when the GPM handshake succeeds.
+
 ### NVIDIA vGPU Metrics
 
 NVIDIA vGPU metrics are emitted only on hosts with vGPU SR-IOV enabled. Non-vGPU hosts produce no output for these metric families.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ http://gpu-node3:9090
 - **Multi-GPU Support:** Handles multiple GPUs per system with individual monitoring
 - **Interactive Sorting:** Sort GPUs by utilization, memory usage, or default (hostname+index) order
 - **Platform-Specific Features:**
-  - NVIDIA: PCIe info, performance states (P0–P15), thermal thresholds (slowdown/shutdown/max-operating/acoustic), power limits, vGPU SR-IOV monitoring, MIG (Multi-Instance GPU) monitoring with per-instance utilization and memory metrics
+  - NVIDIA: PCIe info, performance states (P0–P15), thermal thresholds (slowdown/shutdown/max-operating/acoustic), power limits, vGPU SR-IOV monitoring, MIG (Multi-Instance GPU) monitoring with per-instance utilization and memory metrics, hardware details (NUMA node, GSP firmware mode and version, NvLink remote endpoint classification, GPM SM occupancy and memory bandwidth utilization)
   - AMD: VRAM/GTT memory tracking, fan speed monitoring, GPU process detection with fdinfo
   - NVIDIA Jetson: DLA utilization monitoring
   - Apple Silicon: ANE power monitoring, thermal pressure levels
@@ -331,6 +331,7 @@ http://gpu-node3:9090
   - Background metric updates with realistic variations
   - Set `ALL_SMI_MOCK_VGPU=1` to simulate NVIDIA vGPU SR-IOV data without real vGPU hardware
   - Set `ALL_SMI_MOCK_MIG=1` to simulate NVIDIA MIG (Multi-Instance GPU) data without MIG hardware
+  - NVIDIA hardware details (NUMA, GSP firmware, NvLink) are always included in mock responses
 - **Performance Optimized:**
   - Template-based response generation
   - Efficient memory management
@@ -368,6 +369,7 @@ curl --unix-socket /tmp/all-smi.sock http://localhost/metrics
 
 Metrics are available at `http://localhost:9090/metrics` (TCP) or via Unix socket and include comprehensive hardware monitoring for:
 - **GPUs:** Utilization, memory, temperature, power, frequency (NVIDIA, AMD, Apple Silicon, Intel Gaudi, Google TPU, Tenstorrent)
+- **NVIDIA hardware details:** NUMA node ID, GSP firmware mode and version, NvLink remote endpoint type per active link, GPM SM occupancy and memory bandwidth utilization (all omitted when the driver does not support the underlying API)
 - **NVIDIA vGPUs:** Per-vGPU utilization, framebuffer memory, scheduler state, and SR-IOV host mode (emitted only on vGPU-enabled hosts)
 - **NVIDIA MIG:** Per-GPU MIG mode status and per-MIG-instance utilization, framebuffer memory used/total (emitted only on MIG-enabled hosts)
 - **CPUs:** Utilization, frequency, temperature, power (with P/E core metrics for Apple Silicon)
@@ -547,7 +549,7 @@ See the [LICENSE](./LICENSE) file for details.
 ## Changelog
 
 ### Recent Updates
-- **v0.21.0 (upcoming):** Add NVIDIA vGPU SR-IOV monitoring — per-vGPU utilization, framebuffer memory, scheduler state, and host mode exported as Prometheus metrics; TUI renders per-GPU vGPU sub-sections; remote parser reconstructs vGPU view from scraped metrics; mock server can simulate vGPU data via `ALL_SMI_MOCK_VGPU=1`. Add NVIDIA extended thermal monitoring — slowdown, shutdown, max-operating, and acoustic temperature thresholds exported as Prometheus metrics; TUI shows per-GPU thermal row with proximity highlighting (yellow within 5°C of slowdown, red within 2°C of shutdown); P-state (P0–P15) surfaced in TUI and metrics; all fields degrade gracefully to `None` on older drivers or non-NVIDIA hardware. Add NVIDIA MIG (Multi-Instance GPU) monitoring — per-GPU MIG mode status and per-MIG-instance SM utilization, memory bandwidth utilization, and framebuffer used/total bytes exported as Prometheus metrics; TUI renders MIG instances as nested rows under each parent GPU; remote parser reconstructs MIG view from scraped metrics; mock server can simulate MIG data via `ALL_SMI_MOCK_MIG=1`
+- **v0.21.0 (upcoming):** Add NVIDIA vGPU SR-IOV monitoring — per-vGPU utilization, framebuffer memory, scheduler state, and host mode exported as Prometheus metrics; TUI renders per-GPU vGPU sub-sections; remote parser reconstructs vGPU view from scraped metrics; mock server can simulate vGPU data via `ALL_SMI_MOCK_VGPU=1`. Add NVIDIA extended thermal monitoring — slowdown, shutdown, max-operating, and acoustic temperature thresholds exported as Prometheus metrics; TUI shows per-GPU thermal row with proximity highlighting (yellow within 5°C of slowdown, red within 2°C of shutdown); P-state (P0–P15) surfaced in TUI and metrics; all fields degrade gracefully to `None` on older drivers or non-NVIDIA hardware. Add NVIDIA MIG (Multi-Instance GPU) monitoring — per-GPU MIG mode status and per-MIG-instance SM utilization, memory bandwidth utilization, and framebuffer used/total bytes exported as Prometheus metrics; TUI renders MIG instances as nested rows under each parent GPU; remote parser reconstructs MIG view from scraped metrics; mock server can simulate MIG data via `ALL_SMI_MOCK_MIG=1`. Add NVIDIA extended hardware details — NUMA node ID, GSP firmware mode and version, NvLink remote endpoint classification per active link, and GPM SM occupancy and memory bandwidth utilization exported as Prometheus metrics; TUI shows compact HW row per GPU with NUMA node, GSP state, and NvLink count; all fields degrade gracefully to absent on older drivers, non-NVIDIA hardware, or hosts without NUMA topology
 - **v0.20.1 (2026/04/10):** Fix local header metric row jitter by using fixed-width formatted fields; auto-promote pre-release to release in CI
 - **v0.20.0 (2026/04/10):** Redesign local-mode TUI with Activity panel featuring braille sparklines, CPU per-core view, host summary bar, and per-node LED grid; add Apple M5 Pro/Max Super core (S-CPU) support
 - **v0.19.0 (2026/04/08):** Fix Apple Silicon SMC float decoding to restore real CPU/GPU die temperatures, cache platform detection to avoid per-frame system_profiler on macOS, and fix TIME+/Command column alignment in process list

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -20,9 +20,9 @@ use crate::app_state::AppState;
 
 use super::metrics::{
     MetricExporter, chassis::ChassisMetricExporter, cpu::CpuMetricExporter,
-    disk::DiskMetricExporter, gpu::GpuMetricExporter, memory::MemoryMetricExporter,
-    mig::MigMetricExporter, npu::NpuMetricExporter, process::ProcessMetricExporter,
-    runtime::RuntimeMetricExporter, vgpu::VgpuMetricExporter,
+    disk::DiskMetricExporter, gpu::GpuMetricExporter, hardware::HardwareMetricExporter,
+    memory::MemoryMetricExporter, mig::MigMetricExporter, npu::NpuMetricExporter,
+    process::ProcessMetricExporter, runtime::RuntimeMetricExporter, vgpu::VgpuMetricExporter,
 };
 
 pub type SharedState = Arc<RwLock<AppState>>;
@@ -87,6 +87,16 @@ pub async fn metrics_handler(State(state): State<SharedState>) -> String {
     if !state.mig_info.is_empty() {
         let mig_exporter = MigMetricExporter::new(&state.mig_info);
         all_metrics.push_str(&mig_exporter.export_metrics());
+    }
+
+    // Export extended hardware details (issue #132): NUMA node id, GSP
+    // firmware mode + version, NvLink remote device types, optional GPM
+    // gauges. The exporter self-filters to NVIDIA GPUs that populated at
+    // least one of the new fields so non-NVIDIA and older-driver paths
+    // stay silent in the `/metrics` output.
+    if !state.gpu_info.is_empty() {
+        let hw_exporter = HardwareMetricExporter::new(&state.gpu_info);
+        all_metrics.push_str(&hw_exporter.export_metrics());
     }
 
     all_metrics

--- a/src/api/metrics/gpu.rs
+++ b/src/api/metrics/gpu.rs
@@ -454,6 +454,11 @@ mod tests {
             temperature_threshold_max_operating: Some(85),
             temperature_threshold_acoustic: Some(77),
             performance_state: Some(2),
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail: HashMap::new(),
         }
     }

--- a/src/api/metrics/hardware.rs
+++ b/src/api/metrics/hardware.rs
@@ -1,0 +1,481 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Prometheus exporter for NVIDIA hardware-detail metrics (issue #132).
+//!
+//! Metrics produced by this exporter:
+//!
+//! * `all_smi_gpu_numa_node_id` (gauge): NUMA node the GPU is attached to.
+//!   Emitted only when the reader returned a concrete value — absence
+//!   signals "unavailable" (no NUMA topology, driver too old, non-Linux
+//!   platform). Dashboards MUST treat `absent` as "unknown" rather than
+//!   defaulting to 0.
+//! * `all_smi_gpu_gsp_firmware_mode` (gauge): `0=disabled`, `1=enabled`,
+//!   `2=default`. Absent when unsupported.
+//! * `all_smi_gpu_gsp_firmware_version_info` (gauge, label-only): info-style
+//!   metric carrying the firmware version string in a `version` label with
+//!   a constant value of 1. Absent when unsupported.
+//! * `all_smi_nvlink_remote_device_type` (gauge, label-only): one row per
+//!   active NvLink carrying `link_index` and `remote_type` labels with a
+//!   constant value of 1. Empty when no NvLinks are active.
+//! * `all_smi_gpu_sm_occupancy` (gauge, 0-1): fractional SM occupancy from
+//!   the GPM API. Absent when GPM is not supported.
+//! * `all_smi_gpu_memory_bandwidth_utilization` (gauge, 0-1): fractional
+//!   DRAM bandwidth utilization from the GPM API. Absent when unsupported.
+//!
+//! All metrics carry the standard GPU label set (`gpu`, `instance`, `uuid`,
+//! `index`), matching the core `all_smi_gpu_temperature_celsius` series so
+//! dashboards can correlate by label.
+//!
+//! The exporter emits nothing when no GPUs populated any of the new fields
+//! — non-NVIDIA paths, older NVIDIA drivers without the relevant APIs, and
+//! hosts with zero NvLinks stay silent in the `/metrics` output.
+
+use super::{MetricBuilder, MetricExporter};
+use crate::device::GpuInfo;
+
+/// Hardware-detail exporter.
+///
+/// Takes a borrowed slice of [`GpuInfo`] and emits the issue-#132 metric
+/// families. Row caching (stringifying the device index once per GPU) is
+/// done in [`HardwareMetricExporter::collect_rows`] so the four metric
+/// families iterate without re-allocating labels.
+pub struct HardwareMetricExporter<'a> {
+    pub gpu_info: &'a [GpuInfo],
+}
+
+impl<'a> HardwareMetricExporter<'a> {
+    pub fn new(gpu_info: &'a [GpuInfo]) -> Self {
+        Self { gpu_info }
+    }
+
+    /// Pre-compute the stringified `index` label and only keep GPUs that
+    /// contribute at least one hardware-detail row. Allocates once per
+    /// scrape regardless of how many metric families are later emitted.
+    fn collect_rows(&self) -> Vec<Row<'a>> {
+        self.gpu_info
+            .iter()
+            .enumerate()
+            .filter(|(_, gpu)| has_any_hw_detail(gpu))
+            .map(|(idx, gpu)| Row {
+                gpu,
+                index_str: idx.to_string(),
+            })
+            .collect()
+    }
+
+    fn base_labels<'b>(row: &'b Row<'a>) -> [(&'b str, &'b str); 4] {
+        [
+            ("gpu", row.gpu.name.as_str()),
+            ("instance", row.gpu.instance.as_str()),
+            ("uuid", row.gpu.uuid.as_str()),
+            ("index", row.index_str.as_str()),
+        ]
+    }
+
+    fn export_numa_node_id(&self, builder: &mut MetricBuilder, rows: &[Row<'a>]) {
+        // Emit HELP/TYPE unconditionally so the exposition format is well-
+        // formed even when no GPU has NUMA data. This matches the
+        // per-metric-family pattern used by the vGPU / MIG exporters.
+        let mut emitted_any = false;
+        for row in rows {
+            if let Some(node_id) = row.gpu.numa_node_id {
+                if !emitted_any {
+                    builder
+                        .help(
+                            "all_smi_gpu_numa_node_id",
+                            "NUMA node the GPU is attached to (metric is omitted when the host \
+                             has no NUMA topology or the driver does not report one)",
+                        )
+                        .type_("all_smi_gpu_numa_node_id", "gauge");
+                    emitted_any = true;
+                }
+                let labels = Self::base_labels(row);
+                builder.metric("all_smi_gpu_numa_node_id", &labels, node_id);
+            }
+        }
+    }
+
+    fn export_gsp_firmware_mode(&self, builder: &mut MetricBuilder, rows: &[Row<'a>]) {
+        let mut emitted_any = false;
+        for row in rows {
+            if let Some(mode) = row.gpu.gsp_firmware_mode {
+                if !emitted_any {
+                    builder
+                        .help(
+                            "all_smi_gpu_gsp_firmware_mode",
+                            "GSP firmware mode (0=disabled, 1=enabled, 2=default); omitted when \
+                             the driver does not expose the GSP firmware API",
+                        )
+                        .type_("all_smi_gpu_gsp_firmware_mode", "gauge");
+                    emitted_any = true;
+                }
+                let labels = Self::base_labels(row);
+                builder.metric("all_smi_gpu_gsp_firmware_mode", &labels, mode);
+            }
+        }
+    }
+
+    fn export_gsp_firmware_version(&self, builder: &mut MetricBuilder, rows: &[Row<'a>]) {
+        let mut emitted_any = false;
+        for row in rows {
+            if let Some(ref version) = row.gpu.gsp_firmware_version {
+                if !emitted_any {
+                    builder
+                        .help(
+                            "all_smi_gpu_gsp_firmware_version_info",
+                            "GSP firmware version, encoded as a constant 1 with the version in a \
+                             `version` label; omitted when unsupported",
+                        )
+                        .type_("all_smi_gpu_gsp_firmware_version_info", "gauge");
+                    emitted_any = true;
+                }
+                let base = Self::base_labels(row);
+                let labels = [
+                    base[0],
+                    base[1],
+                    base[2],
+                    base[3],
+                    ("version", version.as_str()),
+                ];
+                builder.metric("all_smi_gpu_gsp_firmware_version_info", &labels, 1);
+            }
+        }
+    }
+
+    fn export_nvlink_remote_device_type(&self, builder: &mut MetricBuilder, rows: &[Row<'a>]) {
+        let mut emitted_any = false;
+        for row in rows {
+            for link in &row.gpu.nvlink_remote_devices {
+                if !emitted_any {
+                    builder
+                        .help(
+                            "all_smi_nvlink_remote_device_type",
+                            "NvLink remote endpoint classification per active link. Value is \
+                             always 1; classification is carried in the `remote_type` label \
+                             (gpu / switch / ibmnpu / unknown).",
+                        )
+                        .type_("all_smi_nvlink_remote_device_type", "gauge");
+                    emitted_any = true;
+                }
+                let link_idx_str = link.link_index.to_string();
+                let base = Self::base_labels(row);
+                let labels = [
+                    base[0],
+                    base[1],
+                    base[2],
+                    base[3],
+                    ("link_index", link_idx_str.as_str()),
+                    ("remote_type", link.remote_type.as_label()),
+                ];
+                builder.metric("all_smi_nvlink_remote_device_type", &labels, 1);
+            }
+        }
+    }
+
+    fn export_gpm_metrics(&self, builder: &mut MetricBuilder, rows: &[Row<'a>]) {
+        // Only emit the gauges when the underlying reader surfaced a
+        // numeric value. Presence of a `GpmMetrics` struct without any
+        // populated field (the reader's "GPM-capable, not yet sampled"
+        // state) should produce no output so dashboards can't confuse it
+        // with a real zero reading.
+        let mut emitted_sm_header = false;
+        let mut emitted_mem_header = false;
+        for row in rows {
+            let Some(ref metrics) = row.gpu.gpm_metrics else {
+                continue;
+            };
+            if let Some(sm) = metrics.sm_occupancy {
+                if !emitted_sm_header {
+                    builder
+                        .help(
+                            "all_smi_gpu_sm_occupancy",
+                            "GPM-reported SM occupancy fraction (0.0-1.0); omitted on devices \
+                             that do not support GPM (pre-Hopper)",
+                        )
+                        .type_("all_smi_gpu_sm_occupancy", "gauge");
+                    emitted_sm_header = true;
+                }
+                let labels = Self::base_labels(row);
+                builder.metric("all_smi_gpu_sm_occupancy", &labels, sm);
+            }
+            if let Some(mem) = metrics.memory_bandwidth_utilization {
+                if !emitted_mem_header {
+                    builder
+                        .help(
+                            "all_smi_gpu_memory_bandwidth_utilization",
+                            "GPM-reported memory bandwidth utilization fraction (0.0-1.0); \
+                             omitted on devices that do not support GPM (pre-Hopper)",
+                        )
+                        .type_("all_smi_gpu_memory_bandwidth_utilization", "gauge");
+                    emitted_mem_header = true;
+                }
+                let labels = Self::base_labels(row);
+                builder.metric("all_smi_gpu_memory_bandwidth_utilization", &labels, mem);
+            }
+        }
+    }
+}
+
+/// Returns true when a GPU has at least one hardware-detail field
+/// populated. Used by [`HardwareMetricExporter::collect_rows`] so we skip
+/// non-NVIDIA rows entirely without iterating them in every metric family.
+fn has_any_hw_detail(gpu: &GpuInfo) -> bool {
+    gpu.numa_node_id.is_some()
+        || gpu.gsp_firmware_mode.is_some()
+        || gpu.gsp_firmware_version.is_some()
+        || !gpu.nvlink_remote_devices.is_empty()
+        || gpu.gpm_metrics.is_some()
+}
+
+/// Borrowed view of a single GPU row with its stringified index cached.
+/// Exists purely to amortise the `.to_string()` on the index label across
+/// the five metric families.
+struct Row<'a> {
+    gpu: &'a GpuInfo,
+    index_str: String,
+}
+
+impl<'a> MetricExporter for HardwareMetricExporter<'a> {
+    fn export_metrics(&self) -> String {
+        let rows = self.collect_rows();
+        if rows.is_empty() {
+            return String::new();
+        }
+
+        let mut builder = MetricBuilder::new();
+        self.export_numa_node_id(&mut builder, &rows);
+        self.export_gsp_firmware_mode(&mut builder, &rows);
+        self.export_gsp_firmware_version(&mut builder, &rows);
+        self.export_nvlink_remote_device_type(&mut builder, &rows);
+        self.export_gpm_metrics(&mut builder, &rows);
+        builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{GpmMetrics, NvLinkRemoteDevice, NvLinkRemoteType};
+    use std::collections::HashMap;
+
+    fn make_nvidia_gpu() -> GpuInfo {
+        GpuInfo {
+            uuid: "GPU-ABC".to_string(),
+            time: String::new(),
+            name: "NVIDIA A100".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "node-1".to_string(),
+            hostname: "node-1".to_string(),
+            instance: "node-1".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: Some(0),
+            gsp_firmware_mode: Some(1),
+            gsp_firmware_version: Some("550.54.15".to_string()),
+            nvlink_remote_devices: vec![
+                NvLinkRemoteDevice {
+                    link_index: 0,
+                    remote_type: NvLinkRemoteType::Gpu,
+                },
+                NvLinkRemoteDevice {
+                    link_index: 1,
+                    remote_type: NvLinkRemoteType::Switch,
+                },
+            ],
+            gpm_metrics: Some(GpmMetrics {
+                sm_occupancy: Some(0.67),
+                memory_bandwidth_utilization: Some(0.42),
+            }),
+            detail: HashMap::new(),
+        }
+    }
+
+    fn make_non_nvidia_gpu() -> GpuInfo {
+        let mut gpu = make_nvidia_gpu();
+        gpu.uuid = "GPU-AMD".to_string();
+        gpu.name = "Radeon RX".to_string();
+        gpu.numa_node_id = None;
+        gpu.gsp_firmware_mode = None;
+        gpu.gsp_firmware_version = None;
+        gpu.nvlink_remote_devices = Vec::new();
+        gpu.gpm_metrics = None;
+        gpu
+    }
+
+    #[test]
+    fn empty_when_no_hardware_details_anywhere() {
+        let gpus = vec![make_non_nvidia_gpu()];
+        let exporter = HardwareMetricExporter::new(&gpus);
+        assert_eq!(exporter.export_metrics(), "");
+    }
+
+    #[test]
+    fn emits_numa_node_id_when_populated() {
+        let gpus = vec![make_nvidia_gpu()];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        assert!(out.contains("# HELP all_smi_gpu_numa_node_id"));
+        assert!(out.contains("# TYPE all_smi_gpu_numa_node_id gauge"));
+        // Pattern: `all_smi_gpu_numa_node_id{...} 0`
+        assert!(
+            out.lines()
+                .any(|l| l.starts_with("all_smi_gpu_numa_node_id{") && l.ends_with(" 0")),
+            "missing numa node id line in:\n{out}"
+        );
+    }
+
+    #[test]
+    fn omits_numa_node_id_when_none() {
+        let mut gpu = make_nvidia_gpu();
+        gpu.numa_node_id = None;
+        let gpus = vec![gpu];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        assert!(
+            !out.contains("all_smi_gpu_numa_node_id"),
+            "should omit numa metric entirely:\n{out}"
+        );
+    }
+
+    #[test]
+    fn emits_gsp_firmware_mode_and_version() {
+        let gpus = vec![make_nvidia_gpu()];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        assert!(out.contains("all_smi_gpu_gsp_firmware_mode{"));
+        assert!(out.contains("all_smi_gpu_gsp_firmware_version_info{"));
+        assert!(out.contains(r#"version="550.54.15""#));
+    }
+
+    #[test]
+    fn emits_one_nvlink_row_per_active_link() {
+        let gpus = vec![make_nvidia_gpu()];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        let nvlink_lines: Vec<_> = out
+            .lines()
+            .filter(|l| l.starts_with("all_smi_nvlink_remote_device_type{"))
+            .collect();
+        assert_eq!(nvlink_lines.len(), 2, "expected 2 NvLink rows:\n{out}");
+        assert!(
+            nvlink_lines
+                .iter()
+                .any(|l| l.contains(r#"remote_type="gpu""#))
+        );
+        assert!(
+            nvlink_lines
+                .iter()
+                .any(|l| l.contains(r#"remote_type="switch""#))
+        );
+        assert!(nvlink_lines.iter().any(|l| l.contains(r#"link_index="0""#)));
+        assert!(nvlink_lines.iter().any(|l| l.contains(r#"link_index="1""#)));
+    }
+
+    #[test]
+    fn emits_no_nvlink_metric_when_vector_empty() {
+        let mut gpu = make_nvidia_gpu();
+        gpu.nvlink_remote_devices.clear();
+        // But keep NUMA so the row survives collect_rows filter.
+        let gpus = vec![gpu];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        assert!(
+            !out.contains("all_smi_nvlink_remote_device_type"),
+            "should omit NvLink metric entirely when no active links:\n{out}"
+        );
+    }
+
+    #[test]
+    fn emits_gpm_metrics_when_populated() {
+        let gpus = vec![make_nvidia_gpu()];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        assert!(out.contains("all_smi_gpu_sm_occupancy{"));
+        assert!(out.contains("all_smi_gpu_memory_bandwidth_utilization{"));
+    }
+
+    #[test]
+    fn omits_gpm_metrics_when_unsupported_device() {
+        let mut gpu = make_nvidia_gpu();
+        gpu.gpm_metrics = None;
+        let gpus = vec![gpu];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        assert!(!out.contains("all_smi_gpu_sm_occupancy"));
+        assert!(!out.contains("all_smi_gpu_memory_bandwidth_utilization"));
+    }
+
+    #[test]
+    fn gpm_supported_but_unsampled_emits_nothing_for_gpm_values() {
+        // Reader emits `Some(GpmMetrics::default())` on Hopper+ until the
+        // two-sample handshake lands. The exporter MUST NOT publish that
+        // as zeros — presence without fields should be silent.
+        let mut gpu = make_nvidia_gpu();
+        gpu.gpm_metrics = Some(GpmMetrics::default());
+        let gpus = vec![gpu];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        assert!(
+            !out.contains("all_smi_gpu_sm_occupancy"),
+            "unsampled GPM must not emit zero:\n{out}"
+        );
+        assert!(
+            !out.contains("all_smi_gpu_memory_bandwidth_utilization"),
+            "unsampled GPM must not emit zero:\n{out}"
+        );
+    }
+
+    #[test]
+    fn preserves_standard_gpu_labels_on_all_metrics() {
+        let gpus = vec![make_nvidia_gpu()];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        // Every emitted line must carry the canonical GPU label set so
+        // operators can correlate hardware-detail rows with basic util /
+        // temperature series by identical labels.
+        let expected_fragments = [
+            r#"gpu="NVIDIA A100""#,
+            r#"instance="node-1""#,
+            r#"uuid="GPU-ABC""#,
+            r#"index="0""#,
+        ];
+        for line in out
+            .lines()
+            .filter(|l| l.starts_with("all_smi_") && l.contains('{'))
+        {
+            for frag in &expected_fragments {
+                assert!(line.contains(frag), "label '{frag}' missing from {line}");
+            }
+        }
+    }
+
+    #[test]
+    fn skips_non_nvidia_rows_when_nvidia_row_also_present() {
+        let gpus = vec![make_non_nvidia_gpu(), make_nvidia_gpu()];
+        let out = HardwareMetricExporter::new(&gpus).export_metrics();
+        // Non-NVIDIA GPU has UUID "GPU-AMD" — it must not appear in the
+        // exposition since it populated no hardware-detail fields.
+        assert!(
+            !out.contains("GPU-AMD"),
+            "non-NVIDIA GPU leaked into hardware exporter:\n{out}"
+        );
+        // NVIDIA GPU must remain observable.
+        assert!(out.contains("GPU-ABC"));
+    }
+}

--- a/src/api/metrics/mod.rs
+++ b/src/api/metrics/mod.rs
@@ -16,6 +16,7 @@ pub mod chassis;
 pub mod cpu;
 pub mod disk;
 pub mod gpu;
+pub mod hardware;
 pub mod memory;
 pub mod mig;
 pub mod npu;

--- a/src/device/readers/amd.rs
+++ b/src/device/readers/amd.rs
@@ -519,6 +519,15 @@ impl GpuReader for AmdGpuReader {
                 temperature_threshold_max_operating: None,
                 temperature_threshold_acoustic: None,
                 performance_state: None,
+                // NVIDIA-specific hardware details (NUMA, GSP firmware,
+                // NvLink, GPM) do not apply to AMD — leave them at the
+                // "unavailable" defaults so consumers render them as
+                // missing rather than zero.
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
                 detail,
             };
             gpu_info.push(info);

--- a/src/device/readers/amd_windows.rs
+++ b/src/device/readers/amd_windows.rs
@@ -170,12 +170,19 @@ impl AmdWindowsGpuReader {
                     power_consumption: 0.0, // Not available via WMI
                     gpu_core_count: None,
                     // AMD-on-Windows surfaces nothing beyond the basic WMI
-                    // query — NVML thermal thresholds / P-states do not apply.
+                    // query — NVML thermal thresholds / P-states and NVIDIA
+                    // hardware details (NUMA, GSP firmware, NvLink, GPM) do
+                    // not apply.
                     temperature_threshold_slowdown: None,
                     temperature_threshold_shutdown: None,
                     temperature_threshold_max_operating: None,
                     temperature_threshold_acoustic: None,
                     performance_state: None,
+                    numa_node_id: None,
+                    gsp_firmware_mode: None,
+                    gsp_firmware_version: None,
+                    nvlink_remote_devices: Vec::new(),
+                    gpm_metrics: None,
                     detail,
                 });
             }

--- a/src/device/readers/apple_silicon_native.rs
+++ b/src/device/readers/apple_silicon_native.rs
@@ -239,11 +239,18 @@ impl GpuReader for AppleSiliconNativeGpuReader {
             // Apple Silicon reports thermal pressure as a qualitative enum
             // (Nominal / Fair / Serious / Critical) via the `detail` map, not
             // as NVML-style numeric thresholds. Leave these fields empty.
+            // NVIDIA-specific hardware details (NUMA, GSP firmware, NvLink,
+            // GPM) do not apply to Apple Silicon either.
             temperature_threshold_slowdown: None,
             temperature_threshold_shutdown: None,
             temperature_threshold_max_operating: None,
             temperature_threshold_acoustic: None,
             performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail,
         }]
     }

--- a/src/device/readers/furiosa.rs
+++ b/src/device/readers/furiosa.rs
@@ -497,13 +497,19 @@ fn create_gpu_info_from_cli_cached(
         frequency,
         power_consumption: power,
         gpu_core_count: None,
-        // Furiosa RNGD exposes temperature only; no NVML thermal threshold
-        // or P-state equivalents exist for this accelerator.
+        // Furiosa RNGD exposes temperature only; no NVML thermal threshold,
+        // P-state, or NVIDIA hardware detail (NUMA/GSP/NvLink/GPM)
+        // equivalents exist for this accelerator.
         temperature_threshold_slowdown: None,
         temperature_threshold_shutdown: None,
         temperature_threshold_max_operating: None,
         temperature_threshold_acoustic: None,
         performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
         detail,
     })
 }
@@ -583,13 +589,19 @@ fn create_gpu_info_from_device_2025_cached(
         frequency: freq_mhz,
         power_consumption: *power,
         gpu_core_count,
-        // Furiosa RNGD exposes temperature only; no NVML thermal threshold
-        // or P-state equivalents exist for this accelerator.
+        // Furiosa RNGD exposes temperature only; no NVML thermal threshold,
+        // P-state, or NVIDIA hardware detail (NUMA/GSP/NvLink/GPM)
+        // equivalents exist for this accelerator.
         temperature_threshold_slowdown: None,
         temperature_threshold_shutdown: None,
         temperature_threshold_max_operating: None,
         temperature_threshold_acoustic: None,
         performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
         detail,
     })
 }
@@ -651,13 +663,19 @@ fn create_gpu_info_from_device_2025(
         frequency: freq_mhz,
         power_consumption: *power,
         gpu_core_count: Some(info.core_num()),
-        // Furiosa RNGD exposes temperature only; no NVML thermal threshold
-        // or P-state equivalents exist for this accelerator.
+        // Furiosa RNGD exposes temperature only; no NVML thermal threshold,
+        // P-state, or NVIDIA hardware detail (NUMA/GSP/NvLink/GPM)
+        // equivalents exist for this accelerator.
         temperature_threshold_slowdown: None,
         temperature_threshold_shutdown: None,
         temperature_threshold_max_operating: None,
         temperature_threshold_acoustic: None,
         performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
         detail,
     })
 }

--- a/src/device/readers/gaudi.rs
+++ b/src/device/readers/gaudi.rs
@@ -273,12 +273,18 @@ fn create_gpu_info_from_device(
         power_consumption: device.power_draw,
         gpu_core_count: None,
         // Intel Gaudi surfaces temperature only; NVML threshold / P-state
-        // APIs do not apply.
+        // APIs and NVIDIA hardware details (NUMA/GSP/NvLink/GPM) do not
+        // apply.
         temperature_threshold_slowdown: None,
         temperature_threshold_shutdown: None,
         temperature_threshold_max_operating: None,
         temperature_threshold_acoustic: None,
         performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
         detail,
     })
 }

--- a/src/device/readers/google_tpu.rs
+++ b/src/device/readers/google_tpu.rs
@@ -973,12 +973,18 @@ fn create_gpu_info_from_device(
         power_consumption: device.power_draw,
         gpu_core_count: Some(device.core_count),
         // Google TPU exposes only a single temperature reading; no NVML
-        // thermal-threshold / P-state equivalents.
+        // thermal-threshold / P-state or NVIDIA hardware-detail
+        // (NUMA/GSP/NvLink/GPM) equivalents.
         temperature_threshold_slowdown: None,
         temperature_threshold_shutdown: None,
         temperature_threshold_max_operating: None,
         temperature_threshold_acoustic: None,
         performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
         detail,
     })
 }

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -29,6 +29,7 @@ pub mod gaudi;
 #[cfg(target_os = "linux")]
 pub mod google_tpu;
 pub mod nvidia;
+pub mod nvidia_hardware;
 pub mod nvidia_jetson;
 pub mod nvidia_mig;
 pub mod nvidia_vgpu;

--- a/src/device/readers/nvidia.rs
+++ b/src/device/readers/nvidia.rs
@@ -17,6 +17,9 @@ use crate::device::common::constants::BYTES_PER_MB;
 use crate::device::common::{execute_command_default, parse_csv_line};
 use crate::device::process_list::{get_all_processes, merge_gpu_processes};
 use crate::device::readers::common_cache::{DetailBuilder, DeviceStaticInfo, MAX_DEVICES};
+use crate::device::readers::nvidia_hardware::{
+    HardwareDetailCache, collect_gpm_metrics, collect_nvlink_remote_devices,
+};
 use crate::device::readers::nvidia_mig::collect_mig_info;
 use crate::device::readers::nvidia_vgpu::collect_vgpu_info;
 use crate::device::types::{GpuInfo, MigGpuInfo, ProcessInfo, VgpuHostInfo};
@@ -71,6 +74,11 @@ pub struct NvidiaGpuReader {
     /// Cached temperature thresholds per device index. Populated lazily on
     /// the first successful read and reused for the lifetime of the process.
     thermal_thresholds: Mutex<HashMap<u32, ThermalThresholds>>,
+    /// Cached static hardware details per device index (NUMA node, GSP
+    /// firmware mode, GSP firmware version). Populated lazily on the first
+    /// call that observes any supported value, following the same "don't
+    /// cache an all-empty snapshot" policy as [`Self::thermal_thresholds`].
+    hardware_details: HardwareDetailCache,
 }
 
 /// Map the NVML [`PerformanceState`] enum to the integer used by the
@@ -114,6 +122,7 @@ impl NvidiaGpuReader {
             device_static_info: OnceLock::new(),
             nvml: Mutex::new(Nvml::init().ok()),
             thermal_thresholds: Mutex::new(HashMap::new()),
+            hardware_details: HardwareDetailCache::new(),
         }
     }
 
@@ -290,6 +299,19 @@ impl NvidiaGpuReader {
                         .ok()
                         .and_then(performance_state_to_u32);
 
+                    // Static hardware details: NUMA node id + GSP firmware
+                    // (mode + version). All three are cached per device
+                    // since they never change at runtime.
+                    let hw = self.hardware_details.get_or_fetch(&device, i);
+                    // Active NvLinks are queried every poll — link state
+                    // can change at runtime if a cable is disconnected.
+                    let nvlink_remote_devices = collect_nvlink_remote_devices(nvml, &device);
+                    // GPM metrics are opt-in (Hopper+). `collect_gpm_metrics`
+                    // returns `None` everywhere else and a populated-but-empty
+                    // snapshot on supported hardware (full two-sample
+                    // implementation deferred to a follow-up).
+                    let gpm_metrics = collect_gpm_metrics(&device);
+
                     let info = GpuInfo {
                         uuid: device.uuid().unwrap_or_else(|_| format!("GPU-{i}")),
                         time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
@@ -328,6 +350,11 @@ impl NvidiaGpuReader {
                         temperature_threshold_max_operating: thresholds.max_operating,
                         temperature_threshold_acoustic: thresholds.acoustic,
                         performance_state,
+                        numa_node_id: hw.numa_node_id,
+                        gsp_firmware_mode: hw.gsp_firmware_mode,
+                        gsp_firmware_version: hw.gsp_firmware_version,
+                        nvlink_remote_devices,
+                        gpm_metrics,
                         detail,
                     };
                     gpu_info.push(info);
@@ -800,6 +827,15 @@ fn get_gpu_info_nvidia_smi() -> Vec<GpuInfo> {
                     temperature_threshold_max_operating: None,
                     temperature_threshold_acoustic: None,
                     performance_state: None,
+                    // Hardware details (issue #132) are only available via
+                    // NVML — the CSV fallback cannot surface them. Leave
+                    // them at the "unavailable" defaults so downstream
+                    // consumers render them as missing rather than zero.
+                    numa_node_id: None,
+                    gsp_firmware_mode: None,
+                    gsp_firmware_version: None,
+                    nvlink_remote_devices: Vec::new(),
+                    gpm_metrics: None,
                     detail,
                 })
             } else {

--- a/src/device/readers/nvidia_hardware.rs
+++ b/src/device/readers/nvidia_hardware.rs
@@ -252,12 +252,16 @@ pub fn collect_nvlink_remote_devices(
         let link_wrapper = device.link_wrapper_for(link);
         match link_wrapper.is_active() {
             Ok(true) => {}
-            // Any error here (`NotSupported`, `InvalidArg`) means the link
-            // does not exist; stop probing early to avoid 18 failing calls
-            // on a GPU with zero NvLinks. Observed behaviour: NVML returns
-            // `InvalidArg` for indices past the physical link count.
             Ok(false) => continue,
-            Err(_) => break,
+            // `InvalidArg` means the index is past the physical link count —
+            // stop probing early because higher indices will also fail.
+            // `NotSupported` means this GPU has no NvLink hardware at all —
+            // stop immediately.
+            // Any other error (transient: `Unknown`, `GpuLost`) skips this
+            // link but continues probing higher indices so that a transient
+            // failure on link N does not silently hide links N+1..MAX.
+            Err(NvmlError::InvalidArg | NvmlError::NotSupported) => break,
+            Err(_transient) => continue,
         }
         let remote_type = match nvlink_remote_device_type_ffi(nvml, device, link) {
             Some(t) => t,

--- a/src/device/readers/nvidia_hardware.rs
+++ b/src/device/readers/nvidia_hardware.rs
@@ -152,10 +152,10 @@ impl HardwareDetailCache {
         F: FnOnce() -> Result<T, NvmlError>,
     {
         // Probe: return immediately if any entry (even `None`) is cached.
-        if let Ok(map) = cache.lock() {
-            if let Some(cached) = map.get(&index) {
-                return cached.clone();
-            }
+        if let Ok(map) = cache.lock()
+            && let Some(cached) = map.get(&index)
+        {
+            return cached.clone();
         }
 
         // Miss: call the NVML function.

--- a/src/device/readers/nvidia_hardware.rs
+++ b/src/device/readers/nvidia_hardware.rs
@@ -22,11 +22,20 @@
 //!
 //! # Caching policy
 //!
-//! [`HardwareDetailCache`] memoises the two static-per-device fields — NUMA
-//! node id and GSP firmware version — so they are only fetched once per
-//! process lifetime. Cache insertions happen only when at least one field
-//! resolved successfully; a transient NVML error on the first call does not
-//! lock the cache to `None` for the process lifetime.
+//! [`HardwareDetailCache`] memoises the three static-per-device fields —
+//! NUMA node id, GSP firmware mode, and GSP firmware version — in independent
+//! per-field caches so each field is fetched only once per process lifetime.
+//!
+//! Cache insertion is conditional on the NVML result:
+//! - `Ok(value)` → cached as `Some(value)`.
+//! - `Err(NotSupported | FunctionNotFound)` → cached as `None` (permanently
+//!   unavailable; will not be retried).
+//! - Any other error (transient: `Unknown`, `GpuIsLost`, etc.) → NOT cached;
+//!   the next poll will retry that field independently.
+//!
+//! This guarantees a transient failure on field A (e.g. GSP mode during a
+//! driver hiccup) does not permanently lock field B (e.g. NUMA node) to
+//! `None`, and vice versa.
 //!
 //! NvLink enumeration and GPM support detection are NOT cached because their
 //! state can change at runtime (links can drop, GPM streaming can be toggled
@@ -60,23 +69,39 @@ pub struct HardwareDetails {
     pub gsp_firmware_version: Option<String>,
 }
 
-impl HardwareDetails {
-    /// Whether this snapshot carries any supported value. Guards the cache
-    /// against storing an all-empty record produced by transient NVML
-    /// failures on the first poll.
-    fn has_any_value(&self) -> bool {
-        self.numa_node_id.is_some()
-            || self.gsp_firmware_mode.is_some()
-            || self.gsp_firmware_version.is_some()
-    }
+/// Determines whether an NVML error should be treated as a permanent
+/// "not available" condition (so `None` can be cached) or as a transient
+/// failure that should be retried on the next poll.
+///
+/// `NotSupported` and `FunctionNotFound` are driver/hardware capabilities
+/// that cannot change at runtime, so caching `None` is correct.  All other
+/// errors (e.g. `Unknown`, `GpuIsLost`, `DriverNotLoaded`) are transient
+/// and must NOT be cached so the next poll retries.
+fn is_permanent_unavailable(err: &NvmlError) -> bool {
+    matches!(err, NvmlError::NotSupported | NvmlError::FunctionNotFound)
 }
 
-/// Cache keyed by NVML device index. Shared state is held behind a single
-/// `Mutex` so the cache insertion is race-free — the sampler only locks
-/// twice per miss (once to probe, once to insert) and blocking callers stay
-/// O(number of GPUs).
+/// Per-field cache entry.  `Some(value)` means the field was read
+/// successfully.  `None` means the driver permanently does not support
+/// this field (e.g. `NotSupported`).  The entry being absent from the map
+/// means the field has never been fetched or only experienced transient
+/// errors so far.
+type FieldCache<T> = Mutex<HashMap<u32, Option<T>>>;
+
+/// Cache keyed by NVML device index. Each hardware-detail field has its
+/// own independent cache so a transient error on one field does not
+/// permanently lock another field to `None`.
+///
+/// Cache insertion semantics per field:
+/// - NVML returns `Ok(value)` → cache `Some(value)`.
+/// - NVML returns a *permanent* error (`NotSupported`, `FunctionNotFound`)
+///   → cache `None` (permanently unavailable).
+/// - NVML returns a *transient* error (anything else) → do NOT insert;
+///   the next poll will retry.
 pub struct HardwareDetailCache {
-    entries: Mutex<HashMap<u32, HardwareDetails>>,
+    numa: FieldCache<i32>,
+    gsp_mode: FieldCache<u8>,
+    gsp_version: FieldCache<String>,
 }
 
 impl Default for HardwareDetailCache {
@@ -88,83 +113,123 @@ impl Default for HardwareDetailCache {
 impl HardwareDetailCache {
     pub fn new() -> Self {
         Self {
-            entries: Mutex::new(HashMap::new()),
+            numa: Mutex::new(HashMap::new()),
+            gsp_mode: Mutex::new(HashMap::new()),
+            gsp_version: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Fetch hardware details for `index`, populating the cache on the
-    /// first successful call. All NVML errors (notably `NotSupported` and
-    /// `FunctionNotFound`) are swallowed and leave the respective field as
-    /// `None` — this feature MUST degrade gracefully on older drivers.
+    /// Fetch hardware details for `index`, consulting and updating the
+    /// per-field caches independently.  A transient NVML error on one field
+    /// leaves that field uncached so the next poll will retry it; a
+    /// permanent error (`NotSupported`, `FunctionNotFound`) caches `None`
+    /// so we stop querying it on every poll.
     pub fn get_or_fetch(&self, device: &nvml_wrapper::Device, index: u32) -> HardwareDetails {
-        if let Ok(cache) = self.entries.lock()
-            && let Some(existing) = cache.get(&index)
-        {
-            return existing.clone();
+        HardwareDetails {
+            numa_node_id: self
+                .get_or_fetch_field(&self.numa, index, || numa_node_id_result(device)),
+            gsp_firmware_mode: self
+                .get_or_fetch_field(&self.gsp_mode, index, || gsp_firmware_mode_result(device)),
+            gsp_firmware_version: self.get_or_fetch_field(&self.gsp_version, index, || {
+                gsp_firmware_version_result(device)
+            }),
+        }
+    }
+
+    /// Generic per-field cache lookup and conditional insertion.
+    ///
+    /// * If the map already contains an entry for `index` (even `None`),
+    ///   return it immediately without calling `fetch`.
+    /// * Otherwise call `fetch`:
+    ///   - `Ok(v)`  → cache `Some(v)`, return `Some(v)`.
+    ///   - `Err(e)` where `e` is a permanent-unavailable variant → cache
+    ///     `None`, return `None`.
+    ///   - `Err(e)` where `e` is transient → do NOT cache, return `None`
+    ///     (the next poll will retry).
+    fn get_or_fetch_field<T, F>(&self, cache: &FieldCache<T>, index: u32, fetch: F) -> Option<T>
+    where
+        T: Clone,
+        F: FnOnce() -> Result<T, NvmlError>,
+    {
+        // Probe: return immediately if any entry (even `None`) is cached.
+        if let Ok(map) = cache.lock() {
+            if let Some(cached) = map.get(&index) {
+                return cached.clone();
+            }
         }
 
-        let details = HardwareDetails {
-            numa_node_id: numa_node_id(device),
-            gsp_firmware_mode: gsp_firmware_mode(device),
-            gsp_firmware_version: gsp_firmware_version(device),
-        };
-
-        if details.has_any_value()
-            && let Ok(mut cache) = self.entries.lock()
-        {
-            cache.insert(index, details.clone());
+        // Miss: call the NVML function.
+        match fetch() {
+            Ok(value) => {
+                if let Ok(mut map) = cache.lock() {
+                    map.insert(index, Some(value.clone()));
+                }
+                Some(value)
+            }
+            Err(ref e) if is_permanent_unavailable(e) => {
+                if let Ok(mut map) = cache.lock() {
+                    map.insert(index, None);
+                }
+                None
+            }
+            Err(_transient) => {
+                // Do NOT cache — retry next poll.
+                None
+            }
         }
-        details
     }
 }
 
-/// Read the NUMA node id via NVML. Canonicalises the sentinel
-/// `u32::MAX` (which some driver versions return when no NUMA topology is
-/// present) to `None` so the UI and exporter can omit the metric rather
-/// than emit a bogus number.
-fn numa_node_id(device: &nvml_wrapper::Device) -> Option<i32> {
+/// Read the NUMA node id via NVML, returning the raw `Result` so the
+/// cache layer can distinguish transient from permanent errors.
+///
+/// Canonicalises the sentinel `u32::MAX` (which some driver versions return
+/// when no NUMA topology is present) to `NvmlError::NotSupported` so it is
+/// treated as permanently unavailable and cached as `None`.
+fn numa_node_id_result(device: &nvml_wrapper::Device) -> Result<i32, NvmlError> {
     // `Device::numa_node_id()` is available on all platforms in
     // nvml-wrapper 0.12.1 — no `cfg(target_os = "linux")` gate is needed.
     // Returns `u32` per the C API: negative values are not possible, but
     // drivers sometimes return the all-bits-set sentinel when no NUMA
     // topology is present.
-    let raw = device.numa_node_id().ok()?;
-    // Treat the classic "no NUMA" sentinel as `None`. Valid NUMA node ids
-    // fit easily into `i32` on any real system.
+    let raw = device.numa_node_id()?;
+    // Treat the classic "no NUMA" sentinel as permanently unsupported.
     if raw == u32::MAX {
-        return None;
+        return Err(NvmlError::NotSupported);
     }
-    i32::try_from(raw).ok()
+    i32::try_from(raw).map_err(|_| NvmlError::NotSupported)
 }
 
 /// Encode the GSP firmware mode as a 3-valued byte matching the
 /// `all_smi_gsp_firmware_mode` gauge contract (0=disabled, 1=enabled,
-/// 2=default).
-fn gsp_firmware_mode(device: &nvml_wrapper::Device) -> Option<u8> {
-    let mode = device.gsp_firmware_mode().ok()?;
+/// 2=default), returning the raw `Result` for cache-layer error
+/// classification.
+fn gsp_firmware_mode_result(device: &nvml_wrapper::Device) -> Result<u8, NvmlError> {
+    let mode = device.gsp_firmware_mode()?;
     // `mode.default == true` takes precedence: the driver reports that
-    // firmware operates in its default mode regardless of the enabled
-    // flag.
+    // firmware operates in its default mode regardless of the enabled flag.
     if mode.default {
-        Some(2)
+        Ok(2)
     } else if mode.enabled {
-        Some(1)
+        Ok(1)
     } else {
-        Some(0)
+        Ok(0)
     }
 }
 
-/// Read the GSP firmware version string. Trims any trailing NUL bytes
-/// NVML leaves in the buffer — the high-level wrapper already takes
-/// care of this, but the defensive trim future-proofs against any
-/// buffer encoding surprises.
-fn gsp_firmware_version(device: &nvml_wrapper::Device) -> Option<String> {
-    let raw = device.gsp_firmware_version().ok()?;
+/// Read the GSP firmware version string, returning the raw `Result` for
+/// cache-layer error classification.
+///
+/// Trims trailing NUL bytes NVML leaves in the buffer — the high-level
+/// wrapper already handles this, but the defensive trim future-proofs
+/// against any buffer encoding surprises.
+fn gsp_firmware_version_result(device: &nvml_wrapper::Device) -> Result<String, NvmlError> {
+    let raw = device.gsp_firmware_version()?;
     let trimmed = raw.trim_end_matches('\0').trim().to_string();
     if trimmed.is_empty() {
-        return None;
+        return Err(NvmlError::NotSupported);
     }
-    Some(trimmed)
+    Ok(trimmed)
 }
 
 /// Enumerate NvLinks for `device` and classify the remote endpoint of
@@ -308,38 +373,124 @@ fn err_unsupported() -> NvmlError {
 mod tests {
     use super::*;
 
+    // ------------------------------------------------------------------
+    // HardwareDetailCache field-level caching behaviour
+    // ------------------------------------------------------------------
+
+    /// Verify that a permanent-unavailable error (`NotSupported`) is cached
+    /// as `None` so the fetcher is never called again.
     #[test]
-    fn hardware_details_has_any_value_false_when_all_none() {
-        let empty = HardwareDetails::default();
-        assert!(!empty.has_any_value());
+    fn field_cache_permanent_error_caches_none() {
+        let cache: FieldCache<i32> = Mutex::new(HashMap::new());
+        let hw = HardwareDetailCache::new();
+
+        let mut call_count = 0u32;
+        let result = hw.get_or_fetch_field(&cache, 0, || {
+            call_count += 1;
+            Err(NvmlError::NotSupported)
+        });
+        assert!(result.is_none());
+        assert_eq!(call_count, 1);
+
+        // Second call must hit the cache — fetcher must NOT be called.
+        let result2 = hw.get_or_fetch_field(&cache, 0, || {
+            call_count += 1;
+            Ok(42) // would override None if caching were broken
+        });
+        assert!(result2.is_none(), "cached None should persist");
+        assert_eq!(call_count, 1, "fetcher must not be called on cache hit");
     }
 
+    /// Verify that a transient error does NOT get cached, so the next poll
+    /// retries the field.
     #[test]
-    fn hardware_details_has_any_value_true_when_numa_set() {
-        let d = HardwareDetails {
-            numa_node_id: Some(0),
-            ..Default::default()
-        };
-        assert!(d.has_any_value());
+    fn field_cache_transient_error_is_not_cached() {
+        let cache: FieldCache<i32> = Mutex::new(HashMap::new());
+        let hw = HardwareDetailCache::new();
+
+        let mut call_count = 0u32;
+
+        // First call: transient error — should NOT be cached.
+        let result = hw.get_or_fetch_field(&cache, 0, || {
+            call_count += 1;
+            Err(NvmlError::Unknown)
+        });
+        assert!(result.is_none());
+        assert_eq!(call_count, 1);
+
+        // Second call: success — fetcher must be called again because the
+        // transient error was not cached.
+        let result2 = hw.get_or_fetch_field(&cache, 0, || {
+            call_count += 1;
+            Ok(7)
+        });
+        assert_eq!(result2, Some(7));
+        assert_eq!(
+            call_count, 2,
+            "fetcher must be called again after transient miss"
+        );
     }
 
+    /// Verify that a successful fetch is cached and returns the same value
+    /// without calling the fetcher a second time.
     #[test]
-    fn hardware_details_has_any_value_true_when_mode_set() {
-        let d = HardwareDetails {
-            gsp_firmware_mode: Some(2),
-            ..Default::default()
-        };
-        assert!(d.has_any_value());
+    fn field_cache_success_is_cached() {
+        let cache: FieldCache<i32> = Mutex::new(HashMap::new());
+        let hw = HardwareDetailCache::new();
+
+        let mut call_count = 0u32;
+        let _ = hw.get_or_fetch_field(&cache, 0, || {
+            call_count += 1;
+            Ok(42)
+        });
+        let result2 = hw.get_or_fetch_field(&cache, 0, || {
+            call_count += 1;
+            Ok(99)
+        });
+        assert_eq!(result2, Some(42));
+        assert_eq!(call_count, 1, "fetcher must not be called on cache hit");
     }
 
+    /// Verify that per-field caches are independent: a transient error on
+    /// one field (e.g. gsp_mode) does not affect cached values on another
+    /// field (e.g. numa).
     #[test]
-    fn hardware_details_has_any_value_true_when_version_set() {
-        let d = HardwareDetails {
-            gsp_firmware_version: Some("550.54.15".to_string()),
-            ..Default::default()
-        };
-        assert!(d.has_any_value());
+    fn field_caches_are_independent() {
+        let hw = HardwareDetailCache::new();
+
+        // Pre-populate gsp_mode with a successful value.
+        let _ = hw.get_or_fetch_field(&hw.gsp_mode, 0, || Ok(2u8));
+
+        // Simulate a transient error on numa — must not clear the gsp_mode cache.
+        let numa_result = hw.get_or_fetch_field(&hw.numa, 0, || Err(NvmlError::Unknown));
+        assert!(numa_result.is_none());
+
+        // gsp_mode cache must still hold its value.
+        let mut mode_calls = 0u32;
+        let mode_result = hw.get_or_fetch_field(&hw.gsp_mode, 0, || {
+            mode_calls += 1;
+            Ok(99u8) // should never be reached
+        });
+        assert_eq!(mode_result, Some(2u8));
+        assert_eq!(
+            mode_calls, 0,
+            "gsp_mode fetcher must not be called — already cached"
+        );
     }
+
+    /// Verify `is_permanent_unavailable` classifies the correct variants.
+    #[test]
+    fn permanent_unavailable_classification() {
+        assert!(is_permanent_unavailable(&NvmlError::NotSupported));
+        assert!(is_permanent_unavailable(&NvmlError::FunctionNotFound));
+        assert!(!is_permanent_unavailable(&NvmlError::Unknown));
+        assert!(!is_permanent_unavailable(&NvmlError::GpuLost));
+        assert!(!is_permanent_unavailable(&NvmlError::DriverNotLoaded));
+    }
+
+    // ------------------------------------------------------------------
+    // Remote-device type mapping
+    // ------------------------------------------------------------------
 
     #[test]
     fn remote_device_type_mapping_is_stable() {

--- a/src/device/readers/nvidia_hardware.rs
+++ b/src/device/readers/nvidia_hardware.rs
@@ -1,0 +1,410 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! NVIDIA hardware-detail queries: NUMA topology, GSP firmware, NvLink
+//! remote endpoints, and GPM support detection (issue #132).
+//!
+//! Each function follows the same contract as the vGPU / MIG readers: any
+//! NVML error degrades to `None` / empty collections so that older drivers,
+//! non-datacenter SKUs, and non-NUMA platforms continue to emit valid
+//! [`GpuInfo`] rows with the surrounding fields intact.
+//!
+//! # Caching policy
+//!
+//! [`HardwareDetailCache`] memoises the two static-per-device fields — NUMA
+//! node id and GSP firmware version — so they are only fetched once per
+//! process lifetime. Cache insertions happen only when at least one field
+//! resolved successfully; a transient NVML error on the first call does not
+//! lock the cache to `None` for the process lifetime.
+//!
+//! NvLink enumeration and GPM support detection are NOT cached because their
+//! state can change at runtime (links can drop, GPM streaming can be toggled
+//! externally). They remain cheap NVML calls per poll.
+
+use std::collections::HashMap;
+use std::os::raw::c_uint;
+use std::sync::Mutex;
+
+use nvml_wrapper::Nvml;
+use nvml_wrapper::enum_wrappers::nv_link::IntDeviceType;
+use nvml_wrapper::error::{NvmlError, nvml_try};
+
+use crate::device::types::{GpmMetrics, NvLinkRemoteDevice, NvLinkRemoteType};
+
+/// Upper bound on the number of NvLinks NVML will report per GPU. NVIDIA's
+/// own header caps this at 18 for current generations; we keep the literal
+/// constant here instead of importing from `nvml-wrapper-sys` so this module
+/// stays free of sys-level dependencies.
+pub const NVML_NVLINK_MAX_LINKS: u32 = 18;
+
+/// Static per-device hardware details that never change at runtime.
+#[derive(Debug, Clone, Default)]
+pub struct HardwareDetails {
+    /// NUMA node the GPU is attached to, or `None` when the host has no
+    /// NUMA topology (Windows, older drivers, non-NUMA platforms).
+    pub numa_node_id: Option<i32>,
+    /// GSP firmware mode code: `0=disabled`, `1=enabled`, `2=default`.
+    pub gsp_firmware_mode: Option<u8>,
+    /// GSP firmware version string. `None` when `NotSupported`.
+    pub gsp_firmware_version: Option<String>,
+}
+
+impl HardwareDetails {
+    /// Whether this snapshot carries any supported value. Guards the cache
+    /// against storing an all-empty record produced by transient NVML
+    /// failures on the first poll.
+    fn has_any_value(&self) -> bool {
+        self.numa_node_id.is_some()
+            || self.gsp_firmware_mode.is_some()
+            || self.gsp_firmware_version.is_some()
+    }
+}
+
+/// Cache keyed by NVML device index. Shared state is held behind a single
+/// `Mutex` so the cache insertion is race-free — the sampler only locks
+/// twice per miss (once to probe, once to insert) and blocking callers stay
+/// O(number of GPUs).
+pub struct HardwareDetailCache {
+    entries: Mutex<HashMap<u32, HardwareDetails>>,
+}
+
+impl Default for HardwareDetailCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HardwareDetailCache {
+    pub fn new() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Fetch hardware details for `index`, populating the cache on the
+    /// first successful call. All NVML errors (notably `NotSupported` and
+    /// `FunctionNotFound`) are swallowed and leave the respective field as
+    /// `None` — this feature MUST degrade gracefully on older drivers.
+    pub fn get_or_fetch(&self, device: &nvml_wrapper::Device, index: u32) -> HardwareDetails {
+        if let Ok(cache) = self.entries.lock()
+            && let Some(existing) = cache.get(&index)
+        {
+            return existing.clone();
+        }
+
+        let details = HardwareDetails {
+            numa_node_id: numa_node_id(device),
+            gsp_firmware_mode: gsp_firmware_mode(device),
+            gsp_firmware_version: gsp_firmware_version(device),
+        };
+
+        if details.has_any_value()
+            && let Ok(mut cache) = self.entries.lock()
+        {
+            cache.insert(index, details.clone());
+        }
+        details
+    }
+}
+
+/// Read the NUMA node id via NVML. Canonicalises the sentinel
+/// `u32::MAX` (which some driver versions return when no NUMA topology is
+/// present) to `None` so the UI and exporter can omit the metric rather
+/// than emit a bogus number.
+fn numa_node_id(device: &nvml_wrapper::Device) -> Option<i32> {
+    // `Device::numa_node_id()` is available on all platforms in
+    // nvml-wrapper 0.12.1 — no `cfg(target_os = "linux")` gate is needed.
+    // Returns `u32` per the C API: negative values are not possible, but
+    // drivers sometimes return the all-bits-set sentinel when no NUMA
+    // topology is present.
+    let raw = device.numa_node_id().ok()?;
+    // Treat the classic "no NUMA" sentinel as `None`. Valid NUMA node ids
+    // fit easily into `i32` on any real system.
+    if raw == u32::MAX {
+        return None;
+    }
+    i32::try_from(raw).ok()
+}
+
+/// Encode the GSP firmware mode as a 3-valued byte matching the
+/// `all_smi_gsp_firmware_mode` gauge contract (0=disabled, 1=enabled,
+/// 2=default).
+fn gsp_firmware_mode(device: &nvml_wrapper::Device) -> Option<u8> {
+    let mode = device.gsp_firmware_mode().ok()?;
+    // `mode.default == true` takes precedence: the driver reports that
+    // firmware operates in its default mode regardless of the enabled
+    // flag.
+    if mode.default {
+        Some(2)
+    } else if mode.enabled {
+        Some(1)
+    } else {
+        Some(0)
+    }
+}
+
+/// Read the GSP firmware version string. Trims any trailing NUL bytes
+/// NVML leaves in the buffer — the high-level wrapper already takes
+/// care of this, but the defensive trim future-proofs against any
+/// buffer encoding surprises.
+fn gsp_firmware_version(device: &nvml_wrapper::Device) -> Option<String> {
+    let raw = device.gsp_firmware_version().ok()?;
+    let trimmed = raw.trim_end_matches('\0').trim().to_string();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed)
+}
+
+/// Enumerate NvLinks for `device` and classify the remote endpoint of
+/// every active link. Returns an empty vector when the driver does not
+/// support any NvLink API, when the device has no active links, or when
+/// all link queries error out.
+///
+/// We iterate up to [`NVML_NVLINK_MAX_LINKS`] and skip any link whose
+/// `is_active()` probe errors or returns `false`. For active links we
+/// query the remote device type via the raw FFI symbol so we avoid the
+/// latent-bug path in `nvml-wrapper-0.12.1::nv_link::remote_device_type`
+/// (that wrapper mistakenly writes to an immutable temporary, leaving the
+/// out-parameter untouched).
+pub fn collect_nvlink_remote_devices(
+    nvml: &Nvml,
+    device: &nvml_wrapper::Device,
+) -> Vec<NvLinkRemoteDevice> {
+    let mut out = Vec::new();
+    for link in 0..NVML_NVLINK_MAX_LINKS {
+        let link_wrapper = device.link_wrapper_for(link);
+        match link_wrapper.is_active() {
+            Ok(true) => {}
+            // Any error here (`NotSupported`, `InvalidArg`) means the link
+            // does not exist; stop probing early to avoid 18 failing calls
+            // on a GPU with zero NvLinks. Observed behaviour: NVML returns
+            // `InvalidArg` for indices past the physical link count.
+            Ok(false) => continue,
+            Err(_) => break,
+        }
+        let remote_type = match nvlink_remote_device_type_ffi(nvml, device, link) {
+            Some(t) => t,
+            None => NvLinkRemoteType::Unknown,
+        };
+        out.push(NvLinkRemoteDevice {
+            link_index: link,
+            remote_type,
+        });
+    }
+    out
+}
+
+/// Query `nvmlDeviceGetNvLinkRemoteDeviceType` directly via the FFI symbol.
+///
+/// The high-level `NvLink::remote_device_type` method in nvml-wrapper 0.12.1
+/// has a latent bug: it passes `&mut device_type.as_c()` which creates an
+/// immutable temporary, so NVML never writes back to the local variable.
+/// Calling the symbol directly avoids that defect and keeps the logic
+/// contained here so we can remove the workaround when the wrapper is
+/// fixed upstream.
+fn nvlink_remote_device_type_ffi(
+    nvml: &Nvml,
+    device: &nvml_wrapper::Device,
+    link: u32,
+) -> Option<NvLinkRemoteType> {
+    let sym = nvml
+        .lib()
+        .nvmlDeviceGetNvLinkRemoteDeviceType
+        .as_ref()
+        .ok()?;
+
+    // SAFETY: `device.handle()` returns the same `nvmlDevice_t` that NVML
+    // owns. We pass a valid out-pointer of the exact type NVML expects
+    // (`c_uint`) and check the return code before trusting the contents.
+    unsafe {
+        let mut value: c_uint = 0;
+        let rc = sym(device.handle(), link, &mut value);
+        nvml_try(rc).ok()?;
+        Some(map_remote_device_type(value))
+    }
+}
+
+/// Map the raw NVML remote device type value to our domain enum. Unknown
+/// values fall back to `NvLinkRemoteType::Unknown` so a future driver that
+/// introduces new remote-device categories does not regress the reader.
+fn map_remote_device_type(value: c_uint) -> NvLinkRemoteType {
+    // Values from NVML's `nvmlIntNvLinkDeviceType_enum`:
+    //   GPU = 0, IBMNPU = 1, SWITCH = 2, UNKNOWN = 255
+    match value {
+        0 => NvLinkRemoteType::Gpu,
+        1 => NvLinkRemoteType::IbmNpu,
+        2 => NvLinkRemoteType::Switch,
+        _ => NvLinkRemoteType::Unknown,
+    }
+}
+
+/// Same mapping as [`map_remote_device_type`] but for the wrapper's enum.
+/// Kept as a utility for tests that construct an `IntDeviceType` directly.
+#[allow(dead_code)]
+pub(crate) fn nvlink_remote_type_from_wrapper(value: IntDeviceType) -> NvLinkRemoteType {
+    match value {
+        IntDeviceType::Gpu => NvLinkRemoteType::Gpu,
+        IntDeviceType::Ibmnpu => NvLinkRemoteType::IbmNpu,
+        IntDeviceType::Switch => NvLinkRemoteType::Switch,
+        IntDeviceType::Unknown => NvLinkRemoteType::Unknown,
+    }
+}
+
+/// Return `true` when the device reports GPM support via NVML's probe.
+/// Any error (symbol missing, `NotSupported`, `InvalidArg`) degrades to
+/// `false` so the caller never emits GPM metrics for a non-GPM device.
+pub fn gpm_is_supported(device: &nvml_wrapper::Device) -> bool {
+    device.gpm_support().unwrap_or(false)
+}
+
+/// Placeholder GPM metric collection.
+///
+/// The GPM API requires two time-separated samples passed to
+/// `gpm_metrics_get`, which is incompatible with all-smi's single-poll
+/// reader contract: we would have to cache the previous sample per device
+/// and wait N seconds before the first reading is meaningful. That work is
+/// tracked as a follow-up. For now we:
+///
+/// * detect support via [`gpm_is_supported`] so the TUI and exporter can
+///   show a "GPM-capable" hint without emitting potentially wrong numbers;
+/// * return `None` from the collection path so the gauge metrics are
+///   omitted entirely (Prometheus convention for "no data") rather than
+///   silently publishing zeros.
+///
+/// When the two-sample implementation lands we will populate
+/// [`GpmMetrics::sm_occupancy`] and
+/// [`GpmMetrics::memory_bandwidth_utilization`] here.
+pub fn collect_gpm_metrics(device: &nvml_wrapper::Device) -> Option<GpmMetrics> {
+    if !gpm_is_supported(device) {
+        return None;
+    }
+    // Supported but unsampled — the two-sample handshake is deferred to a
+    // follow-up. Return a populated struct so the TUI can indicate
+    // "GPM-capable" without pretending specific numeric values are known.
+    Some(GpmMetrics::default())
+}
+
+/// Attempt to fetch a GPM support signal without going through the NVML
+/// API, failing closed. Used exclusively by unit tests that need a
+/// deterministic "unsupported" reading without a real device handle.
+#[allow(dead_code)]
+fn err_unsupported() -> NvmlError {
+    NvmlError::NotSupported
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hardware_details_has_any_value_false_when_all_none() {
+        let empty = HardwareDetails::default();
+        assert!(!empty.has_any_value());
+    }
+
+    #[test]
+    fn hardware_details_has_any_value_true_when_numa_set() {
+        let d = HardwareDetails {
+            numa_node_id: Some(0),
+            ..Default::default()
+        };
+        assert!(d.has_any_value());
+    }
+
+    #[test]
+    fn hardware_details_has_any_value_true_when_mode_set() {
+        let d = HardwareDetails {
+            gsp_firmware_mode: Some(2),
+            ..Default::default()
+        };
+        assert!(d.has_any_value());
+    }
+
+    #[test]
+    fn hardware_details_has_any_value_true_when_version_set() {
+        let d = HardwareDetails {
+            gsp_firmware_version: Some("550.54.15".to_string()),
+            ..Default::default()
+        };
+        assert!(d.has_any_value());
+    }
+
+    #[test]
+    fn remote_device_type_mapping_is_stable() {
+        assert_eq!(map_remote_device_type(0), NvLinkRemoteType::Gpu);
+        assert_eq!(map_remote_device_type(1), NvLinkRemoteType::IbmNpu);
+        assert_eq!(map_remote_device_type(2), NvLinkRemoteType::Switch);
+        assert_eq!(map_remote_device_type(255), NvLinkRemoteType::Unknown);
+    }
+
+    #[test]
+    fn remote_device_type_unknown_future_values_degrade_to_unknown() {
+        // Any value the driver introduces later must not panic.
+        assert_eq!(map_remote_device_type(17), NvLinkRemoteType::Unknown);
+        assert_eq!(map_remote_device_type(u32::MAX), NvLinkRemoteType::Unknown);
+    }
+
+    #[test]
+    fn nvlink_remote_type_label_round_trip() {
+        for v in [
+            NvLinkRemoteType::Gpu,
+            NvLinkRemoteType::IbmNpu,
+            NvLinkRemoteType::Switch,
+            NvLinkRemoteType::Unknown,
+        ] {
+            assert_eq!(NvLinkRemoteType::from_label(v.as_label()), v);
+        }
+    }
+
+    #[test]
+    fn nvlink_remote_type_from_label_unknown_inputs_degrade() {
+        assert_eq!(NvLinkRemoteType::from_label(""), NvLinkRemoteType::Unknown);
+        assert_eq!(
+            NvLinkRemoteType::from_label("garbage"),
+            NvLinkRemoteType::Unknown
+        );
+    }
+
+    #[test]
+    fn nvlink_max_links_matches_nvml_header() {
+        // NVML's NVML_NVLINK_MAX_LINKS is currently 18; this test is a
+        // canary that will fail if we forget to bump this constant when a
+        // future NVML release raises the cap.
+        assert_eq!(NVML_NVLINK_MAX_LINKS, 18);
+    }
+
+    #[test]
+    fn wrapper_enum_mapping_covers_every_variant() {
+        // Guard against new IntDeviceType variants silently collapsing to
+        // Unknown. If nvml-wrapper introduces a new variant, this test
+        // fails until we extend `nvlink_remote_type_from_wrapper`.
+        assert_eq!(
+            nvlink_remote_type_from_wrapper(IntDeviceType::Gpu),
+            NvLinkRemoteType::Gpu
+        );
+        assert_eq!(
+            nvlink_remote_type_from_wrapper(IntDeviceType::Ibmnpu),
+            NvLinkRemoteType::IbmNpu
+        );
+        assert_eq!(
+            nvlink_remote_type_from_wrapper(IntDeviceType::Switch),
+            NvLinkRemoteType::Switch
+        );
+        assert_eq!(
+            nvlink_remote_type_from_wrapper(IntDeviceType::Unknown),
+            NvLinkRemoteType::Unknown
+        );
+    }
+}

--- a/src/device/readers/nvidia_jetson.rs
+++ b/src/device/readers/nvidia_jetson.rs
@@ -163,13 +163,19 @@ impl GpuReader for NvidiaJetsonGpuReader {
             power_consumption,
             gpu_core_count: None,
             // Jetson uses `/sys/class/thermal` readings rather than NVML
-            // thermal-threshold APIs, so the extended thresholds and P-state
-            // are not available on this platform.
+            // thermal-threshold APIs, so the extended thresholds, P-state,
+            // and NVIDIA hardware details (NUMA/GSP/NvLink/GPM) are not
+            // available on this platform.
             temperature_threshold_slowdown: None,
             temperature_threshold_shutdown: None,
             temperature_threshold_max_operating: None,
             temperature_threshold_acoustic: None,
             performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail: static_info.detail.clone(),
         };
 

--- a/src/device/readers/rebellions.rs
+++ b/src/device/readers/rebellions.rs
@@ -416,12 +416,18 @@ fn create_gpu_info_from_device(
         power_consumption: power,
         gpu_core_count: None,
         // Rebellions NPUs expose a single temperature sensor without NVML-style
-        // threshold / P-state metadata. Leave the new fields unavailable.
+        // threshold / P-state or NVIDIA hardware-detail
+        // (NUMA/GSP/NvLink/GPM) metadata. Leave the new fields unavailable.
         temperature_threshold_slowdown: None,
         temperature_threshold_shutdown: None,
         temperature_threshold_max_operating: None,
         temperature_threshold_acoustic: None,
         performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
         detail,
     })
 }

--- a/src/device/readers/tenstorrent.rs
+++ b/src/device/readers/tenstorrent.rs
@@ -383,12 +383,18 @@ fn create_gpu_info(
         power_consumption: power,
         gpu_core_count: None,
         // Tenstorrent telemetry does not expose NVML-style thermal
-        // thresholds or P-states; leave the extended fields unavailable.
+        // thresholds, P-states, or NVIDIA hardware details
+        // (NUMA/GSP/NvLink/GPM); leave the extended fields unavailable.
         temperature_threshold_slowdown: None,
         temperature_threshold_shutdown: None,
         temperature_threshold_max_operating: None,
         temperature_threshold_acoustic: None,
         performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
         detail,
     })
 }

--- a/src/device/types.rs
+++ b/src/device/types.rs
@@ -75,7 +75,108 @@ pub struct GpuInfo {
     /// P-state (e.g. non-NVIDIA, MIG child devices, driver too old).
     #[serde(default)]
     pub performance_state: Option<u32>,
+    /// NUMA node the GPU is attached to. `None` when the host has no NUMA
+    /// topology (non-Linux platforms, driver too old, or an NVML
+    /// `NotSupported` response). Valid values are non-negative; a value of
+    /// -1 in NVML's raw encoding is canonicalised to `None` rather than
+    /// rendered as a negative number.
+    #[serde(default)]
+    pub numa_node_id: Option<i32>,
+    /// GSP firmware mode, encoded as `0=disabled`, `1=enabled`, `2=default`.
+    /// `None` when the driver does not expose the GSP firmware family
+    /// (pre-R525 drivers, non-datacenter SKUs).
+    #[serde(default)]
+    pub gsp_firmware_mode: Option<u8>,
+    /// GSP firmware version string (e.g. `"550.54.15"`). `None` when
+    /// unavailable. Cached once per device since the version is static for
+    /// the lifetime of the process.
+    #[serde(default)]
+    pub gsp_firmware_version: Option<String>,
+    /// Active NvLinks and their remote endpoint classification. Empty when
+    /// the GPU has no active links, when NvLink APIs are not supported by
+    /// the driver, or on non-NVIDIA paths.
+    #[serde(default)]
+    pub nvlink_remote_devices: Vec<NvLinkRemoteDevice>,
+    /// GPU Performance Monitoring metrics snapshot, when supported
+    /// (Hopper+). `None` everywhere else — non-NVIDIA paths and older
+    /// architectures must never populate this field.
+    #[serde(default)]
+    pub gpm_metrics: Option<GpmMetrics>,
     pub detail: HashMap<String, String>,
+}
+
+/// Remote endpoint classification for a single NvLink reported as active on
+/// a parent GPU. Populated by the NVIDIA reader via NVML and round-tripped
+/// through the Prometheus exporter so remote scrapers see the same topology.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct NvLinkRemoteDevice {
+    /// Zero-based link index (0..18 on current NVIDIA hardware). Matches
+    /// the `link` argument of `nvmlDeviceGetNvLinkRemoteDeviceType`.
+    pub link_index: u32,
+    /// Classification of the node sitting on the other side of the link.
+    pub remote_type: NvLinkRemoteType,
+}
+
+/// NvLink remote device classification as returned by
+/// `nvmlDeviceGetNvLinkRemoteDeviceType`. Serialised as lowercase strings so
+/// the Prometheus exporter can surface them as label values without further
+/// encoding.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NvLinkRemoteType {
+    /// Remote endpoint is another GPU.
+    Gpu,
+    /// Remote endpoint is an IBM NPU (POWER9 systems).
+    IbmNpu,
+    /// Remote endpoint is an NvSwitch.
+    Switch,
+    /// Remote endpoint is unknown or not classified by the driver.
+    #[default]
+    Unknown,
+}
+
+impl NvLinkRemoteType {
+    /// Stable lowercase label used for Prometheus values and the network
+    /// parser. MUST stay in sync with the serde `rename_all` annotation so
+    /// the serialised JSON and the exported label encoding agree.
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::Gpu => "gpu",
+            Self::IbmNpu => "ibmnpu",
+            Self::Switch => "switch",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Inverse of [`NvLinkRemoteType::as_label`]. Unknown inputs map to
+    /// [`NvLinkRemoteType::Unknown`] rather than returning an error — the
+    /// parser must never reject metric lines, only classify them.
+    pub fn from_label(value: &str) -> Self {
+        match value {
+            "gpu" => Self::Gpu,
+            "ibmnpu" => Self::IbmNpu,
+            "switch" => Self::Switch,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Optional GPU Performance Monitoring (GPM) metrics snapshot. Populated
+/// only when the device reports `gpm_support() == true` (Hopper+ on a
+/// driver that exposes the GPM family). All fields are `Option<f32>` so
+/// individual metric failures do not invalidate the rest of the snapshot.
+///
+/// Values are expressed as a fraction in `[0.0, 1.0]` to match Prometheus'
+/// convention for utilization gauges — the NVML `*_UTIL` family reports
+/// percentages which the reader divides by 100 on the way in.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Default)]
+pub struct GpmMetrics {
+    /// Fraction of warps active vs theoretical maximum, averaged across
+    /// all SMs. Maps to `NVML_GPM_METRIC_SM_OCCUPANCY` / 100.
+    pub sm_occupancy: Option<f32>,
+    /// Fraction of memory bandwidth in use, averaged across the polling
+    /// window. Maps to `NVML_GPM_METRIC_DRAM_BW_UTIL` / 100.
+    pub memory_bandwidth_utilization: Option<f32>,
 }
 
 /// Proximity classification for the current GPU temperature relative to the

--- a/src/metrics/aggregator.rs
+++ b/src/metrics/aggregator.rs
@@ -301,6 +301,11 @@ mod tests {
             temperature_threshold_max_operating: None,
             temperature_threshold_acoustic: None,
             performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail: HashMap::new(),
         }
     }

--- a/src/mock/templates/nvidia.rs
+++ b/src/mock/templates/nvidia.rs
@@ -55,6 +55,12 @@ impl NvidiaMockGenerator {
         // dev and `cargo test --features mock` see the feature populated.
         self.add_thermal_threshold_metrics(&mut template, gpus);
 
+        // NVIDIA-specific: Hardware details (issue #132). NUMA node id,
+        // GSP firmware mode + version, NvLink topology, plus GPM gauges.
+        // Synthetic but representative so the TUI, exporter, and remote
+        // parser round-trip paths all see the feature populated.
+        self.add_hardware_detail_metrics(&mut template, gpus);
+
         // NVIDIA-specific: Process metrics
         self.add_process_metrics(&mut template, gpus);
 
@@ -146,6 +152,128 @@ impl NvidiaMockGenerator {
             );
             template.push_str(&format!(
                 "all_smi_gpu_performance_state{{{labels}}} {{{{PSTATE_{i}}}}}\n"
+            ));
+        }
+    }
+
+    /// Synthesize extended hardware-detail metrics (issue #132):
+    ///   * NUMA node id alternating between 0 and 1 across GPUs
+    ///   * GSP firmware mode `1=enabled` for every GPU
+    ///   * GSP firmware version string `"550.54.15"` for every GPU
+    ///   * 6 active NvLinks per GPU, 5 remote=gpu + 1 remote=switch
+    ///   * GPM gauges at fixed-plausible values in the 0.45-0.88 band
+    ///
+    /// Fixed values rather than random numbers keep the mock output stable
+    /// across scrapes — hardware details never change at runtime on real
+    /// devices, and stable mock values simplify test assertions.
+    fn add_hardware_detail_metrics(&self, template: &mut String, gpus: &[GpuMetrics]) {
+        const GSP_MODE: u8 = 1;
+        const GSP_VERSION: &str = "550.54.15";
+        const NVLINK_COUNT: u32 = 6;
+        const SM_OCCUPANCY: f32 = 0.67;
+        const MEMORY_BW_UTIL: f32 = 0.42;
+
+        // --- NUMA node id ---
+        template.push_str(
+            "# HELP all_smi_gpu_numa_node_id NUMA node the GPU is attached to \
+             (metric is omitted when the host has no NUMA topology or the driver does not report one)\n",
+        );
+        template.push_str("# TYPE all_smi_gpu_numa_node_id gauge\n");
+        for (i, gpu) in gpus.iter().enumerate() {
+            let numa = (i as u32) % 2;
+            let labels = format!(
+                "gpu=\"{}\", instance=\"{}\", uuid=\"{}\", index=\"{i}\"",
+                self.gpu_name, self.instance_name, gpu.uuid
+            );
+            template.push_str(&format!("all_smi_gpu_numa_node_id{{{labels}}} {numa}\n"));
+        }
+
+        // --- GSP firmware mode ---
+        template.push_str(
+            "# HELP all_smi_gpu_gsp_firmware_mode GSP firmware mode \
+             (0=disabled, 1=enabled, 2=default); omitted when the driver does not expose the GSP firmware API\n",
+        );
+        template.push_str("# TYPE all_smi_gpu_gsp_firmware_mode gauge\n");
+        for (i, gpu) in gpus.iter().enumerate() {
+            let labels = format!(
+                "gpu=\"{}\", instance=\"{}\", uuid=\"{}\", index=\"{i}\"",
+                self.gpu_name, self.instance_name, gpu.uuid
+            );
+            template.push_str(&format!(
+                "all_smi_gpu_gsp_firmware_mode{{{labels}}} {GSP_MODE}\n"
+            ));
+        }
+
+        // --- GSP firmware version info ---
+        template.push_str(
+            "# HELP all_smi_gpu_gsp_firmware_version_info GSP firmware version, encoded as a constant 1 \
+             with the version in a `version` label; omitted when unsupported\n",
+        );
+        template.push_str("# TYPE all_smi_gpu_gsp_firmware_version_info gauge\n");
+        for (i, gpu) in gpus.iter().enumerate() {
+            let labels = format!(
+                "gpu=\"{}\", instance=\"{}\", uuid=\"{}\", index=\"{i}\", version=\"{GSP_VERSION}\"",
+                self.gpu_name, self.instance_name, gpu.uuid
+            );
+            template.push_str(&format!(
+                "all_smi_gpu_gsp_firmware_version_info{{{labels}}} 1\n"
+            ));
+        }
+
+        // --- NvLink remote device types ---
+        template.push_str(
+            "# HELP all_smi_nvlink_remote_device_type NvLink remote endpoint classification per active link. \
+             Value is always 1; classification is carried in the `remote_type` label (gpu / switch / ibmnpu / unknown).\n",
+        );
+        template.push_str("# TYPE all_smi_nvlink_remote_device_type gauge\n");
+        for (i, gpu) in gpus.iter().enumerate() {
+            // 5 remote=gpu, 1 remote=switch — typical NVLink topology on
+            // HGX-style 8-GPU boards.
+            for link in 0..NVLINK_COUNT {
+                let remote_type = if link == NVLINK_COUNT - 1 {
+                    "switch"
+                } else {
+                    "gpu"
+                };
+                let labels = format!(
+                    "gpu=\"{}\", instance=\"{}\", uuid=\"{}\", index=\"{i}\", link_index=\"{link}\", remote_type=\"{remote_type}\"",
+                    self.gpu_name, self.instance_name, gpu.uuid
+                );
+                template.push_str(&format!(
+                    "all_smi_nvlink_remote_device_type{{{labels}}} 1\n"
+                ));
+            }
+        }
+
+        // --- GPM metrics (Hopper+ only in reality; the mock pretends
+        // every GPU is GPM-capable so the TUI / exporter paths see data).
+        template.push_str(
+            "# HELP all_smi_gpu_sm_occupancy GPM-reported SM occupancy fraction (0.0-1.0); \
+             omitted on devices that do not support GPM (pre-Hopper)\n",
+        );
+        template.push_str("# TYPE all_smi_gpu_sm_occupancy gauge\n");
+        for (i, gpu) in gpus.iter().enumerate() {
+            let labels = format!(
+                "gpu=\"{}\", instance=\"{}\", uuid=\"{}\", index=\"{i}\"",
+                self.gpu_name, self.instance_name, gpu.uuid
+            );
+            template.push_str(&format!(
+                "all_smi_gpu_sm_occupancy{{{labels}}} {SM_OCCUPANCY:.2}\n"
+            ));
+        }
+
+        template.push_str(
+            "# HELP all_smi_gpu_memory_bandwidth_utilization GPM-reported memory bandwidth utilization fraction (0.0-1.0); \
+             omitted on devices that do not support GPM (pre-Hopper)\n",
+        );
+        template.push_str("# TYPE all_smi_gpu_memory_bandwidth_utilization gauge\n");
+        for (i, gpu) in gpus.iter().enumerate() {
+            let labels = format!(
+                "gpu=\"{}\", instance=\"{}\", uuid=\"{}\", index=\"{i}\"",
+                self.gpu_name, self.instance_name, gpu.uuid
+            );
+            template.push_str(&format!(
+                "all_smi_gpu_memory_bandwidth_utilization{{{labels}}} {MEMORY_BW_UTIL:.2}\n"
             ));
         }
     }
@@ -615,6 +743,138 @@ mod tests {
         assert!(
             !rendered.contains("{{PSTATE_"),
             "unresolved PSTATE placeholder in rendered output"
+        );
+    }
+
+    // --- hardware-detail mock template tests (issue #132) ---
+
+    fn make_multi_gpu_metrics(count: usize) -> Vec<GpuMetrics> {
+        (0..count)
+            .map(|i| GpuMetrics {
+                uuid: format!("GPU-{i}"),
+                utilization: 50.0,
+                memory_used_bytes: 1024,
+                memory_total_bytes: 8192,
+                temperature_celsius: 65,
+                power_consumption_watts: 200.0,
+                frequency_mhz: 1500,
+                ane_utilization_watts: 0.0,
+                thermal_pressure_level: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mock_template_includes_all_hardware_detail_metrics() {
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_gpu_metrics();
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+
+        assert!(
+            tpl.contains("all_smi_gpu_numa_node_id{"),
+            "mock template missing NUMA metric:\n{tpl}"
+        );
+        assert!(
+            tpl.contains("all_smi_gpu_gsp_firmware_mode{"),
+            "mock template missing GSP firmware mode metric:\n{tpl}"
+        );
+        assert!(
+            tpl.contains("all_smi_gpu_gsp_firmware_version_info{"),
+            "mock template missing GSP firmware version info metric:\n{tpl}"
+        );
+        assert!(
+            tpl.contains("all_smi_nvlink_remote_device_type{"),
+            "mock template missing NvLink metric:\n{tpl}"
+        );
+        assert!(
+            tpl.contains("all_smi_gpu_sm_occupancy{"),
+            "mock template missing SM occupancy metric:\n{tpl}"
+        );
+        assert!(
+            tpl.contains("all_smi_gpu_memory_bandwidth_utilization{"),
+            "mock template missing memory bandwidth utilization metric:\n{tpl}"
+        );
+    }
+
+    #[test]
+    fn mock_template_emits_six_nvlinks_per_gpu() {
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_multi_gpu_metrics(2);
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+        let nvlink_lines: Vec<_> = tpl
+            .lines()
+            .filter(|l| l.starts_with("all_smi_nvlink_remote_device_type{"))
+            .collect();
+        // 2 GPUs * 6 links = 12 lines.
+        assert_eq!(
+            nvlink_lines.len(),
+            12,
+            "expected 12 NvLink rows (2 GPUs x 6 links):\n{}",
+            nvlink_lines.join("\n")
+        );
+        // 5 gpu + 1 switch per GPU = 10 gpu + 2 switch total.
+        let gpu_remote_count = nvlink_lines
+            .iter()
+            .filter(|l| l.contains(r#"remote_type="gpu""#))
+            .count();
+        let switch_remote_count = nvlink_lines
+            .iter()
+            .filter(|l| l.contains(r#"remote_type="switch""#))
+            .count();
+        assert_eq!(gpu_remote_count, 10);
+        assert_eq!(switch_remote_count, 2);
+    }
+
+    #[test]
+    fn mock_template_numa_alternates_between_zero_and_one() {
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_multi_gpu_metrics(4);
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+        // Extract just the NUMA metric lines.
+        let numa_lines: Vec<_> = tpl
+            .lines()
+            .filter(|l| l.starts_with("all_smi_gpu_numa_node_id{"))
+            .collect();
+        assert_eq!(numa_lines.len(), 4);
+        // GPU 0 → 0, GPU 1 → 1, GPU 2 → 0, GPU 3 → 1.
+        for (i, line) in numa_lines.iter().enumerate() {
+            let expected = (i as u32) % 2;
+            assert!(
+                line.ends_with(&format!(" {expected}")),
+                "GPU {i} NUMA line expected to end with ' {expected}', got: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn mock_template_emits_gsp_firmware_version_label() {
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_gpu_metrics();
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+        assert!(
+            tpl.contains(r#"version="550.54.15""#),
+            "mock template missing GSP firmware version label:\n{tpl}"
+        );
+    }
+
+    #[test]
+    fn mock_template_gpm_values_are_in_0_to_1_range() {
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_gpu_metrics();
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+        // Parse the SM occupancy line and sanity-check the value band.
+        let sm_line = tpl
+            .lines()
+            .find(|l| l.starts_with("all_smi_gpu_sm_occupancy{"))
+            .expect("SM occupancy line");
+        let value: f32 = sm_line
+            .rsplit(' ')
+            .next()
+            .and_then(|s| s.parse().ok())
+            .expect("SM occupancy value");
+        assert!(
+            (0.0..=1.0).contains(&value),
+            "SM occupancy out of range: {value}"
         );
     }
 }

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -362,9 +362,17 @@ impl MetricsParser {
             "gpu_gsp_firmware_version_info" => {
                 // The numeric value is always 1 (info-style metric). The
                 // payload is the `version` label.
+                // Reject control characters (including ANSI escape sequences
+                // like ESC[2J) to prevent TUI escape injection when the
+                // version string is rendered in the hardware row. A remote
+                // Prometheus endpoint could embed `\x1b[...` sequences that
+                // would be executed by terminal emulators on display.
                 if let Some(version) = labels.get("version") {
                     let trimmed = version.trim();
-                    if !trimmed.is_empty() && trimmed.len() <= MAX_GSP_VERSION_LEN {
+                    if !trimmed.is_empty()
+                        && trimmed.len() <= MAX_GSP_VERSION_LEN
+                        && trimmed.chars().all(|c| !c.is_control())
+                    {
                         gpu_info.gsp_firmware_version = Some(trimmed.to_string());
                     }
                 }

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -19,8 +19,8 @@ use chrono::Local;
 use regex::Regex;
 
 use crate::device::{
-    AppleSiliconCpuInfo, CpuInfo, CpuPlatformType, GpuInfo, MemoryInfo, MigGpuInfo,
-    MigInstanceInfo, VgpuHostInfo, VgpuInfo,
+    AppleSiliconCpuInfo, CpuInfo, CpuPlatformType, GpmMetrics, GpuInfo, MemoryInfo, MigGpuInfo,
+    MigInstanceInfo, NvLinkRemoteDevice, NvLinkRemoteType, VgpuHostInfo, VgpuInfo,
 };
 use crate::storage::info::StorageInfo;
 
@@ -84,7 +84,10 @@ impl MetricsParser {
 
                 // Process different metric types with size limits.
                 // Route vGPU and MIG lines first so they aren't swallowed by
-                // the broader `gpu_` prefix below.
+                // the broader `gpu_` prefix below. `nvlink_*` metrics from
+                // issue #132 are also hardware-detail lines that must join
+                // the per-GPU accumulator — they carry the same `uuid`
+                // label set as the rest of the GPU rows.
                 if metric_name.starts_with("vgpu_") {
                     vgpu_state.process(&metric_name, &labels, value, host);
                 } else if metric_name == "gpu_mig_mode" || metric_name.starts_with("mig_instance_")
@@ -92,6 +95,7 @@ impl MetricsParser {
                     mig_state.process(&metric_name, &labels, value, host);
                 } else if metric_name.starts_with("gpu_")
                     || metric_name.starts_with("npu_")
+                    || metric_name.starts_with("nvlink_")
                     || metric_name == "ane_utilization"
                 {
                     if gpu_info_map.len() < MAX_DEVICES_PER_TYPE {
@@ -250,6 +254,18 @@ impl MetricsParser {
                 temperature_threshold_max_operating: None,
                 temperature_threshold_acoustic: None,
                 performance_state: None,
+                // Hardware details (issue #132) land via dedicated
+                // `all_smi_gpu_numa_node_id`, `all_smi_gpu_gsp_firmware_*`,
+                // `all_smi_nvlink_remote_device_type`, and GPM metric
+                // handlers further down. Until those lines are seen in
+                // the scrape these fields stay at their "unavailable"
+                // defaults, matching the local graceful-degradation
+                // contract.
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
                 detail,
             }
         });
@@ -314,6 +330,82 @@ impl MetricsParser {
                 // render as "P9999" and corrupt the secondary row layout.
                 if (0.0..=15.0).contains(&value) {
                     gpu_info.performance_state = saturating_u32(value);
+                }
+            }
+            "gpu_numa_node_id" => {
+                // NUMA node ids are non-negative on every real system.
+                // Cap at a paranoid ceiling so a hostile upstream cannot
+                // inject huge values: no real machine exposes more than
+                // ~256 NUMA nodes today. Negative inputs and NaN drop.
+                if let Some(node) = saturating_i32(value)
+                    && (0..=MAX_NUMA_NODE_ID).contains(&node)
+                {
+                    gpu_info.numa_node_id = Some(node);
+                }
+            }
+            "gpu_gsp_firmware_mode" => {
+                // Exporter emits exactly 0/1/2. Accept only that range so
+                // a malicious upstream cannot seed the UI with a bogus
+                // code. Out-of-range values leave the field as `None`.
+                if (0.0..=2.0).contains(&value) {
+                    gpu_info.gsp_firmware_mode =
+                        saturating_u32(value).and_then(|v| u8::try_from(v).ok());
+                }
+            }
+            "gpu_gsp_firmware_version_info" => {
+                // The numeric value is always 1 (info-style metric). The
+                // payload is the `version` label.
+                if let Some(version) = labels.get("version") {
+                    let trimmed = version.trim();
+                    if !trimmed.is_empty() && trimmed.len() <= MAX_GSP_VERSION_LEN {
+                        gpu_info.gsp_firmware_version = Some(trimmed.to_string());
+                    }
+                }
+            }
+            "nvlink_remote_device_type" => {
+                // Info-style metric with `link_index` and `remote_type`
+                // labels. Enforce a defensive per-GPU cap so a malicious
+                // upstream cannot explode the `nvlink_remote_devices` vec
+                // by emitting thousands of distinct link indices.
+                let Some(link_index) = labels.get("link_index").and_then(|s| s.parse::<u32>().ok())
+                else {
+                    return;
+                };
+                if link_index >= MAX_NVLINK_PER_GPU {
+                    return;
+                }
+                let remote_type = labels
+                    .get("remote_type")
+                    .map(|s| NvLinkRemoteType::from_label(s))
+                    .unwrap_or_default();
+                // Coalesce duplicate link_index emissions — most recent
+                // sample wins — so a scrape that contains the same link
+                // multiple times doesn't multiply the vector length.
+                if let Some(existing) = gpu_info
+                    .nvlink_remote_devices
+                    .iter_mut()
+                    .find(|l| l.link_index == link_index)
+                {
+                    existing.remote_type = remote_type;
+                } else if gpu_info.nvlink_remote_devices.len() < MAX_NVLINK_PER_GPU as usize {
+                    gpu_info.nvlink_remote_devices.push(NvLinkRemoteDevice {
+                        link_index,
+                        remote_type,
+                    });
+                }
+            }
+            "gpu_sm_occupancy" => {
+                // GPM fractional utilization — expected in [0.0, 1.0].
+                // Values outside that band come from a buggy upstream and
+                // are dropped rather than clamped so dashboards can
+                // distinguish "unavailable" from "definitely zero".
+                if value.is_finite() && (0.0..=1.0).contains(&value) {
+                    ensure_gpm_metrics(gpu_info).sm_occupancy = Some(value as f32);
+                }
+            }
+            "gpu_memory_bandwidth_utilization" => {
+                if value.is_finite() && (0.0..=1.0).contains(&value) {
+                    ensure_gpm_metrics(gpu_info).memory_bandwidth_utilization = Some(value as f32);
                 }
             }
             "npu_firmware_info" => {
@@ -671,6 +763,48 @@ fn saturating_u32(value: f64) -> Option<u32> {
         return Some(u32::MAX);
     }
     Some(value as u32)
+}
+
+/// Saturating cast of a Prometheus `f64` value to `Option<i32>` for the
+/// NUMA node id field.
+///
+/// * Values above `i32::MAX` saturate to `i32::MAX`.
+/// * Values below `i32::MIN` saturate to `i32::MIN`.
+/// * `NaN` yields `None`.
+fn saturating_i32(value: f64) -> Option<i32> {
+    if value.is_nan() {
+        return None;
+    }
+    if value >= i32::MAX as f64 {
+        return Some(i32::MAX);
+    }
+    if value <= i32::MIN as f64 {
+        return Some(i32::MIN);
+    }
+    Some(value as i32)
+}
+
+/// Maximum NvLinks per GPU accepted from a remote scrape. Current NVIDIA
+/// hardware caps at 18 physical links; 32 leaves headroom for future
+/// generations while still rejecting absurd input.
+pub(crate) const MAX_NVLINK_PER_GPU: u32 = 32;
+
+/// Maximum NUMA node id accepted from a remote scrape. No real system
+/// exposes more than a few hundred NUMA nodes; 4096 is paranoid.
+const MAX_NUMA_NODE_ID: i32 = 4096;
+
+/// Maximum GSP firmware version string length accepted from a remote
+/// scrape. NVIDIA's GSP version strings are well under 32 bytes; 128
+/// truncates any obviously pathological label.
+const MAX_GSP_VERSION_LEN: usize = 128;
+
+/// Lazily populate the GPM metrics slot on a [`GpuInfo`] so we do not
+/// allocate an empty struct unless at least one GPM field was observed.
+fn ensure_gpm_metrics(gpu_info: &mut GpuInfo) -> &mut GpmMetrics {
+    if gpu_info.gpm_metrics.is_none() {
+        gpu_info.gpm_metrics = Some(GpmMetrics::default());
+    }
+    gpu_info.gpm_metrics.as_mut().expect("just populated above")
 }
 
 fn split_labels_respecting_quotes(labels_str: &str) -> Vec<&str> {

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -328,7 +328,9 @@ impl MetricsParser {
                 // in that range so a malicious or buggy upstream cannot emit
                 // an out-of-range value (e.g. 9999) that the TUI would
                 // render as "P9999" and corrupt the secondary row layout.
-                if (0.0..=15.0).contains(&value) {
+                // Fractional inputs (e.g. 1.5) are also rejected — the
+                // exporter only emits integer performance state indices.
+                if (0.0..=15.0).contains(&value) && value.fract() == 0.0 {
                     gpu_info.performance_state = saturating_u32(value);
                 }
             }
@@ -336,18 +338,23 @@ impl MetricsParser {
                 // NUMA node ids are non-negative on every real system.
                 // Cap at a paranoid ceiling so a hostile upstream cannot
                 // inject huge values: no real machine exposes more than
-                // ~256 NUMA nodes today. Negative inputs and NaN drop.
-                if let Some(node) = saturating_i32(value)
+                // ~256 NUMA nodes today. Negative inputs, NaN, and
+                // fractional values (e.g. -0.5 → saturates to 0 without
+                // this guard) are all dropped.
+                if value >= 0.0
+                    && value.fract() == 0.0
+                    && let Some(node) = saturating_i32(value)
                     && (0..=MAX_NUMA_NODE_ID).contains(&node)
                 {
                     gpu_info.numa_node_id = Some(node);
                 }
             }
             "gpu_gsp_firmware_mode" => {
-                // Exporter emits exactly 0/1/2. Accept only that range so
-                // a malicious upstream cannot seed the UI with a bogus
-                // code. Out-of-range values leave the field as `None`.
-                if (0.0..=2.0).contains(&value) {
+                // Exporter emits exactly 0/1/2. Accept only integer values
+                // in that range so a malicious upstream cannot seed the UI
+                // with a bogus code. Fractional inputs (e.g. 1.5) saturate
+                // to 1 without this guard, producing a silently wrong code.
+                if (0.0..=2.0).contains(&value) && value.fract() == 0.0 {
                     gpu_info.gsp_firmware_mode =
                         saturating_u32(value).and_then(|v| u8::try_from(v).ok());
                 }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -421,6 +421,11 @@ mod tests {
                 temperature_threshold_max_operating: None,
                 temperature_threshold_acoustic: None,
                 performance_state: None,
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
                 detail: HashMap::new(),
             });
         }

--- a/src/ui/gpu_sparkline_panel.rs
+++ b/src/ui/gpu_sparkline_panel.rs
@@ -514,6 +514,11 @@ mod tests {
             temperature_threshold_max_operating: None,
             temperature_threshold_acoustic: None,
             performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail,
         });
 
@@ -560,6 +565,11 @@ mod tests {
             temperature_threshold_max_operating: None,
             temperature_threshold_acoustic: None,
             performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail,
         });
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -451,6 +451,11 @@ mod tests {
             temperature_threshold_max_operating: None,
             temperature_threshold_acoustic: None,
             performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail: std::collections::HashMap::new(),
         }
     }

--- a/src/ui/led_grid.rs
+++ b/src/ui/led_grid.rs
@@ -246,6 +246,11 @@ mod tests {
                 temperature_threshold_max_operating: None,
                 temperature_threshold_acoustic: None,
                 performance_state: None,
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
                 detail: HashMap::new(),
             });
         }

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -19,7 +19,7 @@ use crossterm::{queue, style::Color, style::Print};
 use crate::device::GpuInfo;
 use crate::device::MigGpuInfo;
 use crate::device::VgpuHostInfo;
-use crate::device::types::{ThermalProximity, ThermalProximityConfig};
+use crate::device::types::{NvLinkRemoteType, ThermalProximity, ThermalProximityConfig};
 use crate::ui::text::print_colored_text;
 use crate::ui::widgets::draw_bar;
 
@@ -41,17 +41,19 @@ impl GpuRenderer {
 }
 
 /// Compute the number of terminal lines [`print_gpu_info`] will emit for a
-/// single GPU, including any optional thermal/P-state row and any nested
-/// vGPU / MIG section.
+/// single GPU, including any optional thermal/P-state row, the extended
+/// hardware-details row (issue #132), and any nested vGPU / MIG section.
 ///
 /// Layout pieces, in render order:
 ///   1. The base info line (always 1 line).
-///   2. The optional thermal/P-state row (1 line when any of the 5 new
-///      fields are populated; 0 otherwise).
-///   3. The gauge row (always 1 line).
-///   4. A nested vGPU section, when a matching [`VgpuHostInfo`] is present
+///   2. The optional thermal/P-state row (1 line when any of the 5 thermal
+///      fields or the P-state is populated; 0 otherwise).
+///   3. The optional hardware-details row (1 line when NUMA, GSP firmware,
+///      or NvLink topology is populated; 0 otherwise).
+///   4. The gauge row (always 1 line).
+///   5. A nested vGPU section, when a matching [`VgpuHostInfo`] is present
 ///      and the host is "active": 1 header line + 1 line per vGPU instance.
-///   5. A nested MIG section, when a matching [`MigGpuInfo`] is present and
+///   6. A nested MIG section, when a matching [`MigGpuInfo`] is present and
 ///      the host is "active": 1 header line + 1 line per MIG instance.
 ///
 /// The vGPU/MIG matching here mirrors `find_matching_vgpu_host` /
@@ -60,8 +62,8 @@ impl GpuRenderer {
 /// actually rendered.
 ///
 /// Used by the layout calculator and the PgUp/PgDn handlers to size the
-/// scrollable GPU area correctly when the new thermal/P-state row is
-/// present, since it can grow rows from 2 to 3 lines apiece.
+/// scrollable GPU area correctly when optional rows are present, since they
+/// can grow rows from 2 to 4 lines apiece.
 pub fn gpu_render_line_count(
     gpu: &GpuInfo,
     vgpu_info: &[VgpuHostInfo],
@@ -77,6 +79,14 @@ pub fn gpu_render_line_count(
         || gpu.temperature_threshold_acoustic.is_some()
         || gpu.performance_state.is_some();
     if has_thermal_or_pstate {
+        lines += 1;
+    }
+
+    // Optional hardware-details row (issue #132). Rendered when NUMA,
+    // GSP firmware, or NvLink topology is present. GPM metrics are shown
+    // only inline on the same row if NUMA/GSP/NvLink is also present, so
+    // they don't by themselves trigger the row.
+    if gpu_has_hardware_details_row(gpu) {
         lines += 1;
     }
 
@@ -200,6 +210,7 @@ pub fn print_gpu_info<W: Write>(
     };
 
     // Print info line: <device_type> <name> [@ <hostname>] Util:4.0% Mem:25.2/128GB Temp:0°C Pwr:0.0W
+    // (The info / gauges / thermal / HW rows are produced further below.)
     print_colored_text(
         stdout,
         &format!("{:<5}", info.device_type),
@@ -365,6 +376,12 @@ pub fn print_gpu_info<W: Write>(
     // these fields keep their current two-row layout. The row is indented
     // to line up under the device name so it visually hangs off the GPU.
     render_thermal_pstate_row(stdout, info);
+
+    // Optional tertiary row: extended hardware details (issue #132).
+    //
+    // Rendered when NUMA placement, GSP firmware, or NvLink topology is
+    // reported. Keeps the same 5-column indent as the thermal row above.
+    render_hardware_details_row(stdout, info);
 
     // Calculate gauge widths with 5 char padding on each side and 2 space separation
     let available_width = width.saturating_sub(10); // 5 padding each side
@@ -536,6 +553,144 @@ fn render_thermal_pstate_row<W: Write>(stdout: &mut W, info: &GpuInfo) {
     queue!(stdout, Print("\r\n")).unwrap();
 }
 
+/// Return true when a GPU carries at least one hardware-detail field that
+/// the TUI cares about surfacing: NUMA node, GSP firmware mode/version,
+/// or NvLink topology. GPM metrics alone do NOT trigger the row since
+/// they render alongside the other details when present.
+fn gpu_has_hardware_details_row(gpu: &GpuInfo) -> bool {
+    gpu.numa_node_id.is_some()
+        || gpu.gsp_firmware_mode.is_some()
+        || gpu.gsp_firmware_version.is_some()
+        || !gpu.nvlink_remote_devices.is_empty()
+}
+
+/// Human-readable label for the GSP firmware mode gauge, used in the TUI
+/// hardware-details row. Mirrors the `all_smi_gpu_gsp_firmware_mode` code
+/// emitted by the exporter (`0=disabled`, `1=enabled`, `2=default`).
+fn gsp_firmware_mode_label(code: u8) -> &'static str {
+    match code {
+        0 => "disabled",
+        1 => "enabled",
+        2 => "default",
+        _ => "unknown",
+    }
+}
+
+/// Render the compact hardware-details row beneath a GPU (issue #132).
+///
+/// Example output (trailing spaces / ANSI colour codes omitted for
+/// readability):
+///
+/// ```text
+///      HW  NUMA:0  GSP:enabled v550.54.15  NVLink:6x(gpu=5,sw=1)  GPM:SM=0.67 MemBW=0.42
+/// ```
+///
+/// No-op when none of the issue-#132 fields are populated, so non-NVIDIA
+/// rows and older drivers keep their historical layout.
+fn render_hardware_details_row<W: Write>(stdout: &mut W, info: &GpuInfo) {
+    if !gpu_has_hardware_details_row(info) {
+        return;
+    }
+
+    // 5-char indent aligns with the other secondary rows.
+    print_colored_text(stdout, "     ", Color::White, None, None);
+    print_colored_text(stdout, "HW", Color::DarkMagenta, None, None);
+
+    if let Some(numa) = info.numa_node_id {
+        print_colored_text(stdout, " NUMA:", Color::DarkYellow, None, None);
+        print_colored_text(stdout, &format!("{numa}"), Color::White, None, None);
+    }
+
+    if let Some(mode_code) = info.gsp_firmware_mode {
+        print_colored_text(stdout, " GSP:", Color::DarkGreen, None, None);
+        print_colored_text(
+            stdout,
+            gsp_firmware_mode_label(mode_code),
+            Color::White,
+            None,
+            None,
+        );
+    }
+    if let Some(ref version) = info.gsp_firmware_version {
+        // Terse prefix to signal "firmware version" without stealing a
+        // whole column. The value is rendered in parentheses when the
+        // mode is also shown to visually group the two.
+        print_colored_text(stdout, " v", Color::DarkGrey, None, None);
+        print_colored_text(stdout, version, Color::White, None, None);
+    }
+
+    if !info.nvlink_remote_devices.is_empty() {
+        let total = info.nvlink_remote_devices.len();
+        let (gpu_count, switch_count, ibmnpu_count, unknown_count) =
+            count_nvlink_remote_types(&info.nvlink_remote_devices);
+        print_colored_text(stdout, " NVLink:", Color::DarkCyan, None, None);
+        // Summary: "6x(gpu=5,sw=1)" — compact and still machine-parseable
+        // if someone wants to grep.
+        let mut parts: Vec<String> = Vec::with_capacity(4);
+        if gpu_count > 0 {
+            parts.push(format!("gpu={gpu_count}"));
+        }
+        if switch_count > 0 {
+            parts.push(format!("sw={switch_count}"));
+        }
+        if ibmnpu_count > 0 {
+            parts.push(format!("ibmnpu={ibmnpu_count}"));
+        }
+        if unknown_count > 0 {
+            parts.push(format!("?={unknown_count}"));
+        }
+        let summary = if parts.is_empty() {
+            format!("{total}x")
+        } else {
+            format!("{total}x({})", parts.join(","))
+        };
+        print_colored_text(stdout, &summary, Color::White, None, None);
+    }
+
+    // GPM metrics render last so they appear after the topology info.
+    // Only surfaces when at least one scalar is populated — a supported-
+    // but-unsampled snapshot (`Some(GpmMetrics::default())`) produces
+    // nothing so the TUI never shows stale zeros.
+    if let Some(ref gpm) = info.gpm_metrics
+        && (gpm.sm_occupancy.is_some() || gpm.memory_bandwidth_utilization.is_some())
+    {
+        print_colored_text(stdout, " GPM:", Color::DarkBlue, None, None);
+        if let Some(sm) = gpm.sm_occupancy {
+            print_colored_text(stdout, "SM=", Color::DarkGrey, None, None);
+            print_colored_text(stdout, &format!("{sm:.2}"), Color::White, None, None);
+        }
+        if let Some(mem) = gpm.memory_bandwidth_utilization {
+            if gpm.sm_occupancy.is_some() {
+                print_colored_text(stdout, " ", Color::White, None, None);
+            }
+            print_colored_text(stdout, "MemBW=", Color::DarkGrey, None, None);
+            print_colored_text(stdout, &format!("{mem:.2}"), Color::White, None, None);
+        }
+    }
+
+    queue!(stdout, Print("\r\n")).unwrap();
+}
+
+/// Tally NvLinks by remote-type classification for the summary column.
+/// Returns `(gpu, switch, ibmnpu, unknown)` counts.
+fn count_nvlink_remote_types(
+    links: &[crate::device::NvLinkRemoteDevice],
+) -> (usize, usize, usize, usize) {
+    let mut gpu_count = 0;
+    let mut switch_count = 0;
+    let mut ibmnpu_count = 0;
+    let mut unknown_count = 0;
+    for link in links {
+        match link.remote_type {
+            NvLinkRemoteType::Gpu => gpu_count += 1,
+            NvLinkRemoteType::Switch => switch_count += 1,
+            NvLinkRemoteType::IbmNpu => ibmnpu_count += 1,
+            NvLinkRemoteType::Unknown => unknown_count += 1,
+        }
+    }
+    (gpu_count, switch_count, ibmnpu_count, unknown_count)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -565,6 +720,11 @@ mod tests {
             temperature_threshold_max_operating: Some(87),
             temperature_threshold_acoustic: None,
             performance_state: Some(2),
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
             detail: HashMap::new(),
         }
     }
@@ -1048,5 +1208,213 @@ mod tests {
             gpu_render_line_count(&gpu, &[], std::slice::from_ref(&mig_host)),
             2
         );
+    }
+
+    // --- hardware-details row (issue #132) tests ---
+
+    fn bare_gpu() -> GpuInfo {
+        let mut gpu = make_gpu(40);
+        gpu.temperature_threshold_slowdown = None;
+        gpu.temperature_threshold_shutdown = None;
+        gpu.temperature_threshold_max_operating = None;
+        gpu.temperature_threshold_acoustic = None;
+        gpu.performance_state = None;
+        gpu
+    }
+
+    #[test]
+    fn hw_row_noop_when_no_hardware_details() {
+        let gpu = bare_gpu();
+        let mut buf: Vec<u8> = Vec::new();
+        render_hardware_details_row(&mut buf, &gpu);
+        assert!(
+            buf.is_empty(),
+            "expected no output when no hw details populated"
+        );
+    }
+
+    #[test]
+    fn hw_row_renders_numa_when_populated() {
+        let mut gpu = bare_gpu();
+        gpu.numa_node_id = Some(1);
+        let mut buf: Vec<u8> = Vec::new();
+        render_hardware_details_row(&mut buf, &gpu);
+        let rendered = String::from_utf8(buf).expect("valid utf-8");
+        assert!(rendered.contains("HW"), "{rendered}");
+        assert!(rendered.contains("NUMA:"), "{rendered}");
+        assert!(rendered.contains('1'), "{rendered}");
+    }
+
+    #[test]
+    fn hw_row_renders_gsp_mode_label() {
+        for (code, label) in [(0u8, "disabled"), (1, "enabled"), (2, "default")] {
+            let mut gpu = bare_gpu();
+            gpu.gsp_firmware_mode = Some(code);
+            let mut buf: Vec<u8> = Vec::new();
+            render_hardware_details_row(&mut buf, &gpu);
+            let rendered = String::from_utf8(buf).expect("valid utf-8");
+            assert!(
+                rendered.contains(label),
+                "expected '{label}' in: {rendered}"
+            );
+        }
+    }
+
+    /// Strip ANSI escape sequences from a rendered TUI row so substring
+    /// assertions aren't confused by colour control codes embedded inside
+    /// labels like `v550.54.15` that get split across multiple
+    /// `print_colored_text` calls.
+    fn strip_ansi(raw: &str) -> String {
+        let mut out = String::with_capacity(raw.len());
+        let mut chars = raw.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                // Consume up to and including the terminator (e.g. 'm'
+                // for CSI SGR sequences, or any letter for other CSI).
+                for ch in chars.by_ref() {
+                    if ch.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn hw_row_renders_gsp_version_prefix() {
+        let mut gpu = bare_gpu();
+        gpu.gsp_firmware_version = Some("550.54.15".to_string());
+        let mut buf: Vec<u8> = Vec::new();
+        render_hardware_details_row(&mut buf, &gpu);
+        let rendered = strip_ansi(&String::from_utf8(buf).expect("valid utf-8"));
+        assert!(rendered.contains("v550.54.15"), "{rendered}");
+    }
+
+    #[test]
+    fn hw_row_renders_nvlink_summary_with_type_counts() {
+        use crate::device::{NvLinkRemoteDevice, NvLinkRemoteType};
+        let mut gpu = bare_gpu();
+        gpu.nvlink_remote_devices = vec![
+            NvLinkRemoteDevice {
+                link_index: 0,
+                remote_type: NvLinkRemoteType::Gpu,
+            },
+            NvLinkRemoteDevice {
+                link_index: 1,
+                remote_type: NvLinkRemoteType::Gpu,
+            },
+            NvLinkRemoteDevice {
+                link_index: 2,
+                remote_type: NvLinkRemoteType::Gpu,
+            },
+            NvLinkRemoteDevice {
+                link_index: 3,
+                remote_type: NvLinkRemoteType::Gpu,
+            },
+            NvLinkRemoteDevice {
+                link_index: 4,
+                remote_type: NvLinkRemoteType::Gpu,
+            },
+            NvLinkRemoteDevice {
+                link_index: 5,
+                remote_type: NvLinkRemoteType::Switch,
+            },
+        ];
+        let mut buf: Vec<u8> = Vec::new();
+        render_hardware_details_row(&mut buf, &gpu);
+        let rendered = String::from_utf8(buf).expect("valid utf-8");
+        assert!(rendered.contains("NVLink:"), "{rendered}");
+        assert!(rendered.contains("6x"), "{rendered}");
+        assert!(rendered.contains("gpu=5"), "{rendered}");
+        assert!(rendered.contains("sw=1"), "{rendered}");
+    }
+
+    #[test]
+    fn hw_row_omits_gpm_when_only_support_probe_populated() {
+        // Reader emits `Some(GpmMetrics::default())` on Hopper+ until the
+        // two-sample handshake lands. Until then the TUI must not show
+        // "GPM:" at all — a zero reading would be misleading.
+        use crate::device::GpmMetrics;
+        let mut gpu = bare_gpu();
+        gpu.numa_node_id = Some(0);
+        gpu.gpm_metrics = Some(GpmMetrics::default());
+        let mut buf: Vec<u8> = Vec::new();
+        render_hardware_details_row(&mut buf, &gpu);
+        let rendered = String::from_utf8(buf).expect("valid utf-8");
+        assert!(
+            !rendered.contains("GPM:"),
+            "GPM label should be hidden when no values sampled: {rendered}"
+        );
+    }
+
+    #[test]
+    fn hw_row_renders_gpm_values_when_populated() {
+        use crate::device::GpmMetrics;
+        let mut gpu = bare_gpu();
+        gpu.numa_node_id = Some(0);
+        gpu.gpm_metrics = Some(GpmMetrics {
+            sm_occupancy: Some(0.67),
+            memory_bandwidth_utilization: Some(0.42),
+        });
+        let mut buf: Vec<u8> = Vec::new();
+        render_hardware_details_row(&mut buf, &gpu);
+        let rendered = strip_ansi(&String::from_utf8(buf).expect("valid utf-8"));
+        assert!(rendered.contains("GPM:"), "{rendered}");
+        assert!(rendered.contains("SM=0.67"), "{rendered}");
+        assert!(rendered.contains("MemBW=0.42"), "{rendered}");
+    }
+
+    #[test]
+    fn hw_row_accounts_for_line_in_gpu_render_line_count() {
+        // NUMA alone bumps the row count from 2 -> 3.
+        let mut gpu = bare_gpu();
+        gpu.numa_node_id = Some(0);
+        assert_eq!(gpu_render_line_count(&gpu, &[], &[]), 3);
+    }
+
+    #[test]
+    fn hw_row_and_thermal_row_both_counted() {
+        // Both optional rows present: 2 base + thermal + hw = 4.
+        let gpu = make_gpu(50); // make_gpu populates thermals + pstate
+        let mut gpu = gpu;
+        gpu.numa_node_id = Some(0);
+        assert_eq!(gpu_render_line_count(&gpu, &[], &[]), 4);
+    }
+
+    #[test]
+    fn hw_row_gpm_only_does_not_emit_row() {
+        // Support-only GPM must not trigger the row — the row is reserved
+        // for topology / firmware / NUMA info that a human would inspect.
+        use crate::device::GpmMetrics;
+        let mut gpu = bare_gpu();
+        gpu.gpm_metrics = Some(GpmMetrics::default());
+        assert_eq!(gpu_render_line_count(&gpu, &[], &[]), 2);
+    }
+
+    #[test]
+    fn count_nvlink_remote_types_classifies_all_variants() {
+        use crate::device::{NvLinkRemoteDevice, NvLinkRemoteType};
+        let links = vec![
+            NvLinkRemoteDevice {
+                link_index: 0,
+                remote_type: NvLinkRemoteType::Gpu,
+            },
+            NvLinkRemoteDevice {
+                link_index: 1,
+                remote_type: NvLinkRemoteType::Switch,
+            },
+            NvLinkRemoteDevice {
+                link_index: 2,
+                remote_type: NvLinkRemoteType::IbmNpu,
+            },
+            NvLinkRemoteDevice {
+                link_index: 3,
+                remote_type: NvLinkRemoteType::Unknown,
+            },
+        ];
+        assert_eq!(count_nvlink_remote_types(&links), (1, 1, 1, 1));
     }
 }

--- a/src/view/view_cache.rs
+++ b/src/view/view_cache.rs
@@ -385,6 +385,11 @@ mod tests {
                 temperature_threshold_max_operating: None,
                 temperature_threshold_acoustic: None,
                 performance_state: None,
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
                 detail: {
                     let mut m = std::collections::HashMap::new();
                     m.insert("index".to_string(), i.to_string());
@@ -468,6 +473,11 @@ mod tests {
                 temperature_threshold_max_operating: None,
                 temperature_threshold_acoustic: None,
                 performance_state: None,
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
                 detail: std::collections::HashMap::new(),
             });
         }

--- a/tests/hardware_details_integration_test.rs
+++ b/tests/hardware_details_integration_test.rs
@@ -342,3 +342,48 @@ fn parser_rejects_fractional_numa_node_id() {
         parsed[0].numa_node_id
     );
 }
+
+#[test]
+fn parser_rejects_gsp_version_with_control_chars() {
+    // A malicious remote could emit a version string containing ANSI escape
+    // sequences (e.g. ESC[2J ESC[H to clear the terminal). The parser must
+    // reject such strings so the TUI never executes injected escape codes
+    // when rendering the hardware row.
+    //
+    // The metric format uses Prometheus label syntax, so the `version` label
+    // value is a quoted string inside `{...}`. We include a literal ESC
+    // character (U+001B) inside the label to simulate the injection.
+    let text = format!(
+        "all_smi_gpu_utilization{{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-ESC\", index=\"0\"}} 10\n\
+         all_smi_gpu_gsp_firmware_version_info{{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-ESC\", index=\"0\", version=\"\x1b[2J\x1b[H\"}} 1\n"
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(&text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert!(
+        parsed[0].gsp_firmware_version.is_none(),
+        "GSP version containing control characters must be rejected, got {:?}",
+        parsed[0].gsp_firmware_version
+    );
+}
+
+#[test]
+fn parser_accepts_normal_gsp_version_string() {
+    // Confirm a clean version string passes through the control-char guard.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-OK\", index=\"0\"} 10\n",
+        "all_smi_gpu_gsp_firmware_version_info{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-OK\", index=\"0\", version=\"550.54.15\"} 1\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(
+        parsed[0].gsp_firmware_version.as_deref(),
+        Some("550.54.15"),
+        "clean GSP version string must be accepted"
+    );
+}

--- a/tests/hardware_details_integration_test.rs
+++ b/tests/hardware_details_integration_test.rs
@@ -1,0 +1,283 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the NVIDIA extended hardware-detail pipeline
+//! introduced in issue #132: NUMA node id, GSP firmware mode / version,
+//! NvLink remote device types, and GPM metrics.
+//!
+//! The tests build Prometheus-exposition snippets that exactly match the
+//! strings produced by `api/metrics/hardware.rs`, then parse them back
+//! through [`MetricsParser`] and assert every field survives the round
+//! trip. If the exporter changes metric names, label ordering, or the
+//! numeric encoding, update these strings in lockstep with that change.
+
+use all_smi::device::NvLinkRemoteType;
+use all_smi::network::metrics_parser::MetricsParser;
+use regex::Regex;
+
+fn regex() -> Regex {
+    Regex::new(r"^all_smi_([^\{]+)\{([^}]+)\} ([\d\.]+)$").unwrap()
+}
+
+fn full_hardware_exposition() -> String {
+    // Mirror what the exporter emits for a single NVIDIA A100 with:
+    //   * NUMA node 0
+    //   * GSP firmware enabled, version 550.54.15
+    //   * 6 active NvLinks: 5 GPU-to-GPU + 1 GPU-to-Switch
+    //   * GPM: SM occupancy 0.67, memory bandwidth util 0.42
+    concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\"} 30.0\n",
+        "all_smi_gpu_temperature_celsius{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\"} 55\n",
+        "# HELP all_smi_gpu_numa_node_id NUMA node the GPU is attached to\n",
+        "# TYPE all_smi_gpu_numa_node_id gauge\n",
+        "all_smi_gpu_numa_node_id{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\"} 0\n",
+        "# HELP all_smi_gpu_gsp_firmware_mode GSP firmware mode\n",
+        "# TYPE all_smi_gpu_gsp_firmware_mode gauge\n",
+        "all_smi_gpu_gsp_firmware_mode{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\"} 1\n",
+        "# HELP all_smi_gpu_gsp_firmware_version_info GSP firmware version\n",
+        "# TYPE all_smi_gpu_gsp_firmware_version_info gauge\n",
+        "all_smi_gpu_gsp_firmware_version_info{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\", version=\"550.54.15\"} 1\n",
+        "# HELP all_smi_nvlink_remote_device_type NvLink remote endpoint classification\n",
+        "# TYPE all_smi_nvlink_remote_device_type gauge\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\", link_index=\"0\", remote_type=\"gpu\"} 1\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\", link_index=\"1\", remote_type=\"gpu\"} 1\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\", link_index=\"2\", remote_type=\"gpu\"} 1\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\", link_index=\"3\", remote_type=\"gpu\"} 1\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\", link_index=\"4\", remote_type=\"gpu\"} 1\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\", link_index=\"5\", remote_type=\"switch\"} 1\n",
+        "# HELP all_smi_gpu_sm_occupancy GPM SM occupancy\n",
+        "# TYPE all_smi_gpu_sm_occupancy gauge\n",
+        "all_smi_gpu_sm_occupancy{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\"} 0.67\n",
+        "# HELP all_smi_gpu_memory_bandwidth_utilization GPM memory bandwidth util\n",
+        "# TYPE all_smi_gpu_memory_bandwidth_utilization gauge\n",
+        "all_smi_gpu_memory_bandwidth_utilization{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-HW\", index=\"0\"} 0.42\n",
+    )
+    .to_string()
+}
+
+#[test]
+fn hardware_detail_round_trip_preserves_all_fields() {
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) =
+        parser.parse_metrics(&full_hardware_exposition(), "node-9:9090", &regex());
+
+    assert_eq!(parsed.len(), 1, "expected exactly one GPU record");
+    let gpu = &parsed[0];
+    assert_eq!(gpu.uuid, "GPU-HW");
+    assert_eq!(gpu.numa_node_id, Some(0));
+    assert_eq!(gpu.gsp_firmware_mode, Some(1));
+    assert_eq!(gpu.gsp_firmware_version.as_deref(), Some("550.54.15"));
+
+    // NvLinks: 6 total, 5 gpu + 1 switch. Parser preserves link_index.
+    assert_eq!(gpu.nvlink_remote_devices.len(), 6);
+    let gpu_count = gpu
+        .nvlink_remote_devices
+        .iter()
+        .filter(|l| l.remote_type == NvLinkRemoteType::Gpu)
+        .count();
+    let switch_count = gpu
+        .nvlink_remote_devices
+        .iter()
+        .filter(|l| l.remote_type == NvLinkRemoteType::Switch)
+        .count();
+    assert_eq!(gpu_count, 5);
+    assert_eq!(switch_count, 1);
+    let link_indices: Vec<u32> = gpu
+        .nvlink_remote_devices
+        .iter()
+        .map(|l| l.link_index)
+        .collect();
+    for expected in 0..6u32 {
+        assert!(
+            link_indices.contains(&expected),
+            "missing link {expected} in {link_indices:?}"
+        );
+    }
+
+    // GPM metrics: SM occupancy and memory BW util populated.
+    let gpm = gpu.gpm_metrics.as_ref().expect("GPM metrics present");
+    assert!((gpm.sm_occupancy.unwrap() - 0.67).abs() < 1e-4);
+    assert!((gpm.memory_bandwidth_utilization.unwrap() - 0.42).abs() < 1e-4);
+}
+
+#[test]
+fn hardware_detail_partial_scrape_preserves_absence() {
+    // Older driver: only NUMA node id is exposed. GSP firmware, NvLink,
+    // and GPM fields stay at the "unavailable" defaults.
+    let partial = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-OLD\", index=\"0\"} 10\n",
+        "all_smi_gpu_temperature_celsius{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-OLD\", index=\"0\"} 50\n",
+        "all_smi_gpu_numa_node_id{gpu=\"NVIDIA A100\", instance=\"node-9\", \
+         uuid=\"GPU-OLD\", index=\"0\"} 1\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(partial, "node-9:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    let gpu = &parsed[0];
+    assert_eq!(gpu.numa_node_id, Some(1));
+    assert!(gpu.gsp_firmware_mode.is_none());
+    assert!(gpu.gsp_firmware_version.is_none());
+    assert!(gpu.nvlink_remote_devices.is_empty());
+    assert!(gpu.gpm_metrics.is_none());
+}
+
+#[test]
+fn non_nvidia_path_leaves_hardware_fields_unavailable() {
+    // A scrape from an Apple Silicon / AMD node emits no hardware-detail
+    // lines; the resulting `GpuInfo` must carry all new fields as their
+    // "unavailable" defaults so the TUI renders nothing.
+    let non_nvidia = concat!(
+        "all_smi_gpu_utilization{gpu=\"Apple M2 Pro\", instance=\"mac-1\", \
+         uuid=\"APPLE-0\", index=\"0\"} 20\n",
+        "all_smi_gpu_temperature_celsius{gpu=\"Apple M2 Pro\", instance=\"mac-1\", \
+         uuid=\"APPLE-0\", index=\"0\"} 55\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(non_nvidia, "mac-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    let gpu = &parsed[0];
+    assert!(gpu.numa_node_id.is_none());
+    assert!(gpu.gsp_firmware_mode.is_none());
+    assert!(gpu.gsp_firmware_version.is_none());
+    assert!(gpu.nvlink_remote_devices.is_empty());
+    assert!(gpu.gpm_metrics.is_none());
+}
+
+#[test]
+fn nvlink_unknown_remote_type_is_preserved() {
+    // The exporter may label a link with `remote_type="unknown"` when the
+    // driver does not classify the endpoint; the parser must propagate
+    // that classification rather than silently dropping the link.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-U\", index=\"0\"} 10\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-U\", index=\"0\", link_index=\"0\", remote_type=\"unknown\"} 1\n",
+        "all_smi_nvlink_remote_device_type{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-U\", index=\"0\", link_index=\"1\", remote_type=\"ibmnpu\"} 1\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    let gpu = &parsed[0];
+    assert_eq!(gpu.nvlink_remote_devices.len(), 2);
+    assert!(
+        gpu.nvlink_remote_devices
+            .iter()
+            .any(|l| l.remote_type == NvLinkRemoteType::Unknown)
+    );
+    assert!(
+        gpu.nvlink_remote_devices
+            .iter()
+            .any(|l| l.remote_type == NvLinkRemoteType::IbmNpu)
+    );
+}
+
+#[test]
+fn parser_caps_nvlinks_at_max_per_gpu() {
+    // A malicious remote exporter could emit more NvLinks than physically
+    // possible. The parser must bound the per-GPU vector to avoid an
+    // unbounded allocation. Current ceiling is 32 (see
+    // `MAX_NVLINK_PER_GPU` in network/metrics_parser.rs); we test by
+    // emitting 40 distinct link indices — the first 32 must be accepted,
+    // the rest dropped.
+    let mut lines = String::new();
+    lines.push_str(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA H100\", instance=\"node-a\", \
+         uuid=\"GPU-CAP\", index=\"0\"} 10\n",
+    );
+    for link in 0..40u32 {
+        lines.push_str(&format!(
+            "all_smi_nvlink_remote_device_type{{gpu=\"NVIDIA H100\", instance=\"node-a\", \
+             uuid=\"GPU-CAP\", index=\"0\", link_index=\"{link}\", remote_type=\"gpu\"}} 1\n"
+        ));
+    }
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(&lines, "node-a:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert!(
+        parsed[0].nvlink_remote_devices.len() <= 32,
+        "parser failed to cap NvLinks: got {}",
+        parsed[0].nvlink_remote_devices.len()
+    );
+}
+
+#[test]
+fn parser_rejects_out_of_range_gsp_firmware_mode() {
+    // Exporter emits 0/1/2 only. A buggy upstream that sends 99 must leave
+    // the field as `None` so dashboards never render a bogus mode.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-B\", index=\"0\"} 10\n",
+        "all_smi_gpu_gsp_firmware_mode{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-B\", index=\"0\"} 99\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert!(parsed[0].gsp_firmware_mode.is_none());
+}
+
+#[test]
+fn parser_rejects_out_of_range_gpm_fractions() {
+    // GPM gauges are 0..=1 fractions. A malicious 9.9 emission must be
+    // dropped rather than rendered as 990% occupancy.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-R\", index=\"0\"} 10\n",
+        "all_smi_gpu_sm_occupancy{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-R\", index=\"0\"} 9.9\n",
+        "all_smi_gpu_memory_bandwidth_utilization{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-R\", index=\"0\"} 9.9\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    // Neither GPM field accepted → no `GpmMetrics` allocated.
+    assert!(parsed[0].gpm_metrics.is_none());
+}
+
+#[test]
+fn parser_gpm_accepts_only_the_fields_present() {
+    // A partial GPM emission (only SM occupancy) must populate that field
+    // and leave the other as `None`, matching the exporter's "emit only
+    // when you have data" contract.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-P\", index=\"0\"} 10\n",
+        "all_smi_gpu_sm_occupancy{gpu=\"NVIDIA H100\", instance=\"node-1\", \
+         uuid=\"GPU-P\", index=\"0\"} 0.55\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    let gpm = parsed[0].gpm_metrics.as_ref().expect("GPM populated");
+    assert!((gpm.sm_occupancy.unwrap() - 0.55).abs() < 1e-4);
+    assert!(gpm.memory_bandwidth_utilization.is_none());
+}

--- a/tests/hardware_details_integration_test.rs
+++ b/tests/hardware_details_integration_test.rs
@@ -353,12 +353,11 @@ fn parser_rejects_gsp_version_with_control_chars() {
     // The metric format uses Prometheus label syntax, so the `version` label
     // value is a quoted string inside `{...}`. We include a literal ESC
     // character (U+001B) inside the label to simulate the injection.
-    let text = format!(
-        "all_smi_gpu_utilization{{gpu=\"NVIDIA A100\", instance=\"node-1\", \
-         uuid=\"GPU-ESC\", index=\"0\"}} 10\n\
-         all_smi_gpu_gsp_firmware_version_info{{gpu=\"NVIDIA A100\", instance=\"node-1\", \
-         uuid=\"GPU-ESC\", index=\"0\", version=\"\x1b[2J\x1b[H\"}} 1\n"
-    );
+    let text = "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-ESC\", index=\"0\"} 10\n\
+         all_smi_gpu_gsp_firmware_version_info{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-ESC\", index=\"0\", version=\"\x1b[2J\x1b[H\"} 1\n"
+        .to_string();
     let parser = MetricsParser::new();
     let (parsed, _, _, _, _, _) = parser.parse_metrics(&text, "node-1:9090", &regex());
     assert_eq!(parsed.len(), 1);

--- a/tests/hardware_details_integration_test.rs
+++ b/tests/hardware_details_integration_test.rs
@@ -281,3 +281,64 @@ fn parser_gpm_accepts_only_the_fields_present() {
     assert!((gpm.sm_occupancy.unwrap() - 0.55).abs() < 1e-4);
     assert!(gpm.memory_bandwidth_utilization.is_none());
 }
+
+#[test]
+fn parser_rejects_fractional_gsp_firmware_mode() {
+    // Exporter only emits integer 0/1/2. A fractional value like 1.5 would
+    // saturate to 1 without an explicit .fract() guard, silently producing a
+    // wrong code. The parser must reject it and leave the field as `None`.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-FRAC\", index=\"0\"} 10\n",
+        "all_smi_gpu_gsp_firmware_mode{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-FRAC\", index=\"0\"} 1.5\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert!(
+        parsed[0].gsp_firmware_mode.is_none(),
+        "fractional GSP firmware mode must be rejected, got {:?}",
+        parsed[0].gsp_firmware_mode
+    );
+}
+
+#[test]
+fn parser_rejects_negative_numa_node_id() {
+    // A value like -0.5 truncates to 0 via `value as i32`, silently placing
+    // the GPU in NUMA node 0. The `value >= 0.0` guard must reject it.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-NEG\", index=\"0\"} 10\n",
+        "all_smi_gpu_numa_node_id{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-NEG\", index=\"0\"} -0.5\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert!(
+        parsed[0].numa_node_id.is_none(),
+        "negative NUMA node id must be rejected, got {:?}",
+        parsed[0].numa_node_id
+    );
+}
+
+#[test]
+fn parser_rejects_fractional_numa_node_id() {
+    // NUMA node ids are always integers. A fractional value (e.g. 1.7)
+    // would truncate to 1 without the .fract() guard.
+    let text = concat!(
+        "all_smi_gpu_utilization{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-FRAC2\", index=\"0\"} 10\n",
+        "all_smi_gpu_numa_node_id{gpu=\"NVIDIA A100\", instance=\"node-1\", \
+         uuid=\"GPU-FRAC2\", index=\"0\"} 1.7\n",
+    );
+    let parser = MetricsParser::new();
+    let (parsed, _, _, _, _, _) = parser.parse_metrics(text, "node-1:9090", &regex());
+    assert_eq!(parsed.len(), 1);
+    assert!(
+        parsed[0].numa_node_id.is_none(),
+        "fractional NUMA node id must be rejected, got {:?}",
+        parsed[0].numa_node_id
+    );
+}


### PR DESCRIPTION
## Summary

Expose the `nvml-wrapper` 0.12 hardware-detail APIs through the entire all-smi pipeline — NVML reader → `GpuInfo` → Prometheus exporter + remote parser → TUI + mock templates + integration tests. Closes #132.

Five new per-GPU fields land on `GpuInfo`:
- `numa_node_id: Option<i32>` (NVML `nvmlDeviceGetNumaNodeId`)
- `gsp_firmware_mode: Option<u8>` (0=disabled, 1=enabled, 2=default)
- `gsp_firmware_version: Option<String>`
- `nvlink_remote_devices: Vec<NvLinkRemoteDevice>` classifying every active link's remote endpoint (gpu / switch / ibmnpu / unknown)
- `gpm_metrics: Option<GpmMetrics>` for GPU Performance Monitoring (support-detection is live; the two-sample handshake is deferred to a follow-up)

## What's in the commits

1. `feat: add hardware-detail data model` — types + safe defaults in every non-NVIDIA reader and test helper
2. `feat: populate hardware details from NVML in the NVIDIA reader` — new `nvidia_hardware` module with `HardwareDetailCache`, NvLink enumeration via raw FFI (working around a latent wrapper bug), and GPM detection
3. `feat: export NVIDIA hardware details as Prometheus metrics` — new `api/metrics/hardware.rs` exporter + `handlers.rs` wiring
4. `feat: parse hardware-detail metrics on the remote side` — parser updates with defensive caps (`MAX_NVLINK_PER_GPU=32`, NUMA id ≤ 4096, GSP version length ≤ 128) and range checks
5. `feat: surface hardware details on a compact TUI row per GPU` — new indented row `HW NUMA:0 GSP:enabled v550.54.15 NVLink:6x(gpu=5,sw=1)` plus `gpu_render_line_count` update
6. `feat: emit synthetic hardware details from the NVIDIA mock template` — mock server emits 8 GPUs × 6 NvLinks + alternating NUMA nodes + GSP version + GPM gauges
7. `test: add integration tests for the hardware-detail pipeline` — mirrors the vGPU / MIG pattern

## Metrics produced

| Metric | Type | Notes |
|---|---|---|
| `all_smi_gpu_numa_node_id` | gauge | Omitted when NUMA topology unknown |
| `all_smi_gpu_gsp_firmware_mode` | gauge (0/1/2) | Omitted on pre-R525 drivers |
| `all_smi_gpu_gsp_firmware_version_info` | info (value=1) | Version carried in `version` label |
| `all_smi_nvlink_remote_device_type` | info (value=1) | Per active link; `link_index` + `remote_type` labels |
| `all_smi_gpu_sm_occupancy` | gauge 0-1 | GPM; omitted when unsampled |
| `all_smi_gpu_memory_bandwidth_utilization` | gauge 0-1 | GPM; omitted when unsampled |

## Test plan

- [x] `cargo build --features mock` — clean
- [x] `cargo test --features mock` — 14 test suites, 0 failures (536 lib tests + 10 hardware unit tests + 10 nvidia_hardware unit tests + 10 TUI hw_row tests + 11 hardware exporter tests + 8 integration tests + …)
- [x] `cargo clippy --features mock --all-targets` — zero new warnings
- [x] `cargo fmt --check` — clean
- [x] Mock server smoke test: `all-smi-mock-server --port-range 19190 --platform nvidia` emits all six metric families with NUMA alternation and 48 NvLink rows across 8 GPUs
- [x] Non-NVIDIA readers (AMD, Apple Silicon, Gaudi, TPU, Furiosa, Rebellions, Tenstorrent, Jetson) return `None` / empty vectors for every new field — zero behavioural change

## Design decisions

- **GPM scope**: live sampling requires a two-sample handshake (`gpm_sample` → wait N seconds → `gpm_sample` → `gpm_metrics_get`) which doesn't fit all-smi's single-poll reader contract. The issue's instruction was to degrade rather than over-engineer, so the reader currently detects GPM support (`Some(GpmMetrics::default())` on Hopper+) without publishing fabricated numbers. The exporter/parser/TUI all silently skip the gauges when no field is populated, and a `collect_gpm_metrics` docstring marks the follow-up. Every piece of plumbing downstream of the reader is ready for the numeric values to light up.
- **Raw FFI for NvLink remote type**: `nvml_wrapper::nv_link::NvLink::remote_device_type()` in 0.12.1 passes `&mut device_type.as_c()` — an immutable temporary — so NVML never writes back. We call the symbol directly via `nvmlDeviceGetNvLinkRemoteDeviceType` instead. Vendored `map_remote_device_type` keeps the workaround contained so it can be removed when the upstream bug is fixed.
- **`numa_node_id` cross-platform**: `Device::numa_node_id()` is available on all platforms in 0.12.1 (no `cfg(target_os = "linux")` gate), so no FFI stub was needed. The reader canonicalises the `u32::MAX` sentinel to `None` rather than leaking it as a huge number.
- **Cache shape**: NUMA + GSP live in a new `HardwareDetailCache` (static per device, process lifetime), matching the thermal-threshold pattern from #173. NvLink is NOT cached since links can go down at runtime. GPM support detection is cheap and uncached.
- **TUI row separation**: the new `HW` row is distinct from the thermal/P-state row introduced in #173 so operators can see both simultaneously without vertical collisions. `gpu_render_line_count` now correctly accounts for up to 4 rows per GPU (info + thermal + hw + gauges).

## Files touched

**New:**
- `src/device/readers/nvidia_hardware.rs`
- `src/api/metrics/hardware.rs`
- `tests/hardware_details_integration_test.rs`

**Modified:** `src/device/types.rs`, `src/device/readers/{nvidia,amd,amd_windows,apple_silicon_native,furiosa,gaudi,google_tpu,nvidia_jetson,rebellions,tenstorrent,mod}.rs`, `src/api/{handlers.rs,metrics/{mod,gpu}.rs}`, `src/network/metrics_parser.rs`, `src/ui/{renderers/gpu_renderer,dashboard,gpu_sparkline_panel,layout,led_grid}.rs`, `src/view/view_cache.rs`, `src/metrics/aggregator.rs`, `src/mock/templates/nvidia.rs`

Closes #132