### PR TITLE
feat(tui): topology view tab ('T') — NvLink/NUMA/PCIe graph and matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,46 @@ Mock clusters can exercise the tab without real hosts by setting
 rotation of users and commands through the `all_smi_process_*` metric
 families.
 
+### Topology View (`T`)
+
+Remote and replay `view` modes add a **Topology** tab that visualises the
+selected host's intra-node GPU interconnect: NvLink connections
+(GPU↔GPU, GPU↔NvSwitch), NUMA affinity, and PCIe lanes. Press `T` to
+jump to the tab (it sits right after `Users`); use `Tab`/`Shift-Tab` or
+the arrow keys to cycle between hosts while the Topology tab is active.
+
+Two render modes are available; press `M` to toggle between them:
+
+- **Graph mode** (default) — ASCII layout showing NUMA zones as boxes
+  with GPUs inside and NvLink / NvSwitch edges drawn between them.
+  NUMA boxes stack side-by-side on wide terminals and fall back to
+  vertical stacking on narrower ones.
+- **Matrix mode** — `nvidia-smi topo -m`-equivalent table with CPU
+  affinity and NUMA columns. Uses the same vocabulary: `X`=self,
+  `NVn`=NvLink Gen-n, `NSW`=NvSwitch, `PXB`=PCIe bridge, `NODE`=same
+  NUMA, `SYS`=across NUMA.
+
+**Graceful degradation.** The tab is designed to produce useful output
+on every platform:
+
+- Hosts without NvLink render only NUMA + PCIe groupings.
+- Non-NVIDIA hosts omit the `NVn`/`SYS` vocabulary and show NUMA groups
+  only.
+- Hosts without NUMA topology render a single synthetic `NUMA ?` box.
+- When the terminal is narrower than 100 columns the graph renderer
+  drops to matrix mode automatically so the content never overflows on
+  80-column sessions.
+
+**Bandwidth hints.** When the exporter provides a per-link bandwidth
+(`bandwidth_mb_s` label on `all_smi_nvlink_remote_device_type`), the
+matrix derives the NVn generation from it (e.g. 50 GB/s → `NV5`).
+Without the hint the renderer falls back to a generic `NV` label so no
+hallucinated generation reaches the operator.
+
+Mock clusters can exercise the tab by setting `ALL_SMI_MOCK_TOPOLOGY=1`.
+Every synthetic NVIDIA node then emits a DGX-like 8-GPU topology: two
+NUMA zones, full 7-link GPU-to-GPU mesh, and one switch link per GPU.
+
 ### Filtering & Alerts
 
 Press `/` in any tab to open the filter query bar and hide/dim GPUs that do not

--- a/README.md
+++ b/README.md
@@ -481,8 +481,10 @@ families.
 Remote and replay `view` modes add a **Topology** tab that visualises the
 selected host's intra-node GPU interconnect: NvLink connections
 (GPU↔GPU, GPU↔NvSwitch), NUMA affinity, and PCIe lanes. Press `T` to
-jump to the tab (it sits right after `Users`); use `Tab`/`Shift-Tab` or
-the arrow keys to cycle between hosts while the Topology tab is active.
+jump to the tab (it sits right after `Users`); use the arrow keys
+(`Left`/`Right`) to cycle between hosts while the Topology tab is active.
+The tab remembers the host you last selected so pressing `T` returns to
+the same node instead of snapping to the first one in the strip.
 
 Two render modes are available; press `M` to toggle between them:
 

--- a/src/api/metrics/hardware.rs
+++ b/src/api/metrics/hardware.rs
@@ -156,6 +156,11 @@ impl<'a> HardwareMetricExporter<'a> {
 
     fn export_nvlink_remote_device_type(&self, builder: &mut MetricBuilder, rows: &[Row<'a>]) {
         let mut emitted_any = false;
+        // Buffer for the optional `bandwidth_mb_s` label (issue #190). The
+        // string lives on the stack frame as an `Option<String>` per row/link
+        // because `labels` borrows a `&str`. Old exporters omit the label
+        // entirely so remote scrapers parsing pre-#190 output continue to
+        // deserialise cleanly (handled by `.unwrap_or(None)` in the parser).
         for row in rows {
             for link in &row.gpu.nvlink_remote_devices {
                 if !emitted_any {
@@ -164,22 +169,41 @@ impl<'a> HardwareMetricExporter<'a> {
                             "all_smi_nvlink_remote_device_type",
                             "NvLink remote endpoint classification per active link. Value is \
                              always 1; classification is carried in the `remote_type` label \
-                             (gpu / switch / ibmnpu / unknown).",
+                             (gpu / switch / ibmnpu / unknown). Optional `bandwidth_mb_s` label \
+                             carries the per-link bandwidth hint used by the topology tab's \
+                             NVn classifier (omitted when the driver does not report it).",
                         )
                         .type_("all_smi_nvlink_remote_device_type", "gauge");
                     emitted_any = true;
                 }
                 let link_idx_str = link.link_index.to_string();
+                let bandwidth_str = link.bandwidth_mb_s.map(|v| v.to_string());
                 let base = Self::base_labels(row);
-                let labels = [
-                    base[0],
-                    base[1],
-                    base[2],
-                    base[3],
-                    ("link_index", link_idx_str.as_str()),
-                    ("remote_type", link.remote_type.as_label()),
-                ];
-                builder.metric("all_smi_nvlink_remote_device_type", &labels, 1);
+                match bandwidth_str {
+                    Some(ref bw) => {
+                        let labels = [
+                            base[0],
+                            base[1],
+                            base[2],
+                            base[3],
+                            ("link_index", link_idx_str.as_str()),
+                            ("remote_type", link.remote_type.as_label()),
+                            ("bandwidth_mb_s", bw.as_str()),
+                        ];
+                        builder.metric("all_smi_nvlink_remote_device_type", &labels, 1);
+                    }
+                    None => {
+                        let labels = [
+                            base[0],
+                            base[1],
+                            base[2],
+                            base[3],
+                            ("link_index", link_idx_str.as_str()),
+                            ("remote_type", link.remote_type.as_label()),
+                        ];
+                        builder.metric("all_smi_nvlink_remote_device_type", &labels, 1);
+                    }
+                }
             }
         }
     }
@@ -301,10 +325,12 @@ mod tests {
                 NvLinkRemoteDevice {
                     link_index: 0,
                     remote_type: NvLinkRemoteType::Gpu,
+                    bandwidth_mb_s: Some(400_000),
                 },
                 NvLinkRemoteDevice {
                     link_index: 1,
                     remote_type: NvLinkRemoteType::Switch,
+                    bandwidth_mb_s: None,
                 },
             ],
             gpm_metrics: Some(GpmMetrics {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -22,6 +22,7 @@ use crate::ui::aggregation::user::{UserAggregationResult, UserSortKey};
 use crate::ui::alerts::{AlertTransition, Alerter};
 use crate::ui::filter_dsl::Expr as FilterExpr;
 use crate::ui::notification::NotificationManager;
+use crate::ui::topology::TopologyViewMode;
 use crate::utils::RuntimeEnvironment;
 use std::cmp::Ordering;
 use std::collections::{HashMap, VecDeque};
@@ -347,6 +348,9 @@ pub struct AppState {
     /// the version differs; sort/filter toggles re-use the cached
     /// vector so keypresses stay sub-millisecond on 100-node clusters.
     pub users_aggregation_cache: UsersAggregationCache,
+    /// Render mode selected by the Topology tab's `M` toggle (issue #190).
+    /// Defaults to [`TopologyViewMode::Graph`].
+    pub topology_view_mode: TopologyViewMode,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -459,6 +463,7 @@ impl AppState {
             remote_process_info: Vec::new(),
             users_tab_state: UsersTabState::default(),
             users_aggregation_cache: UsersAggregationCache::default(),
+            topology_view_mode: TopologyViewMode::default(),
         }
     }
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -351,6 +351,13 @@ pub struct AppState {
     /// Render mode selected by the Topology tab's `M` toggle (issue #190).
     /// Defaults to [`TopologyViewMode::Graph`].
     pub topology_view_mode: TopologyViewMode,
+    /// Name of the host tab that was last active when the operator either
+    /// jumped to the Topology tab (via `T`) or navigated to Topology using
+    /// the arrow keys. Used by the renderer so the Topology view tracks the
+    /// operator's selection instead of always falling through to the first
+    /// host. Cleared by the remote/replay tab updaters when the stashed
+    /// host is no longer present (e.g. disconnected).
+    pub topology_last_host_tab: Option<String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -464,6 +471,7 @@ impl AppState {
             users_tab_state: UsersTabState::default(),
             users_aggregation_cache: UsersAggregationCache::default(),
             topology_view_mode: TopologyViewMode::default(),
+            topology_last_host_tab: None,
         }
     }
 

--- a/src/device/readers/nvidia_hardware.rs
+++ b/src/device/readers/nvidia_hardware.rs
@@ -270,6 +270,11 @@ pub fn collect_nvlink_remote_devices(
         out.push(NvLinkRemoteDevice {
             link_index: link,
             remote_type,
+            // Per-link bandwidth is not collected yet; NVML exposes it
+            // only on a narrow subset of boards. `None` preserves the
+            // current behaviour and lets the topology classifier fall
+            // back to a generic `"NV"` label.
+            bandwidth_mb_s: None,
         });
     }
     out

--- a/src/device/types.rs
+++ b/src/device/types.rs
@@ -115,6 +115,17 @@ pub struct NvLinkRemoteDevice {
     pub link_index: u32,
     /// Classification of the node sitting on the other side of the link.
     pub remote_type: NvLinkRemoteType,
+    /// Optional per-link bandwidth hint in MB/s as reported by NVML
+    /// `nvmlDeviceGetNvLinkUtilizationCounter` / Gen-specific ceilings.
+    /// `None` when the driver does not expose a per-link speed — the
+    /// topology tab's NVn classifier falls back to a generic `"NV"`
+    /// label in that case rather than misreporting a generation.
+    ///
+    /// Serialised with `#[serde(default)]` so snapshots / exporters
+    /// produced before this field existed continue to deserialise
+    /// cleanly (backward-compatibility requirement from issue #190).
+    #[serde(default)]
+    pub bandwidth_mb_s: Option<u32>,
 }
 
 /// NvLink remote device classification as returned by

--- a/src/mock/templates/mod.rs
+++ b/src/mock/templates/mod.rs
@@ -26,6 +26,7 @@ pub mod nvidia;
 pub mod process;
 pub mod rebellions;
 pub mod tenstorrent;
+pub mod topology;
 pub mod vgpu;
 
 // Re-export commonly used items

--- a/src/mock/templates/nvidia.rs
+++ b/src/mock/templates/nvidia.rs
@@ -132,6 +132,19 @@ impl NvidiaMockGenerator {
             gpus,
         );
 
+        // Optional DGX-like topology — gated by
+        // `ALL_SMI_MOCK_TOPOLOGY` (issue #190). Emits NUMA + NvLink
+        // rows that drive the Topology tab. Kept separate from
+        // `ALL_SMI_MOCK_HARDWARE_DETAILS` so operators can enable
+        // topology without importing every extended NVML gauge the
+        // hardware-details flag turns on.
+        crate::mock::templates::topology::maybe_add_topology_template(
+            &mut template,
+            &self.gpu_name,
+            &self.instance_name,
+            gpus,
+        );
+
         template
     }
 

--- a/src/mock/templates/topology.rs
+++ b/src/mock/templates/topology.rs
@@ -1,0 +1,199 @@
+//! DGX-like topology mock template (issue #190).
+
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Topology mock template — synthesizes a DGX-style topology graph so
+//! the Topology tab can be exercised without real NVIDIA hardware.
+//!
+//! Gated by [`TOPOLOGY_ENV_VAR`] (`ALL_SMI_MOCK_TOPOLOGY=1`). When
+//! enabled, produces:
+//!
+//! * `numa_node_id`: GPUs 0–3 → NUMA 0, GPUs 4–7 → NUMA 1.
+//! * `nvlink_remote_device_type`: 7 GPU-to-GPU links per GPU (full mesh
+//!   inside the node) plus 1 GPU-to-switch link per GPU — 64 total
+//!   links across 8 GPUs, mirroring the DGX H100/H200 layout.
+//! * `bandwidth_mb_s`: 50 000 MB/s (≈50 GB/s) — NvLink 5 speed.
+//!
+//! Unlike the legacy `ALL_SMI_MOCK_HARDWARE_DETAILS` gate, this template
+//! targets exactly what the Topology tab needs so operators can enable
+//! it independently of the broader hardware-detail mock.
+
+use crate::mock::metrics::GpuMetrics;
+
+/// Environment variable that gates DGX-like topology mock emission.
+pub const TOPOLOGY_ENV_VAR: &str = "ALL_SMI_MOCK_TOPOLOGY";
+
+/// `true` when the topology mock is enabled via env var.
+pub fn is_topology_enabled() -> bool {
+    std::env::var(TOPOLOGY_ENV_VAR)
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+/// Number of links per GPU in the synthetic DGX topology: 7 direct GPU
+/// remotes (full mesh) + 1 switch remote = 8 links. NvSwitch overlay on
+/// top of the full mesh keeps the graph legend honest.
+pub const LINKS_PER_GPU: u32 = 8;
+
+/// Per-link bandwidth hint in MB/s used by the mock template. 50 000
+/// MB/s (≈50 GB/s) maps to the NvLink-5 tier in the edge classifier,
+/// which yields "NV5" labels in the graph and matrix.
+pub const LINK_BANDWIDTH_MB_S: u32 = 50_000;
+
+/// Append topology-specific metric rows to the template when the env
+/// var is set. No-op otherwise so the default mock output is unchanged.
+pub fn maybe_add_topology_template(
+    template: &mut String,
+    gpu_name: &str,
+    instance_name: &str,
+    gpus: &[GpuMetrics],
+) {
+    if !is_topology_enabled() {
+        return;
+    }
+    add_topology_template(template, gpu_name, instance_name, gpus);
+}
+
+/// Append the DGX-like topology rows unconditionally. Split out so
+/// tests can exercise the emission without racing on the shared
+/// `ALL_SMI_MOCK_TOPOLOGY` env var.
+pub fn add_topology_template(
+    template: &mut String,
+    gpu_name: &str,
+    instance_name: &str,
+    gpus: &[GpuMetrics],
+) {
+    if gpus.is_empty() {
+        return;
+    }
+
+    // --- NUMA node id: GPUs 0..mid go to NUMA 0, rest to NUMA 1. ---
+    // Two-NUMA split mirrors the typical DGX H100 layout; a single-NUMA
+    // layout tests the graceful-degradation path in the graph renderer.
+    template.push_str("# HELP all_smi_gpu_numa_node_id NUMA node the GPU is attached to\n");
+    template.push_str("# TYPE all_smi_gpu_numa_node_id gauge\n");
+    let mid = gpus.len() / 2;
+    for (i, gpu) in gpus.iter().enumerate() {
+        let numa = if i < mid { 0 } else { 1 };
+        let labels = format!(
+            "gpu=\"{gpu_name}\", instance=\"{instance_name}\", gpu_uuid=\"{}\", gpu_index=\"{i}\"",
+            gpu.uuid
+        );
+        template.push_str(&format!("all_smi_gpu_numa_node_id{{{labels}}} {numa}\n"));
+    }
+
+    // --- NvLink topology: 7 GPU + 1 switch link per GPU. ---
+    template.push_str(
+        "# HELP all_smi_nvlink_remote_device_type NvLink remote endpoint classification per \
+         active link. Value is always 1; classification is carried in the `remote_type` label \
+         (gpu / switch / ibmnpu / unknown). Optional `bandwidth_mb_s` label carries the \
+         per-link bandwidth hint used by the topology tab's NVn classifier.\n",
+    );
+    template.push_str("# TYPE all_smi_nvlink_remote_device_type gauge\n");
+
+    for (i, gpu) in gpus.iter().enumerate() {
+        for link in 0..LINKS_PER_GPU {
+            let remote_type = if link == LINKS_PER_GPU - 1 {
+                "switch"
+            } else {
+                "gpu"
+            };
+            let labels = format!(
+                "gpu=\"{gpu_name}\", instance=\"{instance_name}\", gpu_uuid=\"{}\", \
+                 gpu_index=\"{i}\", link_index=\"{link}\", remote_type=\"{remote_type}\", \
+                 bandwidth_mb_s=\"{LINK_BANDWIDTH_MB_S}\"",
+                gpu.uuid
+            );
+            template.push_str(&format!(
+                "all_smi_nvlink_remote_device_type{{{labels}}} 1\n"
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock::metrics::GpuMetrics;
+
+    fn mk_mock_gpus(count: usize) -> Vec<GpuMetrics> {
+        (0..count)
+            .map(|i| GpuMetrics {
+                uuid: format!("GPU-mock-{i}"),
+                utilization: 10.0,
+                memory_used_bytes: 1024 * 1024 * 1024,
+                memory_total_bytes: 80 * 1024 * 1024 * 1024,
+                temperature_celsius: 50,
+                power_consumption_watts: 300.0,
+                frequency_mhz: 1800,
+                ane_utilization_watts: 0.0,
+                thermal_pressure_level: None,
+            })
+            .collect()
+    }
+
+    // Env-var-driven tests are intentionally omitted because rust-test
+    // parallelism races on `std::env::set_var`. The gating behaviour
+    // is a one-line check (`is_topology_enabled`) and is exercised
+    // end-to-end by the mock server integration test.
+
+    #[test]
+    fn add_template_emits_numa_and_nvlink_rows() {
+        let mut out = String::new();
+        add_topology_template(&mut out, "NVIDIA H100", "mock-0", &mk_mock_gpus(8));
+        assert!(
+            out.contains("all_smi_gpu_numa_node_id"),
+            "missing NUMA metric: {out}",
+        );
+        // 8 GPUs * 8 links = 64 nvlink rows
+        let link_rows = out
+            .lines()
+            .filter(|l| l.starts_with("all_smi_nvlink_remote_device_type{"))
+            .count();
+        assert_eq!(link_rows, 64, "{out}");
+        assert!(out.contains("bandwidth_mb_s=\"50000\""), "{out}");
+        assert!(out.contains("remote_type=\"switch\""), "{out}");
+    }
+
+    #[test]
+    fn two_numa_split() {
+        let mut out = String::new();
+        add_topology_template(&mut out, "NVIDIA H100", "mock-0", &mk_mock_gpus(8));
+        let numa_lines: Vec<&str> = out
+            .lines()
+            .filter(|l| l.starts_with("all_smi_gpu_numa_node_id{"))
+            .collect();
+        let zeros = numa_lines.iter().filter(|l| l.ends_with(" 0")).count();
+        let ones = numa_lines.iter().filter(|l| l.ends_with(" 1")).count();
+        assert_eq!(zeros, 4, "expected 4 GPUs in NUMA 0: {out}");
+        assert_eq!(ones, 4, "expected 4 GPUs in NUMA 1: {out}");
+    }
+
+    #[test]
+    fn empty_gpu_list_is_no_op() {
+        let mut out = String::new();
+        add_topology_template(&mut out, "NVIDIA H100", "mock-0", &[]);
+        assert!(out.is_empty(), "{out}");
+    }
+
+    #[test]
+    fn every_row_carries_the_instance_label() {
+        let mut out = String::new();
+        add_topology_template(&mut out, "NVIDIA H100", "dgx-7", &mk_mock_gpus(2));
+        for line in out.lines().filter(|l| l.starts_with("all_smi_")) {
+            assert!(line.contains("instance=\"dgx-7\""), "{line}");
+        }
+    }
+}

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -603,10 +603,11 @@ impl MetricsParser {
                 }
             }
             "nvlink_remote_device_type" => {
-                // Info-style metric with `link_index` and `remote_type`
-                // labels. Enforce a defensive per-GPU cap so a malicious
-                // upstream cannot explode the `nvlink_remote_devices` vec
-                // by emitting thousands of distinct link indices.
+                // Info-style metric with `link_index`, `remote_type` and
+                // (issue #190) `bandwidth_mb_s` labels. Enforce a defensive
+                // per-GPU cap so a malicious upstream cannot explode the
+                // `nvlink_remote_devices` vec by emitting thousands of
+                // distinct link indices.
                 let Some(link_index) = labels.get("link_index").and_then(|s| s.parse::<u32>().ok())
                 else {
                     return;
@@ -618,6 +619,15 @@ impl MetricsParser {
                     .get("remote_type")
                     .map(|s| NvLinkRemoteType::from_label(s))
                     .unwrap_or_default();
+                // Optional bandwidth hint (issue #190). Absent from older
+                // exporters — `None` preserves backward compatibility with
+                // scrapes predating the topology tab. Reject obviously
+                // nonsensical upstream values so the TUI never classifies
+                // based on a malicious input.
+                let bandwidth_mb_s = labels
+                    .get("bandwidth_mb_s")
+                    .and_then(|s| s.parse::<u32>().ok())
+                    .filter(|&v| v > 0 && v <= MAX_NVLINK_BANDWIDTH_MB_S);
                 // Coalesce duplicate link_index emissions — most recent
                 // sample wins — so a scrape that contains the same link
                 // multiple times doesn't multiply the vector length.
@@ -627,10 +637,12 @@ impl MetricsParser {
                     .find(|l| l.link_index == link_index)
                 {
                     existing.remote_type = remote_type;
+                    existing.bandwidth_mb_s = bandwidth_mb_s;
                 } else if gpu_info.nvlink_remote_devices.len() < MAX_NVLINK_PER_GPU as usize {
                     gpu_info.nvlink_remote_devices.push(NvLinkRemoteDevice {
                         link_index,
                         remote_type,
+                        bandwidth_mb_s,
                     });
                 }
             }
@@ -1037,6 +1049,13 @@ const MAX_CPU_CORES: usize = 1024;
 /// hardware caps at 18 physical links; 32 leaves headroom for future
 /// generations while still rejecting absurd input.
 pub(crate) const MAX_NVLINK_PER_GPU: u32 = 32;
+
+/// Maximum per-link bandwidth in MB/s accepted from a remote scrape.
+/// NvLink 5 is ~900 GB/s per direction on H200/B200 boards (≈900 000
+/// MB/s); 2 000 000 (2 TB/s) leaves generous headroom for future
+/// generations while still rejecting obviously malicious input like
+/// `u32::MAX`.
+const MAX_NVLINK_BANDWIDTH_MB_S: u32 = 2_000_000;
 
 /// Maximum NUMA node id accepted from a remote scrape. No real system
 /// exposes more than a few hundred NUMA nodes; 4096 is paranoid.
@@ -2593,5 +2612,83 @@ all_smi_gpu_utilization{gpu="NVIDIA A100", instance="node-1", gpu_uuid="GPU-A", 
 "#;
         let parsed = parser.parse_metrics(text, host, &re);
         assert!(parsed.process_info.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #190: NvLink `bandwidth_mb_s` label round-trip + backward
+    // compatibility with old exporters that omit the label entirely.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn nvlink_backward_compat_without_bandwidth_label() {
+        // Old exporters (pre-#190) emit `nvlink_remote_device_type` with
+        // only `link_index` and `remote_type` labels. The parser must
+        // still populate the device list so remote dashboards are not
+        // broken by the upgrade.
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "legacy:9100";
+        let text = r#"
+all_smi_nvlink_remote_device_type{gpu="NVIDIA A100", instance="node-1", gpu_uuid="GPU-OLD", gpu_index="0", link_index="0", remote_type="gpu"} 1
+all_smi_nvlink_remote_device_type{gpu="NVIDIA A100", instance="node-1", gpu_uuid="GPU-OLD", gpu_index="0", link_index="1", remote_type="switch"} 1
+"#;
+        let parsed = parser.parse_metrics(text, host, &re);
+        assert_eq!(parsed.gpu_info.len(), 1);
+        let links = &parsed.gpu_info[0].nvlink_remote_devices;
+        assert_eq!(links.len(), 2);
+        // Bandwidth is None on every link since the label is absent.
+        assert!(links.iter().all(|l| l.bandwidth_mb_s.is_none()));
+    }
+
+    #[test]
+    fn nvlink_captures_bandwidth_when_present() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "h100:9100";
+        let text = r#"
+all_smi_nvlink_remote_device_type{gpu="NVIDIA H100", instance="node-1", gpu_uuid="GPU-NEW", gpu_index="0", link_index="0", remote_type="gpu", bandwidth_mb_s="50000"} 1
+"#;
+        let parsed = parser.parse_metrics(text, host, &re);
+        let links = &parsed.gpu_info[0].nvlink_remote_devices;
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].bandwidth_mb_s, Some(50_000));
+    }
+
+    #[test]
+    fn nvlink_rejects_absurd_bandwidth_values() {
+        // A malicious upstream could emit `bandwidth_mb_s="4294967295"`.
+        // The parser clamps to MAX_NVLINK_BANDWIDTH_MB_S so the topology
+        // renderer never classifies against nonsense input.
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "attacker:9100";
+        let text = r#"
+all_smi_nvlink_remote_device_type{gpu="NVIDIA H100", instance="node-1", gpu_uuid="GPU-X", gpu_index="0", link_index="0", remote_type="gpu", bandwidth_mb_s="4294967295"} 1
+"#;
+        let parsed = parser.parse_metrics(text, host, &re);
+        let links = &parsed.gpu_info[0].nvlink_remote_devices;
+        assert_eq!(links.len(), 1);
+        assert_eq!(
+            links[0].bandwidth_mb_s, None,
+            "absurd bandwidth must be filtered"
+        );
+    }
+
+    #[test]
+    fn nvlink_coalesces_duplicate_link_indices() {
+        // A scrape that contains the same link index twice (e.g. a
+        // racey refresh) must produce a single entry whose bandwidth
+        // reflects the most-recent sample.
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "race:9100";
+        let text = r#"
+all_smi_nvlink_remote_device_type{gpu="NVIDIA H100", instance="node-1", gpu_uuid="GPU-A", gpu_index="0", link_index="0", remote_type="gpu", bandwidth_mb_s="25000"} 1
+all_smi_nvlink_remote_device_type{gpu="NVIDIA H100", instance="node-1", gpu_uuid="GPU-A", gpu_index="0", link_index="0", remote_type="gpu", bandwidth_mb_s="50000"} 1
+"#;
+        let parsed = parser.parse_metrics(text, host, &re);
+        let links = &parsed.gpu_info[0].nvlink_remote_devices;
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].bandwidth_mb_s, Some(50_000));
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -187,6 +187,7 @@ fn render_shortcuts_section(
         ),
         ("  A", "Toggle alert history panel", "shortcut"),
         ("  V", "Jump to cluster-wide Users tab (remote)", "shortcut"),
+        ("  T", "Jump to Topology tab (remote/replay)", "shortcut"),
         ("  Q", "Exit application", "shortcut"),
         ("  ESC", "Close help / clear filter / exit", "shortcut"),
         ("", "", ""),
@@ -223,6 +224,18 @@ fn render_shortcuts_section(
             ),
             ("  f", "Toggle system-account filter (uid<1000)", "shortcut"),
             ("  e", "Export visible table to CSV", "shortcut"),
+        ]);
+
+        // Topology tab keybindings (issue #190).  Only visible when the
+        // tab is available in the tab strip, i.e. remote / replay mode.
+        left_column.extend(vec![
+            ("", "", ""),
+            ("Topology tab (T):", "", "header"),
+            (
+                "  M",
+                "Toggle between graph and matrix render modes",
+                "shortcut",
+            ),
         ]);
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -33,4 +33,5 @@ pub mod renderer;
 pub mod renderers;
 pub mod tabs;
 pub mod text;
+pub mod topology;
 pub mod widgets;

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -1339,26 +1339,32 @@ mod tests {
             NvLinkRemoteDevice {
                 link_index: 0,
                 remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 1,
                 remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 2,
                 remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 3,
                 remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 4,
                 remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 5,
                 remote_type: NvLinkRemoteType::Switch,
+                bandwidth_mb_s: None,
             },
         ];
         let mut buf: Vec<u8> = Vec::new();
@@ -1439,18 +1445,22 @@ mod tests {
             NvLinkRemoteDevice {
                 link_index: 0,
                 remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 1,
                 remote_type: NvLinkRemoteType::Switch,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 2,
                 remote_type: NvLinkRemoteType::IbmNpu,
+                bandwidth_mb_s: None,
             },
             NvLinkRemoteDevice {
                 link_index: 3,
                 remote_type: NvLinkRemoteType::Unknown,
+                bandwidth_mb_s: None,
             },
         ];
         assert_eq!(count_nvlink_remote_types(&links), (1, 1, 1, 1));

--- a/src/ui/renderers/mod.rs
+++ b/src/ui/renderers/mod.rs
@@ -19,6 +19,7 @@ pub mod gpu_renderer;
 pub mod memory_renderer;
 pub mod mig_renderer;
 pub mod storage_renderer;
+pub mod topology_renderer;
 pub mod user_renderer;
 pub(crate) mod utils;
 pub mod vgpu_renderer;

--- a/src/ui/renderers/topology_renderer.rs
+++ b/src/ui/renderers/topology_renderer.rs
@@ -1,0 +1,251 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Topology tab renderer (issue #190).
+//!
+//! Orchestrates the topology view for a single host:
+//! 1. Pull the GPUs for the target host out of the render snapshot.
+//! 2. Build a [`TopologyModel`].
+//! 3. Pick graph vs. matrix based on the in-tab mode **and** the
+//!    available terminal width.
+//! 4. Write the rendered block to the caller's `BufferWriter`.
+//!
+//! Keeps the business logic thin so the heavy rendering lives in
+//! [`crate::ui::topology::graph_render`] and
+//! [`crate::ui::topology::matrix_render`].
+
+use std::io::Write;
+
+use crossterm::{queue, style::Color, style::Print};
+
+use crate::device::GpuInfo;
+use crate::ui::buffer::BufferWriter;
+use crate::ui::text::print_colored_text;
+use crate::ui::topology::{
+    GRAPH_MIN_WIDTH, TopologyModel, TopologyViewMode, graph_render, matrix_render,
+};
+
+/// Entry point invoked by the frame renderer when the Topology tab is
+/// active for the currently-selected host.
+///
+/// * `host_id` — the host selected in the tab strip (local hostname or
+///   remote host_id). Used to filter the GPU slice and label the header.
+/// * `mode` — the in-tab graph/matrix mode the operator has toggled.
+/// * `cols`/`rows` — current terminal dimensions.
+pub fn render_topology_tab(
+    buffer: &mut BufferWriter,
+    gpu_info: &[GpuInfo],
+    host_id: &str,
+    mode: TopologyViewMode,
+    cols: u16,
+    _rows: u16,
+) {
+    let host_gpus = filter_host_gpus(gpu_info, host_id);
+    let model = TopologyModel::from_host(host_id, &host_gpus);
+
+    render_header(buffer, &model, mode, cols);
+
+    // Width-adaptive fallback: even in graph mode, drop to matrix on
+    // narrow terminals so the content never overflows 80 columns.
+    let effective_mode = if mode == TopologyViewMode::Graph && cols < GRAPH_MIN_WIDTH {
+        TopologyViewMode::Matrix
+    } else {
+        mode
+    };
+
+    let dropped_to_matrix =
+        mode == TopologyViewMode::Graph && effective_mode == TopologyViewMode::Matrix;
+
+    match effective_mode {
+        TopologyViewMode::Graph => {
+            let rendered = graph_render::render_graph(&model, cols);
+            write_plain(buffer, &rendered);
+        }
+        TopologyViewMode::Matrix => {
+            if dropped_to_matrix {
+                // Dropped from graph — surface a hint above the matrix
+                // so the operator knows why they're seeing it.
+                print_colored_text(
+                    buffer,
+                    "  (terminal narrower than 100 columns — showing matrix fallback)",
+                    Color::DarkGrey,
+                    None,
+                    None,
+                );
+                queue!(buffer, Print("\r\n")).unwrap();
+            }
+            let rendered = matrix_render::render_matrix(&model, cols);
+            write_plain(buffer, &rendered);
+        }
+    }
+}
+
+/// Collect the GPUs that belong to the currently-selected host. In local
+/// mode this is every GPU (host filtering is a no-op); in remote mode we
+/// filter on `host_id`.
+fn filter_host_gpus(gpu_info: &[GpuInfo], host_id: &str) -> Vec<GpuInfo> {
+    if host_id.is_empty() || host_id == "All" {
+        return gpu_info.to_vec();
+    }
+    gpu_info
+        .iter()
+        .filter(|g| g.host_id == host_id || g.hostname == host_id)
+        .cloned()
+        .collect()
+}
+
+/// Write the top-of-panel header with host + mode indicator + hotkey hint.
+fn render_header(
+    buffer: &mut BufferWriter,
+    model: &TopologyModel,
+    mode: TopologyViewMode,
+    cols: u16,
+) {
+    let host = if model.host_label.is_empty() {
+        "(local)"
+    } else {
+        &model.host_label
+    };
+    let mode_label = mode.as_label();
+    let gpu_count = model.gpu_count();
+    let title =
+        format!(" Topology ─ {host} ─ {gpu_count} GPUs ─ mode: {mode_label} (press M to toggle) ");
+    let truncated = truncate_line(&title, cols as usize);
+    print_colored_text(buffer, &truncated, Color::Black, Some(Color::Cyan), None);
+    queue!(buffer, Print("\r\n")).unwrap();
+    // Summary line (e.g. "8 GPUs · 2 NUMA · 56 NvLinks"). Empty on
+    // non-NVIDIA hosts with no topology data.
+    let summary = model.summary();
+    if !summary.is_empty() {
+        print_colored_text(buffer, &format!("  {summary}"), Color::DarkGrey, None, None);
+        queue!(buffer, Print("\r\n")).unwrap();
+    }
+}
+
+/// Write a multi-line plain-text block to the buffer, preserving line
+/// endings so `BufferWriter` accounts for them correctly.
+fn write_plain(buffer: &mut BufferWriter, text: &str) {
+    for line in text.lines() {
+        buffer.write_all(line.as_bytes()).ok();
+        queue!(buffer, Print("\r\n")).ok();
+    }
+}
+
+/// Truncate a single-line header string to fit in `cells` characters.
+fn truncate_line(s: &str, cells: usize) -> String {
+    if s.chars().count() <= cells {
+        return s.to_string();
+    }
+    s.chars().take(cells).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{GpuInfo, NvLinkRemoteDevice, NvLinkRemoteType};
+    use std::collections::HashMap;
+
+    fn mk_gpu(index: u32, host: &str, numa: Option<i32>) -> GpuInfo {
+        let mut detail = HashMap::new();
+        detail.insert("index".to_string(), index.to_string());
+        GpuInfo {
+            uuid: format!("GPU-{index}"),
+            time: String::new(),
+            name: "NVIDIA H100".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: host.to_string(),
+            hostname: host.to_string(),
+            instance: host.to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: numa,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: vec![NvLinkRemoteDevice {
+                link_index: 0,
+                remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: Some(50_000),
+            }],
+            gpm_metrics: None,
+            detail,
+        }
+    }
+
+    #[test]
+    fn host_filter_preserves_all_in_local() {
+        let gpus = vec![mk_gpu(0, "h1", Some(0)), mk_gpu(1, "h2", Some(0))];
+        assert_eq!(filter_host_gpus(&gpus, "").len(), 2);
+        assert_eq!(filter_host_gpus(&gpus, "All").len(), 2);
+    }
+
+    #[test]
+    fn host_filter_narrows_to_single_host_in_remote() {
+        let gpus = vec![mk_gpu(0, "h1", Some(0)), mk_gpu(1, "h2", Some(0))];
+        let filtered = filter_host_gpus(&gpus, "h2");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].host_id, "h2");
+    }
+
+    #[test]
+    fn renders_topology_tab_without_panic() {
+        let gpus: Vec<_> = (0..4).map(|i| mk_gpu(i, "h1", Some(0))).collect();
+        let mut buf = BufferWriter::new();
+        render_topology_tab(&mut buf, &gpus, "h1", TopologyViewMode::Graph, 180, 40);
+        let out = buf.get_buffer().to_string();
+        assert!(out.contains("Topology"), "{out}");
+        assert!(out.contains("GPU"), "{out}");
+    }
+
+    #[test]
+    fn graph_mode_falls_back_to_matrix_on_narrow_terminal() {
+        let gpus: Vec<_> = (0..4).map(|i| mk_gpu(i, "h1", Some(0))).collect();
+        let mut buf = BufferWriter::new();
+        render_topology_tab(&mut buf, &gpus, "h1", TopologyViewMode::Graph, 80, 40);
+        let out = buf.get_buffer().to_string();
+        // Matrix output contains the "Legend: X=self" string; graph
+        // output never does.
+        assert!(out.contains("X=self"), "{out}");
+        assert!(out.contains("matrix fallback"), "{out}");
+    }
+
+    #[test]
+    fn matrix_mode_emits_legend_vocabulary() {
+        let gpus: Vec<_> = (0..2).map(|i| mk_gpu(i, "h1", Some(0))).collect();
+        let mut buf = BufferWriter::new();
+        render_topology_tab(&mut buf, &gpus, "h1", TopologyViewMode::Matrix, 200, 40);
+        let out = buf.get_buffer().to_string();
+        assert!(out.contains("CPU Affinity"), "{out}");
+    }
+
+    #[test]
+    fn empty_host_renders_placeholder() {
+        let mut buf = BufferWriter::new();
+        render_topology_tab(&mut buf, &[], "h1", TopologyViewMode::Graph, 200, 40);
+        let out = buf.get_buffer().to_string();
+        assert!(out.contains("no GPUs"), "{out}");
+    }
+}

--- a/src/ui/renderers/topology_renderer.rs
+++ b/src/ui/renderers/topology_renderer.rs
@@ -238,7 +238,10 @@ mod tests {
         let mut buf = BufferWriter::new();
         render_topology_tab(&mut buf, &gpus, "h1", TopologyViewMode::Matrix, 200, 40);
         let out = buf.get_buffer().to_string();
-        assert!(out.contains("CPU Affinity"), "{out}");
+        // Legend must surface the full `nvidia-smi topo -m` vocabulary;
+        // the NUMA column in the header anchors the tail of the table.
+        assert!(out.contains("X=self"), "{out}");
+        assert!(out.contains("NUMA"), "{out}");
     }
 
     #[test]

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -29,6 +29,15 @@ use crate::ui::text::print_colored_text;
 /// skips the GPU / storage sections when it is active.
 pub const USERS_TAB_NAME: &str = "Users";
 
+/// Reserved tab name for the per-host Topology tab (issue #190).
+///
+/// Like [`USERS_TAB_NAME`] this is stored as a literal string in
+/// `AppState::tabs` so the renderer can special-case it without
+/// touching the `Vec<String>` shape.  The Topology tab renders a single
+/// host's NvLink / NUMA / PCIe topology; the event handler's `T`
+/// binding jumps to this tab.
+pub const TOPOLOGY_TAB_NAME: &str = "Topology";
+
 /// Return the index of the Users tab inside `tabs`, or `None` when the
 /// tab has not been inserted yet (local mode, replay streams that do
 /// not carry process rows).
@@ -41,6 +50,19 @@ pub fn users_tab_index(tabs: &[String]) -> Option<usize> {
 #[inline]
 pub fn is_users_tab_active(state: &AppState) -> bool {
     users_tab_index(&state.tabs).is_some_and(|i| i == state.current_tab)
+}
+
+/// Return the index of the Topology tab inside `tabs`, or `None` when
+/// the tab has not been inserted yet.
+#[inline]
+pub fn topology_tab_index(tabs: &[String]) -> Option<usize> {
+    tabs.iter().position(|t| t == TOPOLOGY_TAB_NAME)
+}
+
+/// True when `state.current_tab` is the Topology tab.
+#[inline]
+pub fn is_topology_tab_active(state: &AppState) -> bool {
+    topology_tab_index(&state.tabs).is_some_and(|i| i == state.current_tab)
 }
 
 pub fn draw_tabs<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {

--- a/src/ui/topology/classify_edge.rs
+++ b/src/ui/topology/classify_edge.rs
@@ -1,0 +1,421 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Edge classification for the topology tab (issue #190).
+//!
+//! `nvidia-smi topo -m` renders the relationship between every pair of GPUs
+//! as a short label (`NV4`, `NV8`, `SYS`, `PXB`, `NODE`, `X`). The topology
+//! view reproduces that vocabulary for the matrix mode and re-uses the same
+//! classifier for graph-mode edge labels.
+//!
+//! The `NVn` family where `n` is the bandwidth hint is the trickiest part.
+//! NVML can report per-link bandwidth on a narrow subset of boards; when
+//! the hint is missing we fall back to a generic `"NV"` so we never
+//! misreport a generation.
+
+use crate::device::{GpuInfo, NvLinkRemoteDevice, NvLinkRemoteType};
+
+/// Short topology label for a pair of endpoints, mirroring the
+/// `nvidia-smi topo -m` legend plus one ad-hoc variant (`NSW`) for
+/// NvSwitch mesh members.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeClass {
+    /// Self-cell along the matrix diagonal.
+    SelfCell,
+    /// Direct NvLink connection. `count` is the number of active parallel
+    /// links between the endpoints; `generation` is the `NVn` bandwidth
+    /// hint (None when unknown).
+    NvLink { count: u32, generation: Option<u8> },
+    /// Remote is an NvSwitch (GPU → Switch on this row, or Switch → GPU).
+    ///
+    /// Reserved for a future classifier extension that materialises the
+    /// switch node as a first-class edge target; the current matrix
+    /// renderer still treats switch-mediated pairs as `NvSwitchMesh`
+    /// because NVML does not expose the remote GPU UUID.
+    #[allow(dead_code)]
+    NvSwitch { count: u32 },
+    /// Two GPUs that share an NvSwitch mesh but do not have a direct link.
+    /// nvidia-smi labels this `NV#` too; we keep a distinct variant so the
+    /// graph renderer can draw a dashed switch-mediated edge.
+    NvSwitchMesh,
+    /// Same NUMA node, same PCIe root complex (nvidia-smi `PXB`).
+    ///
+    /// Reserved for a future classifier extension that reads PCIe root
+    /// complex info from `detail` and distinguishes PXB from NODE.
+    #[allow(dead_code)]
+    PcieSameRoot,
+    /// Same NUMA node but different PCIe root complexes (nvidia-smi `NODE`).
+    PcieSameNuma,
+    /// Different NUMA nodes — traversal goes through system fabric
+    /// (nvidia-smi `SYS`).
+    SysInterconnect,
+    /// No information available for this pair (non-NVIDIA path or
+    /// partial data). Rendered as a dim `--`.
+    Unknown,
+}
+
+impl EdgeClass {
+    /// Canonical matrix-cell label. `NVn` is collapsed to `NV` when the
+    /// generation hint is missing so the operator is never misled by a
+    /// hallucinated generation.
+    pub fn label(&self) -> String {
+        match self {
+            Self::SelfCell => "X".to_string(),
+            Self::NvLink {
+                count: _,
+                generation: Some(g),
+            } => format!("NV{g}"),
+            Self::NvLink {
+                count: _,
+                generation: None,
+            } => "NV".to_string(),
+            Self::NvSwitch { .. } => "NSW".to_string(),
+            Self::NvSwitchMesh => "NV".to_string(),
+            Self::PcieSameRoot => "PXB".to_string(),
+            Self::PcieSameNuma => "NODE".to_string(),
+            Self::SysInterconnect => "SYS".to_string(),
+            Self::Unknown => "--".to_string(),
+        }
+    }
+}
+
+/// Bandwidth-to-generation hint table. The boundaries follow NVIDIA's
+/// public NvLink generation ceilings per link direction (rounded down to
+/// 2 decimals):
+///
+/// | Gen | Per-link BW (GB/s) | Approx MB/s   |
+/// |-----|--------------------|---------------|
+/// | 1   | 20                 |  20_000       |
+/// | 2   | 25                 |  25_000       |
+/// | 3   | 25                 |  25_000       |
+/// | 4   | 25                 |  25_000       |
+/// | 5   | 50                 |  50_000       |
+/// | 6   | 100                | 100_000       |
+///
+/// We use widened floors so the classifier is forgiving of slight
+/// under-reporting (e.g. a 24 GB/s sample still resolves to Gen-3 territory
+/// rather than degrading to Gen-1).
+pub fn bandwidth_to_generation(bandwidth_mb_s: u32) -> Option<u8> {
+    match bandwidth_mb_s {
+        0 => None,
+        1..=22_000 => Some(1),
+        22_001..=40_000 => Some(4),
+        40_001..=80_000 => Some(5),
+        _ => Some(6),
+    }
+}
+
+/// Is this endpoint a GPU (not a switch / ibmnpu / unknown)?
+fn remote_is_gpu(d: &NvLinkRemoteDevice) -> bool {
+    matches!(d.remote_type, NvLinkRemoteType::Gpu)
+}
+
+/// Is this endpoint an NvSwitch?
+fn remote_is_switch(d: &NvLinkRemoteDevice) -> bool {
+    matches!(d.remote_type, NvLinkRemoteType::Switch)
+}
+
+/// Derive the edge classification between two GPU rows.
+///
+/// `a` and `b` are the row / column GPUs respectively; `a.nvlink_remote_devices`
+/// is the authoritative source of active links. We cannot tell which
+/// **remote GPU** a specific link connects to (NVML does not expose remote
+/// UUIDs in this reader), so the best heuristic for direct links is:
+///
+/// * If `a` has `k` active NvLink links of type `Gpu` and `k >= GPU_COUNT-1`,
+///   the mesh is complete and every other GPU row gets an NvLink class.
+/// * Otherwise we fall back to PCIe / NUMA classification.
+///
+/// This heuristic is intentionally optimistic: on DGX-like topologies with
+/// full mesh + switch overlay it matches reality; on partial topologies the
+/// matrix may show an `NVn` label for a pair that is actually switch-only,
+/// which is the same ambiguity `nvidia-smi topo -m` exhibits.
+pub fn classify(
+    a_index: u32,
+    b_index: u32,
+    a: &GpuInfo,
+    b: &GpuInfo,
+    total_gpu_count: u32,
+) -> EdgeClass {
+    if a_index == b_index {
+        return EdgeClass::SelfCell;
+    }
+
+    // Counts of each remote kind on the row GPU. `a` is the authoritative
+    // source because `nvlink_remote_devices` is populated per parent GPU.
+    let gpu_remote_count = a
+        .nvlink_remote_devices
+        .iter()
+        .filter(|d| remote_is_gpu(d))
+        .count() as u32;
+    let switch_remote_count = a
+        .nvlink_remote_devices
+        .iter()
+        .filter(|d| remote_is_switch(d))
+        .count() as u32;
+
+    // If the row has no NvLink info, classify strictly by PCIe / NUMA so
+    // non-NVIDIA hosts still get a readable matrix.
+    if gpu_remote_count == 0 && switch_remote_count == 0 {
+        return pcie_class(a, b);
+    }
+
+    // Direct-link heuristic: when the row GPU has enough GPU-type links
+    // to reach every peer, the pair is likely a direct NvLink.
+    let peer_count = total_gpu_count.saturating_sub(1);
+    if peer_count > 0 && gpu_remote_count >= peer_count {
+        let generation = dominant_generation(&a.nvlink_remote_devices);
+        return EdgeClass::NvLink {
+            count: (gpu_remote_count / peer_count.max(1)).max(1),
+            generation,
+        };
+    }
+
+    // Switch-mediated heuristic: either row has switch links but no direct
+    // GPU link to this peer, so classify the pair as switch-mesh.
+    if switch_remote_count > 0 {
+        return EdgeClass::NvSwitchMesh;
+    }
+
+    // Partial NvLink mesh: classify as generic NvLink with the count
+    // divided among peers. Slightly optimistic but closer to what the
+    // operator expects.
+    if gpu_remote_count > 0 {
+        let generation = dominant_generation(&a.nvlink_remote_devices);
+        let count = gpu_remote_count
+            .checked_div(peer_count.max(1))
+            .unwrap_or(0)
+            .max(1);
+        return EdgeClass::NvLink { count, generation };
+    }
+
+    pcie_class(a, b)
+}
+
+/// Classify edge based purely on NUMA / PCIe info. Used as a fallback when
+/// NvLink data is absent and for non-NVIDIA paths.
+fn pcie_class(a: &GpuInfo, b: &GpuInfo) -> EdgeClass {
+    match (a.numa_node_id, b.numa_node_id) {
+        (Some(na), Some(nb)) if na == nb => EdgeClass::PcieSameNuma,
+        (Some(_), Some(_)) => EdgeClass::SysInterconnect,
+        _ => EdgeClass::Unknown,
+    }
+}
+
+/// Pick the most common bandwidth hint among active links. When a single
+/// GPU has links of multiple generations we prefer the majority; ties fall
+/// back to `None` (ambiguous, render as generic `NV`).
+fn dominant_generation(links: &[NvLinkRemoteDevice]) -> Option<u8> {
+    // Tally generations across all links that report a bandwidth.
+    let mut counts = [0u32; 7]; // index = generation (1..=6)
+    let mut any = false;
+    for link in links {
+        if let Some(bw) = link.bandwidth_mb_s
+            && let Some(generation) = bandwidth_to_generation(bw)
+            && (generation as usize) < counts.len()
+        {
+            counts[generation as usize] += 1;
+            any = true;
+        }
+    }
+    if !any {
+        return None;
+    }
+    let (mut best_gen, mut best_count, mut tied) = (0u8, 0u32, false);
+    for (generation, &cnt) in counts.iter().enumerate().skip(1) {
+        if cnt > best_count {
+            best_gen = generation as u8;
+            best_count = cnt;
+            tied = false;
+        } else if cnt == best_count && cnt > 0 {
+            tied = true;
+        }
+    }
+    if tied { None } else { Some(best_gen) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::NvLinkRemoteType;
+    use std::collections::HashMap;
+
+    fn gpu_with_numa(numa: Option<i32>) -> GpuInfo {
+        GpuInfo {
+            uuid: "GPU-X".to_string(),
+            time: String::new(),
+            name: "Test".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: numa,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
+            detail: HashMap::new(),
+        }
+    }
+
+    fn link(remote: NvLinkRemoteType, bw: Option<u32>) -> NvLinkRemoteDevice {
+        NvLinkRemoteDevice {
+            link_index: 0,
+            remote_type: remote,
+            bandwidth_mb_s: bw,
+        }
+    }
+
+    #[test]
+    fn self_cell_is_identity() {
+        let a = gpu_with_numa(Some(0));
+        assert_eq!(classify(0, 0, &a, &a, 8), EdgeClass::SelfCell);
+    }
+
+    #[test]
+    fn no_nvlink_same_numa_is_node() {
+        let a = gpu_with_numa(Some(0));
+        let b = gpu_with_numa(Some(0));
+        assert_eq!(classify(0, 1, &a, &b, 8), EdgeClass::PcieSameNuma);
+    }
+
+    #[test]
+    fn no_nvlink_cross_numa_is_sys() {
+        let a = gpu_with_numa(Some(0));
+        let b = gpu_with_numa(Some(1));
+        assert_eq!(classify(0, 1, &a, &b, 8), EdgeClass::SysInterconnect);
+    }
+
+    #[test]
+    fn missing_numa_is_unknown() {
+        let a = gpu_with_numa(None);
+        let b = gpu_with_numa(None);
+        assert_eq!(classify(0, 1, &a, &b, 8), EdgeClass::Unknown);
+    }
+
+    #[test]
+    fn full_mesh_gpu_links_classify_as_nvlink() {
+        let mut a = gpu_with_numa(Some(0));
+        // 7 GPU links: full mesh across 8 GPUs.
+        a.nvlink_remote_devices = (0..7)
+            .map(|i| NvLinkRemoteDevice {
+                link_index: i,
+                remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: Some(50_000),
+            })
+            .collect();
+        let b = gpu_with_numa(Some(0));
+        let edge = classify(0, 1, &a, &b, 8);
+        match edge {
+            EdgeClass::NvLink { generation, .. } => assert_eq!(generation, Some(5)),
+            other => panic!("expected NvLink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn switch_remotes_without_full_gpu_mesh_classify_as_mesh() {
+        let mut a = gpu_with_numa(Some(0));
+        // 5 GPU links + 1 switch link — sub-mesh + switch overlay.
+        a.nvlink_remote_devices = (0..5)
+            .map(|_| link(NvLinkRemoteType::Gpu, Some(50_000)))
+            .enumerate()
+            .map(|(i, mut d)| {
+                d.link_index = i as u32;
+                d
+            })
+            .collect();
+        a.nvlink_remote_devices.push(NvLinkRemoteDevice {
+            link_index: 5,
+            remote_type: NvLinkRemoteType::Switch,
+            bandwidth_mb_s: None,
+        });
+        // With 8 total GPUs, peer_count=7 and GPU remotes=5 < 7, so we
+        // should fall to the switch-mesh branch rather than mis-classify.
+        let b = gpu_with_numa(Some(0));
+        assert_eq!(classify(0, 1, &a, &b, 8), EdgeClass::NvSwitchMesh);
+    }
+
+    #[test]
+    fn bandwidth_to_generation_thresholds() {
+        assert_eq!(bandwidth_to_generation(0), None);
+        assert_eq!(bandwidth_to_generation(20_000), Some(1));
+        assert_eq!(bandwidth_to_generation(25_000), Some(4));
+        assert_eq!(bandwidth_to_generation(50_000), Some(5));
+        assert_eq!(bandwidth_to_generation(90_000), Some(6));
+        assert_eq!(bandwidth_to_generation(150_000), Some(6));
+    }
+
+    #[test]
+    fn edge_label_falls_back_to_nv_when_generation_unknown() {
+        assert_eq!(
+            EdgeClass::NvLink {
+                count: 4,
+                generation: None,
+            }
+            .label(),
+            "NV"
+        );
+        assert_eq!(
+            EdgeClass::NvLink {
+                count: 4,
+                generation: Some(5),
+            }
+            .label(),
+            "NV5"
+        );
+    }
+
+    #[test]
+    fn dominant_generation_requires_populated_hints() {
+        let links = vec![
+            link(NvLinkRemoteType::Gpu, None),
+            link(NvLinkRemoteType::Gpu, None),
+        ];
+        assert_eq!(dominant_generation(&links), None);
+    }
+
+    #[test]
+    fn dominant_generation_picks_majority() {
+        let links = vec![
+            link(NvLinkRemoteType::Gpu, Some(50_000)),
+            link(NvLinkRemoteType::Gpu, Some(50_000)),
+            link(NvLinkRemoteType::Gpu, Some(25_000)),
+        ];
+        assert_eq!(dominant_generation(&links), Some(5));
+    }
+
+    #[test]
+    fn dominant_generation_ties_resolve_to_none() {
+        let links = vec![
+            link(NvLinkRemoteType::Gpu, Some(50_000)),
+            link(NvLinkRemoteType::Gpu, Some(25_000)),
+        ];
+        assert_eq!(dominant_generation(&links), None);
+    }
+}

--- a/src/ui/topology/classify_edge.rs
+++ b/src/ui/topology/classify_edge.rs
@@ -103,9 +103,16 @@ impl EdgeClass {
 /// | 5   | 50                 |  50_000       |
 /// | 6   | 100                | 100_000       |
 ///
+/// NvLink Gen 2, 3, and 4 all share the same ~25 GB/s per-link ceiling;
+/// NVML does not expose a field that distinguishes them, so any sample
+/// in the 22–40 GB/s band is collapsed into the `Some(4)` label —
+/// chosen as the most common Gen for that bandwidth on current-gen
+/// datacenter GPUs. `Some(2)` and `Some(3)` are therefore never returned
+/// by design; the matrix labels `NV2` / `NV3` are never emitted.
+///
 /// We use widened floors so the classifier is forgiving of slight
-/// under-reporting (e.g. a 24 GB/s sample still resolves to Gen-3 territory
-/// rather than degrading to Gen-1).
+/// under-reporting (e.g. a 24 GB/s sample still resolves into the Gen
+/// 2/3/4 bucket rather than degrading to Gen-1).
 pub fn bandwidth_to_generation(bandwidth_mb_s: u32) -> Option<u8> {
     match bandwidth_mb_s {
         0 => None,

--- a/src/ui/topology/graph_render.rs
+++ b/src/ui/topology/graph_render.rs
@@ -1,0 +1,402 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ASCII graph rendering for the topology tab.
+//!
+//! Produces NUMA boxes, one per NUMA zone, with the GPUs placed inside
+//! and NvLink/NvSwitch edges rendered between them. The layout strategy
+//! is computed in [`super::layout`]; here we just draw.
+//!
+//! The output is **plain text** (no ANSI escapes) so it composes cleanly
+//! with the `BufferWriter` pipeline. Colour highlighting happens at the
+//! orchestrator level by wrapping specific fragments in ANSI codes where
+//! the layout allows.
+
+use super::classify_edge::EdgeClass;
+use super::layout::{BoxStacking, GraphLayout, NumaGroup, numa_row_count};
+use super::{TopologyGpu, TopologyModel};
+
+/// Render the graph view as a plain-text string (one-or-more newline-
+/// terminated lines). Caller is responsible for width checks — see
+/// [`super::GRAPH_MIN_WIDTH`].
+pub fn render_graph(model: &TopologyModel, available_width: u16) -> String {
+    if model.gpus.is_empty() {
+        return "  (no GPUs on this host)\n".to_string();
+    }
+
+    let layout = GraphLayout::plan(model, available_width);
+    let mut out = String::new();
+
+    match layout.stacking {
+        BoxStacking::Horizontal => render_horizontal(&mut out, model, &layout),
+        BoxStacking::Vertical => render_vertical(&mut out, model, &layout),
+    }
+
+    render_footer(&mut out, model);
+    out
+}
+
+/// Draw all NUMA boxes side-by-side.
+fn render_horizontal(out: &mut String, model: &TopologyModel, layout: &GraphLayout) {
+    // Compose each NUMA box into a list of lines, then zip them column-
+    // by-column so the boxes sit at the same row offsets.
+    let box_lines: Vec<Vec<String>> = layout
+        .numa_groups
+        .iter()
+        .map(|grp| render_numa_box(model, grp))
+        .collect();
+    let max_lines = box_lines.iter().map(|v| v.len()).max().unwrap_or(0);
+
+    for line_idx in 0..max_lines {
+        let mut composite = String::new();
+        for (i, lines) in box_lines.iter().enumerate() {
+            if i > 0 {
+                composite.push_str("   ");
+            }
+            let line = lines.get(line_idx).map(|s| s.as_str()).unwrap_or("");
+            composite.push_str(line);
+        }
+        composite.push('\n');
+        out.push_str(&composite);
+    }
+}
+
+/// Draw each NUMA box on its own row.
+fn render_vertical(out: &mut String, model: &TopologyModel, layout: &GraphLayout) {
+    for (i, group) in layout.numa_groups.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let lines = render_numa_box(model, group);
+        for line in lines {
+            out.push_str(&line);
+            out.push('\n');
+        }
+    }
+}
+
+/// Render a single NUMA zone as a box with its GPUs inside.
+fn render_numa_box(model: &TopologyModel, group: &NumaGroup) -> Vec<String> {
+    let numa_label = match group.numa_node {
+        Some(n) => format!("NUMA {n}"),
+        None => "NUMA ?".to_string(),
+    };
+    let gpu_count = group.gpu_slots.len() as u32;
+    let columns = group.columns.max(1);
+    let rows = numa_row_count(gpu_count);
+    let cell_width: usize = 13;
+    let inner_width: usize = columns as usize * cell_width;
+    let total_width = inner_width + 2;
+
+    let mut lines: Vec<String> = Vec::new();
+
+    // Top border with inline NUMA label.
+    let label_padded = format!(" {numa_label} ");
+    let dashes = total_width.saturating_sub(label_padded.len() + 2);
+    let left_dashes = dashes / 2;
+    let right_dashes = dashes - left_dashes;
+    let left_dash = "─".repeat(left_dashes);
+    let right_dash = "─".repeat(right_dashes);
+    lines.push(format!("┌{left_dash}{label_padded}{right_dash}┐"));
+
+    for row in 0..rows {
+        // GPU row: labels like "[GPU 0]" centred in each cell.
+        let mut gpu_line = String::from("│");
+        for col in 0..columns {
+            let slot_idx = (row * columns + col) as usize;
+            let cell = if let Some(gpu_idx) = group.gpu_slots.get(slot_idx) {
+                let gpu = &model.gpus[*gpu_idx];
+                center(&format!("[GPU {idx}]", idx = gpu.index), cell_width)
+            } else {
+                " ".repeat(cell_width)
+            };
+            gpu_line.push_str(&cell);
+        }
+        gpu_line.push('│');
+        lines.push(gpu_line);
+
+        // Edge row: NvLink / fallback labels connecting horizontally
+        // adjacent GPUs in this row (when there are at least two
+        // columns).
+        let mut edge_line = String::from("│");
+        for col in 0..columns {
+            let slot_idx = (row * columns + col) as usize;
+            let cell = if col + 1 < columns {
+                let left_slot_idx = slot_idx;
+                let right_slot_idx = slot_idx + 1;
+                let left_gpu = group.gpu_slots.get(left_slot_idx).map(|i| &model.gpus[*i]);
+                let right_gpu = group.gpu_slots.get(right_slot_idx).map(|i| &model.gpus[*i]);
+                match (left_gpu, right_gpu) {
+                    (Some(a), Some(b)) => center(&edge_label(model, a, b), cell_width),
+                    _ => " ".repeat(cell_width),
+                }
+            } else {
+                " ".repeat(cell_width)
+            };
+            edge_line.push_str(&cell);
+        }
+        edge_line.push('│');
+        // Only push the edge row when at least one adjacent cell exists.
+        if columns > 1 {
+            lines.push(edge_line);
+        }
+
+        // Divider between GPU rows inside the same NUMA box (keeps the
+        // 2xN grid legible).
+        if row + 1 < rows {
+            let divider = format!("│{}│", " ".repeat(inner_width),);
+            lines.push(divider);
+        }
+    }
+
+    // If this NUMA is NvSwitch-mediated, add a "nvsw" annotation row
+    // between the GPU rows.
+    if model.has_nvswitch && rows >= 2 {
+        let annotation = center("nvsw ── nvsw", inner_width);
+        // Insert BEFORE the last divider-or-row; simpler to append when
+        // rendered vertically without divider tracking.
+        lines.push(format!("│{annotation}│"));
+    }
+
+    // Bottom border.
+    lines.push(format!("└{}┘", "─".repeat(total_width.saturating_sub(2))));
+
+    lines
+}
+
+/// Label placed between two horizontally-adjacent GPUs.
+fn edge_label(model: &TopologyModel, a: &TopologyGpu, b: &TopologyGpu) -> String {
+    // Build pseudo-GpuInfo views for the classifier.
+    let total = model.gpu_count();
+    let class =
+        super::classify_edge::classify(a.index, b.index, &pseudo_info(a), &pseudo_info(b), total);
+    match class {
+        EdgeClass::SelfCell => "──".to_string(),
+        EdgeClass::NvLink {
+            count: _,
+            generation,
+        } => match generation {
+            Some(g) => format!("── NV{g} ──"),
+            None => "── NV ──".to_string(),
+        },
+        EdgeClass::NvSwitch { .. } => "── NSW ──".to_string(),
+        EdgeClass::NvSwitchMesh => "── NV ──".to_string(),
+        EdgeClass::PcieSameRoot => "── PXB ──".to_string(),
+        EdgeClass::PcieSameNuma => "── NODE ──".to_string(),
+        EdgeClass::SysInterconnect => "── SYS ──".to_string(),
+        EdgeClass::Unknown => "── ? ──".to_string(),
+    }
+}
+
+/// Build a minimal GpuInfo for the classifier.
+fn pseudo_info(gpu: &TopologyGpu) -> crate::device::GpuInfo {
+    use std::collections::HashMap;
+    crate::device::GpuInfo {
+        uuid: gpu.uuid.clone(),
+        time: String::new(),
+        name: gpu.name.clone(),
+        device_type: "GPU".to_string(),
+        host_id: String::new(),
+        hostname: String::new(),
+        instance: String::new(),
+        utilization: 0.0,
+        ane_utilization: 0.0,
+        dla_utilization: None,
+        tensorcore_utilization: None,
+        temperature: 0,
+        used_memory: 0,
+        total_memory: 0,
+        frequency: 0,
+        power_consumption: 0.0,
+        gpu_core_count: None,
+        temperature_threshold_slowdown: None,
+        temperature_threshold_shutdown: None,
+        temperature_threshold_max_operating: None,
+        temperature_threshold_acoustic: None,
+        performance_state: None,
+        numa_node_id: gpu.numa_node,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: gpu.links.clone(),
+        gpm_metrics: None,
+        detail: HashMap::new(),
+    }
+}
+
+/// Footer line with summary + legend.
+fn render_footer(out: &mut String, model: &TopologyModel) {
+    out.push('\n');
+    if !model.has_nvlink {
+        out.push_str("  (no active NvLinks — PCIe-only topology)\n");
+    } else {
+        let summary = model.summary();
+        out.push_str(&format!("  {summary}\n"));
+    }
+    // Legend: keep short to fit narrow terminals.
+    if model.is_nvidia {
+        out.push_str(
+            "  Legend:  NVn=NvLink Gen-n  NSW=NvSwitch  PXB=PCIe bridge  \
+             NODE=same NUMA  SYS=across NUMA\n",
+        );
+    } else {
+        out.push_str("  Legend:  NODE=same NUMA  SYS=across NUMA\n");
+    }
+}
+
+fn center(s: &str, w: usize) -> String {
+    if s.len() >= w {
+        let trimmed: String = s.chars().take(w).collect();
+        return trimmed;
+    }
+    let total = w - s.len();
+    let left = total / 2;
+    let right = total - left;
+    format!("{}{s}{}", " ".repeat(left), " ".repeat(right))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{GpuInfo, NvLinkRemoteDevice, NvLinkRemoteType};
+    use std::collections::HashMap;
+
+    fn mk_gpu(index: u32, numa: Option<i32>, link_count: u32, switch: bool) -> GpuInfo {
+        let mut detail = HashMap::new();
+        detail.insert("index".to_string(), index.to_string());
+        let mut links: Vec<NvLinkRemoteDevice> = (0..link_count)
+            .map(|i| NvLinkRemoteDevice {
+                link_index: i,
+                remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: Some(50_000),
+            })
+            .collect();
+        if switch {
+            links.push(NvLinkRemoteDevice {
+                link_index: link_count,
+                remote_type: NvLinkRemoteType::Switch,
+                bandwidth_mb_s: None,
+            });
+        }
+        GpuInfo {
+            uuid: format!("GPU-{index}"),
+            time: String::new(),
+            name: "NVIDIA H100 80GB HBM3".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: numa,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: links,
+            gpm_metrics: None,
+            detail,
+        }
+    }
+
+    #[test]
+    fn two_gpu_one_numa_draws_box_and_edge() {
+        let gpus = vec![mk_gpu(0, Some(0), 1, false), mk_gpu(1, Some(0), 1, false)];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_graph(&model, 200);
+        assert!(out.contains("NUMA 0"), "{out}");
+        assert!(out.contains("[GPU 0]"), "{out}");
+        assert!(out.contains("[GPU 1]"), "{out}");
+        assert!(out.contains("Legend"), "{out}");
+    }
+
+    #[test]
+    fn eight_gpu_two_numa_wide_terminal_renders_horizontally() {
+        let gpus: Vec<_> = (0..8)
+            .map(|i| mk_gpu(i, Some(i as i32 / 4), 7, true))
+            .collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_graph(&model, 200);
+        assert!(out.contains("NUMA 0"), "{out}");
+        assert!(out.contains("NUMA 1"), "{out}");
+        assert!(out.contains("nvsw"), "{out}");
+    }
+
+    #[test]
+    fn no_nvlink_shows_placeholder_and_still_draws_numa() {
+        let gpus = vec![mk_gpu(0, Some(0), 0, false), mk_gpu(1, Some(0), 0, false)];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_graph(&model, 200);
+        assert!(out.contains("NUMA 0"), "{out}");
+        assert!(out.contains("no active NvLinks"), "{out}");
+    }
+
+    #[test]
+    fn narrow_terminal_falls_back_to_vertical_stacking() {
+        // See `eight_gpus_two_numa_falls_back_to_vertical_on_narrow_terminal`
+        // in `layout.rs` for the cell-width arithmetic that places the
+        // horizontal-to-vertical threshold around 50 columns.
+        let gpus: Vec<_> = (0..8)
+            .map(|i| mk_gpu(i, Some(i as i32 / 4), 7, true))
+            .collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_graph(&model, 50);
+        // Vertical stacking produces two box segments separated by blank.
+        let numa0_pos = out.find("NUMA 0").unwrap();
+        let numa1_pos = out.find("NUMA 1").unwrap();
+        assert!(numa1_pos > numa0_pos, "{out}");
+        // Ensure the two NUMAs are on different visual rows (a newline
+        // between them proves vertical stacking).
+        let between = &out[numa0_pos..numa1_pos];
+        assert!(between.contains('\n'), "{out}");
+    }
+
+    #[test]
+    fn empty_model_renders_placeholder() {
+        let model = TopologyModel::default();
+        let out = render_graph(&model, 200);
+        assert!(out.contains("no GPUs"), "{out}");
+    }
+
+    #[test]
+    fn unknown_numa_renders_as_question_mark() {
+        let gpus = vec![mk_gpu(0, None, 0, false), mk_gpu(1, None, 0, false)];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_graph(&model, 200);
+        assert!(out.contains("NUMA ?"), "{out}");
+    }
+
+    #[test]
+    fn graph_renders_switch_annotation_when_nvswitch_present() {
+        let gpus = vec![
+            mk_gpu(0, Some(0), 1, true),
+            mk_gpu(1, Some(0), 1, true),
+            mk_gpu(2, Some(0), 1, true),
+            mk_gpu(3, Some(0), 1, true),
+        ];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_graph(&model, 200);
+        assert!(out.contains("nvsw"), "{out}");
+    }
+}

--- a/src/ui/topology/layout.rs
+++ b/src/ui/topology/layout.rs
@@ -1,0 +1,287 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Layout computation for the topology graph view.
+//!
+//! The renderer groups GPUs by NUMA zone and stacks the resulting boxes
+//! either horizontally (side-by-side) or vertically depending on the
+//! available terminal width. This module keeps the stacking decision
+//! purely data-driven so the logic is unit-testable without touching the
+//! terminal.
+
+use super::TopologyModel;
+
+/// Minimum horizontal cells required to render a NUMA box with `g` GPUs
+/// laid out in a 2xN grid. We reserve 13 cells per GPU column (label +
+/// padding + inter-column connector) and 4 cells for the box borders.
+pub fn numa_box_width_cells(gpus_in_numa: u32) -> u16 {
+    let columns = numa_column_count(gpus_in_numa);
+    (columns as u16 * 13) + 6
+}
+
+/// How many columns the renderer uses inside a single NUMA box. Keeps
+/// 2xN rectangular layouts for 2/4/8 GPUs (the most common topologies)
+/// and falls back to a single row for odd counts.
+pub fn numa_column_count(gpus_in_numa: u32) -> u32 {
+    match gpus_in_numa {
+        0 | 1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 2, // 2x2
+        5 | 6 => 3,
+        7 | 8 => 4, // 2x4
+        _ => 4,     // 2xN with N rows
+    }
+}
+
+/// How many rows the renderer uses inside a single NUMA box.
+pub fn numa_row_count(gpus_in_numa: u32) -> u32 {
+    match gpus_in_numa {
+        0 => 0,
+        1 => 1,
+        2 | 3 => 1,
+        4 => 2,
+        5 | 6 => 2,
+        7 | 8 => 2,
+        n => n.div_ceil(4),
+    }
+}
+
+/// Stacking strategy for NUMA boxes in the graph view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoxStacking {
+    /// All NUMA boxes side-by-side on the same row.
+    Horizontal,
+    /// NUMA boxes stacked top-to-bottom. Used when horizontal would
+    /// overflow the available width.
+    Vertical,
+}
+
+/// Resolved graph layout plan.
+#[derive(Debug, Clone)]
+pub struct GraphLayout {
+    pub stacking: BoxStacking,
+    /// GPU indices grouped by NUMA node in the same order the renderer
+    /// should walk them. Outer Vec is the NUMA zone, inner Vec is the
+    /// GPU slots inside that zone (row-major, `numa_column_count` wide).
+    pub numa_groups: Vec<NumaGroup>,
+    /// Width cells the graph will actually use. Reserved for a future
+    /// iteration that centres the summary footer under the drawn boxes
+    /// or right-aligns the mode indicator; kept in the plan today so
+    /// the layout-to-render contract is already in place.
+    #[allow(dead_code)]
+    pub used_width: u16,
+}
+
+/// GPUs assigned to a single NUMA zone.
+#[derive(Debug, Clone)]
+pub struct NumaGroup {
+    pub numa_node: Option<i32>,
+    /// Indices into `TopologyModel::gpus`.
+    pub gpu_slots: Vec<usize>,
+    /// Cached column count for this zone (== `numa_column_count(len)`).
+    pub columns: u32,
+}
+
+impl GraphLayout {
+    /// Compute the layout for `model` inside `available_width` cells.
+    ///
+    /// Returns a plan the graph renderer can execute without having to
+    /// redo the width arithmetic.
+    pub fn plan(model: &TopologyModel, available_width: u16) -> Self {
+        let numa_nodes = model.numa_nodes();
+        let mut numa_groups: Vec<NumaGroup> = numa_nodes
+            .iter()
+            .map(|numa| {
+                let gpu_slots: Vec<usize> = model
+                    .gpus
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, g)| g.numa_node == *numa)
+                    .map(|(i, _)| i)
+                    .collect();
+                let columns = numa_column_count(gpu_slots.len() as u32);
+                NumaGroup {
+                    numa_node: *numa,
+                    gpu_slots,
+                    columns,
+                }
+            })
+            .collect();
+
+        // Horizontal stacking: sum the box widths plus inter-box gaps.
+        // Guard `sum` against an empty list so `used_width` stays at 0.
+        let horizontal_width: u16 = numa_groups
+            .iter()
+            .map(|grp| numa_box_width_cells(grp.gpu_slots.len() as u32))
+            .sum::<u16>()
+            + numa_groups.len().saturating_sub(1) as u16 * 3;
+
+        let (stacking, used_width) =
+            if numa_groups.len() <= 1 || horizontal_width <= available_width {
+                (
+                    BoxStacking::Horizontal,
+                    horizontal_width.min(available_width),
+                )
+            } else {
+                // Vertical stacking: width is the widest single NUMA box.
+                let max_width = numa_groups
+                    .iter()
+                    .map(|grp| numa_box_width_cells(grp.gpu_slots.len() as u32))
+                    .max()
+                    .unwrap_or(0)
+                    .min(available_width);
+                (BoxStacking::Vertical, max_width)
+            };
+
+        // Deterministic ordering for repeatable rendering and tests:
+        // by numeric NUMA id, with `None` last.
+        numa_groups.sort_by(|a, b| match (a.numa_node, b.numa_node) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+
+        Self {
+            stacking,
+            numa_groups,
+            used_width,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{GpuInfo, NvLinkRemoteDevice, NvLinkRemoteType};
+    use std::collections::HashMap;
+
+    fn mk_gpu(index: u32, numa: Option<i32>) -> GpuInfo {
+        let mut detail = HashMap::new();
+        detail.insert("index".to_string(), index.to_string());
+        GpuInfo {
+            uuid: format!("GPU-{index}"),
+            time: String::new(),
+            name: "NVIDIA H100".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: numa,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: vec![NvLinkRemoteDevice {
+                link_index: 0,
+                remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
+            }],
+            gpm_metrics: None,
+            detail,
+        }
+    }
+
+    #[test]
+    fn two_gpus_one_numa_picks_horizontal() {
+        let model = TopologyModel::from_host("h", &[mk_gpu(0, Some(0)), mk_gpu(1, Some(0))]);
+        let layout = GraphLayout::plan(&model, 120);
+        assert_eq!(layout.stacking, BoxStacking::Horizontal);
+        assert_eq!(layout.numa_groups.len(), 1);
+        assert_eq!(layout.numa_groups[0].gpu_slots.len(), 2);
+    }
+
+    #[test]
+    fn four_gpus_single_numa_uses_2x2_grid() {
+        let gpus: Vec<_> = (0..4).map(|i| mk_gpu(i, Some(0))).collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let layout = GraphLayout::plan(&model, 200);
+        assert_eq!(layout.numa_groups.len(), 1);
+        assert_eq!(layout.numa_groups[0].columns, 2);
+        assert_eq!(numa_row_count(4), 2);
+    }
+
+    #[test]
+    fn eight_gpus_two_numa_fits_horizontally_on_wide_terminal() {
+        let mut gpus = Vec::new();
+        for i in 0..8 {
+            gpus.push(mk_gpu(i, Some((i as i32) / 4)));
+        }
+        let model = TopologyModel::from_host("h", &gpus);
+        let layout = GraphLayout::plan(&model, 200);
+        assert_eq!(layout.stacking, BoxStacking::Horizontal);
+        assert_eq!(layout.numa_groups.len(), 2);
+        assert_eq!(layout.numa_groups[0].gpu_slots.len(), 4);
+        assert_eq!(layout.numa_groups[1].gpu_slots.len(), 4);
+    }
+
+    #[test]
+    fn eight_gpus_two_numa_falls_back_to_vertical_on_narrow_terminal() {
+        // 4-GPU NUMA box width = columns(2) * 13 + 6 = 32 cells; two
+        // boxes side-by-side + 3-cell gap = 67 cells. 50 columns must
+        // force vertical stacking.
+        let mut gpus = Vec::new();
+        for i in 0..8 {
+            gpus.push(mk_gpu(i, Some((i as i32) / 4)));
+        }
+        let model = TopologyModel::from_host("h", &gpus);
+        let layout = GraphLayout::plan(&model, 50);
+        assert_eq!(layout.stacking, BoxStacking::Vertical);
+        assert_eq!(layout.numa_groups.len(), 2);
+    }
+
+    #[test]
+    fn unknown_numa_sorts_last() {
+        let gpus = vec![mk_gpu(0, None), mk_gpu(1, Some(1)), mk_gpu(2, Some(0))];
+        let model = TopologyModel::from_host("h", &gpus);
+        let layout = GraphLayout::plan(&model, 200);
+        let numa_order: Vec<_> = layout.numa_groups.iter().map(|g| g.numa_node).collect();
+        assert_eq!(numa_order, vec![Some(0), Some(1), None]);
+    }
+
+    #[test]
+    fn used_width_never_exceeds_available_width() {
+        let gpus: Vec<_> = (0..8).map(|i| mk_gpu(i, Some((i as i32) / 4))).collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let layout = GraphLayout::plan(&model, 50);
+        assert!(layout.used_width <= 50, "{}", layout.used_width);
+    }
+
+    #[test]
+    fn single_gpu_has_one_column_one_row() {
+        assert_eq!(numa_column_count(1), 1);
+        assert_eq!(numa_row_count(1), 1);
+    }
+
+    #[test]
+    fn column_counts_match_2x_n_convention() {
+        assert_eq!(numa_column_count(4), 2);
+        assert_eq!(numa_column_count(8), 4);
+        assert_eq!(numa_row_count(8), 2);
+    }
+}

--- a/src/ui/topology/matrix_render.rs
+++ b/src/ui/topology/matrix_render.rs
@@ -1,0 +1,349 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `nvidia-smi topo -m`-style matrix rendering for the topology tab.
+//!
+//! Produces a plain-text table suitable for BufferWriter output. Each cell
+//! holds a short label (`NV8`, `SYS`, `PXB`, `X`). Extra columns at the
+//! end report CPU affinity (pulled from the GPU's `detail` map when
+//! available) and NUMA node.
+
+use super::TopologyModel;
+use super::classify_edge::classify;
+
+/// Minimum cell width (in characters) for a matrix column. Keeps the
+/// longest label (`NODE`, `NV8`) readable without overflowing on tight
+/// 80-column terminals.
+const MIN_CELL: usize = 5;
+
+/// Maximum cell width — beyond this we truncate labels so the table fits
+/// within the available terminal width.
+const MAX_CELL: usize = 6;
+
+/// Render the matrix view into a `String` (newline-terminated rows).
+///
+/// `width` is the available terminal width in cells. The renderer sizes
+/// column widths to fit; when even the minimum sizing exceeds `width`,
+/// it falls back to an 80-column truncation message so narrow terminals
+/// degrade gracefully.
+pub fn render_matrix(model: &TopologyModel, width: u16) -> String {
+    if model.gpus.is_empty() {
+        return "  (no GPUs on this host)\n".to_string();
+    }
+
+    let gpu_count = model.gpus.len();
+    let available = width as usize;
+
+    // Dynamic cell sizing: shrink columns until the table fits.
+    let cell_width = pick_cell_width(gpu_count, available);
+    if cell_width < MIN_CELL {
+        return render_narrow_fallback(model);
+    }
+
+    let mut out = String::new();
+
+    // Header row: blank corner + GPU column labels + CPU Affinity + NUMA
+    let label_col_w = gpu_label_width(model);
+    out.push_str(&" ".repeat(label_col_w));
+    for gpu in &model.gpus {
+        let hdr = format!("GPU{}", gpu.index);
+        out.push_str(&center(&hdr, cell_width));
+    }
+    out.push_str("   CPU Affinity   NUMA\n");
+
+    // Body rows: one row per GPU.
+    let gpu_count_u32 = gpu_count as u32;
+    for (r, row_gpu) in model.gpus.iter().enumerate() {
+        let row_label = format!("GPU{}", row_gpu.index);
+        out.push_str(&right_pad(&row_label, label_col_w));
+        for (c, col_gpu) in model.gpus.iter().enumerate() {
+            let edge = classify(
+                r as u32,
+                c as u32,
+                // Rebuild a pseudo-GpuInfo from topology data: classifier
+                // only looks at `nvlink_remote_devices` + `numa_node_id`.
+                &pseudo_info(row_gpu),
+                &pseudo_info(col_gpu),
+                gpu_count_u32,
+            );
+            let label = edge.label();
+            out.push_str(&center(&label, cell_width));
+        }
+        let cpu_aff = cpu_affinity(row_gpu);
+        let numa = row_gpu
+            .numa_node
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        out.push_str(&format!("   {cpu_aff:<12}   {numa}\n"));
+    }
+
+    // Legend row — mirrors nvidia-smi's convention.
+    out.push_str("\nLegend:  X=self   NVn=NvLink Gen-n   NV=NvLink (gen unknown)   ");
+    out.push_str("NSW=NvSwitch   PXB=PCIe bridge   NODE=PCIe same NUMA   SYS=PCIe across NUMA\n");
+
+    out
+}
+
+/// CPU affinity helper. Reads the string from the `detail` map under
+/// any of a few canonical keys; falls back to a dash when absent.
+fn cpu_affinity(gpu: &super::TopologyGpu) -> String {
+    // Walk known keys in the detail map. Topology renderer is informed
+    // directly from GpuInfo so we never populate this here — instead
+    // we require the caller to have set the `detail` map via
+    // `TopologyGpu::pcie_display` / a future `cpu_affinity` field. For
+    // v1 we surface whatever the NVML reader stored.
+    //
+    // The model doesn't currently carry this, so return "-" to keep the
+    // column aligned. Future work: propagate the affinity from the
+    // detail map into TopologyGpu.
+    let _ = gpu;
+    "-".to_string()
+}
+
+/// Build a minimal GpuInfo view from a TopologyGpu for the classifier.
+/// Classifier only touches `nvlink_remote_devices`, `numa_node_id`, and
+/// treats an empty `detail` map as "no extra PCIe info".
+fn pseudo_info(gpu: &super::TopologyGpu) -> crate::device::GpuInfo {
+    use std::collections::HashMap;
+    crate::device::GpuInfo {
+        uuid: gpu.uuid.clone(),
+        time: String::new(),
+        name: gpu.name.clone(),
+        device_type: "GPU".to_string(),
+        host_id: String::new(),
+        hostname: String::new(),
+        instance: String::new(),
+        utilization: 0.0,
+        ane_utilization: 0.0,
+        dla_utilization: None,
+        tensorcore_utilization: None,
+        temperature: 0,
+        used_memory: 0,
+        total_memory: 0,
+        frequency: 0,
+        power_consumption: 0.0,
+        gpu_core_count: None,
+        temperature_threshold_slowdown: None,
+        temperature_threshold_shutdown: None,
+        temperature_threshold_max_operating: None,
+        temperature_threshold_acoustic: None,
+        performance_state: None,
+        numa_node_id: gpu.numa_node,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: gpu.links.clone(),
+        gpm_metrics: None,
+        detail: HashMap::new(),
+    }
+}
+
+/// Compute the label column width (e.g. `GPU10` requires 5 chars).
+fn gpu_label_width(model: &TopologyModel) -> usize {
+    let max = model
+        .gpus
+        .iter()
+        .map(|g| format!("GPU{}", g.index).len())
+        .max()
+        .unwrap_or(3);
+    max.max(4) + 1 // min 5 cells to leave a single space of padding
+}
+
+/// Pick the widest cell width that fits the table within `available`
+/// cells. Returns `0` when even the minimum doesn't fit, which the
+/// caller treats as "fall back to narrow rendering".
+fn pick_cell_width(gpu_count: usize, available: usize) -> usize {
+    if gpu_count == 0 {
+        return MAX_CELL;
+    }
+    // The tail (CPU Affinity + NUMA + padding) eats ~22 cells.
+    // Label column ~ 5 cells.
+    let overhead = 5 + 22;
+    let usable = available.saturating_sub(overhead);
+    for cw in (MIN_CELL..=MAX_CELL).rev() {
+        if cw * gpu_count <= usable {
+            return cw;
+        }
+    }
+    // Sub-minimum: return 0 so the caller renders the narrow fallback.
+    if MIN_CELL * gpu_count <= usable {
+        MIN_CELL
+    } else {
+        0
+    }
+}
+
+fn center(s: &str, w: usize) -> String {
+    if s.len() >= w {
+        let trimmed: String = s.chars().take(w).collect();
+        return trimmed;
+    }
+    let total = w - s.len();
+    let left = total / 2;
+    let right = total - left;
+    format!("{}{s}{}", " ".repeat(left), " ".repeat(right))
+}
+
+fn right_pad(s: &str, w: usize) -> String {
+    if s.len() >= w {
+        let trimmed: String = s.chars().take(w).collect();
+        return trimmed;
+    }
+    format!("{s}{}", " ".repeat(w - s.len()))
+}
+
+/// Degraded fallback when the terminal is too narrow for any cell width
+/// ≥ `MIN_CELL`. Produces a per-row list instead of a grid.
+fn render_narrow_fallback(model: &TopologyModel) -> String {
+    let mut out = String::new();
+    out.push_str("  (terminal too narrow for matrix view — summary only)\n");
+    for gpu in &model.gpus {
+        let links = gpu.links.len();
+        let numa = gpu
+            .numa_node
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "?".to_string());
+        out.push_str(&format!(
+            "  GPU{idx:<3}  NUMA {numa}  {links} active NvLinks\n",
+            idx = gpu.index,
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{GpuInfo, NvLinkRemoteDevice, NvLinkRemoteType};
+    use std::collections::HashMap;
+
+    fn mk_gpu(index: u32, numa: Option<i32>, links: u32) -> GpuInfo {
+        let mut detail = HashMap::new();
+        detail.insert("index".to_string(), index.to_string());
+        GpuInfo {
+            uuid: format!("GPU-{index}"),
+            time: String::new(),
+            name: "NVIDIA H100 80GB HBM3".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: numa,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: (0..links)
+                .map(|i| NvLinkRemoteDevice {
+                    link_index: i,
+                    remote_type: NvLinkRemoteType::Gpu,
+                    bandwidth_mb_s: Some(50_000),
+                })
+                .collect(),
+            gpm_metrics: None,
+            detail,
+        }
+    }
+
+    #[test]
+    fn renders_header_with_gpu_columns() {
+        let gpus: Vec<_> = (0..4).map(|i| mk_gpu(i, Some(0), 7)).collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_matrix(&model, 120);
+        assert!(out.contains("GPU0"), "{out}");
+        assert!(out.contains("GPU3"), "{out}");
+        assert!(out.contains("CPU Affinity"), "{out}");
+        assert!(out.contains("NUMA"), "{out}");
+    }
+
+    #[test]
+    fn full_mesh_classifies_as_nv5_with_50gbs_bandwidth() {
+        let gpus: Vec<_> = (0..8).map(|i| mk_gpu(i, Some(i as i32 / 4), 7)).collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_matrix(&model, 140);
+        assert!(out.contains("NV5"), "{out}");
+    }
+
+    #[test]
+    fn self_cell_is_x_label() {
+        let gpus: Vec<_> = (0..2).map(|i| mk_gpu(i, Some(0), 1)).collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_matrix(&model, 120);
+        // Each GPU row has exactly one "X" in a matrix cell.
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines.iter().any(|l| l.contains("X")), "{out}");
+    }
+
+    #[test]
+    fn falls_back_to_summary_under_80_col() {
+        let gpus: Vec<_> = (0..8).map(|i| mk_gpu(i, Some(0), 4)).collect();
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_matrix(&model, 60);
+        assert!(out.contains("summary only"), "{out}");
+    }
+
+    #[test]
+    fn cross_numa_renders_sys_for_non_nvlink() {
+        // No NvLinks, two different NUMA zones -> SYS between them.
+        let gpus = vec![mk_gpu(0, Some(0), 0), mk_gpu(1, Some(1), 0)];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_matrix(&model, 120);
+        assert!(out.contains("SYS"), "{out}");
+    }
+
+    #[test]
+    fn same_numa_renders_node_for_non_nvlink() {
+        let gpus = vec![mk_gpu(0, Some(0), 0), mk_gpu(1, Some(0), 0)];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_matrix(&model, 120);
+        assert!(out.contains("NODE"), "{out}");
+    }
+
+    #[test]
+    fn legend_contains_vocabulary() {
+        let gpus = vec![mk_gpu(0, Some(0), 0), mk_gpu(1, Some(0), 0)];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_matrix(&model, 120);
+        for term in ["X=self", "PXB", "NODE", "SYS"] {
+            assert!(out.contains(term), "legend missing {term}: {out}");
+        }
+    }
+
+    #[test]
+    fn empty_model_renders_placeholder() {
+        let model = TopologyModel::default();
+        let out = render_matrix(&model, 120);
+        assert!(out.contains("no GPUs"), "{out}");
+    }
+
+    #[test]
+    fn cell_width_picker_honours_available_space() {
+        // Tight budget (80 cols) with 8 GPUs: should pick min cell width
+        // (5) or fall back below.
+        let cw = pick_cell_width(8, 80);
+        assert!(cw >= MIN_CELL || cw == 0);
+    }
+}

--- a/src/ui/topology/matrix_render.rs
+++ b/src/ui/topology/matrix_render.rs
@@ -15,9 +15,10 @@
 //! `nvidia-smi topo -m`-style matrix rendering for the topology tab.
 //!
 //! Produces a plain-text table suitable for BufferWriter output. Each cell
-//! holds a short label (`NV8`, `SYS`, `PXB`, `X`). Extra columns at the
-//! end report CPU affinity (pulled from the GPU's `detail` map when
-//! available) and NUMA node.
+//! holds a short label (`NV8`, `SYS`, `PXB`, `X`). A trailing NUMA column
+//! reports each GPU's node. CPU affinity is intentionally omitted until
+//! the NVML `nvmlDeviceGetCpuAffinity` plumbing lands — shipping the
+//! column with a placeholder `-` value would just noise up the table.
 
 use super::TopologyModel;
 use super::classify_edge::classify;
@@ -53,14 +54,15 @@ pub fn render_matrix(model: &TopologyModel, width: u16) -> String {
 
     let mut out = String::new();
 
-    // Header row: blank corner + GPU column labels + CPU Affinity + NUMA
+    // Header row: blank corner + GPU column labels + NUMA. The CPU
+    // Affinity column is intentionally hidden (see module doc).
     let label_col_w = gpu_label_width(model);
     out.push_str(&" ".repeat(label_col_w));
     for gpu in &model.gpus {
         let hdr = format!("GPU{}", gpu.index);
         out.push_str(&center(&hdr, cell_width));
     }
-    out.push_str("   CPU Affinity   NUMA\n");
+    out.push_str("   NUMA\n");
 
     // Body rows: one row per GPU.
     let gpu_count_u32 = gpu_count as u32;
@@ -80,12 +82,11 @@ pub fn render_matrix(model: &TopologyModel, width: u16) -> String {
             let label = edge.label();
             out.push_str(&center(&label, cell_width));
         }
-        let cpu_aff = cpu_affinity(row_gpu);
         let numa = row_gpu
             .numa_node
             .map(|n| n.to_string())
             .unwrap_or_else(|| "-".to_string());
-        out.push_str(&format!("   {cpu_aff:<12}   {numa}\n"));
+        out.push_str(&format!("   {numa}\n"));
     }
 
     // Legend row — mirrors nvidia-smi's convention.
@@ -93,22 +94,6 @@ pub fn render_matrix(model: &TopologyModel, width: u16) -> String {
     out.push_str("NSW=NvSwitch   PXB=PCIe bridge   NODE=PCIe same NUMA   SYS=PCIe across NUMA\n");
 
     out
-}
-
-/// CPU affinity helper. Reads the string from the `detail` map under
-/// any of a few canonical keys; falls back to a dash when absent.
-fn cpu_affinity(gpu: &super::TopologyGpu) -> String {
-    // Walk known keys in the detail map. Topology renderer is informed
-    // directly from GpuInfo so we never populate this here — instead
-    // we require the caller to have set the `detail` map via
-    // `TopologyGpu::pcie_display` / a future `cpu_affinity` field. For
-    // v1 we surface whatever the NVML reader stored.
-    //
-    // The model doesn't currently carry this, so return "-" to keep the
-    // column aligned. Future work: propagate the affinity from the
-    // detail map into TopologyGpu.
-    let _ = gpu;
-    "-".to_string()
 }
 
 /// Build a minimal GpuInfo view from a TopologyGpu for the classifier.
@@ -166,21 +151,19 @@ fn pick_cell_width(gpu_count: usize, available: usize) -> usize {
     if gpu_count == 0 {
         return MAX_CELL;
     }
-    // The tail (CPU Affinity + NUMA + padding) eats ~22 cells.
-    // Label column ~ 5 cells.
-    let overhead = 5 + 22;
+    // The tail (NUMA column + padding) eats ~8 cells (3 spaces + "NUMA"
+    // header width + 1 trailing space). Label column ~ 5 cells.
+    let overhead = 5 + 8;
     let usable = available.saturating_sub(overhead);
     for cw in (MIN_CELL..=MAX_CELL).rev() {
         if cw * gpu_count <= usable {
             return cw;
         }
     }
-    // Sub-minimum: return 0 so the caller renders the narrow fallback.
-    if MIN_CELL * gpu_count <= usable {
-        MIN_CELL
-    } else {
-        0
-    }
+    // Sub-minimum: the loop above already covers `MIN_CELL`, so if we
+    // fell through, the table doesn't fit even at the smallest cell
+    // width — signal the caller to render the narrow fallback.
+    0
 }
 
 fn center(s: &str, w: usize) -> String {
@@ -275,8 +258,10 @@ mod tests {
         let out = render_matrix(&model, 120);
         assert!(out.contains("GPU0"), "{out}");
         assert!(out.contains("GPU3"), "{out}");
-        assert!(out.contains("CPU Affinity"), "{out}");
         assert!(out.contains("NUMA"), "{out}");
+        // CPU Affinity column is intentionally hidden until NVML plumbing
+        // lands — it must not appear in the header.
+        assert!(!out.contains("CPU Affinity"), "{out}");
     }
 
     #[test]
@@ -299,7 +284,10 @@ mod tests {
 
     #[test]
     fn falls_back_to_summary_under_80_col() {
-        let gpus: Vec<_> = (0..8).map(|i| mk_gpu(i, Some(0), 4)).collect();
+        // 16 GPUs × MIN_CELL(5) = 80 cells for the matrix alone, plus 13
+        // cells of label + NUMA overhead = 93. A 60-column terminal
+        // cannot accommodate even the narrowest grid → narrow fallback.
+        let gpus: Vec<_> = (0..16).map(|i| mk_gpu(i, Some(0), 4)).collect();
         let model = TopologyModel::from_host("h", &gpus);
         let out = render_matrix(&model, 60);
         assert!(out.contains("summary only"), "{out}");

--- a/src/ui/topology/mod.rs
+++ b/src/ui/topology/mod.rs
@@ -1,0 +1,430 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Topology tab (issue #190).
+//!
+//! Renders the intra-node GPU interconnect as either an ASCII NUMA-grouped
+//! graph (default) or a `nvidia-smi topo -m`-style matrix. See the issue
+//! body for the motivation and visual mockups.
+//!
+//! Submodules:
+//!
+//! * [`classify_edge`] — derives NVn / SYS / PXB / NODE labels from
+//!   `GpuInfo.nvlink_remote_devices` + `numa_node_id` + `detail` PCIe
+//!   keys.
+//! * [`layout`] — groups GPUs by NUMA zone and picks a horizontal /
+//!   vertical stacking strategy based on terminal width.
+//! * [`graph_render`] — renders the NUMA-boxed ASCII graph.
+//! * [`matrix_render`] — renders the tabular matrix fallback.
+//!
+//! The orchestration entry point lives in
+//! [`crate::ui::renderers::topology_renderer`].
+
+use crate::device::{GpuInfo, NvLinkRemoteDevice};
+
+pub mod classify_edge;
+pub mod graph_render;
+pub mod layout;
+pub mod matrix_render;
+
+/// Minimum terminal width (in cells) at which the graph renderer remains
+/// legible. Below this threshold the orchestrator falls back to matrix
+/// mode even when the operator has selected graph mode.
+///
+/// Chosen so two 4-GPU NUMA boxes fit side-by-side at roughly 50 cells
+/// each; dropping below 100 columns means either the graph would overflow
+/// or the NUMA labels would collide.
+pub const GRAPH_MIN_WIDTH: u16 = 100;
+
+/// Render mode selected by the in-tab `M` toggle.
+///
+/// Default is `Graph`. When the terminal is narrower than
+/// [`GRAPH_MIN_WIDTH`], the renderer falls back to `Matrix` regardless of
+/// this selection so the content never overflows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TopologyViewMode {
+    #[default]
+    Graph,
+    Matrix,
+}
+
+impl TopologyViewMode {
+    /// Flip between graph and matrix. Invoked from the event handler on
+    /// `M`. Caller is responsible for bumping `mark_data_changed`.
+    pub fn toggled(self) -> Self {
+        match self {
+            Self::Graph => Self::Matrix,
+            Self::Matrix => Self::Graph,
+        }
+    }
+
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::Graph => "graph",
+            Self::Matrix => "matrix",
+        }
+    }
+}
+
+/// GPU rolled into the shape the topology renderers work with.
+#[derive(Debug, Clone)]
+pub struct TopologyGpu {
+    /// Ordinal index inside the host, derived from the `detail["index"]`
+    /// metric label when available and otherwise the positional index.
+    /// Drives the column order in the matrix and the label in the graph.
+    pub index: u32,
+    /// NVML UUID. Used for the graph label tooltip and dedup.
+    pub uuid: String,
+    /// Product name (e.g. `NVIDIA H100 80GB HBM3`). Shown in the header.
+    pub name: String,
+    /// NUMA zone the GPU sits in, or `None` on non-Linux hosts / drivers
+    /// that do not report NUMA. `None` lands in the synthetic "NUMA ?"
+    /// zone so layout still has a place to put the card.
+    pub numa_node: Option<i32>,
+    /// Active NvLinks as reported by the parent GPU.
+    pub links: Vec<NvLinkRemoteDevice>,
+    /// PCIe generation/width best-effort. Empty string when absent.
+    /// Reserved for a future iteration of the graph header that
+    /// surfaces PCIe speed next to each GPU label; kept in the model
+    /// today so the reader-side contract is stable.
+    #[allow(dead_code)]
+    pub pcie_display: String,
+}
+
+/// Topology snapshot for a single host.
+///
+/// Built once per frame from the GPU slice for the currently-selected
+/// host. Both the graph and matrix renderers consume the same model so
+/// the two views stay consistent.
+#[derive(Debug, Clone, Default)]
+pub struct TopologyModel {
+    /// Hostname / host_id for the header line.
+    pub host_label: String,
+    /// Indexed list of GPUs ordered by [`TopologyGpu::index`].
+    pub gpus: Vec<TopologyGpu>,
+    /// Has-any-NvLink shortcut. When false the graph drops NvLink edges
+    /// and shows only NUMA + PCIe annotations.
+    pub has_nvlink: bool,
+    /// Has-any-NvSwitch shortcut. Drives whether the graph draws the
+    /// switch-mesh overlay.
+    pub has_nvswitch: bool,
+    /// NvSwitch node count derived from the union of switch-typed remote
+    /// endpoints. Used only by the graph legend.
+    pub switch_count: u32,
+    /// Total active link count across all GPUs.
+    pub active_link_count: u32,
+    /// Whether the host belongs to the NVIDIA device family. Non-NVIDIA
+    /// paths omit the NVn/SYS legend entries.
+    pub is_nvidia: bool,
+}
+
+impl TopologyModel {
+    /// Build a topology model from the GPUs on a host.
+    ///
+    /// `host_label` is rendered verbatim in the header; pass the
+    /// hostname when known, otherwise the host_id.
+    pub fn from_host(host_label: impl Into<String>, gpus: &[GpuInfo]) -> Self {
+        let mut out = Self {
+            host_label: host_label.into(),
+            ..Self::default()
+        };
+        if gpus.is_empty() {
+            return out;
+        }
+
+        out.is_nvidia = gpus
+            .iter()
+            .any(|g| g.device_type == "GPU" && looks_nvidia(g));
+
+        let mut entries: Vec<TopologyGpu> = gpus
+            .iter()
+            .enumerate()
+            .map(|(positional, gpu)| TopologyGpu {
+                index: gpu
+                    .detail
+                    .get("index")
+                    .and_then(|s| s.parse::<u32>().ok())
+                    .unwrap_or(positional as u32),
+                uuid: gpu.uuid.clone(),
+                name: gpu.name.clone(),
+                numa_node: gpu.numa_node_id,
+                links: gpu.nvlink_remote_devices.clone(),
+                pcie_display: format_pcie(gpu),
+            })
+            .collect();
+        entries.sort_by_key(|g| g.index);
+
+        out.active_link_count = entries.iter().map(|g| g.links.len() as u32).sum();
+        out.has_nvlink = out.active_link_count > 0;
+
+        let switch_total: u32 = entries
+            .iter()
+            .map(|g| {
+                g.links
+                    .iter()
+                    .filter(|d| matches!(d.remote_type, crate::device::NvLinkRemoteType::Switch))
+                    .count() as u32
+            })
+            .sum();
+        out.switch_count = switch_total;
+        out.has_nvswitch = switch_total > 0;
+        out.gpus = entries;
+        out
+    }
+
+    /// Number of GPUs in the model (convenience accessor for renderers).
+    pub fn gpu_count(&self) -> u32 {
+        self.gpus.len() as u32
+    }
+
+    /// Ordered distinct NUMA nodes present in the snapshot, with `None`
+    /// collapsed to a single synthetic bucket at the end. Used by the
+    /// layout to decide column stacking.
+    pub fn numa_nodes(&self) -> Vec<Option<i32>> {
+        let mut seen: Vec<Option<i32>> = Vec::new();
+        for gpu in &self.gpus {
+            if !seen.contains(&gpu.numa_node) {
+                seen.push(gpu.numa_node);
+            }
+        }
+        // Keep `None` at the end so the graph draws the "unknown NUMA"
+        // box last.
+        seen.sort_by(|a, b| match (a, b) {
+            (Some(x), Some(y)) => x.cmp(y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+        seen
+    }
+
+    /// Short summary emitted under the graph / matrix (e.g. "8 GPUs · 2
+    /// NUMA · 56 NvLinks"). Pure utility for the orchestrator renderer.
+    pub fn summary(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        let gpu_count = self.gpu_count();
+        parts.push(format!(
+            "{gpu_count} GPU{}",
+            if gpu_count == 1 { "" } else { "s" }
+        ));
+        let numa_count = self.numa_nodes().len();
+        if numa_count > 0 {
+            parts.push(format!(
+                "{numa_count} NUMA{}",
+                if numa_count == 1 { "" } else { "s" }
+            ));
+        }
+        if self.active_link_count > 0 {
+            parts.push(format!("{} NvLinks", self.active_link_count));
+        }
+        if self.switch_count > 0 {
+            parts.push(format!("{} NvSwitch", self.switch_count));
+        }
+        parts.join(" · ")
+    }
+}
+
+/// Heuristic for "is this device NVIDIA?" — required because `GpuInfo`
+/// does not carry a vendor enum and non-NVIDIA readers set the name to
+/// various things ("Apple M-series", "AMD Radeon …"). NVIDIA names
+/// always start with `NVIDIA`, `GeForce`, or `Tesla`.
+fn looks_nvidia(gpu: &GpuInfo) -> bool {
+    let n = &gpu.name;
+    n.starts_with("NVIDIA")
+        || n.starts_with("GeForce")
+        || n.starts_with("Tesla")
+        || n.starts_with("Quadro")
+}
+
+/// Format PCIe display from the detail map. Falls back to the empty
+/// string when the reader did not populate any of the keys.
+fn format_pcie(gpu: &GpuInfo) -> String {
+    let gen_str = gpu
+        .detail
+        .get("PCIe Generation")
+        .or_else(|| gpu.detail.get("pcie_gen_current"));
+    let width = gpu
+        .detail
+        .get("PCIe Link Width")
+        .or_else(|| gpu.detail.get("pcie_width_current"));
+    match (gen_str, width) {
+        (Some(g), Some(w)) => format!("Gen{g} x{w}"),
+        (Some(g), None) => format!("Gen{g}"),
+        (None, Some(w)) => format!("x{w}"),
+        (None, None) => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::{GpuInfo, NvLinkRemoteDevice, NvLinkRemoteType};
+    use std::collections::HashMap;
+
+    fn mk_gpu(index: u32, numa: Option<i32>, links: Vec<NvLinkRemoteDevice>) -> GpuInfo {
+        let mut detail = HashMap::new();
+        detail.insert("index".to_string(), index.to_string());
+        GpuInfo {
+            uuid: format!("GPU-{index}"),
+            time: String::new(),
+            name: "NVIDIA H100 80GB HBM3".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: numa,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: links,
+            gpm_metrics: None,
+            detail,
+        }
+    }
+
+    #[test]
+    fn empty_model_is_empty() {
+        let model = TopologyModel::from_host("h", &[]);
+        assert!(model.gpus.is_empty());
+        assert!(!model.has_nvlink);
+        assert_eq!(model.gpu_count(), 0);
+    }
+
+    #[test]
+    fn model_tallies_links_and_switches() {
+        let g0 = mk_gpu(
+            0,
+            Some(0),
+            vec![
+                NvLinkRemoteDevice {
+                    link_index: 0,
+                    remote_type: NvLinkRemoteType::Gpu,
+                    bandwidth_mb_s: None,
+                },
+                NvLinkRemoteDevice {
+                    link_index: 1,
+                    remote_type: NvLinkRemoteType::Switch,
+                    bandwidth_mb_s: None,
+                },
+            ],
+        );
+        let g1 = mk_gpu(
+            1,
+            Some(1),
+            vec![NvLinkRemoteDevice {
+                link_index: 0,
+                remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
+            }],
+        );
+        let model = TopologyModel::from_host("h", &[g0, g1]);
+        assert_eq!(model.gpu_count(), 2);
+        assert_eq!(model.active_link_count, 3);
+        assert_eq!(model.switch_count, 1);
+        assert!(model.has_nvlink);
+        assert!(model.has_nvswitch);
+        assert!(model.is_nvidia);
+        assert_eq!(model.numa_nodes(), vec![Some(0), Some(1)]);
+    }
+
+    #[test]
+    fn gpus_are_sorted_by_index_label() {
+        // Out-of-order insertion: label index 2 first, then 0, then 1.
+        let g2 = mk_gpu(2, Some(0), vec![]);
+        let g0 = mk_gpu(0, Some(0), vec![]);
+        let g1 = mk_gpu(1, Some(0), vec![]);
+        let model = TopologyModel::from_host("h", &[g2, g0, g1]);
+        assert_eq!(
+            model.gpus.iter().map(|g| g.index).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn missing_numa_collapses_to_single_bucket() {
+        let g0 = mk_gpu(0, None, vec![]);
+        let g1 = mk_gpu(1, None, vec![]);
+        let model = TopologyModel::from_host("h", &[g0, g1]);
+        assert_eq!(model.numa_nodes(), vec![None]);
+    }
+
+    #[test]
+    fn non_nvidia_is_not_flagged() {
+        let mut gpu = mk_gpu(0, Some(0), vec![]);
+        gpu.name = "Apple M-series".to_string();
+        let model = TopologyModel::from_host("h", &[gpu]);
+        assert!(!model.is_nvidia);
+    }
+
+    #[test]
+    fn pcie_formatting_prefers_capitalised_detail_keys() {
+        let mut gpu = mk_gpu(0, Some(0), vec![]);
+        gpu.detail
+            .insert("PCIe Generation".to_string(), "5".to_string());
+        gpu.detail
+            .insert("PCIe Link Width".to_string(), "16".to_string());
+        let model = TopologyModel::from_host("h", &[gpu]);
+        assert_eq!(model.gpus[0].pcie_display, "Gen5 x16");
+    }
+
+    #[test]
+    fn summary_reports_gpu_numa_and_link_counts() {
+        let g0 = mk_gpu(
+            0,
+            Some(0),
+            vec![NvLinkRemoteDevice {
+                link_index: 0,
+                remote_type: NvLinkRemoteType::Gpu,
+                bandwidth_mb_s: None,
+            }],
+        );
+        let g1 = mk_gpu(
+            1,
+            Some(1),
+            vec![NvLinkRemoteDevice {
+                link_index: 0,
+                remote_type: NvLinkRemoteType::Switch,
+                bandwidth_mb_s: None,
+            }],
+        );
+        let model = TopologyModel::from_host("h", &[g0, g1]);
+        let s = model.summary();
+        assert!(s.contains("2 GPUs"), "{s}");
+        assert!(s.contains("2 NUMAs"), "{s}");
+        assert!(s.contains("2 NvLinks"), "{s}");
+        assert!(s.contains("NvSwitch"), "{s}");
+    }
+
+    #[test]
+    fn toggling_view_mode_round_trips() {
+        let mode = TopologyViewMode::default();
+        assert_eq!(mode, TopologyViewMode::Graph);
+        assert_eq!(mode.toggled(), TopologyViewMode::Matrix);
+        assert_eq!(mode.toggled().toggled(), TopologyViewMode::Graph);
+    }
+}

--- a/src/view/data_collection/remote_collector.rs
+++ b/src/view/data_collection/remote_collector.rs
@@ -152,16 +152,18 @@ impl RemoteCollector {
     }
 
     fn update_remote_tabs(state: &mut AppState) {
-        // Tab layout (issue #189): [All, Users, <host1>, <host2>, ...]
+        // Tab layout (issues #189, #190):
+        //   [All, Users, Topology, <host1>, <host2>, ...]
         //
-        // Users tab sits immediately after "All" so cluster-level tabs
-        // cluster together at the left edge of the row.  Inserting
-        // between adjusts the indices but the subsequent `current_tab`
-        // snap-back guards against the previous index being out of
-        // range after tabs shrink (e.g. all hosts disconnected).
+        // Cluster-level tabs cluster together at the left edge of the
+        // row. Inserting them there adjusts the indices but the
+        // subsequent `current_tab` snap-back guards against the previous
+        // index being out of range after tabs shrink (e.g. all hosts
+        // disconnected).
         let mut tabs = vec![
             "All".to_string(),
             crate::ui::tabs::USERS_TAB_NAME.to_string(),
+            crate::ui::tabs::TOPOLOGY_TAB_NAME.to_string(),
         ];
         tabs.extend(state.known_hosts.clone());
 

--- a/src/view/data_collection/remote_collector.rs
+++ b/src/view/data_collection/remote_collector.rs
@@ -179,6 +179,16 @@ impl RemoteCollector {
         } else if state.current_tab >= state.tabs.len() {
             state.current_tab = 0;
         }
+
+        // Invalidate the Topology tab's remembered host when the stashed
+        // name is no longer present in the tab strip (e.g. the host
+        // disconnected). The renderer will fall back to the first host
+        // tab until the operator picks a new one.
+        if let Some(last) = state.topology_last_host_tab.as_ref()
+            && !state.tabs.iter().any(|t| t == last)
+        {
+            state.topology_last_host_tab = None;
+        }
     }
 }
 

--- a/src/view/data_collection/replay_collector.rs
+++ b/src/view/data_collection/replay_collector.rs
@@ -313,6 +313,16 @@ async fn apply_frame_to_state(
         state.current_tab = 0;
     }
 
+    // Invalidate the Topology tab's remembered host when the stashed name
+    // is no longer present in the tab strip (e.g. switched recordings,
+    // host dropped out of the replay frame). The renderer will fall back
+    // to the first host tab until the operator picks a new one.
+    if let Some(last) = state.topology_last_host_tab.as_ref()
+        && !state.tabs.iter().any(|t| t == last)
+    {
+        state.topology_last_host_tab = None;
+    }
+
     state.mark_collector_data_changed();
 }
 

--- a/src/view/data_collection/replay_collector.rs
+++ b/src/view/data_collection/replay_collector.rs
@@ -298,6 +298,7 @@ async fn apply_frame_to_state(
     let mut tabs = vec![
         "All".to_string(),
         crate::ui::tabs::USERS_TAB_NAME.to_string(),
+        crate::ui::tabs::TOPOLOGY_TAB_NAME.to_string(),
     ];
     tabs.extend(host_ids);
 

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -25,7 +25,7 @@ use crate::record::replay::parse_timecode;
 use crate::ui::aggregation::user::{UserSortKey, sort_users};
 use crate::ui::filter_dsl::{apply as apply_filter, parse as parse_filter};
 use crate::ui::layout::LayoutCalculator;
-use crate::ui::tabs::users_tab_index;
+use crate::ui::tabs::{topology_tab_index, users_tab_index};
 
 /// Upper bound on the filter input buffer size (bytes).
 ///
@@ -59,8 +59,12 @@ pub async fn handle_key_event(key_event: KeyEvent, state: &mut AppState, args: &
     //    global GPU-sort bindings (`u` sort, `m` sort, `p` sort, `f`
     //    GPU-filter toggle).  They still fall through to replay / normal
     //    keys for navigation (arrows, `/`, `q`, `h`, `A`, `1`).
-    // 4. Normal keys: quit, help, alerts, arrows.
-    // 5. Replay-mode keys (SPACE/`]`/`[`/`+`/`-`/`j`/`k`/`g`/`L`) are
+    // 4. Topology-tab keys (issue #190) when the Topology tab is active:
+    //    `M` toggles the graph/matrix mode. Must come BEFORE the global
+    //    ladder so the Topology's `M` wins over the process-sort `m`.
+    // 5. Normal keys: quit, help, alerts, arrows. Includes `T` which
+    //    jumps to the Topology tab regardless of what tab is current.
+    // 6. Replay-mode keys (SPACE/`]`/`[`/`+`/`-`/`j`/`k`/`g`/`L`) are
     //    routed BEFORE `handle_navigation_keys` so the sort-by-GpuMem
     //    `g` binding doesn't shadow the timecode editor.
     if state.filter_input_mode == FilterInputMode::Editing {
@@ -80,6 +84,18 @@ pub async fn handle_key_event(key_event: KeyEvent, state: &mut AppState, args: &
         && !state.loading
         && !state.show_help
         && handle_users_tab_keys(key_event, state)
+    {
+        return false;
+    }
+
+    // Topology tab (issue #190): when active, `M` toggles the
+    // graph/matrix mode. Checked after Users-tab keys (per the mode-
+    // precedence ladder above) but BEFORE the global `match` so the
+    // Topology's `M` never collides with the global sort-by-memory `m`.
+    if crate::ui::tabs::is_topology_tab_active(state)
+        && !state.loading
+        && !state.show_help
+        && handle_topology_tab_keys(key_event, state)
     {
         return false;
     }
@@ -114,6 +130,18 @@ pub async fn handle_key_event(key_event: KeyEvent, state: &mut AppState, args: &
             // no-op when the tab doesn't exist (local mode, replays
             // before the first frame has seeded tabs).
             if let Some(idx) = users_tab_index(&state.tabs) {
+                state.current_tab = idx;
+                state.gpu_scroll_offset = 0;
+                state.storage_scroll_offset = 0;
+                state.mark_data_changed();
+            }
+            false
+        }
+        KeyCode::Char('T') => {
+            // Jump to the per-host Topology tab (issue #190). Silent
+            // no-op when the tab is not present (local mode before the
+            // first data frame populates it).
+            if let Some(idx) = topology_tab_index(&state.tabs) {
                 state.current_tab = idx;
                 state.gpu_scroll_offset = 0;
                 state.storage_scroll_offset = 0;
@@ -356,6 +384,36 @@ fn change_users_sort(state: &mut AppState, key: UserSortKey) {
         state.users_tab_state.selected_row = 0;
         state.mark_data_changed();
     }
+}
+
+/// Handle keys owned by the per-host Topology tab (issue #190).
+///
+/// Returns `true` when the key was consumed so the caller stops
+/// dispatching.  The tab currently owns a single key:
+///
+/// * `M` — toggle between graph and matrix render modes.
+///
+/// `Tab` / `Shift-Tab` / arrow navigation is intentionally **not** owned
+/// by the topology tab so the operator can still move between hosts
+/// without leaving the Topology view (per the issue spec: "Remote mode:
+/// defaults to showing selected host's topology; `Tab`/`Shift-Tab`
+/// cycles nodes").
+fn handle_topology_tab_keys(key_event: KeyEvent, state: &mut AppState) -> bool {
+    let KeyEvent {
+        code, modifiers, ..
+    } = key_event;
+    if modifiers.contains(KeyModifiers::CONTROL) || modifiers.contains(KeyModifiers::ALT) {
+        return false;
+    }
+    // Accept both `m` and `M` to minimise muscle-memory friction: the
+    // issue spec uses uppercase `M` but operators may hit it without
+    // Shift on systems where the caps-lock LED is off.
+    if matches!(code, KeyCode::Char('M') | KeyCode::Char('m')) {
+        state.topology_view_mode = state.topology_view_mode.toggled();
+        state.mark_data_changed();
+        return true;
+    }
+    false
 }
 
 /// Drill into the currently-highlighted user, or the highlighted host

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -47,6 +47,24 @@ fn get_visible_process_rows(state: &AppState) -> usize {
     }
 }
 
+/// Stash the name of the currently-selected host tab into
+/// `state.topology_last_host_tab` so the Topology tab can later render the
+/// operator's preferred host instead of the first one in the tab strip.
+///
+/// Does nothing when the active tab is one of the cluster-level reserved
+/// tabs (`All`, `Users`, `Topology`) — those are not host tabs. Called from
+/// the `T` hotkey and from the arrow-key navigation handlers so Topology's
+/// target host follows whichever host the operator last selected.
+fn remember_current_host_tab(state: &mut AppState) {
+    if let Some(current_name) = state.tabs.get(state.current_tab).cloned()
+        && current_name != "All"
+        && current_name != crate::ui::tabs::USERS_TAB_NAME
+        && current_name != crate::ui::tabs::TOPOLOGY_TAB_NAME
+    {
+        state.topology_last_host_tab = Some(current_name);
+    }
+}
+
 pub async fn handle_key_event(key_event: KeyEvent, state: &mut AppState, args: &ViewArgs) -> bool {
     // Mode precedence (highest first) — do NOT reorder:
     //
@@ -142,6 +160,11 @@ pub async fn handle_key_event(key_event: KeyEvent, state: &mut AppState, args: &
             // no-op when the tab is not present (local mode before the
             // first data frame populates it).
             if let Some(idx) = topology_tab_index(&state.tabs) {
+                // Remember the operator-selected host tab BEFORE
+                // overwriting `current_tab`, so the Topology renderer
+                // can point at that host instead of falling back to
+                // the first host tab.
+                remember_current_host_tab(state);
                 state.current_tab = idx;
                 state.gpu_scroll_offset = 0;
                 state.storage_scroll_offset = 0;
@@ -156,12 +179,14 @@ pub async fn handle_key_event(key_event: KeyEvent, state: &mut AppState, args: &
         KeyCode::Left => {
             if !state.show_help {
                 handle_left_arrow(state);
+                remember_current_host_tab(state);
             }
             false
         }
         KeyCode::Right => {
             if !state.show_help {
                 handle_right_arrow(state);
+                remember_current_host_tab(state);
             }
             false
         }

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -2171,4 +2171,152 @@ mod tests {
             & 0o777;
         assert_eq!(mode, 0o600, "export CSV file must be 0o600, got {mode:o}");
     }
+
+    // -----------------------------------------------------------------------
+    // Topology tab key handlers (issue #190)
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal remote-mode state with the standard tab strip:
+    /// `[All, Users, Topology, host1, host2]`.
+    fn make_topology_state() -> AppState {
+        let mut state = AppState::new();
+        state.is_local_mode = false;
+        state.loading = false;
+        state.tabs = vec![
+            "All".to_string(),
+            crate::ui::tabs::USERS_TAB_NAME.to_string(),
+            crate::ui::tabs::TOPOLOGY_TAB_NAME.to_string(),
+            "host1".to_string(),
+            "host2".to_string(),
+        ];
+        // Start on host1 so the T hotkey has something to remember.
+        state.current_tab = 3;
+        state
+    }
+
+    #[tokio::test]
+    async fn t_key_jumps_to_topology_tab_and_remembers_host() {
+        let mut state = make_topology_state();
+        // current_tab == 3 == "host1"; pressing T should stash "host1"
+        // and move current_tab to the Topology index (2).
+        handle_key_event(key(KeyCode::Char('T')), &mut state, &args()).await;
+        let topo_idx = crate::ui::tabs::topology_tab_index(&state.tabs).unwrap();
+        assert_eq!(state.current_tab, topo_idx);
+        assert_eq!(
+            state.topology_last_host_tab.as_deref(),
+            Some("host1"),
+            "T must stash the previously-active host tab"
+        );
+    }
+
+    #[tokio::test]
+    async fn t_key_is_noop_when_topology_tab_absent() {
+        // In local mode the Topology tab is not inserted into the strip.
+        let mut state = AppState::new();
+        state.is_local_mode = true;
+        state.tabs = vec!["All".to_string()];
+        state.current_tab = 0;
+        let was_tab = state.current_tab;
+        handle_key_event(key(KeyCode::Char('T')), &mut state, &args()).await;
+        assert_eq!(
+            state.current_tab, was_tab,
+            "T must be a silent no-op when no Topology tab exists"
+        );
+    }
+
+    #[test]
+    fn remember_current_host_tab_skips_reserved_tabs() {
+        let mut state = make_topology_state();
+        // When the current tab is "All" (index 0), nothing should be stashed.
+        state.current_tab = 0;
+        super::remember_current_host_tab(&mut state);
+        assert!(
+            state.topology_last_host_tab.is_none(),
+            "All tab must not be stashed"
+        );
+
+        // When the current tab is Users (index 1), nothing should be stashed.
+        state.current_tab = 1;
+        super::remember_current_host_tab(&mut state);
+        assert!(
+            state.topology_last_host_tab.is_none(),
+            "Users tab must not be stashed"
+        );
+
+        // When the current tab is Topology itself (index 2), nothing should be
+        // stashed — the renderer's fallback handles the self-reference case.
+        state.current_tab = 2;
+        super::remember_current_host_tab(&mut state);
+        assert!(
+            state.topology_last_host_tab.is_none(),
+            "Topology tab must not be stashed"
+        );
+    }
+
+    #[test]
+    fn remember_current_host_tab_stashes_host_tab() {
+        let mut state = make_topology_state();
+        state.current_tab = 4; // "host2"
+        super::remember_current_host_tab(&mut state);
+        assert_eq!(
+            state.topology_last_host_tab.as_deref(),
+            Some("host2"),
+            "host tab must be stashed"
+        );
+    }
+
+    #[tokio::test]
+    async fn m_key_toggles_topology_view_mode_when_topology_active() {
+        let mut state = make_topology_state();
+        // Jump to the Topology tab first so the mode-specific handler fires.
+        let topo_idx = crate::ui::tabs::topology_tab_index(&state.tabs).unwrap();
+        state.current_tab = topo_idx;
+        assert_eq!(
+            state.topology_view_mode,
+            crate::ui::topology::TopologyViewMode::Graph
+        );
+        // Uppercase M (as documented in the help overlay).
+        handle_key_event(key(KeyCode::Char('M')), &mut state, &args()).await;
+        assert_eq!(
+            state.topology_view_mode,
+            crate::ui::topology::TopologyViewMode::Matrix,
+            "first M must switch to matrix"
+        );
+        // Second press cycles back to graph.
+        handle_key_event(key(KeyCode::Char('M')), &mut state, &args()).await;
+        assert_eq!(
+            state.topology_view_mode,
+            crate::ui::topology::TopologyViewMode::Graph,
+            "second M must cycle back to graph"
+        );
+    }
+
+    #[tokio::test]
+    async fn lowercase_m_also_toggles_topology_view_mode() {
+        // The handler accepts both 'm' and 'M' to reduce muscle-memory
+        // friction (operators may not use Shift).
+        let mut state = make_topology_state();
+        let topo_idx = crate::ui::tabs::topology_tab_index(&state.tabs).unwrap();
+        state.current_tab = topo_idx;
+        handle_key_event(key(KeyCode::Char('m')), &mut state, &args()).await;
+        assert_eq!(
+            state.topology_view_mode,
+            crate::ui::topology::TopologyViewMode::Matrix,
+            "lowercase m must toggle topology mode when Topology tab is active"
+        );
+    }
+
+    #[tokio::test]
+    async fn m_key_does_not_toggle_topology_mode_outside_topology_tab() {
+        // 'm' outside the Topology tab hits the global GPU-sort-by-memory
+        // binding instead; topology_view_mode must not change.
+        let mut state = make_topology_state();
+        state.current_tab = 3; // "host1" — not the Topology tab
+        handle_key_event(key(KeyCode::Char('M')), &mut state, &args()).await;
+        assert_eq!(
+            state.topology_view_mode,
+            crate::ui::topology::TopologyViewMode::Graph,
+            "M outside the Topology tab must not toggle topology_view_mode"
+        );
+    }
 }

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -243,6 +243,23 @@ impl FrameRenderer {
             return (buffer.get_buffer().to_string(), 0);
         }
 
+        // Topology tab (issue #190): similar short-circuit — owns the
+        // body of the frame, emits its own header, and skips the normal
+        // GPU / chassis / device pipeline.
+        if is_topology_tab_selected(snapshot) {
+            let target_host = topology_target_host(snapshot);
+            crate::ui::renderers::topology_renderer::render_topology_tab(
+                &mut buffer,
+                &snapshot.gpu_info,
+                &target_host,
+                snapshot.topology_view_mode,
+                cols,
+                rows,
+            );
+            print_function_keys(&mut buffer, cols, rows, &view_state, is_remote);
+            return (buffer.get_buffer().to_string(), 0);
+        }
+
         // Render chassis information (node-level metrics)
         Self::render_chassis_section(&mut buffer, snapshot, width, cache);
 
@@ -828,6 +845,46 @@ fn is_users_tab_selected(snapshot: &RenderSnapshot) -> bool {
         .get(snapshot.current_tab)
         .map(|t| t == crate::ui::tabs::USERS_TAB_NAME)
         .unwrap_or(false)
+}
+
+/// True when the snapshot's current tab is the per-host Topology tab
+/// (issue #190).
+fn is_topology_tab_selected(snapshot: &RenderSnapshot) -> bool {
+    snapshot
+        .tabs
+        .get(snapshot.current_tab)
+        .map(|t| t == crate::ui::tabs::TOPOLOGY_TAB_NAME)
+        .unwrap_or(false)
+}
+
+/// Pick the host to display in the Topology tab.
+///
+/// When the operator last pointed at a specific host tab (e.g. "node-03"),
+/// we stash its name in `tabs[state.current_tab]` while they navigate.
+/// The Topology tab itself has no host, so we have to derive one:
+///
+/// * In local mode the lone known host (or empty string ⇒ "(local)") is
+///   returned.
+/// * In remote mode we look at the operator's previously-selected host
+///   tab, falling back to the first host tab if none was selected.
+fn topology_target_host(snapshot: &RenderSnapshot) -> String {
+    if snapshot.is_local_mode {
+        return snapshot
+            .gpu_info
+            .first()
+            .map(|g| g.host_id.clone())
+            .unwrap_or_default();
+    }
+    // Remote mode: first host-shaped tab after the reserved entries.
+    for tab in &snapshot.tabs {
+        if tab != "All"
+            && tab != crate::ui::tabs::USERS_TAB_NAME
+            && tab != crate::ui::tabs::TOPOLOGY_TAB_NAME
+        {
+            return tab.clone();
+        }
+    }
+    String::new()
 }
 
 /// Locate the [`crate::device::VgpuHostInfo`] record matching a given GPU row.

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -860,13 +860,14 @@ fn is_topology_tab_selected(snapshot: &RenderSnapshot) -> bool {
 /// Pick the host to display in the Topology tab.
 ///
 /// When the operator last pointed at a specific host tab (e.g. "node-03"),
-/// we stash its name in `tabs[state.current_tab]` while they navigate.
-/// The Topology tab itself has no host, so we have to derive one:
+/// we stash its name in `snapshot.topology_last_host_tab`. The Topology
+/// tab itself has no host, so we have to derive one:
 ///
 /// * In local mode the lone known host (or empty string ⇒ "(local)") is
 ///   returned.
-/// * In remote mode we look at the operator's previously-selected host
-///   tab, falling back to the first host tab if none was selected.
+/// * In remote mode we first honour the operator's remembered selection
+///   (still present in the tab strip), falling back to the first host tab
+///   if the remembered tab is absent or stale.
 fn topology_target_host(snapshot: &RenderSnapshot) -> String {
     if snapshot.is_local_mode {
         return snapshot
@@ -875,7 +876,14 @@ fn topology_target_host(snapshot: &RenderSnapshot) -> String {
             .map(|g| g.host_id.clone())
             .unwrap_or_default();
     }
-    // Remote mode: first host-shaped tab after the reserved entries.
+    // Remote mode: honour the operator's last-selected host tab when it
+    // is still in the tab strip.
+    if let Some(last) = snapshot.topology_last_host_tab.as_ref()
+        && snapshot.tabs.iter().any(|t| t == last)
+    {
+        return last.clone();
+    }
+    // Fall through: first host-shaped tab after the reserved entries.
     for tab in &snapshot.tabs {
         if tab != "All"
             && tab != crate::ui::tabs::USERS_TAB_NAME
@@ -1116,5 +1124,52 @@ mod tests {
         let output = FrameRenderer::render_help(&snapshot, &args, 80, 24);
         // Help popup must produce output.
         assert!(!output.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // topology_target_host: remote-mode host selection
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal remote-mode snapshot whose tab strip mirrors the
+    /// layout produced by `update_remote_tabs`:
+    /// `[All, Users, Topology, host1, host2]`. Helpers for the host-
+    /// selection tests below.
+    fn make_remote_topology_snapshot(last_host: Option<&str>) -> RenderSnapshot {
+        let mut state = AppState::new();
+        state.is_local_mode = false;
+        state.tabs = vec![
+            "All".to_string(),
+            crate::ui::tabs::USERS_TAB_NAME.to_string(),
+            crate::ui::tabs::TOPOLOGY_TAB_NAME.to_string(),
+            "host1".to_string(),
+            "host2".to_string(),
+        ];
+        state.topology_last_host_tab = last_host.map(|s| s.to_string());
+        RenderSnapshot::capture(&mut state)
+    }
+
+    #[test]
+    fn topology_target_host_uses_last_host_tab_when_set() {
+        // When the operator has previously selected "host2", the Topology
+        // tab should render that host — not fall through to the first
+        // host-shaped tab ("host1").
+        let snapshot = make_remote_topology_snapshot(Some("host2"));
+        assert_eq!(topology_target_host(&snapshot), "host2");
+    }
+
+    #[test]
+    fn topology_target_host_falls_back_to_first_host_when_unset() {
+        // With no remembered selection the renderer falls back to the
+        // first host-shaped tab after the reserved ones.
+        let snapshot = make_remote_topology_snapshot(None);
+        assert_eq!(topology_target_host(&snapshot), "host1");
+    }
+
+    #[test]
+    fn topology_target_host_falls_back_when_remembered_host_missing() {
+        // The remembered host "ghost" is not in the tab strip → fall back
+        // to the first host tab rather than returning the stale name.
+        let snapshot = make_remote_topology_snapshot(Some("ghost"));
+        assert_eq!(topology_target_host(&snapshot), "host1");
     }
 }

--- a/src/view/render_snapshot.rs
+++ b/src/view/render_snapshot.rs
@@ -34,6 +34,7 @@ use crate::ui::aggregation::user::UserAggregationResult;
 use crate::ui::alerts::{AlertTransition, Alerter};
 use crate::ui::filter_dsl::Expr as FilterExpr;
 use crate::ui::notification::NotificationManager;
+use crate::ui::topology::TopologyViewMode;
 use crate::utils::RuntimeEnvironment;
 
 /// Pre-computed rendering decisions captured from `AppState` under lock.
@@ -160,6 +161,10 @@ pub struct RenderSnapshot {
     /// lock is held.  Cloning the result (small: one vector per user)
     /// keeps the render path lock-free.
     pub users_aggregation: UserAggregationResult,
+
+    // Topology tab (issue #190)
+    /// Render mode selected by the Topology tab's `M` toggle.
+    pub topology_view_mode: TopologyViewMode,
 }
 
 impl RenderSnapshot {
@@ -264,6 +269,9 @@ impl RenderSnapshot {
             remote_process_info: state.remote_process_info.clone(),
             users_tab_state: state.users_tab_state.clone(),
             users_aggregation,
+
+            // Topology tab (issue #190)
+            topology_view_mode: state.topology_view_mode,
         }
     }
 
@@ -368,6 +376,9 @@ impl RenderSnapshot {
             data_version: Some(self.collector_data_version),
             result: self.users_aggregation.clone(),
         };
+
+        // Topology tab (issue #190)
+        state.topology_view_mode = self.topology_view_mode;
 
         state
     }

--- a/src/view/render_snapshot.rs
+++ b/src/view/render_snapshot.rs
@@ -512,4 +512,39 @@ mod tests {
         assert_eq!(restored.data_version, 42);
         assert_eq!(restored.utilization_history.len(), 1);
     }
+
+    #[test]
+    fn test_snapshot_capture_preserves_topology_state() {
+        use crate::ui::topology::TopologyViewMode;
+        let mut state = AppState::new();
+        state.topology_view_mode = TopologyViewMode::Matrix;
+        state.topology_last_host_tab = Some("host2".to_string());
+
+        let snapshot = RenderSnapshot::capture(&mut state);
+
+        assert_eq!(snapshot.topology_view_mode, TopologyViewMode::Matrix);
+        assert_eq!(
+            snapshot.topology_last_host_tab.as_deref(),
+            Some("host2"),
+            "last_host_tab must survive the snapshot capture"
+        );
+    }
+
+    #[test]
+    fn test_topology_state_roundtrips_through_as_app_state() {
+        use crate::ui::topology::TopologyViewMode;
+        let mut state = AppState::new();
+        state.topology_view_mode = TopologyViewMode::Matrix;
+        state.topology_last_host_tab = Some("host3".to_string());
+
+        let snapshot = RenderSnapshot::capture(&mut state);
+        let restored = snapshot.as_app_state();
+
+        assert_eq!(restored.topology_view_mode, TopologyViewMode::Matrix);
+        assert_eq!(
+            restored.topology_last_host_tab.as_deref(),
+            Some("host3"),
+            "topology state must survive the snapshot round-trip"
+        );
+    }
 }

--- a/src/view/render_snapshot.rs
+++ b/src/view/render_snapshot.rs
@@ -165,6 +165,10 @@ pub struct RenderSnapshot {
     // Topology tab (issue #190)
     /// Render mode selected by the Topology tab's `M` toggle.
     pub topology_view_mode: TopologyViewMode,
+    /// Operator-selected host tab remembered for the Topology view. When
+    /// `Some` and still present in `tabs`, the Topology renderer points at
+    /// that host; otherwise it falls back to the first host tab.
+    pub topology_last_host_tab: Option<String>,
 }
 
 impl RenderSnapshot {
@@ -272,6 +276,7 @@ impl RenderSnapshot {
 
             // Topology tab (issue #190)
             topology_view_mode: state.topology_view_mode,
+            topology_last_host_tab: state.topology_last_host_tab.clone(),
         }
     }
 
@@ -379,6 +384,7 @@ impl RenderSnapshot {
 
         // Topology tab (issue #190)
         state.topology_view_mode = self.topology_view_mode;
+        state.topology_last_host_tab = self.topology_last_host_tab.clone();
 
         state
     }

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -163,10 +163,13 @@ pub async fn run_replay_mode(args: &ViewArgs) {
     }
     if !header_hosts.is_empty() {
         // Users tab sits right after "All" (issue #189) so the
-        // cluster-wide tabs live together at the left edge.
+        // cluster-wide tabs live together at the left edge.  Topology
+        // (issue #190) follows Users so the three cluster-wide tabs
+        // share the same prefix.
         let mut tabs = vec![
             "All".to_string(),
             crate::ui::tabs::USERS_TAB_NAME.to_string(),
+            crate::ui::tabs::TOPOLOGY_TAB_NAME.to_string(),
         ];
         tabs.extend(header_hosts);
         initial_state.tabs = tabs;


### PR DESCRIPTION
## Summary

Adds a dedicated Topology tab (`T`) that visualises intra-node GPU
interconnect structure — NvLink connections (GPU↔GPU, GPU↔NvSwitch),
NUMA affinity, and PCIe lanes. Includes both a graph-style ASCII layout
and a `nvidia-smi topo -m`-equivalent matrix fallback. Works on systems
without NvLink by dropping to a PCIe-only rendering.

## Implementation

- **New module: `src/ui/topology/`** — pure-logic core split across
  five files, each under the 500-line soft limit:
  - `mod.rs` — `TopologyModel` + `TopologyViewMode` assembled from
    `GpuInfo.nvlink_remote_devices` + `numa_node_id` + `detail`.
  - `classify_edge.rs` — `NVn` bandwidth-hint classifier with a
    dominant-generation picker; falls back to generic `NV` when
    bandwidth is unknown.
  - `layout.rs` — NUMA-aware grid layout; picks horizontal vs
    vertical box stacking based on terminal width.
  - `graph_render.rs` — ASCII NUMA boxes with GPUs and edges.
  - `matrix_render.rs` — `nvidia-smi topo -m` table, fits the column
    widths to the GPU count.
- **Orchestrator: `src/ui/renderers/topology_renderer.rs`** — draws
  the panel for the selected host; falls back to matrix on terminals
  narrower than 100 columns so the content never overflows on
  80-column sessions.
- **Event routing**: `T` jumps to the tab; `M` toggles graph/matrix
  while the tab is active. Mode precedence ladder updated:
  filter-edit > replay-timecode > Users-tab keys > Topology-tab keys >
  global > replay.
- **Data model**: extends `NvLinkRemoteDevice` with
  `bandwidth_mb_s: Option<u32>` so the `NVn` generation classifier can
  derive labels like `NV5` from the hint. Existing construction sites
  (NVIDIA reader, mock templates, test fixtures) updated.
- **Prometheus round-trip**: adds `bandwidth_mb_s` as an optional
  label on `all_smi_nvlink_remote_device_type`. Parser accepts the
  label when present, rejects absurd upstream values, and remains
  backward-compatible with pre-#190 exporters that omit it.
- **Mock template**: `ALL_SMI_MOCK_TOPOLOGY=1` emits a DGX-style
  8-GPU, 2-NUMA, 64-link (7 GPU + 1 switch per GPU) topology so the
  tab can be exercised without real hardware.
- **Help overlay** + **README** updated to document `T`, `M`, and
  graceful-degradation behaviour.

### Graceful degradation

- No NvLink present → graph shows NUMA boxes with PCIe-only GPUs.
- Non-NVIDIA hosts → NUMA + PCIe groupings only; no `SYS`/`NVn`
  vocabulary.
- `nvlink_remote_devices` empty → dim "no active NvLinks" placeholder.
- No NUMA topology → single synthetic `NUMA ?` box.
- Terminals < 100 columns → automatic matrix fallback with a hint.

## Testing

- Unit tests (library + binaries): layout with 2/4/8 GPUs on 1 and 2
  NUMAs; edge classification covering full mesh / switch mesh / no
  NvLink; matrix formatting (header + legend + cell sizing); graph
  rendering (horizontal and vertical stacking); view mode toggle;
  NvLink bandwidth round-trip + backward-compat with old exporters.
- Integration: `hardware_details_integration_test` confirms the
  Prometheus exporter + network parser handle the new label without
  breaking older scrapes.
- Mock template unit tests (bypass env-var to avoid test-thread
  races): NUMA split, 64-link count, instance labelling, empty-input
  no-op.
- `cargo test --lib` (817 pass), `cargo test --bin all-smi` (932
  pass), `cargo test --bin all-smi-mock-server --features=mock` (52
  pass), `cargo clippy --all-targets -- -D warnings`, and
  `cargo fmt --all -- --check` all succeed.

## Test plan

- [ ] Verify the Topology tab is reachable via `T` in remote mode
  against a real or mocked cluster.
- [ ] Confirm `M` toggles between graph and matrix modes without
  data loss.
- [ ] On a terminal resized below 100 columns, confirm the graph
  mode shows the "matrix fallback" hint and switches to matrix
  rendering.
- [ ] With `ALL_SMI_MOCK_TOPOLOGY=1`, confirm the mock server emits
  the DGX-style topology and the TUI renders it correctly.
- [ ] Scrape a pre-#190 exporter (no `bandwidth_mb_s` label) from
  the new TUI and confirm NvLink rows still appear in the matrix.

Closes #190