### PR TITLE
refactor: standardize TUI sub-item indentation across all GPU renderers

### DIFF
--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -418,7 +418,7 @@ pub fn print_gpu_info<W: Write>(
     // Optional tertiary row: extended hardware details (issue #132).
     //
     // Rendered when NUMA placement, GSP firmware, or NvLink topology is
-    // reported. Keeps the same 5-column indent as the thermal row above.
+    // reported. Uses the shared SUB_ITEM_INDENT like the thermal row above.
     render_hardware_details_row(stdout, info);
 
     // Calculate gauge widths with 5 char padding on each side and 2 space separation
@@ -976,7 +976,7 @@ mod tests {
         // The row must contain "P-State:" and "P3".
         assert!(plain.contains("P-State:"), "missing P-State: in {plain:?}");
         assert!(plain.contains("P3"), "missing P3 in {plain:?}");
-        // After the fixed 5-char indent the next printable character must
+        // After the shared SUB_ITEM_INDENT the next printable character must
         // not be another space — that would indicate a double leading space.
         let after_indent = plain.trim_start_matches(' ');
         assert!(

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -21,6 +21,7 @@ use crate::device::GpuInfo;
 use crate::device::MigGpuInfo;
 use crate::device::VgpuHostInfo;
 use crate::device::types::{NvLinkRemoteType, ThermalProximity, ThermalProximityConfig};
+use crate::ui::renderers::utils::SUB_ITEM_INDENT;
 use crate::ui::text::print_colored_text;
 use crate::ui::widgets::draw_bar;
 
@@ -514,8 +515,8 @@ fn render_thermal_pstate_row<W: Write>(stdout: &mut W, info: &GpuInfo) {
         return;
     }
 
-    // 5-char indent aligns with the gauge row below.
-    print_colored_text(stdout, "     ", Color::White, None, None);
+    // Indent aligns with the gauge row below.
+    print_colored_text(stdout, SUB_ITEM_INDENT, Color::White, None, None);
 
     let proximity = info.thermal_proximity(ThermalProximityConfig::default());
     let warn_color = match proximity {
@@ -629,8 +630,8 @@ fn render_hardware_details_row<W: Write>(stdout: &mut W, info: &GpuInfo) {
         return;
     }
 
-    // 5-char indent aligns with the other secondary rows.
-    print_colored_text(stdout, "     ", Color::White, None, None);
+    // Indent aligns with the other secondary rows.
+    print_colored_text(stdout, SUB_ITEM_INDENT, Color::White, None, None);
     print_colored_text(stdout, "HW", Color::DarkMagenta, None, None);
 
     if let Some(numa) = info.numa_node_id {
@@ -941,9 +942,9 @@ mod tests {
     #[test]
     fn render_pstate_only_has_no_double_leading_space() {
         // When only performance_state is populated the row must not start
-        // with two consecutive spaces. The indent ("     ") is always
-        // emitted, but no extra separator space should precede the first
-        // field on the row.
+        // with two consecutive spaces. SUB_ITEM_INDENT is always emitted,
+        // but no extra separator space should precede the first field on
+        // the row.
         let mut gpu = make_gpu(50);
         gpu.temperature_threshold_slowdown = None;
         gpu.temperature_threshold_shutdown = None;

--- a/src/ui/renderers/mig_renderer.rs
+++ b/src/ui/renderers/mig_renderer.rs
@@ -23,7 +23,7 @@ use std::io::Write;
 use crossterm::{queue, style::Color, style::Print};
 
 use crate::device::MigGpuInfo;
-use crate::ui::renderers::utils::truncate_str;
+use crate::ui::renderers::utils::{SECTION_HEADER_INDENT, SUB_ITEM_INDENT, truncate_str};
 use crate::ui::text::print_colored_text;
 
 /// Render a compact MIG sub-section beneath a physical GPU row.
@@ -42,7 +42,8 @@ pub fn print_mig_section<W: Write>(stdout: &mut W, host: &MigGpuInfo, _width: us
         return;
     }
 
-    print_colored_text(stdout, "  MIG host: ", Color::DarkGrey, None, None);
+    print_colored_text(stdout, SECTION_HEADER_INDENT, Color::DarkGrey, None, None);
+    print_colored_text(stdout, "MIG host: ", Color::DarkGrey, None, None);
     if host.mig_mode {
         print_colored_text(stdout, "enabled", Color::Green, None, None);
     } else {
@@ -61,7 +62,8 @@ pub fn print_mig_section<W: Write>(stdout: &mut W, host: &MigGpuInfo, _width: us
     queue!(stdout, Print("\r\n")).unwrap();
 
     for inst in host.instances.iter() {
-        print_colored_text(stdout, "      [", Color::DarkGrey, None, None);
+        print_colored_text(stdout, SUB_ITEM_INDENT, Color::DarkGrey, None, None);
+        print_colored_text(stdout, "[", Color::DarkGrey, None, None);
         // Show NVML's `instance_id` (the slot NVML enumerated the instance
         // at), not the vec index. These diverge whenever the instances are
         // sparse — e.g. slots 0, 1, 4 present but 2 and 3 unprovisioned —

--- a/src/ui/renderers/utils.rs
+++ b/src/ui/renderers/utils.rs
@@ -14,6 +14,22 @@
 
 //! Shared rendering utilities used across multiple renderer modules.
 
+/// Indentation applied to per-instance rows nested under a GPU line (vGPU
+/// instances, MIG instances, and the thermal/P-state / hardware-details
+/// secondary rows in the GPU renderer).
+///
+/// Six spaces were chosen because two of the three affected renderers
+/// (vGPU and MIG) already used that width, and it provides a visually
+/// clear nesting depth beneath the parent GPU row.
+pub(crate) const SUB_ITEM_INDENT: &str = "      ";
+
+/// Indentation applied to section-header lines (e.g. "vGPU host:" and
+/// "MIG host:") that introduce a nested block beneath a parent GPU row.
+///
+/// Two spaces keep the header tight to the left edge while still
+/// signalling that it belongs to the GPU row above it.
+pub(crate) const SECTION_HEADER_INDENT: &str = "  ";
+
 /// Truncate a display string on char boundaries to the given max char count.
 /// Appends a single ellipsis character (`…`, U+2026) when truncation occurred.
 ///

--- a/src/ui/renderers/vgpu_renderer.rs
+++ b/src/ui/renderers/vgpu_renderer.rs
@@ -23,7 +23,7 @@ use std::io::Write;
 use crossterm::{queue, style::Color, style::Print};
 
 use crate::device::VgpuHostInfo;
-use crate::ui::renderers::utils::truncate_str;
+use crate::ui::renderers::utils::{SECTION_HEADER_INDENT, SUB_ITEM_INDENT, truncate_str};
 use crate::ui::text::print_colored_text;
 
 /// Render a compact vGPU sub-section beneath a physical GPU row.
@@ -42,8 +42,9 @@ pub fn print_vgpu_section<W: Write>(stdout: &mut W, host: &VgpuHostInfo, _width:
         return;
     }
 
-    // Indent the entire section to visually nest under the parent GPU line.
-    print_colored_text(stdout, "  vGPU host: ", Color::DarkGrey, None, None);
+    // Indent the section header to visually nest under the parent GPU line.
+    print_colored_text(stdout, SECTION_HEADER_INDENT, Color::DarkGrey, None, None);
+    print_colored_text(stdout, "vGPU host: ", Color::DarkGrey, None, None);
     print_colored_text(stdout, &host.host_mode, Color::Cyan, None, None);
 
     print_colored_text(stdout, "  policy=", Color::DarkGrey, None, None);
@@ -82,7 +83,8 @@ pub fn print_vgpu_section<W: Write>(stdout: &mut W, host: &VgpuHostInfo, _width:
     queue!(stdout, Print("\r\n")).unwrap();
 
     for (i, vgpu) in host.vgpus.iter().enumerate() {
-        print_colored_text(stdout, "      [", Color::DarkGrey, None, None);
+        print_colored_text(stdout, SUB_ITEM_INDENT, Color::DarkGrey, None, None);
+        print_colored_text(stdout, "[", Color::DarkGrey, None, None);
         print_colored_text(stdout, &i.to_string(), Color::Cyan, None, None);
         print_colored_text(stdout, "] ", Color::DarkGrey, None, None);
 


### PR DESCRIPTION
Closes #180

## Summary

- Define two `pub(crate)` constants in `src/ui/renderers/utils.rs`:
  - `SUB_ITEM_INDENT = "      "` (6 spaces) — applied to per-instance rows nested under a GPU line
  - `SECTION_HEADER_INDENT = "  "` (2 spaces) — applied to section-header lines that introduce a nested block
- Apply the constants across the three affected renderers:
  - `gpu_renderer.rs`: `render_thermal_pstate_row` and `render_hardware_details_row` now use `SUB_ITEM_INDENT` (was 5 spaces, unified to 6)
  - `vgpu_renderer.rs`: header line uses `SECTION_HEADER_INDENT`, per-instance rows use `SUB_ITEM_INDENT`
  - `mig_renderer.rs`: same pattern as vgpu_renderer

## Indent value rationale

Six spaces were chosen for `SUB_ITEM_INDENT` because two of the three affected renderers (vGPU and MIG) already used that width. The GPU renderer's secondary rows were using 5 spaces; they are unified up to 6 for visual consistency. The 2-space `SECTION_HEADER_INDENT` matches what both vGPU and MIG renderers already used for their section-header lines — no change in appearance for those, just a named constant replacing the literal.

## Indent literals that did NOT map to these two categories

The following 5-space literals in `gpu_renderer.rs` were intentionally left as literals — they are gauge-bar left-padding (a layout concern, not a sub-item nesting indent) and are shared with the CPU, memory, storage, and chassis renderers which are out of scope for this issue:

- Line 441: `"     "` before the Util/Mem gauge bars
- `cpu_renderer.rs`, `memory_renderer.rs`, `storage_renderer.rs`, `chassis_renderer.rs`: all use 5-space left padding for gauge rows — these belong to a separate, future refactor of the gauge-padding constant

The 2-space literals in `gpu_renderer.rs` (lines 452, 465, 487) are gauge separators between bars, not section-header indents — left unchanged.

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` passes (499 unit + 547 integration tests, 0 failures)