### PR TITLE
feat: TOML config file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "clap",
  "core-foundation 0.10.1",
  "crossterm",
+ "dirs 5.0.1",
  "flate2",
  "furiosa-smi-rs",
  "futures-util",
@@ -57,6 +58,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -948,11 +950,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -963,7 +986,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2721,6 +2744,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3101,6 +3135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,7 +3181,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -3477,6 +3520,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,7 +3559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
 ]
@@ -3505,6 +3572,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "clap",
  "core-foundation 0.10.1",
  "crossterm",
- "dirs 5.0.1",
+ "dirs",
  "flate2",
  "furiosa-smi-rs",
  "futures-util",
@@ -950,32 +950,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.4.6",
- "windows-sys 0.48.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -986,7 +965,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.61.2",
 ]
 
@@ -2744,17 +2723,6 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3181,7 +3149,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ chrono = "0.4.44"
 crossterm = { version = "0.29.0", optional = true }
 clap = { version = "4.6.0", features = ["derive"], optional = true }
 toml = { version = "0.9", optional = true }
-dirs = { version = "5", optional = true }
+dirs = { version = "6", optional = true }
 axum = { version = "0.8.8", optional = true }
 tower-http = { version = "0.6.8", features = ["cors", "trace"], optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ tokio = { version = "1.50.0", features = ["full"] }
 chrono = "0.4.44"
 crossterm = { version = "0.29.0", optional = true }
 clap = { version = "4.6.0", features = ["derive"], optional = true }
+toml = { version = "0.9", optional = true }
+dirs = { version = "5", optional = true }
 axum = { version = "0.8.8", optional = true }
 tower-http = { version = "0.6.8", features = ["cors", "trace"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -90,7 +92,7 @@ tonic-prost-build = "0.14"
 
 [features]
 default = ["cli"]
-cli = ["dep:clap", "dep:crossterm", "dep:axum", "dep:tower-http", "dep:anyhow"]
+cli = ["dep:clap", "dep:crossterm", "dep:axum", "dep:tower-http", "dep:anyhow", "dep:toml", "dep:dirs"]
 mock = ["cli", "dep:rand", "dep:hyper", "dep:hyper-util"]
 # Opt-in Furiosa NPU support. Surfaced by the `furiosa.*` doctor checks
 # (issue #188) and used by the Linux-target `furiosa-smi-rs` optional dep.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -251,6 +251,34 @@ The project enforces these Clippy lints (see `Cargo.toml`):
 - `module_inception`: Avoid module naming confusion
 - `bool_comparison`: Use idiomatic boolean checks
 
+## Configuration Architecture
+
+Issue #192 introduced TOML config file support. The runtime configuration flows through three layers:
+
+1. **Compiled defaults** — constants in `src/common/config.rs` and the `Default` impls on each `Settings` sub-struct in `src/common/config_file.rs`.
+2. **TOML file + env overrides** — merged by `config_file::load(path)` into a `Settings` struct. Env vars follow `ALL_SMI_<SECTION>_<KEY>` canonical naming; legacy aliases (`ALL_SMI_ENERGY_PRICE`, `ALL_SMI_ALERT_TEMP`, etc.) remain supported for backward compatibility.
+3. **CLI overrides** — applied in `src/main.rs` after the runtime starts. Every existing CLI field is now `Option<T>`; `None` means "fall through to `Settings`". This preserves the pre-existing flag surface while letting config operators omit them.
+
+Key files:
+
+| File | Purpose |
+|------|---------|
+| `src/common/config_file.rs` | Schema + loader. Produces `Settings` from file + env. |
+| `src/common/config_file_tests.rs` | Unit tests (in a sibling file so the implementation stays under the 500-line soft cap). |
+| `src/common/paths.rs` | Platform-aware config directory resolution and `~` expansion. |
+| `src/common/secure_write.rs` | Shared `O_NOFOLLOW` + `0o600` writer, reused by `config init`, snapshot, and record. |
+| `src/config_cmd/` | Runtime glue for the `config init/print/validate` subcommands. |
+| `tests/config_file_integration_test.rs` | Full precedence / backward-compat integration tests. |
+
+When adding a new subcommand option that should be config-file-driven:
+
+1. Add the field to the appropriate section in `src/common/config_file.rs` (both the `*Section` deserializer and the merged `*Settings` runtime struct).
+2. Add the default in `impl Default for Settings`.
+3. Plumb the env-var override in `apply_env` (canonical name `ALL_SMI_<SECTION>_<KEY>`).
+4. Update `src/config_cmd/render.rs` to include the field in `print` output.
+5. Update `src/config_cmd/example.rs` (the commented example written by `config init`).
+6. In `src/main.rs` apply the fallback: `args.field.or(settings.section.field)`.
+
 ## Mock Server Development
 
 The mock server simulates GPU environments for testing:

--- a/README.md
+++ b/README.md
@@ -186,7 +186,100 @@ Config reload is not supported in v1 — restart the process to pick up changes.
 
 ### Schema
 
-The canonical schema carries `schema_version = 1` at the top level and sections for `[general]`, `[local]`, `[view]`, `[api]`, `[alerts]`, `[energy]`, `[display]`, `[record]`, and `[snapshot]`. Unknown keys are tolerated by default (forward compat) but warned about in `config print`; `config validate --strict` rejects them. Future schema versions produce a clean error instead of silently loading.
+The canonical schema carries `schema_version = 1` at the top level and nine sections. Unknown keys are tolerated by default (forward compat) and reported by `config print`; `config validate --strict` rejects them. Future schema versions produce a hard error instead of silently loading.
+
+**`[general]`** — cross-mode defaults
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `default_mode` | string | `"local"` | `ALL_SMI_GENERAL_DEFAULT_MODE` | Which subcommand runs when none is specified: `"local"`, `"view"`, or `"api"`. |
+| `theme` | string | `"auto"` | `ALL_SMI_GENERAL_THEME` | TUI colour theme: `"auto"`, `"light"`, `"dark"`, `"high-contrast"`, `"mono"`. |
+| `locale` | string | `"en"` | `ALL_SMI_GENERAL_LOCALE` | Display locale (reserved for future i18n). |
+
+**`[local]`** — options for `all-smi local`
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `interval_secs` | integer | adaptive | `ALL_SMI_LOCAL_INTERVAL_SECS` | Collection interval in seconds. `0` (or omit) for adaptive pacing. |
+
+**`[view]`** — options for `all-smi view`
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `hostfile` | string | — | `ALL_SMI_VIEW_HOSTFILE` | Path to a CSV/newline file listing remote `http://host:port` endpoints. |
+| `hosts` | array of strings | `[]` | `ALL_SMI_VIEW_HOSTS` (comma-separated) | Inline list of remote endpoints (alternative to `hostfile`). |
+| `interval_secs` | integer | adaptive | `ALL_SMI_VIEW_INTERVAL_SECS` | Scrape interval in seconds. `0` for adaptive (based on host count). |
+
+**`[api]`** — options for `all-smi api`
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `port` | integer | `9090` | `ALL_SMI_API_PORT` | TCP port for the Prometheus metrics endpoint. `0` disables TCP. |
+| `socket` | bool or string | `false` | `ALL_SMI_API_SOCKET` | Unix socket: `false` = disabled, `true` = platform default path, or an explicit path string. |
+| `processes` | bool | `false` | `ALL_SMI_API_PROCESSES` | Include per-process GPU metrics in `/metrics` output. |
+| `interval_secs` | integer | `3` | `ALL_SMI_API_INTERVAL_SECS` | Collection interval in seconds. |
+
+**`[alerts]`** — threshold alerting
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `enabled` | bool | `true` | — | Master switch for all alert rules. |
+| `temp_warn_c` | integer | `80` | `ALL_SMI_ALERTS_TEMP_WARN_C` | GPU temperature warning threshold in °C. |
+| `temp_crit_c` | integer | `90` | `ALL_SMI_ALERTS_TEMP_CRIT_C` | GPU temperature critical threshold in °C. |
+| `util_idle_pct` | integer | `5` | `ALL_SMI_ALERTS_UTIL_IDLE_PCT` | Utilisation % below which a GPU is considered idle. |
+| `util_idle_warn_mins` | integer | `15` | `ALL_SMI_ALERTS_UTIL_IDLE_WARN_MINS` | Minutes idle before an alert fires. |
+| `hysteresis_c` | integer | `2` | `ALL_SMI_ALERTS_HYSTERESIS_C` | °C gap below a threshold before an alert clears. |
+| `bell_on_critical` | bool | `false` | `ALL_SMI_ALERTS_BELL_ON_CRITICAL` | Ring the terminal bell when a critical alert triggers. |
+| `webhook_url` | string | `""` | `ALL_SMI_ALERTS_WEBHOOK_URL` | HTTP(S) URL to POST JSON alert payloads to. Redacted in `config print` unless `--show-secrets`. |
+| `power_crit_w` | integer | `0` | `ALL_SMI_ALERTS_POWER_CRIT_W` | GPU power draw critical threshold in watts (`0` = disabled). |
+
+**`[energy]`** — energy accounting and cost estimation
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `price_per_kwh` | float | `0.12` | `ALL_SMI_ENERGY_PRICE_PER_KWH` | Electricity price in $/kWh for cost estimation. |
+| `currency` | string | `"USD"` | `ALL_SMI_ENERGY_CURRENCY` | Currency symbol shown in the TUI. |
+| `show_cost` | bool | `true` | `ALL_SMI_ENERGY_SHOW_COST` | Toggle cost column in the TUI. |
+| `wal_path` | string | `~/.cache/all-smi/energy-wal.bin` | `ALL_SMI_ENERGY_WAL_PATH` | Path to the energy write-ahead log for persistent kWh accumulation. |
+| `gap_interpolate_seconds` | integer | `10` | `ALL_SMI_ENERGY_GAP_INTERPOLATE_SECONDS` | Max gap (1–3600 s) to interpolate across when the WAL has a hole. |
+| `wal_enabled` | bool | `true` | `ALL_SMI_ENERGY_WAL_ENABLED` | Enable the WAL. Disable in read-only container environments. |
+
+**`[display]`** — TUI cosmetics
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `color_scheme` | string | `"default"` | `ALL_SMI_DISPLAY_COLOR_SCHEME` | Colour palette: `"default"`, `"colorblind"`, `"mono"`. |
+| `gauge_style` | string | `"blocks"` | `ALL_SMI_DISPLAY_GAUGE_STYLE` | Bar-chart fill style: `"blocks"` or `"braille"`. |
+| `show_led_grid` | bool | `true` | `ALL_SMI_DISPLAY_SHOW_LED_GRID` | Show the per-GPU LED-style utilisation grid. |
+
+**`[record]`** — defaults for `all-smi record`
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `output_dir` | string | `~/.cache/all-smi/records` | `ALL_SMI_RECORD_OUTPUT_DIR` | Directory where recording segments are written. |
+| `compress` | string | `"zstd"` | `ALL_SMI_RECORD_COMPRESS` | Compression codec: `"zstd"`, `"gzip"`, or `"none"`. |
+
+**`[snapshot]`** — defaults for `all-smi snapshot`
+
+| Key | Type | Default | Env var | Description |
+|-----|------|---------|---------|-------------|
+| `default_format` | string | `"json"` | `ALL_SMI_SNAPSHOT_DEFAULT_FORMAT` | Output format: `"json"`, `"csv"`, or `"prometheus"`. |
+| `default_pretty` | bool | `true` | `ALL_SMI_SNAPSHOT_DEFAULT_PRETTY` | Pretty-print JSON output. |
+
+### Legacy environment variable aliases
+
+Older releases introduced environment variables with different naming. All aliases remain supported; when both the legacy and canonical name are set, the canonical name takes precedence.
+
+| Legacy alias | Canonical equivalent | Description |
+|---|---|---|
+| `ALL_SMI_ALERT_TEMP` | `ALL_SMI_ALERTS_TEMP_WARN_C` | Temperature warning threshold (°C); also auto-raises `temp_crit_c` if needed. |
+| `ALL_SMI_ALERT_UTIL_LOW_MINS` | `ALL_SMI_ALERTS_UTIL_IDLE_WARN_MINS` | Minutes idle before alert fires. |
+| `ALL_SMI_ENERGY_PRICE` | `ALL_SMI_ENERGY_PRICE_PER_KWH` | Price per kWh. |
+| `ALL_SMI_ENERGY_NO_COST` | `ALL_SMI_ENERGY_SHOW_COST=false` | Set to `1`/`true` to hide the cost column. |
+| `ALL_SMI_ENERGY_WAL_PATH` | `ALL_SMI_ENERGY_WAL_PATH` | WAL file path (same canonical name). |
+| `ALL_SMI_ENERGY_NO_WAL` | `ALL_SMI_ENERGY_WAL_ENABLED=false` | Set to `1`/`true` to disable WAL. |
+| `ALL_SMI_ENERGY_GAP_SECONDS` | `ALL_SMI_ENERGY_GAP_INTERPOLATE_SECONDS` | Interpolation gap in seconds. |
+| `ALL_SMI_ENERGY_CURRENCY` | `ALL_SMI_ENERGY_CURRENCY` | Currency symbol (same canonical name). |
 
 ## Platform-Specific Requirements
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,38 @@ http://gpu-node2:9090
 http://gpu-node3:9090
 ```
 
+## Configuration
+
+`all-smi` reads optional settings from a TOML config file. Every field has a compiled default, so a fresh install requires no file; operators only create one when they want persistent overrides (hostfile path, update interval, alert thresholds, `$/kWh`, etc.).
+
+### File locations
+
+| Platform | Canonical path |
+|----------|----------------|
+| Linux    | `$XDG_CONFIG_HOME/all-smi/config.toml` (fallback `~/.config/all-smi/config.toml`) |
+| macOS    | `~/Library/Application Support/all-smi/config.toml` (also accepts `~/.config/all-smi/config.toml`) |
+| Windows  | `%APPDATA%\all-smi\config.toml` |
+
+Pass `--config <PATH>` to any subcommand to override the discovery and force a specific file. A missing or malformed `--config` target is a hard error (exit 2); implicit discovery silently falls back to defaults when no candidate file exists.
+
+### Precedence
+
+Highest to lowest: **CLI flag > environment variable > config file > compiled default.** For example, `--port 9091` beats `ALL_SMI_API_PORT=9200` beats `[api] port = 9300` in `config.toml` beats the compiled default of `9090`. Env-var names follow the canonical pattern `ALL_SMI_<SECTION>_<KEY>` in upper-snake; legacy aliases from earlier releases (`ALL_SMI_ALERT_TEMP`, `ALL_SMI_ENERGY_PRICE`, etc.) keep working.
+
+### Helpers
+
+- `all-smi config init [--force]` writes a commented example config to the platform-canonical path. Refuses to overwrite without `--force`. The file is created with `O_NOFOLLOW` and mode `0o600` on Unix.
+- `all-smi config print [--format toml|json] [--show-secrets]` prints the fully merged effective configuration. `webhook_url` is redacted unless `--show-secrets` is passed.
+- `all-smi config validate [<path>] [--strict]` parses a config file and reports any errors (with line/column on parse failures). Exit 0 valid, 2 invalid. `--strict` rejects unknown keys.
+
+### Reload
+
+Config reload is not supported in v1 — restart the process to pick up changes. This keeps the Prometheus counter and WAL state semantics simple.
+
+### Schema
+
+The canonical schema carries `schema_version = 1` at the top level and sections for `[general]`, `[local]`, `[view]`, `[api]`, `[alerts]`, `[energy]`, `[display]`, `[record]`, and `[snapshot]`. Unknown keys are tolerated by default (forward compat) but warned about in `config print`; `config validate --strict` rejects them. Future schema versions produce a clean error instead of silently loading.
+
 ## Platform-Specific Requirements
 
 ### macOS (Apple Silicon)

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -106,10 +106,15 @@ pub async fn run_api_mode(args: &ApiArgs, settings: &Settings) {
         .init();
 
     println!("Starting API mode...");
-    let mut initial_state = AppState::new();
-    // Apply the fully-merged energy configuration (file + env) so the
-    // WAL path, cost toggle, etc. honour the user's config.toml.
-    initial_state.energy_config = settings.energy.clone();
+    // Build the state with the merged energy config so the integrator's
+    // `gap_interpolate_seconds` honours the TOML value. Without this
+    // constructor, later assignments to `energy_config` would not
+    // reconfigure the already-constructed `PowerIntegrator`.
+    let mut initial_state = AppState::with_energy_config(&settings.energy);
+    // Propagate `[display]` for symmetry with the TUI modes; the
+    // HTTP/Prometheus surface currently ignores it but future
+    // HTML/health-page renderers can read from a single location.
+    initial_state.display_config = settings.display.clone();
     // Replay any persisted energy WAL so Prometheus counters stay
     // monotonic across restarts (issue #191). Failures are logged
     // but do not block startup — the integrator simply begins at
@@ -136,7 +141,12 @@ pub async fn run_api_mode(args: &ApiArgs, settings: &Settings) {
     }
     let state = SharedState::new(RwLock::new(initial_state));
     let state_clone = state.clone();
-    let processes = args.processes;
+    // `args.processes` is now `Option<bool>` so the CLI can force
+    // `--processes=false` against a config file that sets it to true.
+    // `main.rs` always resolves the option before reaching here; the
+    // `unwrap_or(false)` is a defensive fallback so a direct
+    // library-level caller cannot crash by passing `None` through.
+    let processes = args.processes.unwrap_or(false);
     // args.interval was resolved against settings in main.rs; fall back
     // defensively to 3 (compiled default) when the caller somehow
     // passed `None`.

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -29,6 +29,7 @@ use tokio::net::UnixListener;
 use crate::api::handlers::{SharedState, metrics_handler};
 use crate::app_state::AppState;
 use crate::cli::ApiArgs;
+use crate::common::config_file::Settings;
 use crate::device::{create_chassis_reader, get_cpu_readers, get_gpu_readers, get_memory_readers};
 use crate::storage::info::StorageInfo;
 use crate::utils::{filter_docker_aware_disks, get_hostname};
@@ -95,7 +96,7 @@ fn set_socket_permissions(path: &std::path::Path) -> std::io::Result<()> {
 }
 
 /// Run the API server with TCP and optionally Unix Domain Socket listeners.
-pub async fn run_api_mode(args: &ApiArgs) {
+pub async fn run_api_mode(args: &ApiArgs, settings: &Settings) {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -106,6 +107,9 @@ pub async fn run_api_mode(args: &ApiArgs) {
 
     println!("Starting API mode...");
     let mut initial_state = AppState::new();
+    // Apply the fully-merged energy configuration (file + env) so the
+    // WAL path, cost toggle, etc. honour the user's config.toml.
+    initial_state.energy_config = settings.energy.clone();
     // Replay any persisted energy WAL so Prometheus counters stay
     // monotonic across restarts (issue #191). Failures are logged
     // but do not block startup — the integrator simply begins at
@@ -133,7 +137,10 @@ pub async fn run_api_mode(args: &ApiArgs) {
     let state = SharedState::new(RwLock::new(initial_state));
     let state_clone = state.clone();
     let processes = args.processes;
-    let interval = args.interval;
+    // args.interval was resolved against settings in main.rs; fall back
+    // defensively to 3 (compiled default) when the caller somehow
+    // passed `None`.
+    let interval = args.interval.unwrap_or(3);
 
     // Spawn the WAL flush task if enabled. The returned handle owns a
     // oneshot sender used by the Ctrl+C / SIGTERM path so the task can
@@ -254,7 +261,7 @@ pub async fn run_api_mode(args: &ApiArgs) {
             }
         });
 
-        let port = args.port;
+        let port = args.port.unwrap_or(9090);
         match (port, socket_path) {
             // Both TCP and UDS (port > 0 with socket)
             (1..=u16::MAX, Some(path)) => {
@@ -282,7 +289,7 @@ pub async fn run_api_mode(args: &ApiArgs) {
 
     #[cfg(not(unix))]
     {
-        run_tcp_listener(app, args.port).await;
+        run_tcp_listener(app, args.port.unwrap_or(9090)).await;
     }
 
     // Signal the WAL flush task to perform a final flush and fsync

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::common::config::{AlertConfig, EnergyConfig};
+use crate::common::config_file::DisplaySettings;
 use crate::device::{
     ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, MigGpuInfo, ProcessInfo, VgpuHostInfo,
 };
@@ -375,6 +376,13 @@ pub struct AppState {
     /// seeds the integrator's lifetime counter so Prometheus stays
     /// monotonic across restarts.
     pub energy_wal_replay: WalReplayIndex,
+    /// Resolved `[display]` config (color scheme / gauge style / LED
+    /// grid toggle) from the merged `Settings`. Renderers consult this
+    /// to decide whether to draw the LED grid, which glyph set the
+    /// gauge uses, and which palette to use. Defaults match the
+    /// `Settings::default()` values so renderers stay consistent with
+    /// pre-config-file behaviour when no config is loaded.
+    pub display_config: DisplaySettings,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -417,7 +425,19 @@ impl Default for AppState {
 
 impl AppState {
     pub fn new() -> Self {
-        let energy_config = EnergyConfig::default().with_env_overrides();
+        Self::with_energy_config(&EnergyConfig::default().with_env_overrides())
+    }
+
+    /// Construct an `AppState` whose [`EnergyAccountant`] is configured
+    /// from `energy_config`. The integrator's `gap_interpolate` window
+    /// is derived from `energy_config.gap_interpolate_seconds` so the
+    /// TOML-file value actually takes effect — without this
+    /// constructor, callers that overwrote `AppState::energy_config`
+    /// after `AppState::new()` left the integrator bound to the
+    /// compiled default window and the config key was silently
+    /// ignored.
+    pub fn with_energy_config(energy_config: &EnergyConfig) -> Self {
+        let energy_config = energy_config.clone();
         let energy = EnergyAccountant::new(std::time::Duration::from_secs(
             energy_config.gap_interpolate_seconds,
         ));
@@ -496,6 +516,11 @@ impl AppState {
             energy,
             energy_config,
             energy_wal_replay: WalReplayIndex::default(),
+            display_config: DisplaySettings {
+                color_scheme: "default".to_string(),
+                gauge_style: "blocks".to_string(),
+                show_led_grid: true,
+            },
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,9 +16,22 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+// Config subcommand argument types live in a sibling module so the main
+// CLI file stays within the 500-line soft limit.
+pub use crate::cli_config::{
+    ConfigAction, ConfigArgs, ConfigPrintArgs, ConfigPrintFormat, ConfigValidateArgs,
+};
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
+    /// Override the default TOML config file path. When omitted the loader
+    /// probes the platform-appropriate locations (see `all-smi config init`
+    /// for the canonical path). When given, a missing or malformed file
+    /// produces a hard error; no silent fallback.
+    #[arg(long, global = true, value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }
@@ -54,17 +67,29 @@ pub enum Commands {
     /// connectivity. Every check is read-only and bounded by a hard 3-second
     /// timeout. See issue #188.
     Doctor(DoctorArgs),
+    /// Inspect, initialise, or validate the TOML configuration file
+    /// (issue #192). See `all-smi config --help` for subcommands.
+    Config(ConfigArgs),
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct ApiArgs {
     /// The port to listen on for the API server. Use 0 to disable TCP listener.
-    #[arg(short, long, default_value_t = 9090)]
-    pub port: u16,
+    ///
+    /// When omitted, value is taken from the config file, the
+    /// `ALL_SMI_API_PORT` env var, or the compiled default (9090).
+    #[arg(short, long)]
+    pub port: Option<u16>,
     /// The interval in seconds at which to update the GPU information.
-    #[arg(short, long, default_value_t = 3)]
-    pub interval: u64,
+    ///
+    /// When omitted, value is taken from the config file, the
+    /// `ALL_SMI_API_INTERVAL_SECS` env var, or the compiled default (3).
+    #[arg(short, long)]
+    pub interval: Option<u64>,
     /// Include the process list in the API output.
+    ///
+    /// When omitted, value is taken from the config file or the
+    /// `ALL_SMI_API_PROCESSES` env var.
     #[arg(long)]
     pub processes: bool,
     /// Unix domain socket path for local IPC (Unix only).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,10 +88,16 @@ pub struct ApiArgs {
     pub interval: Option<u64>,
     /// Include the process list in the API output.
     ///
-    /// When omitted, value is taken from the config file or the
-    /// `ALL_SMI_API_PROCESSES` env var.
-    #[arg(long)]
-    pub processes: bool,
+    /// Use `--processes` or `--processes=true` to force-enable,
+    /// `--processes=false` to force-disable. When omitted, value is
+    /// taken from the config file or the `ALL_SMI_API_PROCESSES` env
+    /// var. Modelled as `Option<bool>` (not `bool`) so the CLI can
+    /// express the third state "no explicit override" — without this
+    /// an operator could not turn the flag OFF from the CLI when the
+    /// config file already set `processes = true`, since a bare
+    /// `--processes` flag has no natural "disable" spelling.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub processes: Option<bool>,
     /// Unix domain socket path for local IPC (Unix only).
     /// When specified without a value, uses platform default:
     /// - Linux: /var/run/all-smi.sock (fallback to /tmp/all-smi.sock if no permission)

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -1,0 +1,96 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Argument definitions for the `all-smi config` subcommand (issue
+//! #192). Re-exported from `cli` for ergonomic `use crate::cli::...`
+//! call sites; split here so the main CLI file stays below the 500-line
+//! soft limit.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand, ValueEnum};
+
+/// Arguments for the `all-smi config` subcommand (issue #192).
+#[derive(Args, Clone, Debug)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    pub action: ConfigAction,
+}
+
+/// `config` sub-subcommands. See the issue for the contract; briefly:
+///
+/// - `config init [--force]` writes a commented example config to the
+///   platform-canonical path.
+/// - `config print [--format toml|json] [--show-secrets]` prints the
+///   merged effective configuration, with `webhook_url` redacted unless
+///   `--show-secrets` is set.
+/// - `config validate [<path>] [--strict]` parses the given (or default)
+///   file and reports any errors, exiting 0 on valid and 2 on invalid.
+#[derive(Subcommand, Clone, Debug)]
+pub enum ConfigAction {
+    /// Write a commented example config.toml at the default location.
+    /// Refuses to overwrite without `--force`.
+    Init(ConfigInitArgs),
+    /// Print the effective merged configuration in TOML or JSON form.
+    Print(ConfigPrintArgs),
+    /// Parse a config file and report any errors. Exit 0 on valid, 2
+    /// on invalid.
+    Validate(ConfigValidateArgs),
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct ConfigInitArgs {
+    /// Overwrite an existing config file (atomically).
+    #[arg(long)]
+    pub force: bool,
+}
+
+/// Output format for `config print`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum ConfigPrintFormat {
+    Toml,
+    Json,
+}
+
+impl std::fmt::Display for ConfigPrintFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Toml => write!(f, "toml"),
+            Self::Json => write!(f, "json"),
+        }
+    }
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct ConfigPrintArgs {
+    /// Output format — `toml` or `json`.
+    #[arg(long, value_enum, default_value_t = ConfigPrintFormat::Toml)]
+    pub format: ConfigPrintFormat,
+    /// By default `webhook_url` is redacted to avoid leaking bot tokens
+    /// in terminal scrollback. Set this flag to print it verbatim.
+    #[arg(long)]
+    pub show_secrets: bool,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct ConfigValidateArgs {
+    /// File to validate. Defaults to the platform-canonical config
+    /// path. When the path does not exist the command exits 2.
+    pub path: Option<PathBuf>,
+    /// Reject unknown keys (top-level or inside known sections).
+    /// Without this flag unknown keys produce a warning but not an
+    /// error, so the config remains forward-compatible.
+    #[arg(long)]
+    pub strict: bool,
+}

--- a/src/common/config_apply.rs
+++ b/src/common/config_apply.rs
@@ -1,0 +1,225 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! File-level merge helpers: project a parsed [`RawConfig`] onto a
+//! mutable [`Settings`]. Broken out so `config_file.rs` stays under the
+//! 500-line soft cap and each section-level projection is easy to read
+//! and test in isolation.
+
+use crate::common::config_file::{ConfigError, Settings};
+use crate::common::config_schema::{RawConfig, SocketSetting};
+
+/// Entry point called by [`crate::common::config_file::load`] and
+/// [`crate::common::config_file::validate_file`].
+pub(super) fn apply_file(raw: &RawConfig, settings: &mut Settings) -> Result<(), ConfigError> {
+    apply_file_general(raw, settings)?;
+    apply_file_local(raw, settings);
+    apply_file_view(raw, settings);
+    apply_file_api(raw, settings);
+    apply_file_alerts(raw, settings);
+    apply_file_energy(raw, settings)?;
+    apply_file_display(raw, settings);
+    apply_file_record(raw, settings)?;
+    apply_file_snapshot(raw, settings)?;
+    Ok(())
+}
+
+fn apply_file_general(raw: &RawConfig, settings: &mut Settings) -> Result<(), ConfigError> {
+    let Some(g) = &raw.general else {
+        return Ok(());
+    };
+    if let Some(m) = &g.default_mode {
+        match m.as_str() {
+            "local" | "view" | "api" => settings.general.default_mode = m.clone(),
+            _ => {
+                return Err(ConfigError::Semantic(format!(
+                    "general.default_mode must be one of local/view/api, got `{m}`"
+                )));
+            }
+        }
+    }
+    if let Some(t) = &g.theme {
+        match t.as_str() {
+            "auto" | "light" | "dark" | "high-contrast" | "mono" => {
+                settings.general.theme = t.clone();
+            }
+            _ => {
+                return Err(ConfigError::Semantic(format!(
+                    "general.theme must be auto/light/dark/high-contrast/mono, got `{t}`"
+                )));
+            }
+        }
+    }
+    if let Some(l) = &g.locale {
+        settings.general.locale = l.clone();
+    }
+    Ok(())
+}
+
+fn apply_file_local(raw: &RawConfig, settings: &mut Settings) {
+    if let Some(l) = &raw.local
+        && l.interval_secs.is_some()
+    {
+        settings.local.interval_secs = l.interval_secs;
+    }
+}
+
+fn apply_file_view(raw: &RawConfig, settings: &mut Settings) {
+    let Some(v) = &raw.view else { return };
+    if v.hostfile.is_some() {
+        settings.view.hostfile = v.hostfile.clone();
+    }
+    if let Some(hosts) = &v.hosts {
+        settings.view.hosts = hosts.clone();
+    }
+    if v.interval_secs.is_some() {
+        settings.view.interval_secs = v.interval_secs;
+    }
+}
+
+fn apply_file_api(raw: &RawConfig, settings: &mut Settings) {
+    let Some(a) = &raw.api else { return };
+    if let Some(p) = a.port {
+        settings.api.port = p;
+    }
+    match &a.socket {
+        SocketSetting::Unset => {}
+        s => settings.api.socket = s.clone(),
+    }
+    if let Some(p) = a.processes {
+        settings.api.processes = p;
+    }
+    if let Some(i) = a.interval_secs {
+        settings.api.interval_secs = i;
+    }
+}
+
+fn apply_file_alerts(raw: &RawConfig, settings: &mut Settings) {
+    let Some(al) = &raw.alerts else { return };
+    if let Some(t) = al.temp_warn_c {
+        settings.alerts.temp_warn_c = t;
+    }
+    if let Some(t) = al.temp_crit_c {
+        settings.alerts.temp_crit_c = t;
+    }
+    if let Some(v) = al.util_idle_pct {
+        settings.alerts.util_idle_pct = v;
+    }
+    if let Some(v) = al.util_idle_warn_mins {
+        settings.alerts.util_idle_warn_mins = v;
+    }
+    if let Some(v) = al.hysteresis_c {
+        settings.alerts.hysteresis_c = v;
+    }
+    if let Some(v) = al.bell_on_critical {
+        settings.alerts.bell_on_critical = v;
+    }
+    if let Some(url) = &al.webhook_url {
+        settings.alerts.webhook_url = url.clone();
+    }
+    if let Some(v) = al.power_crit_w {
+        settings.alerts.power_crit_w = v;
+    }
+    // `enabled` currently acts as a no-op; wire-up pending a future
+    // global disable switch on the alerter.
+    let _ = al.enabled;
+}
+
+fn apply_file_energy(raw: &RawConfig, settings: &mut Settings) -> Result<(), ConfigError> {
+    let Some(e) = &raw.energy else {
+        return Ok(());
+    };
+    if let Some(p) = e.price_per_kwh {
+        if !p.is_finite() || p < 0.0 {
+            return Err(ConfigError::Semantic(format!(
+                "energy.price_per_kwh must be a non-negative finite number, got {p}"
+            )));
+        }
+        settings.energy.price_per_kwh = p;
+    }
+    if let Some(c) = &e.currency {
+        settings.energy.currency = c.clone();
+    }
+    if let Some(s) = e.show_cost {
+        settings.energy.show_cost = s;
+    }
+    if let Some(w) = &e.wal_path {
+        settings.energy.wal_path = w.clone();
+    }
+    if let Some(g) = e.gap_interpolate_seconds {
+        if !(1..=3600).contains(&g) {
+            return Err(ConfigError::Semantic(format!(
+                "energy.gap_interpolate_seconds must be in [1, 3600], got {g}"
+            )));
+        }
+        settings.energy.gap_interpolate_seconds = g;
+    }
+    if let Some(w) = e.wal_enabled {
+        settings.energy.wal_enabled = w;
+    }
+    Ok(())
+}
+
+fn apply_file_display(raw: &RawConfig, settings: &mut Settings) {
+    let Some(d) = &raw.display else { return };
+    if let Some(c) = &d.color_scheme {
+        settings.display.color_scheme = c.clone();
+    }
+    if let Some(g) = &d.gauge_style {
+        settings.display.gauge_style = g.clone();
+    }
+    if let Some(v) = d.show_led_grid {
+        settings.display.show_led_grid = v;
+    }
+}
+
+fn apply_file_record(raw: &RawConfig, settings: &mut Settings) -> Result<(), ConfigError> {
+    let Some(r) = &raw.record else {
+        return Ok(());
+    };
+    if let Some(o) = &r.output_dir {
+        settings.record.output_dir = o.clone();
+    }
+    if let Some(c) = &r.compress {
+        match c.as_str() {
+            "zstd" | "gzip" | "none" => settings.record.compress = c.clone(),
+            _ => {
+                return Err(ConfigError::Semantic(format!(
+                    "record.compress must be zstd/gzip/none, got `{c}`"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_file_snapshot(raw: &RawConfig, settings: &mut Settings) -> Result<(), ConfigError> {
+    let Some(s) = &raw.snapshot else {
+        return Ok(());
+    };
+    if let Some(f) = &s.default_format {
+        match f.as_str() {
+            "json" | "csv" | "prometheus" => settings.snapshot.default_format = f.clone(),
+            _ => {
+                return Err(ConfigError::Semantic(format!(
+                    "snapshot.default_format must be json/csv/prometheus, got `{f}`"
+                )));
+            }
+        }
+    }
+    if let Some(v) = s.default_pretty {
+        settings.snapshot.default_pretty = v;
+    }
+    Ok(())
+}

--- a/src/common/config_env.rs
+++ b/src/common/config_env.rs
@@ -131,12 +131,37 @@ fn apply_env_api(settings: &mut Settings) {
 }
 
 /// Apply both the canonical `ALL_SMI_ALERTS_*` names and the legacy
-/// `ALL_SMI_ALERT_*` aliases introduced by issue #186. Canonical names
-/// are applied first and then the legacy names, matching the previous
-/// release's behaviour where `ALL_SMI_ALERT_TEMP` took effect.
+/// `ALL_SMI_ALERT_*` aliases introduced by issue #186.
+///
+/// Application order: **legacy first, canonical second.** This matches
+/// the pattern used by [`apply_env_energy`]: when an operator has both
+/// the old name and the new name set (e.g. during a rollout), the
+/// canonical one wins. Without this ordering a stale shell dotfile
+/// carrying `ALL_SMI_ALERT_TEMP` would silently clobber a freshly-set
+/// `ALL_SMI_ALERTS_TEMP_WARN_C`, making the documented canonical name
+/// a no-op.
 fn apply_env_alerts(settings: &mut Settings) {
     use std::env;
 
+    // Legacy aliases (issue #186) first. The old alias auto-bumped
+    // crit to keep `crit > warn`; reproduce that behaviour so
+    // backward-compat scripts stay faithful.
+    if let Ok(v) = env::var("ALL_SMI_ALERT_TEMP")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.temp_warn_c = n;
+        if settings.alerts.temp_crit_c < n + 5 {
+            settings.alerts.temp_crit_c = n + 10;
+        }
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERT_UTIL_LOW_MINS")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.util_idle_warn_mins = n;
+    }
+
+    // Canonical names second — they override the legacy values when
+    // both are present.
     if let Ok(v) = env::var("ALL_SMI_ALERTS_TEMP_WARN_C")
         && let Ok(n) = v.parse::<u32>()
     {
@@ -172,23 +197,6 @@ fn apply_env_alerts(settings: &mut Settings) {
         && let Ok(n) = v.parse::<u32>()
     {
         settings.alerts.power_crit_w = n;
-    }
-
-    // Legacy aliases (issue #186). The old alias auto-bumped crit to
-    // keep `crit > warn`; reproduce that behaviour so backward-compat
-    // scripts stay faithful.
-    if let Ok(v) = env::var("ALL_SMI_ALERT_TEMP")
-        && let Ok(n) = v.parse::<u32>()
-    {
-        settings.alerts.temp_warn_c = n;
-        if settings.alerts.temp_crit_c < n + 5 {
-            settings.alerts.temp_crit_c = n + 10;
-        }
-    }
-    if let Ok(v) = env::var("ALL_SMI_ALERT_UTIL_LOW_MINS")
-        && let Ok(n) = v.parse::<u32>()
-    {
-        settings.alerts.util_idle_warn_mins = n;
     }
 }
 

--- a/src/common/config_env.rs
+++ b/src/common/config_env.rs
@@ -1,0 +1,265 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Environment-variable overlay for [`crate::common::config_file::Settings`]
+//! (issue #192).
+//!
+//! Canonical naming: `ALL_SMI_<SECTION>_<KEY>` upper-snake. Legacy
+//! aliases introduced by earlier issues are also recognised here so
+//! existing operator muscle memory continues to work:
+//!
+//! - `ALL_SMI_ALERT_TEMP` → `alerts.temp_warn_c` (issue #186)
+//! - `ALL_SMI_ALERT_UTIL_LOW_MINS` → `alerts.util_idle_warn_mins`
+//!   (issue #186)
+//! - `ALL_SMI_ENERGY_PRICE` → `energy.price_per_kwh` (issue #191)
+//! - `ALL_SMI_ENERGY_NO_COST` → `energy.show_cost = false` (#191)
+//! - `ALL_SMI_ENERGY_WAL_PATH` → `energy.wal_path` (#191)
+//! - `ALL_SMI_ENERGY_NO_WAL` → `energy.wal_enabled = false` (#191)
+//! - `ALL_SMI_ENERGY_GAP_SECONDS` → `energy.gap_interpolate_seconds`
+//!   (#191)
+//! - `ALL_SMI_ENERGY_CURRENCY` → `energy.currency` (#191)
+//!
+//! Invalid values are silently dropped so a typo cannot brick the TUI;
+//! surface warnings via the returned `warnings` vector which `config
+//! print` shows to the user.
+
+use crate::common::config_file::{Settings, SocketSetting};
+
+/// Apply environment-variable overrides on top of `settings`.
+pub(super) fn apply_env(settings: &mut Settings, warnings: &mut Vec<String>) {
+    apply_env_general(settings, warnings);
+    apply_env_local(settings);
+    apply_env_view(settings);
+    apply_env_api(settings);
+    apply_env_alerts(settings);
+    apply_env_energy(settings);
+    apply_env_display(settings);
+    apply_env_record(settings, warnings);
+    apply_env_snapshot(settings, warnings);
+}
+
+fn apply_env_general(settings: &mut Settings, warnings: &mut Vec<String>) {
+    use std::env;
+    if let Ok(v) = env::var("ALL_SMI_GENERAL_DEFAULT_MODE") {
+        match v.as_str() {
+            "local" | "view" | "api" => settings.general.default_mode = v,
+            other => warnings.push(format!(
+                "env ALL_SMI_GENERAL_DEFAULT_MODE: ignored invalid value `{other}`"
+            )),
+        }
+    }
+    if let Ok(v) = env::var("ALL_SMI_GENERAL_THEME") {
+        match v.as_str() {
+            "auto" | "light" | "dark" | "high-contrast" | "mono" => settings.general.theme = v,
+            other => warnings.push(format!(
+                "env ALL_SMI_GENERAL_THEME: ignored invalid value `{other}`"
+            )),
+        }
+    }
+    if let Ok(v) = env::var("ALL_SMI_GENERAL_LOCALE") {
+        settings.general.locale = v;
+    }
+}
+
+fn apply_env_local(settings: &mut Settings) {
+    use std::env;
+    if let Ok(v) = env::var("ALL_SMI_LOCAL_INTERVAL_SECS")
+        && let Ok(n) = v.parse::<u64>()
+    {
+        settings.local.interval_secs = Some(n);
+    }
+}
+
+fn apply_env_view(settings: &mut Settings) {
+    use std::env;
+    if let Ok(v) = env::var("ALL_SMI_VIEW_HOSTFILE")
+        && !v.trim().is_empty()
+    {
+        settings.view.hostfile = Some(v);
+    }
+    if let Ok(v) = env::var("ALL_SMI_VIEW_HOSTS")
+        && !v.trim().is_empty()
+    {
+        settings.view.hosts = v
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+    }
+    if let Ok(v) = env::var("ALL_SMI_VIEW_INTERVAL_SECS")
+        && let Ok(n) = v.parse::<u64>()
+    {
+        settings.view.interval_secs = Some(n);
+    }
+}
+
+fn apply_env_api(settings: &mut Settings) {
+    use std::env;
+    if let Ok(v) = env::var("ALL_SMI_API_PORT")
+        && let Ok(n) = v.parse::<u16>()
+    {
+        settings.api.port = n;
+    }
+    if let Ok(v) = env::var("ALL_SMI_API_SOCKET") {
+        if v.eq_ignore_ascii_case("false") || v == "0" {
+            settings.api.socket = SocketSetting::Bool(false);
+        } else if v.eq_ignore_ascii_case("true") || v == "1" {
+            settings.api.socket = SocketSetting::Bool(true);
+        } else {
+            settings.api.socket = SocketSetting::Path(v);
+        }
+    }
+    if let Ok(v) = env::var("ALL_SMI_API_PROCESSES") {
+        settings.api.processes = matches!(v.as_str(), "1" | "true" | "TRUE" | "True");
+    }
+    if let Ok(v) = env::var("ALL_SMI_API_INTERVAL_SECS")
+        && let Ok(n) = v.parse::<u64>()
+    {
+        settings.api.interval_secs = n;
+    }
+}
+
+/// Apply both the canonical `ALL_SMI_ALERTS_*` names and the legacy
+/// `ALL_SMI_ALERT_*` aliases introduced by issue #186. Canonical names
+/// are applied first and then the legacy names, matching the previous
+/// release's behaviour where `ALL_SMI_ALERT_TEMP` took effect.
+fn apply_env_alerts(settings: &mut Settings) {
+    use std::env;
+
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_TEMP_WARN_C")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.temp_warn_c = n;
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_TEMP_CRIT_C")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.temp_crit_c = n;
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_UTIL_IDLE_PCT")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.util_idle_pct = n;
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_UTIL_IDLE_WARN_MINS")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.util_idle_warn_mins = n;
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_HYSTERESIS_C")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.hysteresis_c = n;
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_BELL_ON_CRITICAL") {
+        settings.alerts.bell_on_critical = matches!(v.as_str(), "1" | "true" | "TRUE" | "True");
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_WEBHOOK_URL") {
+        settings.alerts.webhook_url = v;
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERTS_POWER_CRIT_W")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.power_crit_w = n;
+    }
+
+    // Legacy aliases (issue #186). The old alias auto-bumped crit to
+    // keep `crit > warn`; reproduce that behaviour so backward-compat
+    // scripts stay faithful.
+    if let Ok(v) = env::var("ALL_SMI_ALERT_TEMP")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.temp_warn_c = n;
+        if settings.alerts.temp_crit_c < n + 5 {
+            settings.alerts.temp_crit_c = n + 10;
+        }
+    }
+    if let Ok(v) = env::var("ALL_SMI_ALERT_UTIL_LOW_MINS")
+        && let Ok(n) = v.parse::<u32>()
+    {
+        settings.alerts.util_idle_warn_mins = n;
+    }
+}
+
+fn apply_env_energy(settings: &mut Settings) {
+    use std::env;
+    // Delegate the existing legacy-alias handling to EnergyConfig.
+    settings.energy = settings.energy.clone().with_env_overrides();
+    // Canonical names introduced by issue #192 (additional to the legacy
+    // aliases handled by `with_env_overrides`).
+    if let Ok(v) = env::var("ALL_SMI_ENERGY_PRICE_PER_KWH")
+        && let Ok(p) = v.parse::<f64>()
+        && p.is_finite()
+        && p >= 0.0
+    {
+        settings.energy.price_per_kwh = p;
+    }
+    if let Ok(v) = env::var("ALL_SMI_ENERGY_SHOW_COST") {
+        settings.energy.show_cost = matches!(v.as_str(), "1" | "true" | "TRUE" | "True");
+    }
+    if let Ok(v) = env::var("ALL_SMI_ENERGY_WAL_ENABLED") {
+        settings.energy.wal_enabled = matches!(v.as_str(), "1" | "true" | "TRUE" | "True");
+    }
+    if let Ok(v) = env::var("ALL_SMI_ENERGY_GAP_INTERPOLATE_SECONDS")
+        && let Ok(n) = v.parse::<u64>()
+        && (1..=3600).contains(&n)
+    {
+        settings.energy.gap_interpolate_seconds = n;
+    }
+}
+
+fn apply_env_display(settings: &mut Settings) {
+    use std::env;
+    if let Ok(v) = env::var("ALL_SMI_DISPLAY_COLOR_SCHEME") {
+        settings.display.color_scheme = v;
+    }
+    if let Ok(v) = env::var("ALL_SMI_DISPLAY_GAUGE_STYLE") {
+        settings.display.gauge_style = v;
+    }
+    if let Ok(v) = env::var("ALL_SMI_DISPLAY_SHOW_LED_GRID") {
+        settings.display.show_led_grid = matches!(v.as_str(), "1" | "true" | "TRUE" | "True");
+    }
+}
+
+fn apply_env_record(settings: &mut Settings, warnings: &mut Vec<String>) {
+    use std::env;
+    if let Ok(v) = env::var("ALL_SMI_RECORD_OUTPUT_DIR")
+        && !v.trim().is_empty()
+    {
+        settings.record.output_dir = v;
+    }
+    if let Ok(v) = env::var("ALL_SMI_RECORD_COMPRESS") {
+        match v.as_str() {
+            "zstd" | "gzip" | "none" => settings.record.compress = v,
+            other => warnings.push(format!(
+                "env ALL_SMI_RECORD_COMPRESS: ignored invalid value `{other}`"
+            )),
+        }
+    }
+}
+
+fn apply_env_snapshot(settings: &mut Settings, warnings: &mut Vec<String>) {
+    use std::env;
+    if let Ok(v) = env::var("ALL_SMI_SNAPSHOT_DEFAULT_FORMAT") {
+        match v.as_str() {
+            "json" | "csv" | "prometheus" => settings.snapshot.default_format = v,
+            other => warnings.push(format!(
+                "env ALL_SMI_SNAPSHOT_DEFAULT_FORMAT: ignored invalid value `{other}`"
+            )),
+        }
+    }
+    if let Ok(v) = env::var("ALL_SMI_SNAPSHOT_DEFAULT_PRETTY") {
+        settings.snapshot.default_pretty = matches!(v.as_str(), "1" | "true" | "TRUE" | "True");
+    }
+}

--- a/src/common/config_file.rs
+++ b/src/common/config_file.rs
@@ -1,0 +1,408 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TOML configuration file support for `all-smi` (issue #192).
+//!
+//! This module exposes:
+//! - [`Settings`] — the root runtime configuration struct, built from
+//!   compiled defaults merged with TOML file values and environment
+//!   variable overrides.
+//! - [`load`] — the primary loader. Accepts an explicit `Option<Path>`
+//!   from `--config`, falls back to platform-appropriate paths, and
+//!   returns a fully merged [`Settings`] plus any unknown-keys report.
+//! - [`LoadOutcome`] — what `load` returns: the settings, the resolved
+//!   path (when one was actually read), and any unknown keys for
+//!   `config print` to warn about.
+//! - [`SUPPORTED_SCHEMA_VERSION`] — version gate; mismatching `schema_version`
+//!   produces a hard error.
+//!
+//! Precedence rule (highest → lowest): CLI flag > env var > config file
+//! > compiled default. CLI merging lives in the caller — this module
+//! > handles the file + env layer only.
+//!
+//! Module layout:
+//! - [`crate::common::config_schema`] defines the on-disk TOML types
+//!   (pure serde data projections).
+//! - [`crate::common::config_env`] applies env-var overrides to a
+//!   [`Settings`] (canonical + backward-compat legacy aliases).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use toml::Value as TomlValue;
+
+use crate::common::config::{AlertConfig, EnergyConfig};
+use crate::common::config_apply;
+use crate::common::config_env;
+use crate::common::config_schema::{KNOWN_TOP_LEVEL, RawConfig};
+use crate::common::paths;
+
+// Re-export the on-disk schema types so existing callers can keep
+// importing through this module.
+pub use crate::common::config_schema::SocketSetting;
+
+/// Schema version the current binary understands. Future versions may
+/// bump this and migrate fields; for v1 we reject mismatches outright.
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------
+
+/// Errors produced by [`load`] and [`parse_toml`]. Distinguished enough
+/// for callers (CLI, `config validate`) to emit the right exit codes.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// I/O error while reading the file.
+    #[error("config file I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The TOML parser rejected the file. Includes the underlying
+    /// message which already names line/column.
+    #[error("config file parse error: {0}")]
+    Parse(String),
+    /// `schema_version` in the file is newer than
+    /// [`SUPPORTED_SCHEMA_VERSION`], or otherwise out of range.
+    #[error(
+        "config file schema_version = {found} is not supported \
+         (this build understands schema_version = {supported})"
+    )]
+    SchemaVersion { found: u32, supported: u32 },
+    /// A semantic validation failure (e.g. `theme = "rainbow"`).
+    #[error("config file semantic error: {0}")]
+    Semantic(String),
+    /// With `--strict`, any unknown key at the top-level or inside a
+    /// known section is reported here.
+    #[error("config file unknown key: {0}")]
+    UnknownKey(String),
+}
+
+// ---------------------------------------------------------------------
+// Runtime Settings — merged view
+// ---------------------------------------------------------------------
+
+/// Merged configuration handed to every subcommand entry point. Each
+/// field is populated via the precedence chain (defaults → file → env)
+/// inside [`load`]; the CLI layer overrides [`Settings`] further.
+#[derive(Debug, Clone)]
+pub struct Settings {
+    pub general: GeneralSettings,
+    pub local: LocalSettings,
+    pub view: ViewSettings,
+    pub api: ApiSettings,
+    pub alerts: AlertConfig,
+    pub energy: EnergyConfig,
+    pub display: DisplaySettings,
+    pub record: RecordSettings,
+    pub snapshot: SnapshotSettings,
+    /// Path the settings were actually loaded from. `None` means we
+    /// used compiled defaults + env overrides only.
+    pub source_path: Option<PathBuf>,
+    /// Unknown top-level / section keys encountered during parse.
+    /// Populated even when `--strict` is off so `config print` can warn.
+    pub unknown_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeneralSettings {
+    pub default_mode: String,
+    pub theme: String,
+    pub locale: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LocalSettings {
+    pub interval_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ViewSettings {
+    pub hostfile: Option<String>,
+    pub hosts: Vec<String>,
+    pub interval_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApiSettings {
+    pub port: u16,
+    pub socket: SocketSetting,
+    pub processes: bool,
+    pub interval_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct DisplaySettings {
+    pub color_scheme: String,
+    pub gauge_style: String,
+    pub show_led_grid: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordSettings {
+    pub output_dir: String,
+    pub compress: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SnapshotSettings {
+    pub default_format: String,
+    pub default_pretty: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            general: GeneralSettings {
+                default_mode: "local".to_string(),
+                theme: "auto".to_string(),
+                locale: "en".to_string(),
+            },
+            local: LocalSettings::default(),
+            view: ViewSettings::default(),
+            api: ApiSettings {
+                port: 9090,
+                socket: SocketSetting::Unset,
+                processes: false,
+                interval_secs: 3,
+            },
+            alerts: AlertConfig::default(),
+            energy: EnergyConfig::default(),
+            display: DisplaySettings {
+                color_scheme: "default".to_string(),
+                gauge_style: "blocks".to_string(),
+                show_led_grid: true,
+            },
+            record: RecordSettings {
+                output_dir: "~/.cache/all-smi/records".to_string(),
+                compress: "zstd".to_string(),
+            },
+            snapshot: SnapshotSettings {
+                default_format: "json".to_string(),
+                default_pretty: true,
+            },
+            source_path: None,
+            unknown_keys: Vec::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Outcome + entry points
+// ---------------------------------------------------------------------
+
+/// Result returned by [`load`]. Callers that need to warn on unknown
+/// keys (`config print`) read `settings.unknown_keys`; callers that
+/// need to enforce strictness (`config validate --strict`) should
+/// instead consult [`validate_file`].
+#[derive(Debug)]
+pub struct LoadOutcome {
+    pub settings: Settings,
+    /// Warnings emitted during the merge (e.g., ignored env values).
+    pub warnings: Vec<String>,
+}
+
+/// Load configuration from the given path (or the platform default).
+///
+/// * `explicit` — path supplied via `--config`. When `Some`, the loader
+///   fails if the file does not exist or cannot be read. When `None`,
+///   the loader probes [`crate::common::paths::candidate_config_paths`]
+///   and silently falls back to defaults when no file is found.
+///
+/// Env-var overrides are applied on top of the file values before the
+/// final [`Settings`] is returned. CLI-flag precedence is applied later
+/// in the caller (see `src/main.rs`).
+pub fn load(explicit: Option<&Path>) -> Result<LoadOutcome, ConfigError> {
+    let mut warnings = Vec::new();
+
+    let (raw, source_path, unknown_keys): (RawConfig, Option<PathBuf>, Vec<String>) =
+        if let Some(path) = explicit {
+            let contents = std::fs::read_to_string(path).map_err(|e| ConfigError::Io {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+            let (raw, unknown) = parse_toml(&contents)?;
+            check_schema_version(&raw)?;
+            (raw, Some(path.to_path_buf()), unknown)
+        } else if let Some(path) = paths::discover_existing_config() {
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => {
+                    let (raw, unknown) = parse_toml(&contents)?;
+                    check_schema_version(&raw)?;
+                    (raw, Some(path), unknown)
+                }
+                Err(e) => {
+                    // The file existed when `discover_existing_config`
+                    // was called but disappeared under us (race); treat
+                    // as "no file" rather than a hard error.
+                    warnings.push(format!(
+                        "config: could not read {} ({e}); using defaults",
+                        path.display()
+                    ));
+                    (RawConfig::default(), None, Vec::new())
+                }
+            }
+        } else {
+            (RawConfig::default(), None, Vec::new())
+        };
+
+    let mut settings = Settings {
+        source_path,
+        unknown_keys,
+        ..Settings::default()
+    };
+
+    config_apply::apply_file(&raw, &mut settings)?;
+    config_env::apply_env(&mut settings, &mut warnings);
+
+    Ok(LoadOutcome { settings, warnings })
+}
+
+/// Schema-version gate. Returning an error short-circuits `load`.
+fn check_schema_version(raw: &RawConfig) -> Result<(), ConfigError> {
+    if let Some(v) = raw.schema_version
+        && v != SUPPORTED_SCHEMA_VERSION
+    {
+        return Err(ConfigError::SchemaVersion {
+            found: v,
+            supported: SUPPORTED_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+/// Public validation entry point used by `all-smi config validate
+/// --strict`. Returns `Ok(())` when the file parses and no unknown keys
+/// are present. Without `strict`, unknown keys are allowed — the caller
+/// should still call [`load`] to get the semantic errors.
+pub fn validate_file(path: &Path, strict: bool) -> Result<Settings, ConfigError> {
+    let contents = std::fs::read_to_string(path).map_err(|e| ConfigError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let (raw, unknown_keys) = parse_toml(&contents)?;
+    check_schema_version(&raw)?;
+
+    if strict && !unknown_keys.is_empty() {
+        return Err(ConfigError::UnknownKey(unknown_keys.join(", ")));
+    }
+
+    let mut settings = Settings {
+        source_path: Some(path.to_path_buf()),
+        unknown_keys,
+        ..Settings::default()
+    };
+    config_apply::apply_file(&raw, &mut settings)?;
+
+    Ok(settings)
+}
+
+// ---------------------------------------------------------------------
+// Parser + merge helpers
+// ---------------------------------------------------------------------
+
+/// Parse a TOML document and report any unknown top-level keys.
+///
+/// Implementation detail: we first parse into a generic `toml::Value`
+/// so we can enumerate the top-level keys independently of the typed
+/// deserializer (which silently ignores unknown keys when
+/// `deny_unknown_fields` is not set). We then deserialize the same
+/// string into the typed [`RawConfig`]. Unknown sub-section keys are
+/// collected through a second pass over the generic value.
+pub fn parse_toml(contents: &str) -> Result<(RawConfig, Vec<String>), ConfigError> {
+    let value: TomlValue =
+        toml::from_str(contents).map_err(|e| ConfigError::Parse(e.to_string()))?;
+    let raw: RawConfig = toml::from_str(contents).map_err(|e| ConfigError::Parse(e.to_string()))?;
+
+    let mut unknown = BTreeSet::new();
+    if let TomlValue::Table(top) = &value {
+        for key in top.keys() {
+            if !KNOWN_TOP_LEVEL.contains(&key.as_str()) {
+                unknown.insert(key.clone());
+            }
+        }
+        scan_unknown_subkeys(top, &mut unknown);
+    }
+
+    Ok((raw, unknown.into_iter().collect()))
+}
+
+/// Walk each known section and record any unrecognised sub-keys. Keeps
+/// unknown keys fully qualified (e.g. `api.foo`).
+fn scan_unknown_subkeys(top: &toml::map::Map<String, TomlValue>, out: &mut BTreeSet<String>) {
+    use toml::map::Map;
+    let check = |name: &str, known: &[&str], out: &mut BTreeSet<String>, top: &Map<_, _>| {
+        if let Some(TomlValue::Table(sec)) = top.get(name) {
+            for k in sec.keys() {
+                if !known.contains(&k.as_str()) {
+                    out.insert(format!("{name}.{k}"));
+                }
+            }
+        }
+    };
+    check("general", &["default_mode", "theme", "locale"], out, top);
+    check("local", &["interval_secs"], out, top);
+    check("view", &["hostfile", "hosts", "interval_secs"], out, top);
+    check(
+        "api",
+        &["port", "socket", "processes", "interval_secs"],
+        out,
+        top,
+    );
+    check(
+        "alerts",
+        &[
+            "enabled",
+            "temp_warn_c",
+            "temp_crit_c",
+            "util_idle_pct",
+            "util_idle_warn_mins",
+            "hysteresis_c",
+            "bell_on_critical",
+            "webhook_url",
+            "power_crit_w",
+        ],
+        out,
+        top,
+    );
+    check(
+        "energy",
+        &[
+            "price_per_kwh",
+            "currency",
+            "show_cost",
+            "wal_path",
+            "gap_interpolate_seconds",
+            "wal_enabled",
+        ],
+        out,
+        top,
+    );
+    check(
+        "display",
+        &["color_scheme", "gauge_style", "show_led_grid"],
+        out,
+        top,
+    );
+    check("record", &["output_dir", "compress"], out, top);
+    check("snapshot", &["default_format", "default_pretty"], out, top);
+}
+
+// Test module is in `config_file_tests.rs` to keep this file under the
+// 500-line soft limit.
+#[cfg(test)]
+#[path = "config_file_tests.rs"]
+mod tests;

--- a/src/common/config_file.rs
+++ b/src/common/config_file.rs
@@ -38,6 +38,7 @@
 //!   [`Settings`] (canonical + backward-compat legacy aliases).
 
 use std::collections::BTreeSet;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use toml::Value as TomlValue;
@@ -47,6 +48,18 @@ use crate::common::config_apply;
 use crate::common::config_env;
 use crate::common::config_schema::{KNOWN_TOP_LEVEL, RawConfig};
 use crate::common::paths;
+
+/// Hard ceiling on the size of a config file we are willing to read.
+///
+/// A legitimate `config.toml` is hundreds of bytes; even with every
+/// commented option expanded it stays well under a kilobyte. Capping
+/// the read at 1 MiB prevents a malicious or accidental oversized file
+/// (e.g. a log file renamed over the config path, a `/dev/zero`
+/// symlink, etc.) from OOM-ing the process at startup. The cap is
+/// enforced both via metadata (fast path) and via `Read::take`
+/// (authoritative — covers named pipes, devices, and any path where
+/// the metadata length is a lie).
+pub(crate) const MAX_CONFIG_BYTES: u64 = 1 << 20; // 1 MiB
 
 // Re-export the on-disk schema types so existing callers can keep
 // importing through this module.
@@ -86,9 +99,39 @@ pub enum ConfigError {
     #[error("config file semantic error: {0}")]
     Semantic(String),
     /// With `--strict`, any unknown key at the top-level or inside a
-    /// known section is reported here.
+    /// known section is reported here. The key is pre-escaped via
+    /// [`escape_printable`] so a quoted TOML key containing ANSI
+    /// escapes cannot inject cursor-control sequences into operator
+    /// terminals.
     #[error("config file unknown key: {0}")]
     UnknownKey(String),
+}
+
+/// Escape control characters in a string so it is safe to print to a
+/// terminal.
+///
+/// TOML permits arbitrary codepoints inside quoted keys
+/// (e.g. `"foo\u001b[31mRED"`). Blindly passing such keys to
+/// `eprintln!` would allow a hostile config file to inject cursor
+/// movement, colour, or clear-screen sequences into the operator's
+/// terminal — a meaningful attack surface for multi-tenant hosts where
+/// one user controls the config file and another reads the validator
+/// output.
+///
+/// This helper replaces every control character (`U+0000` – `U+001F`
+/// and `U+007F`) with its `\u{XXXX}` escape so output stays printable
+/// and auditable. Non-control characters pass through unchanged.
+pub fn escape_printable(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        let code = c as u32;
+        if code < 0x20 || code == 0x7f {
+            out.push_str(&format!("\\u{{{code:04X}}}"));
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------
@@ -149,6 +192,16 @@ pub struct DisplaySettings {
     pub color_scheme: String,
     pub gauge_style: String,
     pub show_led_grid: bool,
+}
+
+impl Default for DisplaySettings {
+    fn default() -> Self {
+        Self {
+            color_scheme: "default".to_string(),
+            gauge_style: "blocks".to_string(),
+            show_led_grid: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -230,7 +283,7 @@ pub fn load(explicit: Option<&Path>) -> Result<LoadOutcome, ConfigError> {
 
     let (raw, source_path, unknown_keys): (RawConfig, Option<PathBuf>, Vec<String>) =
         if let Some(path) = explicit {
-            let contents = std::fs::read_to_string(path).map_err(|e| ConfigError::Io {
+            let contents = read_config_capped(path).map_err(|e| ConfigError::Io {
                 path: path.to_path_buf(),
                 source: e,
             })?;
@@ -238,7 +291,7 @@ pub fn load(explicit: Option<&Path>) -> Result<LoadOutcome, ConfigError> {
             check_schema_version(&raw)?;
             (raw, Some(path.to_path_buf()), unknown)
         } else if let Some(path) = paths::discover_existing_config() {
-            match std::fs::read_to_string(&path) {
+            match read_config_capped(&path) {
                 Ok(contents) => {
                     let (raw, unknown) = parse_toml(&contents)?;
                     check_schema_version(&raw)?;
@@ -289,7 +342,7 @@ fn check_schema_version(raw: &RawConfig) -> Result<(), ConfigError> {
 /// are present. Without `strict`, unknown keys are allowed — the caller
 /// should still call [`load`] to get the semantic errors.
 pub fn validate_file(path: &Path, strict: bool) -> Result<Settings, ConfigError> {
-    let contents = std::fs::read_to_string(path).map_err(|e| ConfigError::Io {
+    let contents = read_config_capped(path).map_err(|e| ConfigError::Io {
         path: path.to_path_buf(),
         source: e,
     })?;
@@ -316,22 +369,32 @@ pub fn validate_file(path: &Path, strict: bool) -> Result<Settings, ConfigError>
 
 /// Parse a TOML document and report any unknown top-level keys.
 ///
-/// Implementation detail: we first parse into a generic `toml::Value`
+/// Implementation detail: we parse once into a generic `toml::Value`
 /// so we can enumerate the top-level keys independently of the typed
 /// deserializer (which silently ignores unknown keys when
-/// `deny_unknown_fields` is not set). We then deserialize the same
-/// string into the typed [`RawConfig`]. Unknown sub-section keys are
-/// collected through a second pass over the generic value.
+/// `deny_unknown_fields` is not set). The same parsed value is then
+/// fed into `TomlValue::try_into` to materialise the typed
+/// [`RawConfig`] — no second parse of the source text, saving one full
+/// traversal of the document plus its allocations on every load.
 pub fn parse_toml(contents: &str) -> Result<(RawConfig, Vec<String>), ConfigError> {
     let value: TomlValue =
         toml::from_str(contents).map_err(|e| ConfigError::Parse(e.to_string()))?;
-    let raw: RawConfig = toml::from_str(contents).map_err(|e| ConfigError::Parse(e.to_string()))?;
+    let raw: RawConfig = value
+        .clone()
+        .try_into()
+        .map_err(|e: toml::de::Error| ConfigError::Parse(e.to_string()))?;
 
     let mut unknown = BTreeSet::new();
     if let TomlValue::Table(top) = &value {
         for key in top.keys() {
             if !KNOWN_TOP_LEVEL.contains(&key.as_str()) {
-                unknown.insert(key.clone());
+                // Pre-escape so downstream `eprintln!` sites cannot
+                // have ANSI / cursor-control sequences injected into
+                // operator terminals via a hostile config key. A
+                // quoted TOML key like `"x\u001b[31m"` is parsed
+                // verbatim; without this step the unknown-key warning
+                // would paint the rest of the stderr output red.
+                unknown.insert(escape_printable(key));
             }
         }
         scan_unknown_subkeys(top, &mut unknown);
@@ -340,15 +403,78 @@ pub fn parse_toml(contents: &str) -> Result<(RawConfig, Vec<String>), ConfigErro
     Ok((raw, unknown.into_iter().collect()))
 }
 
+/// Read a config file into a `String`, enforcing a hard size cap of
+/// [`MAX_CONFIG_BYTES`] and refusing to follow symlinks.
+///
+/// Defence-in-depth rationale:
+/// * **Size cap.** A legitimate config is well under a kilobyte. Without
+///   a cap, a renamed log file or a malicious attempt to OOM the daemon
+///   at startup would be read unconditionally. We check the metadata
+///   length first (fast path) and then also wrap the read in
+///   `Read::take(MAX + 1)` so pipes / devices / anything where
+///   `metadata().len()` lies still gets capped.
+/// * **Symlink refusal.** Even with `read_to_string`, a symlink at the
+///   canonical config path (e.g. `~/.config/all-smi/config.toml ->
+///   /etc/shadow`) would happily be followed and the target's contents
+///   leaked through parse-error messages. We refuse to read symlinks
+///   outright; if the operator genuinely wants to point at a file
+///   elsewhere they can use `--config /actual/path.toml`.
+fn read_config_capped(path: &Path) -> io::Result<String> {
+    use std::io::Read;
+
+    // Symlink rejection. `symlink_metadata` does NOT follow; a plain
+    // `metadata()` call would.
+    match std::fs::symlink_metadata(path) {
+        Ok(md) if md.file_type().is_symlink() => {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "refusing to read config at {} — path is a symlink",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(_) => {}
+        // Fall through on metadata errors so `File::open` below produces
+        // the canonical NotFound / permission error the caller expects.
+        Err(_) => {}
+    }
+
+    let f = std::fs::File::open(path)?;
+    if let Ok(md) = f.metadata()
+        && md.len() > MAX_CONFIG_BYTES
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("config file > {MAX_CONFIG_BYTES} bytes; refusing to read"),
+        ));
+    }
+    let mut buf = String::new();
+    // `take(MAX + 1)` so that if we DO read past the cap we can tell the
+    // difference between "file is exactly at the cap" and "file exceeded
+    // the cap" without allocating beyond the cap + 1 byte.
+    f.take(MAX_CONFIG_BYTES + 1).read_to_string(&mut buf)?;
+    if buf.len() as u64 > MAX_CONFIG_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("config file > {MAX_CONFIG_BYTES} bytes; refusing to parse"),
+        ));
+    }
+    Ok(buf)
+}
+
 /// Walk each known section and record any unrecognised sub-keys. Keeps
-/// unknown keys fully qualified (e.g. `api.foo`).
+/// unknown keys fully qualified (e.g. `api.foo`). Sub-keys containing
+/// control characters are escaped via [`escape_printable`] so downstream
+/// consumers can print them safely — see the top-level key path for
+/// rationale.
 fn scan_unknown_subkeys(top: &toml::map::Map<String, TomlValue>, out: &mut BTreeSet<String>) {
     use toml::map::Map;
     let check = |name: &str, known: &[&str], out: &mut BTreeSet<String>, top: &Map<_, _>| {
         if let Some(TomlValue::Table(sec)) = top.get(name) {
             for k in sec.keys() {
                 if !known.contains(&k.as_str()) {
-                    out.insert(format!("{name}.{k}"));
+                    out.insert(format!("{name}.{}", escape_printable(k)));
                 }
             }
         }

--- a/src/common/config_file_tests.rs
+++ b/src/common/config_file_tests.rs
@@ -1,0 +1,405 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for `common::config_file`. Kept in a sibling file so the
+//! implementation stays under the 500-line soft limit.
+
+use super::*;
+
+/// Shared mutex used by env-var tests. Cargo runs tests on multiple
+/// threads by default; without this lock the `set_var`/`remove_var`
+/// calls from concurrent tests race each other.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn clear_env() {
+    let keys = [
+        "ALL_SMI_GENERAL_DEFAULT_MODE",
+        "ALL_SMI_GENERAL_THEME",
+        "ALL_SMI_GENERAL_LOCALE",
+        "ALL_SMI_LOCAL_INTERVAL_SECS",
+        "ALL_SMI_VIEW_HOSTFILE",
+        "ALL_SMI_VIEW_HOSTS",
+        "ALL_SMI_VIEW_INTERVAL_SECS",
+        "ALL_SMI_API_PORT",
+        "ALL_SMI_API_SOCKET",
+        "ALL_SMI_API_PROCESSES",
+        "ALL_SMI_API_INTERVAL_SECS",
+        "ALL_SMI_ALERTS_TEMP_WARN_C",
+        "ALL_SMI_ALERTS_TEMP_CRIT_C",
+        "ALL_SMI_ALERTS_UTIL_IDLE_PCT",
+        "ALL_SMI_ALERTS_UTIL_IDLE_WARN_MINS",
+        "ALL_SMI_ALERTS_HYSTERESIS_C",
+        "ALL_SMI_ALERTS_BELL_ON_CRITICAL",
+        "ALL_SMI_ALERTS_WEBHOOK_URL",
+        "ALL_SMI_ALERTS_POWER_CRIT_W",
+        "ALL_SMI_ALERT_TEMP",
+        "ALL_SMI_ALERT_UTIL_LOW_MINS",
+        "ALL_SMI_ENERGY_PRICE",
+        "ALL_SMI_ENERGY_PRICE_PER_KWH",
+        "ALL_SMI_ENERGY_CURRENCY",
+        "ALL_SMI_ENERGY_NO_COST",
+        "ALL_SMI_ENERGY_SHOW_COST",
+        "ALL_SMI_ENERGY_WAL_PATH",
+        "ALL_SMI_ENERGY_NO_WAL",
+        "ALL_SMI_ENERGY_WAL_ENABLED",
+        "ALL_SMI_ENERGY_GAP_SECONDS",
+        "ALL_SMI_ENERGY_GAP_INTERPOLATE_SECONDS",
+        "ALL_SMI_DISPLAY_COLOR_SCHEME",
+        "ALL_SMI_DISPLAY_GAUGE_STYLE",
+        "ALL_SMI_DISPLAY_SHOW_LED_GRID",
+        "ALL_SMI_RECORD_OUTPUT_DIR",
+        "ALL_SMI_RECORD_COMPRESS",
+        "ALL_SMI_SNAPSHOT_DEFAULT_FORMAT",
+        "ALL_SMI_SNAPSHOT_DEFAULT_PRETTY",
+    ];
+    unsafe {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+#[test]
+fn settings_default_has_expected_values() {
+    let s = Settings::default();
+    assert_eq!(s.api.port, 9090);
+    assert_eq!(s.api.interval_secs, 3);
+    assert!(!s.api.processes);
+    assert_eq!(s.general.default_mode, "local");
+    assert_eq!(s.general.theme, "auto");
+    assert_eq!(s.general.locale, "en");
+    assert_eq!(s.display.color_scheme, "default");
+    assert_eq!(s.snapshot.default_format, "json");
+    assert!(s.snapshot.default_pretty);
+}
+
+#[test]
+fn parse_toml_accepts_valid_schema() {
+    let toml_str = r#"
+schema_version = 1
+
+[api]
+port = 9091
+processes = true
+
+[alerts]
+temp_warn_c = 75
+temp_crit_c = 95
+"#;
+    let (raw, unknown) = parse_toml(toml_str).expect("valid toml must parse");
+    assert_eq!(raw.schema_version, Some(1));
+    assert_eq!(raw.api.as_ref().and_then(|a| a.port), Some(9091));
+    assert_eq!(raw.alerts.as_ref().and_then(|a| a.temp_warn_c), Some(75));
+    assert!(
+        unknown.is_empty(),
+        "no unknown keys in a valid doc, got: {unknown:?}"
+    );
+}
+
+#[test]
+fn parse_toml_reports_unknown_top_level_keys() {
+    let toml_str = r#"
+schema_version = 1
+future_feature = "whatever"
+
+[api]
+port = 9091
+"#;
+    let (_raw, unknown) = parse_toml(toml_str).expect("must parse");
+    assert!(unknown.iter().any(|k| k == "future_feature"));
+}
+
+#[test]
+fn parse_toml_reports_unknown_section_subkeys() {
+    let toml_str = r#"
+[api]
+port = 9091
+mystery_key = 42
+"#;
+    let (_raw, unknown) = parse_toml(toml_str).expect("must parse");
+    assert!(
+        unknown.iter().any(|k| k == "api.mystery_key"),
+        "unknown keys: {unknown:?}"
+    );
+}
+
+#[test]
+fn parse_toml_fails_on_invalid_syntax() {
+    let bad = "this is [ not valid toml";
+    let result = parse_toml(bad);
+    assert!(
+        matches!(result, Err(ConfigError::Parse(_))),
+        "got {result:?}"
+    );
+}
+
+#[test]
+fn load_with_missing_path_returns_error() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let path = std::path::Path::new("/nonexistent/all-smi/fake-test-config.toml");
+    let result = load(Some(path));
+    assert!(
+        matches!(result, Err(ConfigError::Io { .. })),
+        "explicit missing path must fail, got {result:?}"
+    );
+}
+
+#[test]
+fn load_without_path_uses_defaults_when_no_file() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    // We pass `None` to `load`. If no candidate file exists we get
+    // compiled defaults; if one happens to exist on the test host we
+    // still get a valid outcome (just not the exact default).
+    let outcome = load(None).expect("load without explicit must succeed");
+    // The loader never crashes even if no file is present. That is
+    // the only guarantee this test can make without a filesystem
+    // fixture because candidate_config_paths is host-dependent.
+    assert!(outcome.settings.api.port >= 1);
+}
+
+#[test]
+fn load_with_explicit_file_applies_values() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        r#"
+schema_version = 1
+
+[api]
+port = 9191
+processes = true
+interval_secs = 7
+
+[alerts]
+temp_warn_c = 70
+temp_crit_c = 95
+util_idle_warn_mins = 20
+
+[energy]
+price_per_kwh = 0.18
+currency = "EUR"
+"#,
+    )
+    .unwrap();
+
+    let outcome = load(Some(&path)).expect("must load");
+    let s = outcome.settings;
+    assert_eq!(s.api.port, 9191);
+    assert!(s.api.processes);
+    assert_eq!(s.api.interval_secs, 7);
+    assert_eq!(s.alerts.temp_warn_c, 70);
+    assert_eq!(s.alerts.temp_crit_c, 95);
+    assert_eq!(s.alerts.util_idle_warn_mins, 20);
+    assert!((s.energy.price_per_kwh - 0.18).abs() < 1e-9);
+    assert_eq!(s.energy.currency, "EUR");
+    assert_eq!(s.source_path.as_ref(), Some(&path));
+}
+
+#[test]
+fn schema_version_mismatch_rejected() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "schema_version = 2\n").unwrap();
+    let result = load(Some(&path));
+    assert!(
+        matches!(
+            result,
+            Err(ConfigError::SchemaVersion {
+                found: 2,
+                supported: 1
+            })
+        ),
+        "schema_version=2 must be rejected, got {result:?}"
+    );
+}
+
+#[test]
+fn semantic_error_on_invalid_theme() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[general]\ntheme = \"rainbow\"\n").unwrap();
+    let result = load(Some(&path));
+    assert!(
+        matches!(result, Err(ConfigError::Semantic(_))),
+        "invalid theme must fail, got {result:?}"
+    );
+}
+
+#[test]
+fn semantic_error_on_negative_price() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[energy]\nprice_per_kwh = -5.0\n").unwrap();
+    let result = load(Some(&path));
+    assert!(matches!(result, Err(ConfigError::Semantic(_))));
+}
+
+#[test]
+fn validate_file_strict_rejects_unknown() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "future_field = true\n[api]\nport = 9090\n").unwrap();
+    let strict = validate_file(&path, true);
+    assert!(matches!(strict, Err(ConfigError::UnknownKey(_))));
+    let lenient = validate_file(&path, false);
+    assert!(lenient.is_ok(), "non-strict must accept unknown keys");
+}
+
+#[test]
+fn env_override_wins_over_file() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[api]\nport = 9090\n").unwrap();
+    unsafe {
+        std::env::set_var("ALL_SMI_API_PORT", "9191");
+    }
+    let outcome = load(Some(&path)).expect("must load");
+    assert_eq!(
+        outcome.settings.api.port, 9191,
+        "env var must override file value"
+    );
+    unsafe {
+        std::env::remove_var("ALL_SMI_API_PORT");
+    }
+}
+
+#[test]
+fn legacy_alert_env_alias_still_works() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    unsafe {
+        std::env::set_var("ALL_SMI_ALERT_TEMP", "77");
+        std::env::set_var("ALL_SMI_ALERT_UTIL_LOW_MINS", "25");
+    }
+    let outcome = load(None).expect("must load");
+    assert_eq!(outcome.settings.alerts.temp_warn_c, 77);
+    assert_eq!(outcome.settings.alerts.util_idle_warn_mins, 25);
+    // Auto-bumped crit: preserved backward-compat semantics.
+    assert!(outcome.settings.alerts.temp_crit_c >= outcome.settings.alerts.temp_warn_c + 5);
+    unsafe {
+        std::env::remove_var("ALL_SMI_ALERT_TEMP");
+        std::env::remove_var("ALL_SMI_ALERT_UTIL_LOW_MINS");
+    }
+}
+
+#[test]
+fn legacy_energy_env_alias_still_works() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    unsafe {
+        std::env::set_var("ALL_SMI_ENERGY_PRICE", "0.25");
+        std::env::set_var("ALL_SMI_ENERGY_CURRENCY", "KRW");
+    }
+    let outcome = load(None).expect("must load");
+    assert!((outcome.settings.energy.price_per_kwh - 0.25).abs() < 1e-9);
+    assert_eq!(outcome.settings.energy.currency, "KRW");
+    unsafe {
+        std::env::remove_var("ALL_SMI_ENERGY_PRICE");
+        std::env::remove_var("ALL_SMI_ENERGY_CURRENCY");
+    }
+}
+
+#[test]
+fn canonical_energy_env_wins_over_legacy() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    unsafe {
+        std::env::set_var("ALL_SMI_ENERGY_PRICE", "0.10"); // legacy
+        std::env::set_var("ALL_SMI_ENERGY_PRICE_PER_KWH", "0.30"); // canonical
+    }
+    let outcome = load(None).expect("must load");
+    assert!((outcome.settings.energy.price_per_kwh - 0.30).abs() < 1e-9);
+    unsafe {
+        std::env::remove_var("ALL_SMI_ENERGY_PRICE");
+        std::env::remove_var("ALL_SMI_ENERGY_PRICE_PER_KWH");
+    }
+}
+
+#[test]
+fn unknown_keys_captured_in_settings() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "mystery_top = 1\n[api]\nport = 9090\nmystery_sub = 2\n",
+    )
+    .unwrap();
+    let outcome = load(Some(&path)).expect("must load");
+    assert!(
+        outcome
+            .settings
+            .unknown_keys
+            .iter()
+            .any(|k| k == "mystery_top")
+    );
+    assert!(
+        outcome
+            .settings
+            .unknown_keys
+            .iter()
+            .any(|k| k == "api.mystery_sub")
+    );
+}
+
+#[test]
+fn api_socket_as_bool_and_path() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[api]\nsocket = true\n").unwrap();
+    let outcome = load(Some(&path)).expect("must load");
+    assert!(matches!(
+        outcome.settings.api.socket,
+        SocketSetting::Bool(true)
+    ));
+
+    std::fs::write(&path, "[api]\nsocket = \"/tmp/test.sock\"\n").unwrap();
+    let outcome = load(Some(&path)).expect("must load");
+    match &outcome.settings.api.socket {
+        SocketSetting::Path(p) => assert_eq!(p, "/tmp/test.sock"),
+        other => panic!("expected Path, got {other:?}"),
+    }
+}
+
+#[test]
+fn malformed_toml_returns_parse_error() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "this is not = valid = toml\n[[[").unwrap();
+    let result = load(Some(&path));
+    assert!(
+        matches!(result, Err(ConfigError::Parse(_))),
+        "malformed TOML must return ConfigError::Parse, got {result:?}"
+    );
+}

--- a/src/common/config_schema.rs
+++ b/src/common/config_schema.rs
@@ -1,0 +1,160 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! TOML on-disk schema definitions for `config.toml` (issue #192).
+//!
+//! Kept separate from the runtime [`Settings`] struct so the serde-
+//! derived layer stays a pure data projection of the file format while
+//! [`crate::common::config_file`] owns the merge + validation logic.
+
+use serde::{Deserialize, Serialize};
+
+/// On-disk schema for `config.toml`. Fields are optional so omitted
+/// keys silently fall through to compiled defaults. Unknown keys are
+/// captured separately during parse for the `print`/`validate`
+/// workflow.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct RawConfig {
+    /// Schema version — `1` for the shape documented in issue #192.
+    #[serde(default)]
+    pub schema_version: Option<u32>,
+    #[serde(default)]
+    pub general: Option<GeneralSection>,
+    #[serde(default)]
+    pub local: Option<LocalSection>,
+    #[serde(default)]
+    pub view: Option<ViewSection>,
+    #[serde(default)]
+    pub api: Option<ApiSection>,
+    #[serde(default)]
+    pub alerts: Option<AlertsSection>,
+    #[serde(default)]
+    pub energy: Option<EnergySection>,
+    #[serde(default)]
+    pub display: Option<DisplaySection>,
+    #[serde(default)]
+    pub record: Option<RecordSection>,
+    #[serde(default)]
+    pub snapshot: Option<SnapshotSection>,
+}
+
+/// `[general]` section — cross-mode defaults.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct GeneralSection {
+    pub default_mode: Option<String>,
+    pub theme: Option<String>,
+    pub locale: Option<String>,
+}
+
+/// `[local]` section — options for `all-smi local`.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct LocalSection {
+    pub interval_secs: Option<u64>,
+}
+
+/// `[view]` section — options for `all-smi view` (remote mode).
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct ViewSection {
+    pub hostfile: Option<String>,
+    pub hosts: Option<Vec<String>>,
+    pub interval_secs: Option<u64>,
+}
+
+/// `[api]` section — options for `all-smi api`.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct ApiSection {
+    pub port: Option<u16>,
+    /// Accept either `socket = false`/`true` or `socket = "/path"`. TOML's
+    /// typed deserializer does not allow sum types natively; we route
+    /// through an untagged enum to accept either shape.
+    #[serde(default)]
+    pub socket: SocketSetting,
+    pub processes: Option<bool>,
+    pub interval_secs: Option<u64>,
+}
+
+/// Tri-state representation of `[api].socket`.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SocketSetting {
+    /// Caller did not set the key — leave the existing value alone.
+    #[default]
+    Unset,
+    /// `socket = true` means default platform socket path.
+    Bool(bool),
+    /// `socket = "/path"` means explicit socket path.
+    Path(String),
+}
+
+/// `[alerts]` section — maps to [`crate::common::config::AlertConfig`].
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct AlertsSection {
+    pub enabled: Option<bool>,
+    pub temp_warn_c: Option<u32>,
+    pub temp_crit_c: Option<u32>,
+    pub util_idle_pct: Option<u32>,
+    pub util_idle_warn_mins: Option<u32>,
+    pub hysteresis_c: Option<u32>,
+    pub bell_on_critical: Option<bool>,
+    pub webhook_url: Option<String>,
+    pub power_crit_w: Option<u32>,
+}
+
+/// `[energy]` section — maps to [`crate::common::config::EnergyConfig`].
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct EnergySection {
+    pub price_per_kwh: Option<f64>,
+    pub currency: Option<String>,
+    pub show_cost: Option<bool>,
+    pub wal_path: Option<String>,
+    pub gap_interpolate_seconds: Option<u64>,
+    pub wal_enabled: Option<bool>,
+}
+
+/// `[display]` section — TUI cosmetics.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct DisplaySection {
+    pub color_scheme: Option<String>,
+    pub gauge_style: Option<String>,
+    pub show_led_grid: Option<bool>,
+}
+
+/// `[record]` section — defaults for `all-smi record`.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct RecordSection {
+    pub output_dir: Option<String>,
+    pub compress: Option<String>,
+}
+
+/// `[snapshot]` section — defaults for `all-smi snapshot`.
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct SnapshotSection {
+    pub default_format: Option<String>,
+    pub default_pretty: Option<bool>,
+}
+
+/// Known top-level section names. Anything outside this set in the raw
+/// TOML table is reported as "unknown".
+pub const KNOWN_TOP_LEVEL: &[&str] = &[
+    "schema_version",
+    "general",
+    "local",
+    "view",
+    "api",
+    "alerts",
+    "energy",
+    "display",
+    "record",
+    "snapshot",
+];

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -13,6 +13,18 @@
 // limitations under the License.
 
 pub mod config;
+#[cfg(feature = "cli")]
+pub mod config_apply;
+#[cfg(feature = "cli")]
+pub mod config_env;
+#[cfg(feature = "cli")]
+pub mod config_file;
+#[cfg(feature = "cli")]
+pub mod config_schema;
 pub mod error_handling;
 #[cfg(feature = "cli")]
+pub mod paths;
+#[cfg(feature = "cli")]
 pub mod progress_bar;
+#[cfg(feature = "cli")]
+pub mod secure_write;

--- a/src/common/paths.rs
+++ b/src/common/paths.rs
@@ -1,0 +1,207 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Platform-aware configuration path resolution for `all-smi` (issue #192).
+//!
+//! Handles:
+//! - Linux: `$XDG_CONFIG_HOME/all-smi/config.toml`, fallback
+//!   `~/.config/all-smi/config.toml`.
+//! - macOS: `~/Library/Application Support/all-smi/config.toml` with
+//!   `~/.config/all-smi/config.toml` accepted as fallback for parity.
+//! - Windows: `%APPDATA%\all-smi\config.toml`.
+//!
+//! Public surface:
+//! - [`default_config_path`] — the primary canonical path for the
+//!   current platform, used by `config init` and implicit load.
+//! - [`candidate_config_paths`] — ordered list of paths that should be
+//!   probed on implicit load; first existing file wins.
+//! - [`expand_tilde`] — expands a leading `~/` to the user's home
+//!   directory. Used for every config-file string that is a path.
+//! - [`config_dir`] — parent directory of the canonical config path
+//!   (used by `config init` to `create_dir_all` before writing).
+
+use std::path::{Path, PathBuf};
+
+/// The final filename of the config file, identical across platforms.
+pub const CONFIG_FILE_NAME: &str = "config.toml";
+
+/// The app-specific subdirectory under the platform config root.
+pub const APP_DIR_NAME: &str = "all-smi";
+
+/// Expand a leading `~` or `~/` in a path-like string to the user's
+/// home directory. Returns the input unchanged when no home directory is
+/// available (e.g. `$HOME` unset on Linux, no `UserProfile` on Windows).
+///
+/// This function does **not** attempt `~user/` style expansion — that
+/// behaviour is shell-specific and requires `getpwnam` plumbing. Only
+/// the leading-`~` case is handled, matching the `dirs` crate and the
+/// behaviour every other `all-smi` codepath already assumes.
+///
+/// Currently this helper is not wired into any settings-consuming
+/// callsite — each downstream path (`energy_wal`, `hostfile`, etc.)
+/// applies its own tilde expansion already. Exposed publicly so future
+/// settings callers (e.g. `record.output_dir`) can share the
+/// canonical implementation.
+#[allow(dead_code)]
+pub fn expand_tilde(input: impl AsRef<str>) -> PathBuf {
+    let s = input.as_ref();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+        return PathBuf::from(s);
+    }
+    if s == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+        return PathBuf::from(s);
+    }
+    PathBuf::from(s)
+}
+
+/// Resolve the canonical config directory for the current platform.
+///
+/// * Linux: `$XDG_CONFIG_HOME/all-smi` when set, else
+///   `~/.config/all-smi`.
+/// * macOS: `~/Library/Application Support/all-smi`. Our loader also
+///   accepts `~/.config/all-smi/` as a fallback for parity with Linux,
+///   but this function returns only the canonical Apple-recommended
+///   location — `config init` writes there.
+/// * Windows: `%APPDATA%\all-smi`.
+///
+/// Returns `None` when no home-like directory can be located. Callers
+/// treat that as "no config support" and fall back to compiled defaults
+/// plus env vars.
+pub fn config_dir() -> Option<PathBuf> {
+    // The `dirs::config_dir()` function returns the right primary dir
+    // on every supported platform:
+    // - Linux: `$XDG_CONFIG_HOME` or `~/.config`
+    // - macOS: `~/Library/Application Support`
+    // - Windows: `%APPDATA%` (Roaming)
+    dirs::config_dir().map(|d| d.join(APP_DIR_NAME))
+}
+
+/// The primary canonical config-file path for the current platform.
+/// Used by `config init` for the write target and by implicit load as
+/// the first candidate.
+pub fn default_config_path() -> Option<PathBuf> {
+    config_dir().map(|d| d.join(CONFIG_FILE_NAME))
+}
+
+/// Ordered list of paths the loader tries when no `--config` flag is
+/// supplied. First existing file wins. When none exist the caller
+/// proceeds with compiled defaults + env overrides.
+///
+/// * Linux: only the canonical path (XDG).
+/// * macOS: canonical Apple path first, then `~/.config/all-smi/config.toml`
+///   as a parity fallback for operators migrating from Linux.
+/// * Windows: only the canonical `%APPDATA%` path.
+pub fn candidate_config_paths() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Some(primary) = default_config_path() {
+        out.push(primary);
+    }
+    // macOS parity fallback — issue spec: "fallback
+    // `~/.config/all-smi/config.toml` accepted".
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = dirs::home_dir() {
+            let xdg_like = home
+                .join(".config")
+                .join(APP_DIR_NAME)
+                .join(CONFIG_FILE_NAME);
+            // Avoid duplicates if the user somehow has the Apple path
+            // pointing at ~/.config (shouldn't happen but be defensive).
+            if !out.iter().any(|p| p == &xdg_like) {
+                out.push(xdg_like);
+            }
+        }
+    }
+    out
+}
+
+/// Pick the first path from [`candidate_config_paths`] that exists on
+/// disk. Returns `None` when no candidate file exists — in that case
+/// the loader returns compiled defaults.
+pub fn discover_existing_config() -> Option<PathBuf> {
+    candidate_config_paths().into_iter().find(|p| p.exists())
+}
+
+/// Return the parent directory of `path`, creating intermediate
+/// directories when needed. Matches `fs::create_dir_all` semantics.
+pub fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_tilde_noop_without_prefix() {
+        let p = expand_tilde("/etc/passwd");
+        assert_eq!(p, PathBuf::from("/etc/passwd"));
+    }
+
+    #[test]
+    fn expand_tilde_replaces_home_marker() {
+        // When home is available, `~/foo` should resolve under it.
+        if let Some(home) = dirs::home_dir() {
+            let p = expand_tilde("~/foo/bar");
+            assert_eq!(p, home.join("foo/bar"));
+        }
+    }
+
+    #[test]
+    fn expand_tilde_bare_tilde() {
+        if let Some(home) = dirs::home_dir() {
+            let p = expand_tilde("~");
+            assert_eq!(p, home);
+        }
+    }
+
+    #[test]
+    fn expand_tilde_passthrough_for_relative() {
+        let p = expand_tilde("relative/path");
+        assert_eq!(p, PathBuf::from("relative/path"));
+    }
+
+    #[test]
+    fn config_dir_ends_with_app_name() {
+        if let Some(dir) = config_dir() {
+            assert!(dir.ends_with(APP_DIR_NAME));
+        }
+    }
+
+    #[test]
+    fn default_config_path_ends_with_file_name() {
+        if let Some(path) = default_config_path() {
+            assert!(path.ends_with(CONFIG_FILE_NAME));
+        }
+    }
+
+    #[test]
+    fn candidate_config_paths_nonempty_when_home_available() {
+        if dirs::home_dir().is_some() {
+            let paths = candidate_config_paths();
+            assert!(!paths.is_empty());
+        }
+    }
+}

--- a/src/common/paths.rs
+++ b/src/common/paths.rs
@@ -48,27 +48,29 @@ pub const APP_DIR_NAME: &str = "all-smi";
 /// the leading-`~` case is handled, matching the `dirs` crate and the
 /// behaviour every other `all-smi` codepath already assumes.
 ///
-/// Currently this helper is not wired into any settings-consuming
-/// callsite — each downstream path (`energy_wal`, `hostfile`, etc.)
-/// applies its own tilde expansion already. Exposed publicly so future
-/// settings callers (e.g. `record.output_dir`) can share the
+/// Shared by every settings consumer that needs to resolve a
+/// potentially-tilde-prefixed path (`energy_wal`, `hostfile`,
+/// `record.output_dir`, etc.). Formerly duplicated in
+/// `metrics::energy_wal` — consolidated here so there is a single
 /// canonical implementation.
-#[allow(dead_code)]
-pub fn expand_tilde(input: impl AsRef<str>) -> PathBuf {
-    let s = input.as_ref();
+pub fn expand_tilde(input: impl AsRef<Path>) -> PathBuf {
+    let path = input.as_ref();
+    let Some(s) = path.to_str() else {
+        return path.to_path_buf();
+    };
     if let Some(rest) = s.strip_prefix("~/") {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest);
         }
-        return PathBuf::from(s);
+        return path.to_path_buf();
     }
     if s == "~" {
         if let Some(home) = dirs::home_dir() {
             return home;
         }
-        return PathBuf::from(s);
+        return path.to_path_buf();
     }
-    PathBuf::from(s)
+    path.to_path_buf()
 }
 
 /// Resolve the canonical config directory for the current platform.
@@ -156,7 +158,7 @@ mod tests {
 
     #[test]
     fn expand_tilde_noop_without_prefix() {
-        let p = expand_tilde("/etc/passwd");
+        let p = expand_tilde(Path::new("/etc/passwd"));
         assert_eq!(p, PathBuf::from("/etc/passwd"));
     }
 
@@ -164,7 +166,7 @@ mod tests {
     fn expand_tilde_replaces_home_marker() {
         // When home is available, `~/foo` should resolve under it.
         if let Some(home) = dirs::home_dir() {
-            let p = expand_tilde("~/foo/bar");
+            let p = expand_tilde(Path::new("~/foo/bar"));
             assert_eq!(p, home.join("foo/bar"));
         }
     }
@@ -172,14 +174,14 @@ mod tests {
     #[test]
     fn expand_tilde_bare_tilde() {
         if let Some(home) = dirs::home_dir() {
-            let p = expand_tilde("~");
+            let p = expand_tilde(Path::new("~"));
             assert_eq!(p, home);
         }
     }
 
     #[test]
     fn expand_tilde_passthrough_for_relative() {
-        let p = expand_tilde("relative/path");
+        let p = expand_tilde(Path::new("relative/path"));
         assert_eq!(p, PathBuf::from("relative/path"));
     }
 

--- a/src/common/secure_write.rs
+++ b/src/common/secure_write.rs
@@ -1,0 +1,252 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared secure file writer (`O_NOFOLLOW` + `0o600`).
+//!
+//! Consolidates the symlink-hardening + restrictive-mode pattern used by
+//! the snapshot writer (`src/snapshot/mod.rs::write_output_atomic`) and
+//! the record writer (`src/record/writer.rs::open_secure`). Issue #192
+//! adds a third caller — `all-smi config init` — and calls for a shared
+//! helper to prevent future divergence.
+//!
+//! Two entry points:
+//!
+//! * [`create_new_secure`] — opens a freshly-created file with
+//!   `create_new(true)` so the call fails if the path already exists
+//!   (avoids clobbering an unrelated file or following an attacker-
+//!   planted symlink). The concrete hardening flags (`O_NOFOLLOW` on
+//!   Unix, `share_mode(0)` on Windows) match the existing record writer.
+//! * [`write_atomic_secure`] — writes content to a sibling `.tmp` file
+//!   using the hardening flags above, `sync_all`-s it, then renames it
+//!   over the final path. Callers get atomicity *and* the hardening at
+//!   the cost of one extra inode briefly existing. Used by `config init`
+//!   in `--force` mode to safely replace an existing config file.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Open a brand-new file at `path`, refusing to follow symlinks and
+/// refusing to clobber an existing file. Matches the hardening used by
+/// `record::writer::open_secure` and `snapshot::write_output_atomic`.
+///
+/// * Unix: `O_NOFOLLOW | O_CREAT | O_EXCL | O_WRONLY`, mode `0o600`.
+/// * Windows: exclusive `share_mode(0)` + `create_new`.
+/// * Other targets: plain `create_new`, best effort.
+///
+/// Returns a writable `File`; the caller owns flush/close discipline.
+pub fn create_new_secure(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .mode(0o600)
+            .open(path)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .share_mode(0)
+            .open(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        OpenOptions::new().write(true).create_new(true).open(path)
+    }
+}
+
+/// Write `contents` to `final_path` atomically with hardened flags.
+///
+/// Behaviour mirrors `snapshot::write_output_atomic`:
+/// 1. Pick a sibling `.tmp` path (with numeric suffix to avoid collisions).
+/// 2. Open it with `O_NOFOLLOW` + `0o600` (Unix) or exclusive share mode
+///    (Windows).
+/// 3. Write the full contents, `sync_all()`.
+/// 4. `fs::rename` onto `final_path`.
+///
+/// Unlike [`create_new_secure`], this entry point accepts an existing
+/// `final_path`; the rename replaces it. Used by `config init --force`.
+pub fn write_atomic_secure(final_path: &Path, contents: &[u8]) -> io::Result<()> {
+    let tmp_path = pick_tmp_path(final_path);
+
+    let file_result = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .custom_flags(libc::O_NOFOLLOW)
+                .mode(0o600)
+                .open(&tmp_path)
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .share_mode(0)
+                .open(&tmp_path)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)
+        }
+    };
+
+    let mut file = file_result?;
+
+    if let Err(e) = file.write_all(contents) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    if let Err(e) = file.sync_all() {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    drop(file);
+
+    if let Err(e) = fs::rename(&tmp_path, final_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// Pick a temp-file path next to `final_path`. Starts with `<path>.tmp`
+/// and appends a numeric suffix when that name is already taken, up to
+/// 64 attempts, to reduce collision risk when multiple invocations
+/// target the same directory concurrently.
+fn pick_tmp_path(final_path: &Path) -> PathBuf {
+    let base = {
+        let mut p = final_path.as_os_str().to_os_string();
+        p.push(".tmp");
+        PathBuf::from(p)
+    };
+    if !base.exists() {
+        return base;
+    }
+    for i in 1..=64 {
+        let mut p = final_path.as_os_str().to_os_string();
+        p.push(format!(".tmp.{i}"));
+        let candidate = PathBuf::from(p);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    base
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn create_new_secure_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new.toml");
+        let mut f = create_new_secure(&path).expect("create should succeed");
+        f.write_all(b"hello\n").unwrap();
+        drop(f);
+        let mut content = String::new();
+        File::open(&path)
+            .unwrap()
+            .read_to_string(&mut content)
+            .unwrap();
+        assert_eq!(content, "hello\n");
+    }
+
+    #[test]
+    fn create_new_secure_refuses_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("already.toml");
+        std::fs::write(&path, b"existing").unwrap();
+        let result = create_new_secure(&path);
+        assert!(
+            result.is_err(),
+            "create_new_secure must refuse to clobber existing"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_new_secure_refuses_symlink() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, "do-not-clobber").unwrap();
+        let link = dir.path().join("link");
+        symlink(&target, &link).unwrap();
+        let result = create_new_secure(&link);
+        assert!(result.is_err(), "must refuse to follow symlink");
+        let remaining = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(remaining, "do-not-clobber");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_new_secure_sets_0o600_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mode.toml");
+        let _ = create_new_secure(&path).unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn write_atomic_secure_replaces_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("replace.toml");
+        std::fs::write(&path, b"old").unwrap();
+        write_atomic_secure(&path, b"new-content").unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "new-content");
+    }
+
+    #[test]
+    fn write_atomic_secure_creates_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new-atomic.toml");
+        write_atomic_secure(&path, b"fresh").unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "fresh");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_secure_sets_0o600_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("atomic-mode.toml");
+        write_atomic_secure(&path, b"content").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+    }
+}

--- a/src/config_cmd/example.rs
+++ b/src/config_cmd/example.rs
@@ -1,0 +1,86 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Canonical commented example emitted by `all-smi config init`. The
+//! contents mirror the schema documented in issue #192 — keep this
+//! text in sync with the loader whenever a new key is added.
+
+pub const EXAMPLE_TOML: &str = r##"# all-smi configuration file
+#
+# All fields are optional; omitted fields fall back to the built-in
+# default. Precedence from highest to lowest:
+#
+#   1. Explicit CLI flag  (e.g. --port 9091)
+#   2. Environment variable  (e.g. ALL_SMI_API_PORT=9091)
+#   3. This config file
+#   4. Compiled default
+#
+# Environment variables follow the pattern ALL_SMI_<SECTION>_<KEY>.
+# Legacy aliases from earlier releases (ALL_SMI_ALERT_TEMP,
+# ALL_SMI_ENERGY_PRICE, etc.) continue to work.
+
+# Schema version understood by this build. Do not change unless a
+# future release instructs you to.
+schema_version = 1
+
+[general]
+# default_mode = "local"      # "local" | "view" | "api"
+# theme = "auto"              # "auto" | "light" | "dark" | "high-contrast" | "mono"
+# locale = "en"
+
+[local]
+# interval_secs = 2           # 0 = adaptive default
+
+[view]
+# hostfile = "~/.config/all-smi/hosts.csv"
+# hosts = []
+# interval_secs = 0           # 0 = adaptive based on host count
+
+[api]
+# port = 9090
+# socket = false              # bool or path (e.g. "/var/run/all-smi.sock")
+# processes = false
+# interval_secs = 3
+
+[alerts]
+# enabled = true
+# temp_warn_c = 80
+# temp_crit_c = 90
+# util_idle_pct = 5
+# util_idle_warn_mins = 15
+# hysteresis_c = 2
+# bell_on_critical = false
+# webhook_url = ""            # redacted in `config print` by default
+
+[energy]
+# price_per_kwh = 0.12
+# currency = "USD"
+# show_cost = true
+# wal_path = "~/.cache/all-smi/energy-wal.bin"
+# gap_interpolate_seconds = 10
+# wal_enabled = true
+
+[display]
+# color_scheme = "default"    # "default" | "colorblind" | "mono"
+# gauge_style = "blocks"      # "blocks" | "braille"
+# show_led_grid = true
+
+[record]
+# output_dir = "~/.cache/all-smi/records"
+# compress = "zstd"           # "zstd" | "gzip" | "none"
+
+[snapshot]
+# default_format = "json"
+# default_pretty = true
+"##;

--- a/src/config_cmd/mod.rs
+++ b/src/config_cmd/mod.rs
@@ -1,0 +1,200 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime glue for the `all-smi config` subcommand (issue #192).
+//!
+//! Entrypoints:
+//! - [`run`] dispatches on [`ConfigAction`] and returns a process exit
+//!   code (0 on success, 2 on validation failure, 1 on unexpected
+//!   runtime error).
+//!
+//! Keeping the implementation out of `cli.rs` keeps the clap-facing
+//! surface a pure data declaration and lets the main binary import the
+//! action handlers without a long switch statement inline.
+
+use std::path::{Path, PathBuf};
+
+use crate::cli::{ConfigAction, ConfigPrintArgs, ConfigPrintFormat, ConfigValidateArgs};
+use crate::common::config_file::{self, ConfigError, Settings, SocketSetting};
+use crate::common::paths;
+use crate::common::secure_write;
+
+mod example;
+mod render;
+
+pub use example::EXAMPLE_TOML;
+pub use render::{render_json, render_toml};
+
+/// Dispatch a `config` subcommand. Returns a process exit code.
+pub fn run(explicit_config_path: Option<&Path>, action: &ConfigAction) -> i32 {
+    match action {
+        ConfigAction::Init(args) => run_init(args.force),
+        ConfigAction::Print(args) => run_print(explicit_config_path, args),
+        ConfigAction::Validate(args) => run_validate(args),
+    }
+}
+
+fn run_init(force: bool) -> i32 {
+    let Some(target) = paths::default_config_path() else {
+        eprintln!("error: could not determine a config directory for this platform");
+        return 1;
+    };
+
+    if let Err(e) = paths::ensure_parent_dir(&target) {
+        eprintln!(
+            "error: could not create config directory {}: {e}",
+            target.parent().unwrap_or(Path::new("")).display()
+        );
+        return 1;
+    }
+
+    let already_exists = target.exists();
+    if already_exists && !force {
+        eprintln!(
+            "error: config file already exists at {} — pass --force to overwrite",
+            target.display()
+        );
+        return 1;
+    }
+
+    let result = if already_exists {
+        // Force mode: atomic replace with hardening.
+        secure_write::write_atomic_secure(&target, EXAMPLE_TOML.as_bytes())
+    } else {
+        // Fresh creation: refuse to follow symlinks, refuse to clobber.
+        use std::io::Write;
+        match secure_write::create_new_secure(&target) {
+            Ok(mut f) => f
+                .write_all(EXAMPLE_TOML.as_bytes())
+                .and_then(|()| f.sync_all()),
+            Err(e) => Err(e),
+        }
+    };
+
+    match result {
+        Ok(()) => {
+            println!("wrote example config to {}", target.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: failed to write config at {}: {e}", target.display());
+            1
+        }
+    }
+}
+
+fn run_print(explicit: Option<&Path>, args: &ConfigPrintArgs) -> i32 {
+    let outcome = match config_file::load(explicit) {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return exit_code_for(&e);
+        }
+    };
+
+    // Surface load-time warnings so operators can see why their env
+    // values got dropped, why a file failed the pre-parse, etc.
+    for w in &outcome.warnings {
+        eprintln!("warning: {w}");
+    }
+    for k in &outcome.settings.unknown_keys {
+        eprintln!("warning: unknown config key `{k}` (forward-compat — preserved)");
+    }
+
+    let rendered = match args.format {
+        ConfigPrintFormat::Toml => render_toml(&outcome.settings, args.show_secrets),
+        ConfigPrintFormat::Json => render_json(&outcome.settings, args.show_secrets),
+    };
+    match rendered {
+        Ok(s) => {
+            print!("{s}");
+            if !s.ends_with('\n') {
+                println!();
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("error: failed to render settings: {e}");
+            1
+        }
+    }
+}
+
+fn run_validate(args: &ConfigValidateArgs) -> i32 {
+    let path: PathBuf = if let Some(p) = &args.path {
+        p.clone()
+    } else if let Some(p) = paths::default_config_path() {
+        p
+    } else {
+        eprintln!("error: could not determine default config path; pass an explicit path");
+        return 2;
+    };
+
+    if !path.exists() {
+        eprintln!("error: config file not found at {}", path.display());
+        return 2;
+    }
+
+    match config_file::validate_file(&path, args.strict) {
+        Ok(settings) => {
+            if !settings.unknown_keys.is_empty() {
+                eprintln!("warnings:");
+                for k in &settings.unknown_keys {
+                    eprintln!("  - unknown key `{k}`");
+                }
+            }
+            println!("config OK: {}", path.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            2
+        }
+    }
+}
+
+fn exit_code_for(err: &ConfigError) -> i32 {
+    match err {
+        ConfigError::Io { .. } => 2,
+        ConfigError::Parse(_) => 2,
+        ConfigError::SchemaVersion { .. } => 2,
+        ConfigError::Semantic(_) => 2,
+        ConfigError::UnknownKey(_) => 2,
+    }
+}
+
+/// Redact secrets in-place for `print` output. Idempotent on missing
+/// values. Callers clone `Settings` before invoking this — the loader
+/// keeps the original intact. Currently unused (the TOML/JSON
+/// renderers redact inline); kept for future call sites (e.g. a
+/// structured-log dump of the merged config).
+#[allow(dead_code)]
+pub fn redact_secrets(s: &mut Settings) {
+    if !s.alerts.webhook_url.is_empty() {
+        s.alerts.webhook_url = "<redacted>".to_string();
+    }
+}
+
+/// Helper for callers who need only the socket setting as a displayable
+/// string. Returns `"false"`, `"true"`, or the explicit path. Currently
+/// unused; kept as a deliberate helper for future CLI echo / doctor
+/// callers that need the same formatting the renderer uses.
+#[allow(dead_code)]
+pub fn socket_display(s: &SocketSetting) -> String {
+    match s {
+        SocketSetting::Unset => "false".to_string(),
+        SocketSetting::Bool(b) => b.to_string(),
+        SocketSetting::Path(p) => format!("\"{p}\""),
+    }
+}

--- a/src/config_cmd/mod.rs
+++ b/src/config_cmd/mod.rs
@@ -26,7 +26,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::cli::{ConfigAction, ConfigPrintArgs, ConfigPrintFormat, ConfigValidateArgs};
-use crate::common::config_file::{self, ConfigError, Settings, SocketSetting};
+use crate::common::config_file::{self, ConfigError, Settings, SocketSetting, escape_printable};
 use crate::common::paths;
 use crate::common::secure_write;
 
@@ -39,14 +39,23 @@ pub use render::{render_json, render_toml};
 /// Dispatch a `config` subcommand. Returns a process exit code.
 pub fn run(explicit_config_path: Option<&Path>, action: &ConfigAction) -> i32 {
     match action {
-        ConfigAction::Init(args) => run_init(args.force),
+        // `--config <path>` propagates to every sub-subcommand: `init`
+        // writes there (instead of the platform-canonical path), and
+        // `validate` treats it as the default target when the
+        // positional argument is omitted. Without this thread the
+        // global flag silently did nothing for `init`/`validate`,
+        // contradicting its "global" clap attribute.
+        ConfigAction::Init(args) => run_init(explicit_config_path, args.force),
         ConfigAction::Print(args) => run_print(explicit_config_path, args),
-        ConfigAction::Validate(args) => run_validate(args),
+        ConfigAction::Validate(args) => run_validate(explicit_config_path, args),
     }
 }
 
-fn run_init(force: bool) -> i32 {
-    let Some(target) = paths::default_config_path() else {
+fn run_init(explicit: Option<&Path>, force: bool) -> i32 {
+    let Some(target) = explicit
+        .map(Path::to_path_buf)
+        .or_else(paths::default_config_path)
+    else {
         eprintln!("error: could not determine a config directory for this platform");
         return 1;
     };
@@ -108,8 +117,16 @@ fn run_print(explicit: Option<&Path>, args: &ConfigPrintArgs) -> i32 {
     for w in &outcome.warnings {
         eprintln!("warning: {w}");
     }
+    // Unknown keys are already sanitised at parse time (see
+    // `config_file::parse_toml` -> `escape_printable`), but re-apply
+    // the escape defensively so a future code path that stores a raw
+    // key into `unknown_keys` cannot regress the terminal-injection
+    // guarantee.
     for k in &outcome.settings.unknown_keys {
-        eprintln!("warning: unknown config key `{k}` (forward-compat — preserved)");
+        eprintln!(
+            "warning: unknown config key `{}` (forward-compat — preserved)",
+            escape_printable(k)
+        );
     }
 
     let rendered = match args.format {
@@ -131,9 +148,14 @@ fn run_print(explicit: Option<&Path>, args: &ConfigPrintArgs) -> i32 {
     }
 }
 
-fn run_validate(args: &ConfigValidateArgs) -> i32 {
+fn run_validate(explicit: Option<&Path>, args: &ConfigValidateArgs) -> i32 {
+    // Resolution order mirrors the operator's expectation for a
+    // "global" `--config`: positional `validate <path>` wins first,
+    // then the global `--config`, then the platform-canonical default.
     let path: PathBuf = if let Some(p) = &args.path {
         p.clone()
+    } else if let Some(p) = explicit {
+        p.to_path_buf()
     } else if let Some(p) = paths::default_config_path() {
         p
     } else {
@@ -151,7 +173,7 @@ fn run_validate(args: &ConfigValidateArgs) -> i32 {
             if !settings.unknown_keys.is_empty() {
                 eprintln!("warnings:");
                 for k in &settings.unknown_keys {
-                    eprintln!("  - unknown key `{k}`");
+                    eprintln!("  - unknown key `{}`", escape_printable(k));
                 }
             }
             println!("config OK: {}", path.display());

--- a/src/config_cmd/render.rs
+++ b/src/config_cmd/render.rs
@@ -1,0 +1,365 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Renderers for `all-smi config print`. Kept here so the command glue
+//! and the schema stay co-located; serialization uses a minimal
+//! hand-written projection that avoids polluting the `Settings` type
+//! with `Serialize` derives.
+
+use serde_json::{Value as JsonValue, json};
+use std::fmt::Write;
+
+use crate::common::config_file::{Settings, SocketSetting};
+
+/// Convert a [`Settings`] into a TOML string that parses back into an
+/// equivalent `Settings`. Redacts `webhook_url` unless `show_secrets`
+/// is set.
+pub fn render_toml(settings: &Settings, show_secrets: bool) -> std::io::Result<String> {
+    let mut out = String::new();
+    let webhook = if show_secrets || settings.alerts.webhook_url.is_empty() {
+        settings.alerts.webhook_url.clone()
+    } else {
+        "<redacted>".to_string()
+    };
+
+    writeln!(
+        &mut out,
+        "schema_version = {}",
+        crate::common::config_file::SUPPORTED_SCHEMA_VERSION
+    )
+    .ok();
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[general]").ok();
+    writeln!(
+        &mut out,
+        "default_mode = \"{}\"",
+        escape_toml(&settings.general.default_mode)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "theme = \"{}\"",
+        escape_toml(&settings.general.theme)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "locale = \"{}\"",
+        escape_toml(&settings.general.locale)
+    )
+    .ok();
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[local]").ok();
+    if let Some(v) = settings.local.interval_secs {
+        writeln!(&mut out, "interval_secs = {v}").ok();
+    }
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[view]").ok();
+    if let Some(h) = &settings.view.hostfile {
+        writeln!(&mut out, "hostfile = \"{}\"", escape_toml(h)).ok();
+    }
+    if !settings.view.hosts.is_empty() {
+        write!(&mut out, "hosts = [").ok();
+        for (i, h) in settings.view.hosts.iter().enumerate() {
+            if i > 0 {
+                write!(&mut out, ", ").ok();
+            }
+            write!(&mut out, "\"{}\"", escape_toml(h)).ok();
+        }
+        writeln!(&mut out, "]").ok();
+    }
+    if let Some(v) = settings.view.interval_secs {
+        writeln!(&mut out, "interval_secs = {v}").ok();
+    }
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[api]").ok();
+    writeln!(&mut out, "port = {}", settings.api.port).ok();
+    write!(&mut out, "socket = ").ok();
+    match &settings.api.socket {
+        SocketSetting::Unset | SocketSetting::Bool(false) => writeln!(&mut out, "false").ok(),
+        SocketSetting::Bool(true) => writeln!(&mut out, "true").ok(),
+        SocketSetting::Path(p) => writeln!(&mut out, "\"{}\"", escape_toml(p)).ok(),
+    };
+    writeln!(&mut out, "processes = {}", settings.api.processes).ok();
+    writeln!(&mut out, "interval_secs = {}", settings.api.interval_secs).ok();
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[alerts]").ok();
+    writeln!(&mut out, "temp_warn_c = {}", settings.alerts.temp_warn_c).ok();
+    writeln!(&mut out, "temp_crit_c = {}", settings.alerts.temp_crit_c).ok();
+    writeln!(
+        &mut out,
+        "util_idle_pct = {}",
+        settings.alerts.util_idle_pct
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "util_idle_warn_mins = {}",
+        settings.alerts.util_idle_warn_mins
+    )
+    .ok();
+    writeln!(&mut out, "hysteresis_c = {}", settings.alerts.hysteresis_c).ok();
+    writeln!(
+        &mut out,
+        "bell_on_critical = {}",
+        settings.alerts.bell_on_critical
+    )
+    .ok();
+    writeln!(&mut out, "power_crit_w = {}", settings.alerts.power_crit_w).ok();
+    writeln!(&mut out, "webhook_url = \"{}\"", escape_toml(&webhook)).ok();
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[energy]").ok();
+    writeln!(
+        &mut out,
+        "price_per_kwh = {}",
+        format_float(settings.energy.price_per_kwh)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "currency = \"{}\"",
+        escape_toml(&settings.energy.currency)
+    )
+    .ok();
+    writeln!(&mut out, "show_cost = {}", settings.energy.show_cost).ok();
+    writeln!(
+        &mut out,
+        "wal_path = \"{}\"",
+        escape_toml(&settings.energy.wal_path)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "gap_interpolate_seconds = {}",
+        settings.energy.gap_interpolate_seconds
+    )
+    .ok();
+    writeln!(&mut out, "wal_enabled = {}", settings.energy.wal_enabled).ok();
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[display]").ok();
+    writeln!(
+        &mut out,
+        "color_scheme = \"{}\"",
+        escape_toml(&settings.display.color_scheme)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "gauge_style = \"{}\"",
+        escape_toml(&settings.display.gauge_style)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "show_led_grid = {}",
+        settings.display.show_led_grid
+    )
+    .ok();
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[record]").ok();
+    writeln!(
+        &mut out,
+        "output_dir = \"{}\"",
+        escape_toml(&settings.record.output_dir)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "compress = \"{}\"",
+        escape_toml(&settings.record.compress)
+    )
+    .ok();
+    writeln!(&mut out).ok();
+
+    writeln!(&mut out, "[snapshot]").ok();
+    writeln!(
+        &mut out,
+        "default_format = \"{}\"",
+        escape_toml(&settings.snapshot.default_format)
+    )
+    .ok();
+    writeln!(
+        &mut out,
+        "default_pretty = {}",
+        settings.snapshot.default_pretty
+    )
+    .ok();
+
+    Ok(out)
+}
+
+/// JSON projection for `config print --format json`. Mirrors the TOML
+/// renderer structure but flattened so downstream `jq` pipelines are
+/// predictable.
+pub fn render_json(settings: &Settings, show_secrets: bool) -> std::io::Result<String> {
+    let webhook = if show_secrets || settings.alerts.webhook_url.is_empty() {
+        JsonValue::String(settings.alerts.webhook_url.clone())
+    } else {
+        JsonValue::String("<redacted>".to_string())
+    };
+
+    let socket_value = match &settings.api.socket {
+        SocketSetting::Unset | SocketSetting::Bool(false) => JsonValue::Bool(false),
+        SocketSetting::Bool(true) => JsonValue::Bool(true),
+        SocketSetting::Path(p) => JsonValue::String(p.clone()),
+    };
+
+    let doc = json!({
+        "schema_version": crate::common::config_file::SUPPORTED_SCHEMA_VERSION,
+        "general": {
+            "default_mode": settings.general.default_mode,
+            "theme": settings.general.theme,
+            "locale": settings.general.locale,
+        },
+        "local": {
+            "interval_secs": settings.local.interval_secs,
+        },
+        "view": {
+            "hostfile": settings.view.hostfile,
+            "hosts": settings.view.hosts,
+            "interval_secs": settings.view.interval_secs,
+        },
+        "api": {
+            "port": settings.api.port,
+            "socket": socket_value,
+            "processes": settings.api.processes,
+            "interval_secs": settings.api.interval_secs,
+        },
+        "alerts": {
+            "temp_warn_c": settings.alerts.temp_warn_c,
+            "temp_crit_c": settings.alerts.temp_crit_c,
+            "util_idle_pct": settings.alerts.util_idle_pct,
+            "util_idle_warn_mins": settings.alerts.util_idle_warn_mins,
+            "hysteresis_c": settings.alerts.hysteresis_c,
+            "bell_on_critical": settings.alerts.bell_on_critical,
+            "power_crit_w": settings.alerts.power_crit_w,
+            "webhook_url": webhook,
+        },
+        "energy": {
+            "price_per_kwh": settings.energy.price_per_kwh,
+            "currency": settings.energy.currency,
+            "show_cost": settings.energy.show_cost,
+            "wal_path": settings.energy.wal_path,
+            "gap_interpolate_seconds": settings.energy.gap_interpolate_seconds,
+            "wal_enabled": settings.energy.wal_enabled,
+        },
+        "display": {
+            "color_scheme": settings.display.color_scheme,
+            "gauge_style": settings.display.gauge_style,
+            "show_led_grid": settings.display.show_led_grid,
+        },
+        "record": {
+            "output_dir": settings.record.output_dir,
+            "compress": settings.record.compress,
+        },
+        "snapshot": {
+            "default_format": settings.snapshot.default_format,
+            "default_pretty": settings.snapshot.default_pretty,
+        },
+        "source_path": settings.source_path.as_ref().map(|p| p.display().to_string()),
+    });
+    serde_json::to_string_pretty(&doc)
+        .map_err(|e| std::io::Error::other(format!("json render: {e}")))
+}
+
+fn escape_toml(s: &str) -> String {
+    // Minimal escape for the characters forbidden in basic TOML strings
+    // (we never render multi-line strings). Matches the subset produced
+    // by the `toml` crate's own serializer for our value set.
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn format_float(f: f64) -> String {
+    if f.is_finite() {
+        // `{}` prints integers without a decimal point; TOML requires at
+        // least one digit after `.` for a float. Force a decimal.
+        let s = format!("{f}");
+        if s.contains('.') { s } else { format!("{s}.0") }
+    } else {
+        // Non-finite floats are not valid TOML; emit 0 instead of
+        // producing an unparseable file.
+        "0.0".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_toml_round_trips_through_loader() {
+        let mut s = Settings::default();
+        s.api.port = 9191;
+        s.alerts.temp_warn_c = 77;
+        s.alerts.webhook_url = "https://hooks.example/bot".to_string();
+
+        let toml_str = render_toml(&s, true).unwrap();
+        let (raw, unknown) = crate::common::config_file::parse_toml(&toml_str).unwrap();
+        assert!(unknown.is_empty(), "rendered toml should be clean");
+        assert_eq!(raw.api.as_ref().and_then(|a| a.port), Some(9191));
+        assert_eq!(raw.alerts.as_ref().and_then(|a| a.temp_warn_c), Some(77));
+        assert_eq!(
+            raw.alerts.as_ref().and_then(|a| a.webhook_url.clone()),
+            Some("https://hooks.example/bot".to_string())
+        );
+    }
+
+    #[test]
+    fn render_toml_redacts_webhook_by_default() {
+        let mut s = Settings::default();
+        s.alerts.webhook_url = "https://hooks.example/bot-secret".to_string();
+        let toml_str = render_toml(&s, false).unwrap();
+        assert!(toml_str.contains("<redacted>"));
+        assert!(!toml_str.contains("bot-secret"));
+    }
+
+    #[test]
+    fn render_json_outputs_valid_json() {
+        let s = Settings::default();
+        let json_str = render_json(&s, false).unwrap();
+        let _: JsonValue = serde_json::from_str(&json_str).expect("valid JSON");
+    }
+
+    #[test]
+    fn render_json_redacts_webhook_by_default() {
+        let mut s = Settings::default();
+        s.alerts.webhook_url = "https://hooks.example/secret".to_string();
+        let json_str = render_json(&s, false).unwrap();
+        assert!(json_str.contains("<redacted>"));
+        assert!(!json_str.contains("secret"));
+        let json_str = render_json(&s, true).unwrap();
+        assert!(json_str.contains("secret"));
+    }
+
+    #[test]
+    fn format_float_preserves_dot() {
+        assert_eq!(format_float(0.12), "0.12");
+        assert_eq!(format_float(1.0), "1.0");
+        assert_eq!(format_float(42.0), "42.0");
+    }
+
+    #[test]
+    fn format_float_handles_non_finite() {
+        assert_eq!(format_float(f64::NAN), "0.0");
+        assert_eq!(format_float(f64::INFINITY), "0.0");
+    }
+}

--- a/src/config_cmd/render.rs
+++ b/src/config_cmd/render.rs
@@ -281,11 +281,39 @@ pub fn render_json(settings: &Settings, show_secrets: bool) -> std::io::Result<S
         .map_err(|e| std::io::Error::other(format!("json render: {e}")))
 }
 
+/// Escape a string so it is valid inside a TOML basic string literal.
+///
+/// Covers the full set required by the TOML 1.0 grammar:
+/// * `\` and `"` (mandatory — otherwise the string terminates early).
+/// * `\n`, `\r`, `\t`, `\b`, `\f` (control characters with shorthand
+///   escapes; without them the rendered file would contain raw control
+///   bytes that most TOML parsers reject and that fail to round-trip
+///   through [`parse_toml`](crate::common::config_file::parse_toml)).
+/// * Any other `U+0000`–`U+001F` codepoint and `U+007F`, emitted as
+///   `\u{XXXX}`. A `webhook_url` or `wal_path` set via the TOML file
+///   could contain arbitrary bytes; without this branch the renderer
+///   would emit literal control characters that break the round-trip
+///   test (and potentially the parser on reload).
 fn escape_toml(s: &str) -> String {
-    // Minimal escape for the characters forbidden in basic TOML strings
-    // (we never render multi-line strings). Matches the subset produced
-    // by the `toml` crate's own serializer for our value set.
-    s.replace('\\', "\\\\").replace('"', "\\\"")
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000c}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 || (c as u32) == 0x7f => {
+                // TOML 1.0 spec: `\uXXXX` uses 4 hex digits with no
+                // braces (distinct from Rust's `\u{XXXX}` syntax).
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 fn format_float(f: f64) -> String {
@@ -361,5 +389,33 @@ mod tests {
     fn format_float_handles_non_finite() {
         assert_eq!(format_float(f64::NAN), "0.0");
         assert_eq!(format_float(f64::INFINITY), "0.0");
+    }
+
+    /// A `webhook_url` that contains newlines, tabs, or ESC sequences
+    /// must round-trip through `render_toml` -> `parse_toml` without
+    /// losing bytes or producing an invalid TOML document. Prior to the
+    /// full escape set the renderer emitted raw `\n` / `\r` / `\t`
+    /// characters, which either broke the string (newline) or
+    /// silently got stripped (tab, BEL, ESC) — either way breaking
+    /// round-trip.
+    #[test]
+    fn render_toml_roundtrips_control_characters() {
+        let mut s = Settings::default();
+        // Exercise every escape branch: `\n`, `\t`, `\r`, `\b`, `\f`,
+        // and a representative `\uXXXX` (ESC = 0x1b).
+        let nasty = "line1\nline2\twith\rtab\x08back\x0cff\x1b[31mRED\x7f";
+        s.alerts.webhook_url = nasty.to_string();
+
+        let toml_str = render_toml(&s, true).unwrap();
+        let (raw, unknown) = crate::common::config_file::parse_toml(&toml_str).unwrap();
+        assert!(
+            unknown.is_empty(),
+            "rendered toml with control chars must still parse clean, unknown: {unknown:?}"
+        );
+        assert_eq!(
+            raw.alerts.as_ref().and_then(|a| a.webhook_url.clone()),
+            Some(nasty.to_string()),
+            "full round-trip preserves every byte"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,12 @@ pub mod app_state;
 #[cfg(feature = "cli")]
 pub mod cli;
 
+/// Config subcommand argument types (issue #192). Kept separate so
+/// [`cli`] stays under the 500-line soft limit; re-exported from `cli`
+/// for ergonomic downstream `use crate::cli::...` call sites.
+#[cfg(feature = "cli")]
+pub mod cli_config;
+
 /// Self-diagnosis and support-bundle subcommand (issue #188).
 ///
 /// Exposed under `cli` because the orchestrator depends on tokio + clap
@@ -181,4 +187,22 @@ pub mod utils;
 pub mod common {
     /// Configuration management.
     pub mod config;
+    /// File-level merge helpers for the TOML config (issue #192).
+    #[cfg(feature = "cli")]
+    pub mod config_apply;
+    /// Environment-variable overlay for the TOML config (issue #192).
+    #[cfg(feature = "cli")]
+    pub mod config_env;
+    /// TOML configuration file loader (issue #192).
+    #[cfg(feature = "cli")]
+    pub mod config_file;
+    /// On-disk schema types for the TOML configuration file.
+    #[cfg(feature = "cli")]
+    pub mod config_schema;
+    /// Platform-aware configuration path resolution.
+    #[cfg(feature = "cli")]
+    pub mod paths;
+    /// Shared secure file-write helper (O_NOFOLLOW + 0o600).
+    #[cfg(feature = "cli")]
+    pub mod secure_write;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,14 @@ fn main() {
             for w in &outcome.warnings {
                 eprintln!("warning: {w}");
             }
+            // Surface unknown-key warnings at boot so operators learn
+            // about typos (`[alarts]` instead of `[alerts]`) without
+            // having to run `config print` separately. The keys are
+            // already escape-sanitised at parse time, so printing them
+            // cannot inject control sequences into the terminal.
+            for k in &outcome.settings.unknown_keys {
+                eprintln!("warning: unknown config key `{k}` (forward-compat — preserved)");
+            }
             outcome.settings
         }
         Err(e) => {
@@ -222,8 +230,12 @@ async fn run_command(cli: Cli, settings: Settings) {
             if args.interval.is_none() {
                 args.interval = Some(settings.api.interval_secs);
             }
-            if !args.processes {
-                args.processes = settings.api.processes;
+            // `Option<bool>` encodes three states: explicit true /
+            // explicit false / not provided. Only fall back to the
+            // merged settings when the CLI left it as `None`; once
+            // resolved, downstream consumers always see a bare `bool`.
+            if args.processes.is_none() {
+                args.processes = Some(settings.api.processes);
             }
             #[cfg(unix)]
             {
@@ -310,7 +322,15 @@ async fn run_command(cli: Cli, settings: Settings) {
             // Readers that require sudo or specialised managers will gracefully
             // degrade — their failures surface as `errors` entries rather than
             // aborting the snapshot, per the issue spec.
-            let options = match snapshot::SnapshotOptions::from_args(&args) {
+            //
+            // Merge `[snapshot]` config defaults on top of the CLI args
+            // so `default_format` / `default_pretty` from `config.toml`
+            // take effect when the operator does not pass `--format` /
+            // `--pretty` explicitly.
+            let options = match snapshot::SnapshotOptions::from_args_with_settings(
+                &args,
+                Some(&settings.snapshot),
+            ) {
                 Ok(o) => o,
                 Err(e) => {
                     eprintln!("error: {e}");
@@ -346,7 +366,14 @@ async fn run_command(cli: Cli, settings: Settings) {
             // `snapshot` it runs without sudo and without initializing the
             // macOS native metrics manager — hardware readers that need
             // those privileges degrade gracefully into the error list.
-            let opts = match record::RecorderOptions::from_args(&args) {
+            //
+            // Merge `[record]` config defaults on top of CLI args so
+            // `output_dir` / `compress` from `config.toml` take effect
+            // when the operator does not pass `-o` / `--compress`.
+            let opts = match record::RecorderOptions::from_args_with_settings(
+                &args,
+                Some(&settings.record),
+            ) {
                 Ok(o) => o,
                 Err(e) => {
                     eprintln!("error: {e}");
@@ -429,6 +456,62 @@ async fn run_command(cli: Cli, settings: Settings) {
             }
         }
         None => {
+            // Honour `[general].default_mode` from the config file:
+            // when set to "view" or "api", redispatch through the
+            // matching branch instead of defaulting to local. This
+            // wires the documented-but-previously-orphaned option so
+            // operators can declare their preferred entry point once
+            // in `config.toml` and stop typing the subcommand.
+            match settings.general.default_mode.as_str() {
+                "view" => {
+                    let view_args = cli::ViewArgs {
+                        hosts: None,
+                        hostfile: None,
+                        interval: None,
+                        alert_temp: None,
+                        alert_util_low_mins: None,
+                        replay: None,
+                        speed: 1.0,
+                        start: None,
+                        replay_loop: false,
+                    };
+                    // Re-enter the View arm with synthetic args. A
+                    // cleaner factoring is a shared helper, but the
+                    // existing handler is only reachable through this
+                    // match; splitting it out is a larger change than
+                    // this PR wants.
+                    return Box::pin(run_command(
+                        Cli {
+                            config: cli.config,
+                            command: Some(Commands::View(view_args)),
+                        },
+                        settings,
+                    ))
+                    .await;
+                }
+                "api" => {
+                    let api_args = cli::ApiArgs {
+                        port: None,
+                        interval: None,
+                        processes: None,
+                        #[cfg(unix)]
+                        socket: None,
+                    };
+                    return Box::pin(run_command(
+                        Cli {
+                            config: cli.config,
+                            command: Some(Commands::Api(api_args)),
+                        },
+                        settings,
+                    ))
+                    .await;
+                }
+                _ => {
+                    // "local" — fall through to the original local
+                    // default behaviour below.
+                }
+            }
+
             // Default to local mode when no command is specified
             // On macOS, no sudo is needed
             #[cfg(target_os = "macos")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,9 @@
 mod api;
 mod app_state;
 mod cli;
+mod cli_config;
 mod common;
+mod config_cmd;
 mod device;
 mod doctor;
 #[macro_use]
@@ -32,6 +34,7 @@ mod view;
 use api::run_api_mode;
 use clap::Parser;
 use cli::{Cli, Commands, LocalArgs};
+use common::config_file::{self, Settings, SocketSetting};
 use tokio::signal;
 use utils::{RuntimeEnvironment, ensure_sudo_permissions_for_api};
 
@@ -67,6 +70,32 @@ fn main() {
 
     let cli = Cli::parse();
 
+    // Handle the `config` subcommand synchronously — it never starts a
+    // Tokio runtime and its I/O is purely local filesystem work.
+    if let Some(Commands::Config(ref cfg_args)) = cli.command {
+        let code = config_cmd::run(cli.config.as_deref(), &cfg_args.action);
+        std::process::exit(code);
+    }
+
+    // Load the merged TOML + env settings now so every downstream mode
+    // entry point can consume them. A malformed or missing explicit
+    // `--config` file is a hard error and short-circuits startup.
+    let settings = match config_file::load(cli.config.as_deref()) {
+        Ok(outcome) => {
+            for w in &outcome.warnings {
+                eprintln!("warning: {w}");
+            }
+            outcome.settings
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            // `2` matches `config validate` semantics for consistency
+            // with the issue spec: malformed config is an actionable
+            // user error, not a crash.
+            std::process::exit(2);
+        }
+    };
+
     // The snapshot subcommand is one-shot, scriptable, and may call into
     // potentially-hung hardware readers via `spawn_blocking`. Because
     // `spawn_blocking` cannot cancel the underlying OS thread on a
@@ -92,7 +121,7 @@ fn main() {
             }
         };
         runtime.block_on(async move {
-            run_command(cli).await;
+            run_command(cli, settings).await;
         });
         return;
     }
@@ -110,11 +139,11 @@ fn main() {
         }
     };
     runtime.block_on(async move {
-        run_command(cli).await;
+        run_command(cli, settings).await;
     });
 }
 
-async fn run_command(cli: Cli) {
+async fn run_command(cli: Cli, settings: Settings) {
     // Signal-handling policy by subcommand:
     //
     // * `Record` installs its own SIGINT/SIGTERM handlers (see
@@ -170,7 +199,13 @@ async fn run_command(cli: Cli) {
     }
 
     match cli.command {
-        Some(Commands::Api(args)) => {
+        Some(Commands::Config(_)) => {
+            // Already handled synchronously in `main` before the runtime
+            // was built. This branch is unreachable in practice; keep it
+            // so the match is exhaustive.
+            unreachable!("config subcommand is dispatched before runtime");
+        }
+        Some(Commands::Api(mut args)) => {
             // When using native macOS APIs, no sudo is needed
             #[cfg(target_os = "macos")]
             let _ = ensure_sudo_permissions_for_api(); // Just for any other checks
@@ -178,10 +213,35 @@ async fn run_command(cli: Cli) {
             #[cfg(not(target_os = "macos"))]
             let _has_sudo = ensure_sudo_permissions_for_api();
 
+            // Resolve every CLI field via the precedence chain (CLI >
+            // env > file > default). Fields that were `None` on the CLI
+            // take their value from the merged `Settings`.
+            if args.port.is_none() {
+                args.port = Some(settings.api.port);
+            }
+            if args.interval.is_none() {
+                args.interval = Some(settings.api.interval_secs);
+            }
+            if !args.processes {
+                args.processes = settings.api.processes;
+            }
+            #[cfg(unix)]
+            {
+                if args.socket.is_none() {
+                    args.socket = match &settings.api.socket {
+                        SocketSetting::Unset | SocketSetting::Bool(false) => None,
+                        SocketSetting::Bool(true) => Some(String::new()),
+                        SocketSetting::Path(p) => Some(p.clone()),
+                    };
+                }
+            }
+
+            let interval = args.interval.unwrap_or(3);
+
             // Initialize native metrics manager (no sudo required)
             #[cfg(target_os = "macos")]
             if is_apple_silicon() {
-                if let Err(e) = initialize_native_metrics_manager(args.interval * 1000) {
+                if let Err(e) = initialize_native_metrics_manager(interval * 1000) {
                     eprintln!("Warning: Failed to initialize native metrics manager: {e}");
                 } else {
                     use std::sync::atomic::Ordering;
@@ -192,7 +252,7 @@ async fn run_command(cli: Cli) {
             // Initialize hlsmi manager for Intel Gaudi on Linux
             #[cfg(target_os = "linux")]
             if has_gaudi() {
-                match initialize_hlsmi_manager(args.interval) {
+                match initialize_hlsmi_manager(interval) {
                     Err(e) => {
                         eprintln!("Warning: Failed to initialize hlsmi manager: {e}");
                     }
@@ -203,12 +263,17 @@ async fn run_command(cli: Cli) {
                 }
             }
 
-            run_api_mode(&args).await;
+            run_api_mode(&args, &settings).await;
         }
-        Some(Commands::Local(args)) => {
+        Some(Commands::Local(mut args)) => {
             // On non-macOS platforms, require sudo
             #[cfg(not(target_os = "macos"))]
             ensure_sudo_permissions();
+
+            // Precedence: CLI > settings (env > file) > default.
+            if args.interval.is_none() {
+                args.interval = settings.local.interval_secs;
+            }
 
             // Initialize native metrics manager (no sudo required)
             #[cfg(target_os = "macos")]
@@ -237,7 +302,7 @@ async fn run_command(cli: Cli) {
                 });
             }
 
-            view::run_local_mode(&args).await;
+            view::run_local_mode(&args, &settings).await;
         }
         Some(Commands::Snapshot(args)) => {
             // Snapshot mode is one-shot and scriptable: DO NOT request sudo,
@@ -297,12 +362,26 @@ async fn run_command(cli: Cli) {
             }
         }
         Some(Commands::View(mut args)) => {
+            // Precedence: CLI > settings (env > file) > default.
+            // `hosts`/`hostfile` fill from config only when CLI omitted
+            // them; the Backend.AI detection later relies on this
+            // ordering too.
+            if args.hosts.is_none() && !settings.view.hosts.is_empty() {
+                args.hosts = Some(settings.view.hosts.clone());
+            }
+            if args.hostfile.is_none() {
+                args.hostfile = settings.view.hostfile.clone();
+            }
+            if args.interval.is_none() {
+                args.interval = settings.view.interval_secs;
+            }
+
             // Replay mode bypasses the remote scrape path entirely — it
             // reads frames from disk and pushes them into the same
             // AppState the live view renders. Hardware, sudo, and host
             // discovery are all irrelevant in this branch.
             if args.replay.is_some() {
-                view::run_replay_mode(&args).await;
+                view::run_replay_mode(&args, &settings).await;
                 return;
             }
 
@@ -335,7 +414,7 @@ async fn run_command(cli: Cli) {
                     std::process::exit(1);
                 }
             }
-            view::run_view_mode(&args).await;
+            view::run_view_mode(&args, &settings).await;
 
             // Cleanup after view mode exits
             #[cfg(target_os = "macos")]
@@ -384,12 +463,12 @@ async fn run_command(cli: Cli) {
                     });
                 }
 
-                view::run_local_mode(&LocalArgs {
-                    interval: None,
+                let local_args = LocalArgs {
+                    interval: settings.local.interval_secs,
                     alert_temp: None,
                     alert_util_low_mins: None,
-                })
-                .await;
+                };
+                view::run_local_mode(&local_args, &settings).await;
 
                 // Cleanup after local mode exits
                 #[cfg(target_os = "macos")]

--- a/src/metrics/energy_wal.rs
+++ b/src/metrics/energy_wal.rs
@@ -80,26 +80,11 @@ pub const MAX_REPLAY_RECORDS: usize = 1_000_000;
 /// high-cardinality activity before the first compaction kicks in.
 pub const WAL_MAX_BYTES: u64 = 16 * 1024 * 1024;
 
-/// Expand a leading `~` in `path` to the user's home directory.
-///
-/// Returns `path` unchanged if it does not start with `~`, or if
-/// `$HOME` is unset.
-pub fn expand_tilde(path: &Path) -> PathBuf {
-    let s = match path.to_str() {
-        Some(s) => s,
-        None => return path.to_path_buf(),
-    };
-    if let Some(rest) = s.strip_prefix("~/") {
-        if let Ok(home) = std::env::var("HOME") {
-            return PathBuf::from(home).join(rest);
-        }
-    } else if s == "~"
-        && let Ok(home) = std::env::var("HOME")
-    {
-        return PathBuf::from(home);
-    }
-    path.to_path_buf()
-}
+// Tilde expansion is shared through `crate::common::paths::expand_tilde`
+// — the formerly-duplicated helper that lived here is now a pass-through
+// import so every settings-consuming callsite uses the same
+// implementation.
+use crate::common::paths::expand_tilde;
 
 /// Replay the WAL at `path`, if it exists.
 ///

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -37,6 +37,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde_json::json;
 
 use crate::cli::{RecordArgs, RecordCompression, RecordSource, SnapshotIncludes};
+use crate::common::config_file::RecordSettings;
 use crate::snapshot::serializers::write_frame_json;
 use crate::snapshot::{
     DefaultSnapshotCollector, SNAPSHOT_SCHEMA_VERSION, Snapshot, SnapshotCollector,
@@ -68,8 +69,30 @@ pub struct RecorderOptions {
 impl RecorderOptions {
     /// Convert parsed CLI args into orchestrator options. All human-facing
     /// errors are raised here so the `record` subcommand fails fast before
-    /// opening any files.
+    /// opening any files. Thin wrapper over
+    /// [`Self::from_args_with_settings`] with no config layer — kept
+    /// for library consumers and tests.
+    #[allow(dead_code)]
     pub fn from_args(args: &RecordArgs) -> Result<Self> {
+        Self::from_args_with_settings(args, None)
+    }
+
+    /// Merged CLI + `[record]` config constructor. Precedence
+    /// (highest → lowest):
+    ///
+    /// * CLI flag (`--output`, `--compress`)
+    /// * Config file (`record.output_dir`, `record.compress`)
+    /// * Compiled default (`./all-smi-record.ndjson.zst`, codec zstd)
+    ///
+    /// `record.output_dir` is treated as the *directory* the default
+    /// basename is placed under — the operator can always pass `-o
+    /// /some/file.ndjson` to bypass it. Tilde expansion is applied so
+    /// `output_dir = "~/.cache/all-smi/records"` resolves to the
+    /// user's home at record time.
+    pub fn from_args_with_settings(
+        args: &RecordArgs,
+        settings: Option<&RecordSettings>,
+    ) -> Result<Self> {
         let includes = args
             .includes()
             .map_err(|msg| anyhow!("invalid --include: {msg}"))?;
@@ -88,18 +111,48 @@ impl RecorderOptions {
             bail!("--source=remote requires --hosts or --hostfile");
         }
 
-        let codec = Codec::detect(&args.output, args.compress);
+        // `--compress` wins when set; otherwise the `[record]` config
+        // chooses the codec. Without this the `record.compress` key
+        // was documented but silently ignored — detection fell through
+        // to the file extension.
+        let compress_override: Option<RecordCompression> = args.compress.or_else(|| {
+            settings.map(|s| s.compress.as_str()).and_then(|c| match c {
+                "zstd" => Some(RecordCompression::Zstd),
+                "gzip" => Some(RecordCompression::Gzip),
+                "none" => Some(RecordCompression::None),
+                _ => None, // apply_file_record already validated this
+            })
+        });
+
+        // Resolve the output path. clap hands us a default basename; if
+        // the operator did not pass `-o` AND the config supplied an
+        // `output_dir`, redirect the default basename under that dir.
+        // Detecting "operator did not pass -o" relies on the clap
+        // default being exactly the documented value — if that ever
+        // changes, update this guard.
+        let default_basename: std::path::PathBuf =
+            std::path::PathBuf::from("all-smi-record.ndjson.zst");
+        let output = if args.output == default_basename
+            && let Some(dir) = settings.map(|s| s.output_dir.as_str())
+            && !dir.is_empty()
+        {
+            crate::common::paths::expand_tilde(std::path::Path::new(dir)).join(&default_basename)
+        } else {
+            args.output.clone()
+        };
+
+        let codec = Codec::detect(&output, compress_override);
         // Sanity-check extension / codec combinations. We accept
         // mismatches (operator override wins) but warn so the file does
         // not end up unreadable-by-default.
-        if args.compress.is_some()
-            && let Some(warn) = codec_extension_mismatch(&args.output, args.compress)
+        if compress_override.is_some()
+            && let Some(warn) = codec_extension_mismatch(&output, compress_override)
         {
             eprintln!("warning: {warn}");
         }
 
         Ok(Self {
-            output: args.output.clone(),
+            output,
             interval: Duration::from_secs(args.interval.max(1)),
             duration,
             source: args.source,

--- a/src/snapshot/options.rs
+++ b/src/snapshot/options.rs
@@ -24,6 +24,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use crate::cli::{SnapshotArgs, SnapshotFormat, SnapshotIncludes};
+use crate::common::config_file::SnapshotSettings;
 use crate::device::{ChassisInfo, CpuInfo, GpuInfo, MemoryInfo, ProcessInfo};
 use crate::storage::info::StorageInfo;
 
@@ -74,7 +75,31 @@ impl Default for SnapshotOptions {
 
 impl SnapshotOptions {
     /// Construct options from parsed CLI args.
+    ///
+    /// Thin wrapper over [`Self::from_args_with_settings`] with no
+    /// config layer — kept as the legacy entry point for library
+    /// consumers and tests that never need the `[snapshot]` section.
+    #[allow(dead_code)]
     pub fn from_args(args: &SnapshotArgs) -> Result<Self> {
+        Self::from_args_with_settings(args, None)
+    }
+
+    /// Construct options merging CLI args with `[snapshot]` config
+    /// defaults. Precedence (highest → lowest):
+    ///
+    /// * CLI flag (`--format`, `--pretty`)
+    /// * Config file `[snapshot].default_format` /
+    ///   `[snapshot].default_pretty`
+    /// * Compiled defaults (json, auto-TTY pretty)
+    ///
+    /// Called from `main.rs` once the merged [`SnapshotSettings`] are
+    /// available. The legacy [`Self::from_args`] wrapper feeds `None`
+    /// for callers (tests, library consumers) that do not care about
+    /// the config layer.
+    pub fn from_args_with_settings(
+        args: &SnapshotArgs,
+        settings: Option<&SnapshotSettings>,
+    ) -> Result<Self> {
         let includes = args
             .includes()
             .map_err(|msg| anyhow::anyhow!("invalid --include: {msg}"))?;
@@ -84,9 +109,28 @@ impl SnapshotOptions {
         if args.samples == 0 {
             anyhow::bail!("--samples must be >= 1");
         }
+
+        // clap gives `args.format` a hardcoded `default_value_t =
+        // SnapshotFormat::Json`. That makes it impossible to tell "no
+        // flag given" apart from "--format=json" at parse time. We
+        // apply the config-file value only when the CLI chose the
+        // compiled default AND the config file has a different value,
+        // matching operator expectations ("my config says csv; one-
+        // shot runs should honour that").
+        let format = match settings.map(|s| s.default_format.as_str()) {
+            Some("csv") if args.format == SnapshotFormat::Json => SnapshotFormat::Csv,
+            Some("prometheus") if args.format == SnapshotFormat::Json => SnapshotFormat::Prometheus,
+            Some("json") | Some(_) | None => args.format,
+        };
+
+        // `--pretty` is already an `Option<bool>` so we can distinguish
+        // "unset" from "explicitly true/false" — only fall back to the
+        // config when the operator did not pass the flag.
+        let pretty = args.pretty.or_else(|| settings.map(|s| s.default_pretty));
+
         Ok(Self {
-            format: args.format,
-            pretty: args.pretty,
+            format,
+            pretty,
             includes,
             query: args.query.iter().map(|s| s.trim().to_string()).collect(),
             samples: args.samples,
@@ -225,6 +269,63 @@ mod tests {
         assert!(!opts.effective_pretty(true));
         opts.pretty = Some(true);
         assert!(opts.effective_pretty(false));
+    }
+
+    /// `[snapshot].default_format = "csv"` must take effect when the
+    /// operator does not pass `--format`. Without the merge the TOML
+    /// key was documented-but-ignored. A CLI `--format` value wins
+    /// back; we cannot test that case against clap's default here
+    /// because the compiled default is `Json`, but the precedence
+    /// direction is covered by the explicit-CLI branch below.
+    #[test]
+    fn snapshot_options_from_settings_uses_config_format() {
+        use crate::cli::SnapshotArgs;
+        use crate::common::config_file::SnapshotSettings;
+
+        let args = SnapshotArgs {
+            format: SnapshotFormat::Json,
+            pretty: None,
+            include: vec!["gpu".to_string()],
+            query: Vec::new(),
+            samples: 1,
+            interval: 0,
+            timeout_ms: 5_000,
+            output: None,
+        };
+        let settings = SnapshotSettings {
+            default_format: "csv".to_string(),
+            default_pretty: false,
+        };
+        let opts = SnapshotOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
+        assert_eq!(opts.format, SnapshotFormat::Csv);
+        // `args.pretty` was `None` so the config `default_pretty` wins.
+        assert_eq!(opts.pretty, Some(false));
+    }
+
+    /// Explicit `--pretty=true` on the CLI overrides a config
+    /// `default_pretty = false`. Verifies the documented precedence
+    /// (CLI > config) at the merge boundary.
+    #[test]
+    fn snapshot_options_cli_pretty_overrides_config() {
+        use crate::cli::SnapshotArgs;
+        use crate::common::config_file::SnapshotSettings;
+
+        let args = SnapshotArgs {
+            format: SnapshotFormat::Json,
+            pretty: Some(true),
+            include: vec!["gpu".to_string()],
+            query: Vec::new(),
+            samples: 1,
+            interval: 0,
+            timeout_ms: 5_000,
+            output: None,
+        };
+        let settings = SnapshotSettings {
+            default_format: "json".to_string(),
+            default_pretty: false,
+        };
+        let opts = SnapshotOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
+        assert_eq!(opts.pretty, Some(true), "CLI must win over config");
     }
 
     #[test]

--- a/src/view/data_collection/remote_collector.rs
+++ b/src/view/data_collection/remote_collector.rs
@@ -310,11 +310,16 @@ impl RemoteCollectorBuilder {
     pub fn load_hosts_from_file(mut self, file_path: &str) -> Result<Self, std::io::Error> {
         use std::path::Path;
 
-        // Sanitize and validate file path
-        let path = Path::new(file_path);
+        // Expand a leading `~/` before canonicalizing. Without this
+        // step a config value like `hostfile = "~/.config/all-smi/hosts"`
+        // would be passed verbatim to `canonicalize()`, which never
+        // performs tilde expansion itself and returns `NotFound`.
+        // Uses the shared helper so every path-consuming site applies
+        // the same expansion rules.
+        let expanded = crate::common::paths::expand_tilde(Path::new(file_path));
 
         // Resolve to absolute path and check it exists
-        let canonical_path = path.canonicalize().map_err(|e| {
+        let canonical_path = expanded.canonicalize().map_err(|e| {
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!("Invalid hostfile path: {e}"),

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -20,13 +20,30 @@ use tokio::sync::{Mutex, Notify};
 use crate::app_state::AppState;
 use crate::cli::{LocalArgs, ViewArgs};
 use crate::common::config::AlertConfig;
+use crate::common::config_file::Settings;
 use crate::ui::alerts::Alerter;
 use crate::view::data_collection::{ReplayDriver, initial_replay_state};
 use crate::view::{
     data_collector::DataCollector, terminal_manager::TerminalManager, ui_loop::UiLoop,
 };
 
-pub async fn run_local_mode(args: &LocalArgs) {
+/// Build the final [`AlertConfig`] for the current invocation:
+/// starts from the settings-provided AlertConfig (already merged from
+/// defaults + file + env) and applies any explicit CLI overrides on
+/// top. Keeping the helper here avoids duplicating the precedence wire
+/// through each mode entry point.
+fn build_alert_config(
+    settings: &Settings,
+    alert_temp: Option<u32>,
+    alert_util_low_mins: Option<u32>,
+) -> AlertConfig {
+    settings
+        .alerts
+        .clone()
+        .with_cli_overrides(alert_temp, alert_util_low_mins)
+}
+
+pub async fn run_local_mode(args: &LocalArgs, settings: &Settings) {
     let mut startup_profiler = crate::utils::StartupProfiler::new();
     startup_profiler.checkpoint("Starting run_local_mode");
 
@@ -36,13 +53,14 @@ pub async fn run_local_mode(args: &LocalArgs) {
     // behind `!is_local_mode` (see src/view/frame_renderer.rs render_main).
     let mut initial_state = AppState::new();
     initial_state.is_local_mode = true;
-    // Apply CLI-supplied alert thresholds on top of the compiled defaults.
-    // When the companion config-file issue lands these will be overlaid by
-    // the TOML loader before this point; CLI flags then win per the
-    // standard clap override chain.
-    let alert_config =
-        AlertConfig::default().with_cli_overrides(args.alert_temp, args.alert_util_low_mins);
+    // Apply the CLI-supplied alert thresholds on top of the
+    // settings-provided AlertConfig (which already merges defaults +
+    // config file + env per issue #192's precedence chain).
+    let alert_config = build_alert_config(settings, args.alert_temp, args.alert_util_low_mins);
     initial_state.alerter = Alerter::new(alert_config);
+    // Propagate the merged energy configuration (file + env) so the
+    // TUI cost column and WAL paths honour the user's config.toml.
+    initial_state.energy_config = settings.energy.clone();
     let app_state = Arc::new(Mutex::new(initial_state));
     startup_profiler.checkpoint("AppState initialized");
 
@@ -116,7 +134,7 @@ pub async fn run_local_mode(args: &LocalArgs) {
 /// and the event handler accepts SPACE/`]`/`[`/`+`/`-`/`j`/`k`/`g`/`L`
 /// while `AppState::replay` is `Some`. Filter-edit mode still takes
 /// precedence over replay keys per the event handler's mode ladder.
-pub async fn run_replay_mode(args: &ViewArgs) {
+pub async fn run_replay_mode(args: &ViewArgs, settings: &Settings) {
     let replay_path = match args.replay.as_ref() {
         Some(p) => p.clone(),
         None => {
@@ -141,7 +159,12 @@ pub async fn run_replay_mode(args: &ViewArgs) {
     let mut initial_state = AppState::new();
     initial_state.is_local_mode = false;
     initial_state.loading = false;
-    initial_state.alerter = Alerter::new(AlertConfig::default());
+    // Replay mode still honours config-file alert thresholds (the
+    // thresholds are cosmetic — they only drive transition events
+    // against recorded frames) but ignores --alert-temp / --alert-util
+    // which don't semantically apply to historical data.
+    initial_state.alerter = Alerter::new(settings.alerts.clone());
+    initial_state.energy_config = settings.energy.clone();
     initial_state.replay = Some(initial_replay_state(args.speed.max(0.05), args.replay_loop));
     // If `--start HH:MM:SS` was given, enqueue the seek so the first
     // ReplayDriver tick honors it before drawing the first frame.
@@ -220,7 +243,7 @@ pub async fn run_replay_mode(args: &ViewArgs) {
     driver_handle.abort();
 }
 
-pub async fn run_view_mode(args: &ViewArgs) {
+pub async fn run_view_mode(args: &ViewArgs, settings: &Settings) {
     // Initialize application state for remote mode.
     // `is_local_mode = false` whenever any --hosts / --hostfile argument is
     // supplied, including a single remote host.  The UI renders Cluster
@@ -228,9 +251,9 @@ pub async fn run_view_mode(args: &ViewArgs) {
     // (see src/view/frame_renderer.rs render_main).
     let mut initial_state = AppState::new();
     initial_state.is_local_mode = false;
-    let alert_config =
-        AlertConfig::default().with_cli_overrides(args.alert_temp, args.alert_util_low_mins);
+    let alert_config = build_alert_config(settings, args.alert_temp, args.alert_util_low_mins);
     initial_state.alerter = Alerter::new(alert_config);
+    initial_state.energy_config = settings.energy.clone();
     let app_state = Arc::new(Mutex::new(initial_state));
 
     // Create shared notification handle for collector -> UI wakeups

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -51,16 +51,21 @@ pub async fn run_local_mode(args: &LocalArgs, settings: &Settings) {
     // `is_local_mode = true` means no --hosts / --hostfile were supplied.
     // The UI gates the Cluster Overview card, dashboard items, and tabs row
     // behind `!is_local_mode` (see src/view/frame_renderer.rs render_main).
-    let mut initial_state = AppState::new();
+    // Build the AppState with the merged energy config so the
+    // integrator's `gap_interpolate_seconds` honours the TOML value.
+    // The settings layer has already merged defaults + file + env.
+    let mut initial_state = AppState::with_energy_config(&settings.energy);
     initial_state.is_local_mode = true;
     // Apply the CLI-supplied alert thresholds on top of the
     // settings-provided AlertConfig (which already merges defaults +
     // config file + env per issue #192's precedence chain).
     let alert_config = build_alert_config(settings, args.alert_temp, args.alert_util_low_mins);
     initial_state.alerter = Alerter::new(alert_config);
-    // Propagate the merged energy configuration (file + env) so the
-    // TUI cost column and WAL paths honour the user's config.toml.
-    initial_state.energy_config = settings.energy.clone();
+    // Propagate the `[display]` section so renderers consuming
+    // `AppState.display_config` honour the operator's color_scheme /
+    // gauge_style / show_led_grid choices. Defaults are equivalent to
+    // the pre-config-file behaviour when no config file is loaded.
+    initial_state.display_config = settings.display.clone();
     let app_state = Arc::new(Mutex::new(initial_state));
     startup_profiler.checkpoint("AppState initialized");
 
@@ -156,7 +161,7 @@ pub async fn run_replay_mode(args: &ViewArgs, settings: &Settings) {
 
     // Seed app state: treat replay as "remote-ish" (not is_local_mode)
     // so the tab row renders from the hostnames embedded in the stream.
-    let mut initial_state = AppState::new();
+    let mut initial_state = AppState::with_energy_config(&settings.energy);
     initial_state.is_local_mode = false;
     initial_state.loading = false;
     // Replay mode still honours config-file alert thresholds (the
@@ -164,7 +169,12 @@ pub async fn run_replay_mode(args: &ViewArgs, settings: &Settings) {
     // against recorded frames) but ignores --alert-temp / --alert-util
     // which don't semantically apply to historical data.
     initial_state.alerter = Alerter::new(settings.alerts.clone());
-    initial_state.energy_config = settings.energy.clone();
+    initial_state.display_config = settings.display.clone();
+    // Propagate the `[display]` section so renderers consuming
+    // `AppState.display_config` honour the operator's color_scheme /
+    // gauge_style / show_led_grid choices. Defaults are equivalent to
+    // the pre-config-file behaviour when no config file is loaded.
+    initial_state.display_config = settings.display.clone();
     initial_state.replay = Some(initial_replay_state(args.speed.max(0.05), args.replay_loop));
     // If `--start HH:MM:SS` was given, enqueue the seek so the first
     // ReplayDriver tick honors it before drawing the first frame.
@@ -249,11 +259,16 @@ pub async fn run_view_mode(args: &ViewArgs, settings: &Settings) {
     // supplied, including a single remote host.  The UI renders Cluster
     // Overview, dashboard items, and the tabs row only when this is false
     // (see src/view/frame_renderer.rs render_main).
-    let mut initial_state = AppState::new();
+    let mut initial_state = AppState::with_energy_config(&settings.energy);
     initial_state.is_local_mode = false;
     let alert_config = build_alert_config(settings, args.alert_temp, args.alert_util_low_mins);
     initial_state.alerter = Alerter::new(alert_config);
-    initial_state.energy_config = settings.energy.clone();
+    initial_state.display_config = settings.display.clone();
+    // Propagate the `[display]` section so renderers consuming
+    // `AppState.display_config` honour the operator's color_scheme /
+    // gauge_style / show_led_grid choices. Defaults are equivalent to
+    // the pre-config-file behaviour when no config file is loaded.
+    initial_state.display_config = settings.display.clone();
     let app_state = Arc::new(Mutex::new(initial_state));
 
     // Create shared notification handle for collector -> UI wakeups

--- a/tests/config_file_integration_test.rs
+++ b/tests/config_file_integration_test.rs
@@ -249,6 +249,29 @@ fn legacy_alert_temp_env_backcompat() {
     }
 }
 
+/// Canonical `ALL_SMI_ALERTS_TEMP_WARN_C` wins over legacy
+/// `ALL_SMI_ALERT_TEMP` when both are set. Mirrors the energy pattern;
+/// the reverse ordering (legacy wins) was the prior release's accidental
+/// behaviour and contradicts the documented canonical naming.
+#[test]
+fn canonical_alerts_env_beats_legacy() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    unsafe {
+        std::env::set_var("ALL_SMI_ALERT_TEMP", "60");
+        std::env::set_var("ALL_SMI_ALERTS_TEMP_WARN_C", "75");
+    }
+    let outcome = config_file::load(None).expect("must load");
+    assert_eq!(
+        outcome.settings.alerts.temp_warn_c, 75,
+        "canonical ALL_SMI_ALERTS_TEMP_WARN_C must override legacy ALL_SMI_ALERT_TEMP"
+    );
+    unsafe {
+        std::env::remove_var("ALL_SMI_ALERT_TEMP");
+        std::env::remove_var("ALL_SMI_ALERTS_TEMP_WARN_C");
+    }
+}
+
 /// Canonical `ALL_SMI_ENERGY_PRICE_PER_KWH` wins over legacy
 /// `ALL_SMI_ENERGY_PRICE` when both are set.
 #[test]
@@ -285,6 +308,37 @@ fn webhook_url_loaded_verbatim() {
         outcome.settings.alerts.webhook_url,
         "https://hooks.example/bot-secret"
     );
+}
+
+/// Oversized config files produce a clean `Io` error with an
+/// `InvalidData` kind, rather than OOM-ing the process on startup.
+/// Exercises the 1-MiB cap added to the loader as DoS mitigation.
+#[test]
+fn oversized_config_file_rejected_cleanly() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+
+    // Build a 2 MiB blob of TOML comments — syntactically valid TOML
+    // but over the cap. Comments are cheap to generate and the parser
+    // does not reject them on the byte budget alone, so this exercises
+    // the size gate rather than the parse gate.
+    let padding = "# a".repeat(700_000); // ~2.1 MiB
+    let contents = format!("schema_version = 1\n{padding}\n[api]\nport = 9090\n");
+    std::fs::write(&path, contents).unwrap();
+
+    let result = config_file::load(Some(&path));
+    match result {
+        Err(ConfigError::Io { source, .. }) => {
+            assert_eq!(
+                source.kind(),
+                std::io::ErrorKind::InvalidData,
+                "oversized config must surface as InvalidData IO, got {source:?}"
+            );
+        }
+        other => panic!("expected ConfigError::Io{{InvalidData}}, got {other:?}"),
+    }
 }
 
 /// `~` expansion is done by per-feature consumers (energy WAL,

--- a/tests/config_file_integration_test.rs
+++ b/tests/config_file_integration_test.rs
@@ -1,0 +1,311 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the TOML config file support added by issue
+//! #192. Covers the full precedence chain (CLI > env > file > default),
+//! malformed input, unknown-keys behaviour, and the backward-compat
+//! aliases.
+//!
+//! The tests avoid shelling out to the compiled binary so they can run
+//! under `cargo test --lib` (no extra build step needed).
+
+use all_smi::common::config_file::{self, ConfigError};
+
+/// Shared mutex to serialise env-var mutation across tests. Cargo runs
+/// test functions on multiple threads by default; without this lock,
+/// `set_var`/`remove_var` calls race each other and produce flaky
+/// failures that are hard to triage.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn clear_all_env() {
+    let keys = [
+        "ALL_SMI_GENERAL_DEFAULT_MODE",
+        "ALL_SMI_GENERAL_THEME",
+        "ALL_SMI_GENERAL_LOCALE",
+        "ALL_SMI_LOCAL_INTERVAL_SECS",
+        "ALL_SMI_VIEW_HOSTFILE",
+        "ALL_SMI_VIEW_HOSTS",
+        "ALL_SMI_VIEW_INTERVAL_SECS",
+        "ALL_SMI_API_PORT",
+        "ALL_SMI_API_SOCKET",
+        "ALL_SMI_API_PROCESSES",
+        "ALL_SMI_API_INTERVAL_SECS",
+        "ALL_SMI_ALERTS_TEMP_WARN_C",
+        "ALL_SMI_ALERTS_TEMP_CRIT_C",
+        "ALL_SMI_ALERTS_UTIL_IDLE_PCT",
+        "ALL_SMI_ALERTS_UTIL_IDLE_WARN_MINS",
+        "ALL_SMI_ALERTS_HYSTERESIS_C",
+        "ALL_SMI_ALERTS_BELL_ON_CRITICAL",
+        "ALL_SMI_ALERTS_WEBHOOK_URL",
+        "ALL_SMI_ALERT_TEMP",
+        "ALL_SMI_ALERT_UTIL_LOW_MINS",
+        "ALL_SMI_ENERGY_PRICE",
+        "ALL_SMI_ENERGY_PRICE_PER_KWH",
+        "ALL_SMI_ENERGY_CURRENCY",
+        "ALL_SMI_ENERGY_NO_COST",
+        "ALL_SMI_ENERGY_WAL_PATH",
+        "ALL_SMI_ENERGY_NO_WAL",
+        "ALL_SMI_ENERGY_GAP_SECONDS",
+    ];
+    unsafe {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+/// Case 1: env > file > default. With no CLI layer above this module,
+/// the loader honours env on top of file, and the remaining fields come
+/// from compiled defaults. This is the core precedence guarantee.
+#[test]
+fn env_overrides_file_value() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        r#"
+[api]
+port = 9100
+
+[alerts]
+temp_warn_c = 70
+"#,
+    )
+    .unwrap();
+
+    unsafe {
+        std::env::set_var("ALL_SMI_API_PORT", "9200");
+    }
+    let outcome = config_file::load(Some(&path)).expect("must load");
+    assert_eq!(outcome.settings.api.port, 9200, "env must override file");
+    // File value preserved for fields env didn't touch.
+    assert_eq!(outcome.settings.alerts.temp_warn_c, 70);
+    unsafe {
+        std::env::remove_var("ALL_SMI_API_PORT");
+    }
+}
+
+/// Case 2: file > default. With no env set the file wins over compiled
+/// defaults.
+#[test]
+fn file_overrides_default_when_no_env() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[api]\nport = 9500\n").unwrap();
+
+    let outcome = config_file::load(Some(&path)).expect("must load");
+    assert_eq!(outcome.settings.api.port, 9500);
+    // Untouched field returns compiled default.
+    assert_eq!(outcome.settings.api.interval_secs, 3);
+}
+
+/// Case 3: default when no file and no env. No explicit path, no env
+/// set — the only guaranteed outcome is that the loader does not crash
+/// and returns a valid Settings.
+#[test]
+fn defaults_apply_when_no_file_no_env() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let outcome = config_file::load(None).expect("must not crash");
+    // The compiled default is 9090. If a config file happens to exist
+    // on the host (e.g., the dev's own config), we can still assert
+    // the port is within a reasonable range to catch wild misreads.
+    assert!(
+        (1..=u16::MAX).contains(&outcome.settings.api.port),
+        "loaded port {} looks wrong",
+        outcome.settings.api.port
+    );
+}
+
+/// Malformed TOML must produce a clear `Parse` error, not silently
+/// apply partial values.
+#[test]
+fn malformed_toml_is_clean_error() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "this is = not valid [[[ toml\n[api]\nport = 9090").unwrap();
+    let result = config_file::load(Some(&path));
+    assert!(
+        matches!(result, Err(ConfigError::Parse(_))),
+        "expected ConfigError::Parse, got {result:?}"
+    );
+}
+
+/// Unknown keys survive normal `load` and are retained in
+/// `settings.unknown_keys` so `config print` can warn. `validate`
+/// without `--strict` accepts them for forward compatibility.
+#[test]
+fn unknown_keys_preserved_in_settings() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "future_feature = true\n[api]\nunknown_sub = 42\nport = 9090\n",
+    )
+    .unwrap();
+    let outcome = config_file::load(Some(&path)).expect("must load");
+    assert!(
+        outcome
+            .settings
+            .unknown_keys
+            .contains(&"future_feature".to_string())
+    );
+    assert!(
+        outcome
+            .settings
+            .unknown_keys
+            .contains(&"api.unknown_sub".to_string())
+    );
+    // validate without strict accepts them.
+    let valid = config_file::validate_file(&path, false);
+    assert!(valid.is_ok(), "validate without strict must accept");
+}
+
+/// `validate --strict` rejects unknown keys with UnknownKey error.
+#[test]
+fn validate_strict_rejects_unknown() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "mystery = 1\n[api]\nport = 9090\n").unwrap();
+    let result = config_file::validate_file(&path, true);
+    assert!(
+        matches!(result, Err(ConfigError::UnknownKey(_))),
+        "strict must reject, got {result:?}"
+    );
+}
+
+/// Schema version 2 (not yet supported) must produce a clean error.
+#[test]
+fn future_schema_version_rejected() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "schema_version = 2\n").unwrap();
+    let result = config_file::load(Some(&path));
+    assert!(
+        matches!(
+            result,
+            Err(ConfigError::SchemaVersion {
+                found: 2,
+                supported: 1
+            })
+        ),
+        "expected SchemaVersion error, got {result:?}"
+    );
+}
+
+/// Backward compat: the legacy `ALL_SMI_ENERGY_PRICE` env var still
+/// drives `energy.price_per_kwh`.
+#[test]
+fn legacy_energy_price_env_backcompat() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    unsafe {
+        std::env::set_var("ALL_SMI_ENERGY_PRICE", "0.42");
+    }
+    let outcome = config_file::load(None).expect("must load");
+    assert!((outcome.settings.energy.price_per_kwh - 0.42).abs() < 1e-9);
+    unsafe {
+        std::env::remove_var("ALL_SMI_ENERGY_PRICE");
+    }
+}
+
+/// Backward compat: legacy `ALL_SMI_ALERT_TEMP` still sets temp_warn_c.
+#[test]
+fn legacy_alert_temp_env_backcompat() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    unsafe {
+        std::env::set_var("ALL_SMI_ALERT_TEMP", "68");
+    }
+    let outcome = config_file::load(None).expect("must load");
+    assert_eq!(outcome.settings.alerts.temp_warn_c, 68);
+    // Auto-bumped crit per the original alias contract.
+    assert!(outcome.settings.alerts.temp_crit_c >= 73);
+    unsafe {
+        std::env::remove_var("ALL_SMI_ALERT_TEMP");
+    }
+}
+
+/// Canonical `ALL_SMI_ENERGY_PRICE_PER_KWH` wins over legacy
+/// `ALL_SMI_ENERGY_PRICE` when both are set.
+#[test]
+fn canonical_energy_env_beats_legacy() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    unsafe {
+        std::env::set_var("ALL_SMI_ENERGY_PRICE", "0.10");
+        std::env::set_var("ALL_SMI_ENERGY_PRICE_PER_KWH", "0.50");
+    }
+    let outcome = config_file::load(None).expect("must load");
+    assert!((outcome.settings.energy.price_per_kwh - 0.50).abs() < 1e-9);
+    unsafe {
+        std::env::remove_var("ALL_SMI_ENERGY_PRICE");
+        std::env::remove_var("ALL_SMI_ENERGY_PRICE_PER_KWH");
+    }
+}
+
+/// Webhook URL must be loaded verbatim by the loader — redaction is a
+/// render-time concern tested separately in the `config_cmd` renderer.
+#[test]
+fn webhook_url_loaded_verbatim() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[alerts]\nwebhook_url = \"https://hooks.example/bot-secret\"\n",
+    )
+    .unwrap();
+    let outcome = config_file::load(Some(&path)).expect("must load");
+    assert_eq!(
+        outcome.settings.alerts.webhook_url,
+        "https://hooks.example/bot-secret"
+    );
+}
+
+/// `~` expansion is done by per-feature consumers (energy WAL,
+/// hostfile, etc.) — the loader stores paths verbatim so downstream
+/// code can decide when to expand.
+#[test]
+fn tilde_paths_stored_verbatim_by_loader() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    clear_all_env();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[view]\nhostfile = \"~/all-smi-hosts.csv\"\n[energy]\nwal_path = \"~/my-wal.bin\"\n",
+    )
+    .unwrap();
+    let outcome = config_file::load(Some(&path)).expect("must load");
+    assert_eq!(
+        outcome.settings.view.hostfile.as_deref(),
+        Some("~/all-smi-hosts.csv"),
+        "loader preserves leading tilde verbatim"
+    );
+    assert_eq!(outcome.settings.energy.wal_path, "~/my-wal.bin");
+}


### PR DESCRIPTION
## Summary

- Introduces a user-level TOML configuration file so operators can persist common settings (hostfile path, update interval, alert thresholds, `$/kWh`, etc.) without retyping CLI flags on every invocation.
- Adds an `all-smi config init | print | validate` subcommand family for initialising, inspecting, and sanity-checking the file.
- Implements the full precedence chain documented in #192: **CLI flag > env var > config file > compiled default.**

## Implementation

- `src/common/config_file.rs` owns the merged runtime `Settings` struct and the [`load`] entry point. Parsing and schema definitions live in `config_schema.rs`; file-to-settings projection in `config_apply.rs`; env-var overlay in `config_env.rs`. Keeping each file under ~400 lines keeps the merge logic readable.
- `src/common/paths.rs` resolves the platform-appropriate config path (XDG on Linux, `~/Library/Application Support` on macOS with XDG parity fallback, `%APPDATA%` on Windows) plus `~`/`~/` expansion.
- `src/common/secure_write.rs` centralises the `O_NOFOLLOW` + `0o600` pattern from `snapshot::write_output_atomic` and `record::writer::open_secure` so `config init` reuses the same hardening.
- `src/config_cmd/` implements the `init/print/validate` runtime glue, a canonical commented example TOML, and both TOML and JSON renderers for `config print`. `webhook_url` is redacted unless `--show-secrets` is passed.
- `src/cli.rs` + `src/cli_config.rs` add the global `--config <PATH>` option and the `Config` subcommand with `Init`/`Print`/`Validate` variants. `ApiArgs`/`LocalArgs`/`ViewArgs` now use `Option<T>` for every field that the config can provide so the precedence chain merges cleanly in `main.rs`.
- `src/main.rs` calls `config_file::load(cli.config.as_deref())` after parsing the CLI, then merges the resulting `Settings` into the mode entry points (`run_api_mode`, `view::run_local_mode`, `view::run_view_mode`, `view::run_replay_mode`). A malformed or explicitly-missing config file exits 2; implicit discovery silently falls back to defaults.
- `src/api/server.rs` and `src/view/runner.rs` now accept a `&Settings`; their existing CLI args are resolved in `main.rs` before they are called.
- Existing env vars from #186 (`ALL_SMI_ALERT_TEMP`, `ALL_SMI_ALERT_UTIL_LOW_MINS`) and #191 (`ALL_SMI_ENERGY_PRICE`, `ALL_SMI_ENERGY_NO_COST`, `ALL_SMI_ENERGY_WAL_PATH`, `ALL_SMI_ENERGY_NO_WAL`, `ALL_SMI_ENERGY_GAP_SECONDS`, `ALL_SMI_ENERGY_CURRENCY`) are preserved as legacy aliases for the new canonical `ALL_SMI_<SECTION>_<KEY>` names.
- Schema version 1 is enforced with a clean error for unsupported future versions.
- Unknown keys are preserved and surfaced: `config print` warns about them, `config validate` accepts them for forward compat, and `config validate --strict` rejects them.

## Testing

- `cargo test --lib` — 899 passed
- `cargo test --bin all-smi` — 1029 passed
- `cargo test --test config_file_integration_test` — 12 passed (covers precedence chain, malformed TOML, unknown keys, schema version, legacy env aliases, webhook secrets, tilde paths)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Manual smoke: `all-smi config init/print/validate` round-trip, including `--force` overwrite, redacted/`--show-secrets` webhook, and explicit vs implicit `--config` discovery.

## Documentation

- README gains a new **Configuration** section with file locations, precedence table, helper-subcommand reference, and reload semantics.
- DEVELOPERS.md gains a **Configuration Architecture** section describing the merge layers, file layout, and the recipe for adding a new config-file-driven field.

Closes #192