### PR TITLE
refactor: extract shared truncate_str helper into renderers/utils.rs

### DIFF
--- a/src/ui/renderers/mig_renderer.rs
+++ b/src/ui/renderers/mig_renderer.rs
@@ -23,6 +23,7 @@ use std::io::Write;
 use crossterm::{queue, style::Color, style::Print};
 
 use crate::device::MigGpuInfo;
+use crate::ui::renderers::utils::truncate_str;
 use crate::ui::text::print_colored_text;
 
 /// Render a compact MIG sub-section beneath a physical GPU row.
@@ -117,17 +118,6 @@ pub fn print_mig_section<W: Write>(stdout: &mut W, host: &MigGpuInfo, _width: us
 
         queue!(stdout, Print("\r\n")).unwrap();
     }
-}
-
-/// Truncate a display string on char boundaries to the given max char count.
-/// Appends an ellipsis when truncation actually occurred.
-fn truncate_str(s: &str, max_chars: usize) -> String {
-    if s.chars().count() <= max_chars {
-        return s.to_string();
-    }
-    let mut out: String = s.chars().take(max_chars.saturating_sub(1)).collect();
-    out.push('…');
-    out
 }
 
 #[cfg(test)]
@@ -311,18 +301,5 @@ mod tests {
             !plain.contains("[2]"),
             "must not print the enumeration index `[2]` when instance_id is sparse:\n{plain}"
         );
-    }
-
-    #[test]
-    fn truncate_str_preserves_short_strings() {
-        assert_eq!(truncate_str("abc", 10), "abc");
-        assert_eq!(truncate_str("abcdefghij", 10), "abcdefghij");
-    }
-
-    #[test]
-    fn truncate_str_trims_and_appends_ellipsis() {
-        let out = truncate_str("abcdefghij", 5);
-        assert_eq!(out.chars().count(), 5);
-        assert!(out.ends_with('…'));
     }
 }

--- a/src/ui/renderers/mod.rs
+++ b/src/ui/renderers/mod.rs
@@ -18,6 +18,7 @@ pub mod gpu_renderer;
 pub mod memory_renderer;
 pub mod mig_renderer;
 pub mod storage_renderer;
+pub(crate) mod utils;
 pub mod vgpu_renderer;
 pub mod widgets;
 

--- a/src/ui/renderers/utils.rs
+++ b/src/ui/renderers/utils.rs
@@ -1,0 +1,123 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared rendering utilities used across multiple renderer modules.
+
+/// Truncate a display string on char boundaries to the given max char count.
+/// Appends a single ellipsis character (`…`, U+2026) when truncation occurred.
+///
+/// Truncation is based on Unicode scalar values (`char`) rather than bytes.
+/// This means multi-byte sequences such as CJK ideographs, emoji, or accented
+/// characters each count as one "character" regardless of their byte length.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(truncate_str("hello", 10), "hello");
+/// assert_eq!(truncate_str("hello", 5), "hello");
+/// assert_eq!(truncate_str("hello world", 5), "hell…");
+/// ```
+pub(crate) fn truncate_str(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_stays_empty() {
+        assert_eq!(truncate_str("", 0), "");
+        assert_eq!(truncate_str("", 5), "");
+    }
+
+    #[test]
+    fn string_shorter_than_cap_is_unchanged() {
+        assert_eq!(truncate_str("abc", 10), "abc");
+        assert_eq!(truncate_str("abc", 4), "abc");
+    }
+
+    #[test]
+    fn string_equal_to_cap_is_unchanged() {
+        assert_eq!(truncate_str("abcde", 5), "abcde");
+        assert_eq!(truncate_str("abcdefghij", 10), "abcdefghij");
+    }
+
+    #[test]
+    fn string_longer_than_cap_is_truncated_with_ellipsis() {
+        let out = truncate_str("abcdefghij", 5);
+        // Total char count must equal max_chars.
+        assert_eq!(out.chars().count(), 5);
+        // Last character must be the ellipsis.
+        assert!(out.ends_with('…'), "expected ellipsis, got: {out:?}");
+        // Prefix must be first (max_chars - 1) chars of the original.
+        assert!(out.starts_with("abcd"), "unexpected prefix: {out:?}");
+    }
+
+    #[test]
+    fn truncation_at_cap_one_keeps_only_ellipsis() {
+        let out = truncate_str("hello", 1);
+        assert_eq!(out, "…");
+    }
+
+    #[test]
+    fn multibyte_cjk_characters_counted_by_char_not_byte() {
+        // Each CJK character is 3 bytes in UTF-8, but should count as 1 char.
+        let input = "你好世界ABC"; // 4 CJK + 3 ASCII = 7 chars, 15 bytes
+        assert_eq!(input.chars().count(), 7);
+
+        // No truncation: 7 chars fits in cap 7.
+        assert_eq!(truncate_str(input, 7), input);
+        assert_eq!(truncate_str(input, 10), input);
+
+        // Truncated to 4 chars: "你好世…"
+        let out = truncate_str(input, 4);
+        assert_eq!(out.chars().count(), 4);
+        assert!(out.ends_with('…'), "expected ellipsis, got: {out:?}");
+        assert!(out.starts_with("你好世"), "unexpected prefix: {out:?}");
+    }
+
+    #[test]
+    fn multibyte_emoji_counted_by_scalar_value() {
+        // Emoji are multi-byte but each counts as one char (scalar value).
+        // Note: grapheme clusters (e.g. family emoji with ZWJ) would differ,
+        // but this function intentionally uses scalar-value counting.
+        let input = "🦀🎉🚀AB"; // 3 emoji + 2 ASCII = 5 chars
+        assert_eq!(input.chars().count(), 5);
+
+        assert_eq!(truncate_str(input, 5), input);
+
+        let out = truncate_str(input, 4);
+        assert_eq!(out.chars().count(), 4);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn max_chars_zero_returns_empty() {
+        // saturating_sub(1) on 0 yields 0, so take(0) collects nothing,
+        // then we push '…'. Result: a single ellipsis if max_chars==0
+        // only when the string has content; an empty string stays empty.
+        assert_eq!(truncate_str("", 0), "");
+        // A non-empty string with max_chars=0: "…"
+        let out = truncate_str("x", 0);
+        // chars().count() == 1 > 0, so we enter the truncation path.
+        // take(0.saturating_sub(1) = 0) → empty, then push '…'.
+        assert_eq!(out, "…");
+    }
+}

--- a/src/ui/renderers/vgpu_renderer.rs
+++ b/src/ui/renderers/vgpu_renderer.rs
@@ -23,6 +23,7 @@ use std::io::Write;
 use crossterm::{queue, style::Color, style::Print};
 
 use crate::device::VgpuHostInfo;
+use crate::ui::renderers::utils::truncate_str;
 use crate::ui::text::print_colored_text;
 
 /// Render a compact vGPU sub-section beneath a physical GPU row.
@@ -141,17 +142,6 @@ fn arr_label(arr_mode: u32) -> &'static str {
         2 => "on",
         _ => "?",
     }
-}
-
-/// Truncate a display string on char boundaries to the given max char count.
-/// Appends an ellipsis when truncation actually occurred.
-fn truncate_str(s: &str, max_chars: usize) -> String {
-    if s.chars().count() <= max_chars {
-        return s.to_string();
-    }
-    let mut out: String = s.chars().take(max_chars.saturating_sub(1)).collect();
-    out.push('…');
-    out
 }
 
 #[cfg(test)]
@@ -273,18 +263,5 @@ mod tests {
         assert_eq!(arr_label(1), "off");
         assert_eq!(arr_label(2), "on");
         assert_eq!(arr_label(99), "?");
-    }
-
-    #[test]
-    fn truncate_str_preserves_short_strings() {
-        assert_eq!(truncate_str("abc", 10), "abc");
-        assert_eq!(truncate_str("abcdefghij", 10), "abcdefghij");
-    }
-
-    #[test]
-    fn truncate_str_trims_and_appends_ellipsis() {
-        let out = truncate_str("abcdefghij", 5);
-        assert_eq!(out.chars().count(), 5);
-        assert!(out.ends_with('…'));
     }
 }


### PR DESCRIPTION
## Summary

- The private `truncate_str` function existed as byte-identical copies in both `vgpu_renderer.rs` and `mig_renderer.rs`
- Extracted the shared function into a new `src/ui/renderers/utils.rs` module (`pub(crate)` visibility)
- Declared the module in `src/ui/renderers/mod.rs` as `pub(crate) mod utils`
- Updated both `vgpu_renderer.rs` and `mig_renderer.rs` to import and use `crate::ui::renderers::utils::truncate_str`
- Removed the old private copies and their local test duplicates from each renderer file

## Implementation notes

- Target location chosen: `src/ui/renderers/utils.rs` (new dedicated file). `mod.rs` only contained module declarations and re-exports, not shared helpers, so a separate `utils.rs` is the cleaner choice.
- The implementation is preserved exactly as-is: char-based counting via `chars().count()` and `chars().take()`, not byte-based — no behavioral change.
- No UTF-8 safety bugs were found. The existing implementation correctly uses char boundaries throughout.

## Tests added

The new `utils.rs` module includes 8 unit tests covering:
- Empty string with cap 0 and cap > 0
- String shorter than cap (unchanged)
- String equal to cap (unchanged)
- String longer than cap (truncated with ellipsis, total char count == max_chars)
- `max_chars = 1` (only ellipsis returned)
- Multibyte CJK characters (3 bytes each, counted as 1 char each)
- Multibyte emoji (4 bytes each, counted as 1 char each)
- `max_chars = 0` edge case (empty input stays empty; non-empty input yields `"…"`)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (499 unit tests + 547 integration tests — all green)
- [x] `cargo clippy -- -D warnings` produces no warnings
- [x] Pre-commit formatting hook (`cargo fmt`) applied and committed

Closes #179