### PR TITLE
feat: add ALL_SMI_MOCK_HARDWARE_DETAILS env-var gate for extended NVIDIA mock metrics

### DIFF
--- a/API.md
+++ b/API.md
@@ -153,6 +153,7 @@ Extended NVIDIA hardware detail metrics (NUMA topology, GSP firmware, NvLink top
 - `all_smi_gpu_gsp_firmware_version_info`: the `version` label carries a string such as `"550.54.15"`. Because the version is static for the lifetime of the driver, it is cached after the first successful NVML call.
 - `all_smi_nvlink_remote_device_type`: one metric row is emitted per active NvLink. A GPU with no active links produces no rows for this metric family.
 - `all_smi_gpu_sm_occupancy` and `all_smi_gpu_memory_bandwidth_utilization`: GPM requires a two-sample handshake before values are available. Until the handshake completes the exporter holds `None` for both fields and emits nothing, preventing spurious zero readings. These metrics are currently plumbing only — values are populated on Hopper and later hardware when the GPM handshake succeeds.
+- To simulate the full set of extended hardware detail metrics (including the thermal thresholds and `performance_state` listed in the NVIDIA GPU Specific Metrics table above) in development/testing without a modern NVIDIA driver, set `ALL_SMI_MOCK_HARDWARE_DETAILS=1` when running with the `mock` feature. When unset, the mock omits these families to simulate an older driver that does not expose the underlying NVML APIs.
 
 ### NVIDIA vGPU Metrics
 
@@ -1022,3 +1023,8 @@ Higher update rates provide more real-time data but increase system load. For pr
     - TUI renders MIG instances as nested rows under each parent GPU, matched by UUID with hostname+GPU-name fallback
     - Completely silent on non-MIG hosts — no empty metric families are emitted
     - Set `ALL_SMI_MOCK_MIG=1` (with `--features mock` build) to simulate MIG data for development
+14. NVIDIA extended hardware detail metrics include:
+    - NUMA topology (`all_smi_gpu_numa_node_id`), GSP firmware mode/version, NvLink remote endpoint classification, and GPM SM occupancy / memory bandwidth utilization
+    - Thermal thresholds (`all_smi_gpu_temperature_threshold_{slowdown,shutdown,max_operating,acoustic}_celsius`) and the canonical `all_smi_gpu_performance_state` gauge
+    - Emitted only when the driver exposes the underlying NVML APIs; older drivers silently omit these metrics
+    - Set `ALL_SMI_MOCK_HARDWARE_DETAILS=1` (with `--features mock` build) to have the mock emit the full extended hardware-detail set; when unset, the mock simulates an older driver

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ http://gpu-node3:9090
   - Background metric updates with realistic variations
   - Set `ALL_SMI_MOCK_VGPU=1` to simulate NVIDIA vGPU SR-IOV data without real vGPU hardware
   - Set `ALL_SMI_MOCK_MIG=1` to simulate NVIDIA MIG (Multi-Instance GPU) data without MIG hardware
-  - NVIDIA hardware details (NUMA, GSP firmware, NvLink) are always included in mock responses
+  - Set `ALL_SMI_MOCK_HARDWARE_DETAILS=1` to include extended NVIDIA hardware detail metrics (NUMA node ID, GSP firmware mode/version, NvLink remote endpoint types, GPM SM occupancy/memory bandwidth utilization, thermal thresholds, P-state); omitted by default to simulate older drivers that do not expose these APIs
 - **Performance Optimized:**
   - Template-based response generation
   - Efficient memory management

--- a/src/mock/templates/nvidia.rs
+++ b/src/mock/templates/nvidia.rs
@@ -734,36 +734,88 @@ mod tests {
         }
     }
 
-    // Helper: set HARDWARE_DETAILS_ENV_VAR for the duration of a closure, then
-    // restore the prior value. Uses unsafe env mutation the same way the vGPU
-    // and MIG test helpers do.
-    fn with_hardware_details_enabled<F: FnOnce()>(f: F) {
-        let prior = std::env::var(HARDWARE_DETAILS_ENV_VAR).ok();
-        // SAFETY: this helper is called from single-threaded test functions
-        // that do not spawn additional threads. Env mutation is restored before
-        // returning, matching the pattern used by is_vgpu_enabled_reflects_env_var
-        // and is_mig_enabled_reflects_env_var in the sibling mock modules.
-        unsafe {
-            std::env::set_var(HARDWARE_DETAILS_ENV_VAR, "1");
+    // Process-global mutex that serialises every test in this module which
+    // reads or writes `HARDWARE_DETAILS_ENV_VAR`. `cargo test` runs tests in
+    // parallel threads inside a single process, and `std::env::set_var` /
+    // `remove_var` mutate shared process state — without this mutex, sibling
+    // tests race each other and observe arbitrary intermediate values. Unlike
+    // the sibling vgpu/mig modules (which have only a single env-mutating test
+    // each), this module has many, so a serialisation primitive is required.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard that acquires the module-wide env lock, snapshots the prior
+    /// `HARDWARE_DETAILS_ENV_VAR` value, and restores it on drop. The lock is
+    /// held for the entire lifetime of the guard so other env-mutating tests
+    /// cannot run concurrently. Poisoned locks are recovered from so a
+    /// previously panicking test does not block subsequent tests.
+    ///
+    /// Restoration on `Drop` is what gives the helper panic safety: if the
+    /// test body panics partway through, unwinding still runs `Drop` and the
+    /// env var is returned to its prior state before other tests run.
+    struct EnvVarGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prior: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        /// Acquire the lock and snapshot the current env value. Does not
+        /// mutate the env; call `set` / `remove` on the returned guard to
+        /// change it.
+        fn new() -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let prior = std::env::var(HARDWARE_DETAILS_ENV_VAR).ok();
+            Self { _lock: lock, prior }
         }
-        f();
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var(HARDWARE_DETAILS_ENV_VAR, v),
-                None => std::env::remove_var(HARDWARE_DETAILS_ENV_VAR),
+
+        fn set(&self, value: &str) {
+            // SAFETY: `_lock` serialises all env mutations in this module,
+            // so no other thread in the test binary mutates or reads
+            // HARDWARE_DETAILS_ENV_VAR while this guard is live.
+            unsafe {
+                std::env::set_var(HARDWARE_DETAILS_ENV_VAR, value);
             }
         }
+
+        fn remove(&self) {
+            // SAFETY: see `set`.
+            unsafe {
+                std::env::remove_var(HARDWARE_DETAILS_ENV_VAR);
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: `_lock` is still held for the duration of this method.
+            unsafe {
+                match &self.prior {
+                    Some(v) => std::env::set_var(HARDWARE_DETAILS_ENV_VAR, v),
+                    None => std::env::remove_var(HARDWARE_DETAILS_ENV_VAR),
+                }
+            }
+        }
+    }
+
+    // Helper: enable HARDWARE_DETAILS_ENV_VAR for the duration of a closure.
+    // The returned guard restores the prior value on drop, including when the
+    // closure panics, and holds the module-wide env lock so sibling tests
+    // cannot concurrently mutate or read the same variable.
+    fn with_hardware_details_enabled<F: FnOnce()>(f: F) {
+        let guard = EnvVarGuard::new();
+        guard.set("1");
+        f();
+        // `guard` dropped here restores the prior value under the lock.
     }
 
     // --- default (env var unset) behaviour ---
 
     #[test]
     fn mock_template_omits_hardware_details_by_default() {
-        // Ensure the env var is absent for this test.
-        let prior = std::env::var(HARDWARE_DETAILS_ENV_VAR).ok();
-        unsafe {
-            std::env::remove_var(HARDWARE_DETAILS_ENV_VAR);
-        }
+        // `EnvVarGuard` holds the module-wide env lock and restores the prior
+        // value on drop (including on panic), so sibling tests cannot set the
+        // env var while this test is asserting its default-off behaviour.
+        let guard = EnvVarGuard::new();
+        guard.remove();
 
         let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
         let gpus = make_gpu_metrics();
@@ -795,45 +847,27 @@ mod tests {
             tpl.contains("all_smi_gpu_utilization{"),
             "basic GPU metric absent"
         );
-
-        // Restore prior state.
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var(HARDWARE_DETAILS_ENV_VAR, v),
-                None => std::env::remove_var(HARDWARE_DETAILS_ENV_VAR),
-            }
-        }
+        // `guard` drops here and restores the prior env value under the lock.
     }
 
     // --- is_hardware_details_enabled reflects env var ---
 
     #[test]
     fn is_hardware_details_enabled_reflects_env_var() {
-        let prior = std::env::var(HARDWARE_DETAILS_ENV_VAR).ok();
-        // SAFETY: See with_hardware_details_enabled docstring.
-        unsafe {
-            std::env::remove_var(HARDWARE_DETAILS_ENV_VAR);
-        }
+        // EnvVarGuard serialises with sibling env-mutating tests and restores
+        // the prior value on drop (including on panic).
+        let guard = EnvVarGuard::new();
+        guard.remove();
         assert!(!is_hardware_details_enabled());
 
-        unsafe {
-            std::env::set_var(HARDWARE_DETAILS_ENV_VAR, "1");
-        }
+        guard.set("1");
         assert!(is_hardware_details_enabled());
 
         // Empty value treated as disabled.
-        unsafe {
-            std::env::set_var(HARDWARE_DETAILS_ENV_VAR, "");
-        }
+        guard.set("");
         assert!(!is_hardware_details_enabled());
 
-        // Restore prior state.
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var(HARDWARE_DETAILS_ENV_VAR, v),
-                None => std::env::remove_var(HARDWARE_DETAILS_ENV_VAR),
-            }
-        }
+        // `guard` drops here and restores the prior env value under the lock.
     }
 
     // --- extended-detail tests (require env var set) ---

--- a/src/mock/templates/nvidia.rs
+++ b/src/mock/templates/nvidia.rs
@@ -19,6 +19,28 @@ use all_smi::traits::mock_generator::{
     MockConfig, MockData, MockGenerator, MockPlatform, MockResult,
 };
 
+/// Environment variable that gates hardware-detail metric emission in NVIDIA
+/// mock responses.
+///
+/// When set to any non-empty value the mock will emit:
+/// * NUMA node id
+/// * GSP firmware mode and version
+/// * NvLink remote endpoint classification per active link
+/// * GPM SM occupancy and memory bandwidth utilization (Hopper+)
+/// * Thermal thresholds (slowdown, shutdown, max-operating, acoustic)
+/// * Canonical P-state gauge (`all_smi_gpu_performance_state`)
+///
+/// When unset (the default) only basic GPU metrics are emitted, simulating an
+/// older driver or a node where NVML does not expose these extended APIs.
+pub const HARDWARE_DETAILS_ENV_VAR: &str = "ALL_SMI_MOCK_HARDWARE_DETAILS";
+
+/// `true` when the hardware-detail mock mode is enabled via env var.
+pub fn is_hardware_details_enabled() -> bool {
+    std::env::var(HARDWARE_DETAILS_ENV_VAR)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
 /// NVIDIA GPU mock generator
 pub struct NvidiaMockGenerator {
     gpu_name: String,
@@ -45,21 +67,29 @@ impl NvidiaMockGenerator {
         // Basic GPU metrics
         self.add_gpu_metrics(&mut template, gpus);
 
-        // NVIDIA-specific: P-state metrics (legacy `all_smi_gpu_pstate` name
-        // kept for backwards compatibility with older scrapers; the new
-        // canonical name is emitted by `add_thermal_threshold_metrics`).
-        self.add_pstate_metrics(&mut template, gpus);
+        // NVIDIA-specific extended hardware detail metrics — gated by
+        // ALL_SMI_MOCK_HARDWARE_DETAILS so the default bare-metal mock
+        // simulates a minimal/older driver that does not expose these APIs.
+        //
+        // Gated together under one flag because they all originate from the
+        // same family of extended NVML calls (thermal thresholds, P-state,
+        // NUMA, GSP, NvLink, GPM) and a consumer either has access to all of
+        // them or none. Splitting into per-feature flags would add complexity
+        // without a clear use case.
+        if is_hardware_details_enabled() {
+            // Legacy `all_smi_gpu_pstate` gauge — kept for backwards
+            // compatibility with scrapers predating issue #130.
+            self.add_pstate_metrics(&mut template, gpus);
 
-        // NVIDIA-specific: Temperature thresholds + canonical P-state metric
-        // (issue #130). Emitted with synthetic but realistic numbers so local
-        // dev and `cargo test --features mock` see the feature populated.
-        self.add_thermal_threshold_metrics(&mut template, gpus);
+            // Temperature thresholds + canonical P-state metric (issue #130).
+            // Fixed synthetic values that match typical H100/A100 limits.
+            self.add_thermal_threshold_metrics(&mut template, gpus);
 
-        // NVIDIA-specific: Hardware details (issue #132). NUMA node id,
-        // GSP firmware mode + version, NvLink topology, plus GPM gauges.
-        // Synthetic but representative so the TUI, exporter, and remote
-        // parser round-trip paths all see the feature populated.
-        self.add_hardware_detail_metrics(&mut template, gpus);
+            // NUMA node id, GSP firmware mode + version, NvLink topology,
+            // GPM gauges (issue #132). Representative synthetic values so the
+            // TUI, exporter, and remote-parser round-trip paths all compile.
+            self.add_hardware_detail_metrics(&mut template, gpus);
+        }
 
         // NVIDIA-specific: Process metrics
         self.add_process_metrics(&mut template, gpus);
@@ -704,46 +734,160 @@ mod tests {
         }
     }
 
+    // Helper: set HARDWARE_DETAILS_ENV_VAR for the duration of a closure, then
+    // restore the prior value. Uses unsafe env mutation the same way the vGPU
+    // and MIG test helpers do.
+    fn with_hardware_details_enabled<F: FnOnce()>(f: F) {
+        let prior = std::env::var(HARDWARE_DETAILS_ENV_VAR).ok();
+        // SAFETY: this helper is called from single-threaded test functions
+        // that do not spawn additional threads. Env mutation is restored before
+        // returning, matching the pattern used by is_vgpu_enabled_reflects_env_var
+        // and is_mig_enabled_reflects_env_var in the sibling mock modules.
+        unsafe {
+            std::env::set_var(HARDWARE_DETAILS_ENV_VAR, "1");
+        }
+        f();
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(HARDWARE_DETAILS_ENV_VAR, v),
+                None => std::env::remove_var(HARDWARE_DETAILS_ENV_VAR),
+            }
+        }
+    }
+
+    // --- default (env var unset) behaviour ---
+
     #[test]
-    fn mock_template_includes_threshold_metrics() {
+    fn mock_template_omits_hardware_details_by_default() {
+        // Ensure the env var is absent for this test.
+        let prior = std::env::var(HARDWARE_DETAILS_ENV_VAR).ok();
+        unsafe {
+            std::env::remove_var(HARDWARE_DETAILS_ENV_VAR);
+        }
+
         let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
         let gpus = make_gpu_metrics();
         let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
 
+        // All extended-detail metrics must be absent in the minimal output.
+        for metric in &[
+            "all_smi_gpu_temperature_threshold_slowdown_celsius",
+            "all_smi_gpu_temperature_threshold_shutdown_celsius",
+            "all_smi_gpu_temperature_threshold_max_operating_celsius",
+            "all_smi_gpu_temperature_threshold_acoustic_celsius",
+            "all_smi_gpu_performance_state{",
+            "all_smi_gpu_pstate{",
+            "all_smi_gpu_numa_node_id{",
+            "all_smi_gpu_gsp_firmware_mode{",
+            "all_smi_gpu_gsp_firmware_version_info{",
+            "all_smi_nvlink_remote_device_type{",
+            "all_smi_gpu_sm_occupancy{",
+            "all_smi_gpu_memory_bandwidth_utilization{",
+        ] {
+            assert!(
+                !tpl.contains(metric),
+                "metric {metric:?} should be absent when ALL_SMI_MOCK_HARDWARE_DETAILS is unset, but was found in:\n{tpl}"
+            );
+        }
+
+        // Basic metrics must still be present.
         assert!(
-            tpl.contains("all_smi_gpu_temperature_threshold_slowdown_celsius"),
-            "mock template missing slowdown metric:\n{tpl}"
+            tpl.contains("all_smi_gpu_utilization{"),
+            "basic GPU metric absent"
         );
-        assert!(
-            tpl.contains("all_smi_gpu_temperature_threshold_shutdown_celsius"),
-            "mock template missing shutdown metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_gpu_temperature_threshold_max_operating_celsius"),
-            "mock template missing max_operating metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_gpu_temperature_threshold_acoustic_celsius"),
-            "mock template missing acoustic metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_gpu_performance_state{"),
-            "mock template missing canonical pstate metric:\n{tpl}"
-        );
+
+        // Restore prior state.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(HARDWARE_DETAILS_ENV_VAR, v),
+                None => std::env::remove_var(HARDWARE_DETAILS_ENV_VAR),
+            }
+        }
+    }
+
+    // --- is_hardware_details_enabled reflects env var ---
+
+    #[test]
+    fn is_hardware_details_enabled_reflects_env_var() {
+        let prior = std::env::var(HARDWARE_DETAILS_ENV_VAR).ok();
+        // SAFETY: See with_hardware_details_enabled docstring.
+        unsafe {
+            std::env::remove_var(HARDWARE_DETAILS_ENV_VAR);
+        }
+        assert!(!is_hardware_details_enabled());
+
+        unsafe {
+            std::env::set_var(HARDWARE_DETAILS_ENV_VAR, "1");
+        }
+        assert!(is_hardware_details_enabled());
+
+        // Empty value treated as disabled.
+        unsafe {
+            std::env::set_var(HARDWARE_DETAILS_ENV_VAR, "");
+        }
+        assert!(!is_hardware_details_enabled());
+
+        // Restore prior state.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(HARDWARE_DETAILS_ENV_VAR, v),
+                None => std::env::remove_var(HARDWARE_DETAILS_ENV_VAR),
+            }
+        }
+    }
+
+    // --- extended-detail tests (require env var set) ---
+
+    #[test]
+    fn mock_template_includes_threshold_metrics() {
+        with_hardware_details_enabled(|| {
+            let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+            let gpus = make_gpu_metrics();
+            let tpl =
+                gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+
+            assert!(
+                tpl.contains("all_smi_gpu_temperature_threshold_slowdown_celsius"),
+                "mock template missing slowdown metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_temperature_threshold_shutdown_celsius"),
+                "mock template missing shutdown metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_temperature_threshold_max_operating_celsius"),
+                "mock template missing max_operating metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_temperature_threshold_acoustic_celsius"),
+                "mock template missing acoustic metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_performance_state{"),
+                "mock template missing canonical pstate metric:\n{tpl}"
+            );
+        });
     }
 
     #[test]
     fn mock_render_resolves_pstate_placeholders() {
-        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
-        let gpus = make_gpu_metrics();
-        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
-        let rendered =
-            gen_.render_nvidia_response(&tpl, &gpus, &make_cpu_metrics(), &make_memory_metrics());
-        // After rendering, no `{{PSTATE_...}}` placeholders should remain.
-        assert!(
-            !rendered.contains("{{PSTATE_"),
-            "unresolved PSTATE placeholder in rendered output"
-        );
+        with_hardware_details_enabled(|| {
+            let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+            let gpus = make_gpu_metrics();
+            let tpl =
+                gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+            let rendered = gen_.render_nvidia_response(
+                &tpl,
+                &gpus,
+                &make_cpu_metrics(),
+                &make_memory_metrics(),
+            );
+            // After rendering, no `{{PSTATE_...}}` placeholders should remain.
+            assert!(
+                !rendered.contains("{{PSTATE_"),
+                "unresolved PSTATE placeholder in rendered output"
+            );
+        });
     }
 
     // --- hardware-detail mock template tests (issue #132) ---
@@ -766,115 +910,130 @@ mod tests {
 
     #[test]
     fn mock_template_includes_all_hardware_detail_metrics() {
-        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
-        let gpus = make_gpu_metrics();
-        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+        with_hardware_details_enabled(|| {
+            let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+            let gpus = make_gpu_metrics();
+            let tpl =
+                gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
 
-        assert!(
-            tpl.contains("all_smi_gpu_numa_node_id{"),
-            "mock template missing NUMA metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_gpu_gsp_firmware_mode{"),
-            "mock template missing GSP firmware mode metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_gpu_gsp_firmware_version_info{"),
-            "mock template missing GSP firmware version info metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_nvlink_remote_device_type{"),
-            "mock template missing NvLink metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_gpu_sm_occupancy{"),
-            "mock template missing SM occupancy metric:\n{tpl}"
-        );
-        assert!(
-            tpl.contains("all_smi_gpu_memory_bandwidth_utilization{"),
-            "mock template missing memory bandwidth utilization metric:\n{tpl}"
-        );
+            assert!(
+                tpl.contains("all_smi_gpu_numa_node_id{"),
+                "mock template missing NUMA metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_gsp_firmware_mode{"),
+                "mock template missing GSP firmware mode metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_gsp_firmware_version_info{"),
+                "mock template missing GSP firmware version info metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_nvlink_remote_device_type{"),
+                "mock template missing NvLink metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_sm_occupancy{"),
+                "mock template missing SM occupancy metric:\n{tpl}"
+            );
+            assert!(
+                tpl.contains("all_smi_gpu_memory_bandwidth_utilization{"),
+                "mock template missing memory bandwidth utilization metric:\n{tpl}"
+            );
+        });
     }
 
     #[test]
     fn mock_template_emits_six_nvlinks_per_gpu() {
-        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
-        let gpus = make_multi_gpu_metrics(2);
-        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
-        let nvlink_lines: Vec<_> = tpl
-            .lines()
-            .filter(|l| l.starts_with("all_smi_nvlink_remote_device_type{"))
-            .collect();
-        // 2 GPUs * 6 links = 12 lines.
-        assert_eq!(
-            nvlink_lines.len(),
-            12,
-            "expected 12 NvLink rows (2 GPUs x 6 links):\n{}",
-            nvlink_lines.join("\n")
-        );
-        // 5 gpu + 1 switch per GPU = 10 gpu + 2 switch total.
-        let gpu_remote_count = nvlink_lines
-            .iter()
-            .filter(|l| l.contains(r#"remote_type="gpu""#))
-            .count();
-        let switch_remote_count = nvlink_lines
-            .iter()
-            .filter(|l| l.contains(r#"remote_type="switch""#))
-            .count();
-        assert_eq!(gpu_remote_count, 10);
-        assert_eq!(switch_remote_count, 2);
+        with_hardware_details_enabled(|| {
+            let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+            let gpus = make_multi_gpu_metrics(2);
+            let tpl =
+                gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+            let nvlink_lines: Vec<_> = tpl
+                .lines()
+                .filter(|l| l.starts_with("all_smi_nvlink_remote_device_type{"))
+                .collect();
+            // 2 GPUs * 6 links = 12 lines.
+            assert_eq!(
+                nvlink_lines.len(),
+                12,
+                "expected 12 NvLink rows (2 GPUs x 6 links):\n{}",
+                nvlink_lines.join("\n")
+            );
+            // 5 gpu + 1 switch per GPU = 10 gpu + 2 switch total.
+            let gpu_remote_count = nvlink_lines
+                .iter()
+                .filter(|l| l.contains(r#"remote_type="gpu""#))
+                .count();
+            let switch_remote_count = nvlink_lines
+                .iter()
+                .filter(|l| l.contains(r#"remote_type="switch""#))
+                .count();
+            assert_eq!(gpu_remote_count, 10);
+            assert_eq!(switch_remote_count, 2);
+        });
     }
 
     #[test]
     fn mock_template_numa_alternates_between_zero_and_one() {
-        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
-        let gpus = make_multi_gpu_metrics(4);
-        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
-        // Extract just the NUMA metric lines.
-        let numa_lines: Vec<_> = tpl
-            .lines()
-            .filter(|l| l.starts_with("all_smi_gpu_numa_node_id{"))
-            .collect();
-        assert_eq!(numa_lines.len(), 4);
-        // GPU 0 → 0, GPU 1 → 1, GPU 2 → 0, GPU 3 → 1.
-        for (i, line) in numa_lines.iter().enumerate() {
-            let expected = (i as u32) % 2;
-            assert!(
-                line.ends_with(&format!(" {expected}")),
-                "GPU {i} NUMA line expected to end with ' {expected}', got: {line}"
-            );
-        }
+        with_hardware_details_enabled(|| {
+            let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+            let gpus = make_multi_gpu_metrics(4);
+            let tpl =
+                gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+            // Extract just the NUMA metric lines.
+            let numa_lines: Vec<_> = tpl
+                .lines()
+                .filter(|l| l.starts_with("all_smi_gpu_numa_node_id{"))
+                .collect();
+            assert_eq!(numa_lines.len(), 4);
+            // GPU 0 → 0, GPU 1 → 1, GPU 2 → 0, GPU 3 → 1.
+            for (i, line) in numa_lines.iter().enumerate() {
+                let expected = (i as u32) % 2;
+                assert!(
+                    line.ends_with(&format!(" {expected}")),
+                    "GPU {i} NUMA line expected to end with ' {expected}', got: {line}"
+                );
+            }
+        });
     }
 
     #[test]
     fn mock_template_emits_gsp_firmware_version_label() {
-        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
-        let gpus = make_gpu_metrics();
-        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
-        assert!(
-            tpl.contains(r#"version="550.54.15""#),
-            "mock template missing GSP firmware version label:\n{tpl}"
-        );
+        with_hardware_details_enabled(|| {
+            let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+            let gpus = make_gpu_metrics();
+            let tpl =
+                gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+            assert!(
+                tpl.contains(r#"version="550.54.15""#),
+                "mock template missing GSP firmware version label:\n{tpl}"
+            );
+        });
     }
 
     #[test]
     fn mock_template_gpm_values_are_in_0_to_1_range() {
-        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
-        let gpus = make_gpu_metrics();
-        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
-        // Parse the SM occupancy line and sanity-check the value band.
-        let sm_line = tpl
-            .lines()
-            .find(|l| l.starts_with("all_smi_gpu_sm_occupancy{"))
-            .expect("SM occupancy line");
-        let value: f32 = sm_line
-            .rsplit(' ')
-            .next()
-            .and_then(|s| s.parse().ok())
-            .expect("SM occupancy value");
-        assert!(
-            (0.0..=1.0).contains(&value),
-            "SM occupancy out of range: {value}"
-        );
+        with_hardware_details_enabled(|| {
+            let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+            let gpus = make_gpu_metrics();
+            let tpl =
+                gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+            // Parse the SM occupancy line and sanity-check the value band.
+            let sm_line = tpl
+                .lines()
+                .find(|l| l.starts_with("all_smi_gpu_sm_occupancy{"))
+                .expect("SM occupancy line");
+            let value: f32 = sm_line
+                .rsplit(' ')
+                .next()
+                .and_then(|s| s.parse().ok())
+                .expect("SM occupancy value");
+            assert!(
+                (0.0..=1.0).contains(&value),
+                "SM occupancy out of range: {value}"
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary

Closes #178.

Add `ALL_SMI_MOCK_HARDWARE_DETAILS` environment variable to gate extended NVIDIA hardware detail metrics in the mock server, consistent with the existing `ALL_SMI_MOCK_VGPU` and `ALL_SMI_MOCK_MIG` patterns.

- When `ALL_SMI_MOCK_HARDWARE_DETAILS` is set to any non-empty value, the mock emits the full set of extended metrics: NUMA node ID, GSP firmware mode and version, NvLink remote endpoint classification, GPM SM occupancy and memory bandwidth utilization, thermal thresholds (slowdown, shutdown, max-operating, acoustic), legacy `all_smi_gpu_pstate`, and canonical `all_smi_gpu_performance_state`.
- When unset (the default), only basic GPU metrics are emitted, simulating an older NVIDIA driver that does not expose these extended NVML APIs.

## Thermal thresholds and P-state gating decision

Thermal thresholds and P-state are gated under the same `ALL_SMI_MOCK_HARDWARE_DETAILS` flag rather than a separate one. Rationale: these metrics all originate from the same family of extended NVML calls. In practice a host either has access to all of them (modern driver) or none of them (older driver without GSP/NvLink/thermal-threshold support). A separate per-feature flag would add API surface and flag-management complexity without a meaningful use case that requires mixed presence.

## Changes

- `src/mock/templates/nvidia.rs`: add `HARDWARE_DETAILS_ENV_VAR` constant and `is_hardware_details_enabled()` function; gate `add_pstate_metrics`, `add_thermal_threshold_metrics`, and `add_hardware_detail_metrics` behind the env var check in `build_nvidia_template`; add `with_hardware_details_enabled()` test helper; wrap existing hardware-detail tests inside the helper; add `mock_template_omits_hardware_details_by_default` and `is_hardware_details_enabled_reflects_env_var` tests.
- `README.md`: document `ALL_SMI_MOCK_HARDWARE_DETAILS` alongside `ALL_SMI_MOCK_VGPU` and `ALL_SMI_MOCK_MIG` in the mock server section.

## Test plan

- All existing tests pass with `ALL_SMI_MOCK_HARDWARE_DETAILS` unset (default CI environment).
- `mock_template_omits_hardware_details_by_default` verifies that none of the 12 extended metric families appear in the default output.
- `is_hardware_details_enabled_reflects_env_var` verifies the truthy/falsy/absent logic.
- All prior hardware-detail tests continue to pass when run with the env var set via `with_hardware_details_enabled()`.