### PR TITLE
feat(view): agentless SSH transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+dependencies = [
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+dependencies = [
+ "cipher 0.5.1",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
+dependencies = [
+ "aead 0.6.0-rc.10",
+ "aes 0.9.0",
+ "cipher 0.5.1",
+ "ctr 0.10.0",
+ "ghash 0.6.0",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +121,7 @@ dependencies = [
  "rand 0.10.0",
  "regex",
  "reqwest",
+ "russh",
  "serde",
  "serde_json",
  "sysinfo",
@@ -195,6 +266,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -368,6 +451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -436,10 +520,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.12.2",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "bincode"
@@ -503,12 +610,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -522,6 +665,16 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -551,10 +704,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
+dependencies = [
+ "cipher 0.5.1",
+]
 
 [[package]]
 name = "cc"
@@ -611,6 +788,17 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -632,6 +820,27 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -718,6 +927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +971,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +1016,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
@@ -851,13 +1084,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.0",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+dependencies = [
+ "crypto-bigint",
+ "libm",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -879,6 +1151,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
+dependencies = [
+ "cipher 0.5.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.11.2",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -917,6 +1244,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,8 +1299,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -996,10 +1365,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecdsa"
+version = "0.17.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
+dependencies = [
+ "der",
+ "digest 0.11.2",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.10.0",
+ "serde",
+ "sha2 0.11.0",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.0-rc.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "crypto-common 0.2.1",
+ "digest 0.11.2",
+ "hkdf",
+ "hybrid-array",
+ "once_cell",
+ "pem-rfc7468 1.0.0",
+ "pkcs8",
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "rustcrypto-group",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1021,6 +1454,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1085,6 +1530,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -1291,6 +1742,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1791,25 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -1390,6 +1871,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1956,18 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "ctutils",
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -1685,6 +2211,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding 0.3.3",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
+]
+
+[[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.18+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f8a978272e3cbdf4768f7363eb1c8e1e6ba63c52a3ed05e29e222da4aec7cb"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "crypto-bigint",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac 0.13.0",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.10.0",
+ "rsa",
+ "sec1",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,10 +2384,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -1859,6 +2469,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1933,6 +2549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2619,30 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04437cb1a66c0b78740927b76cc61f218344b9f6ef3dd430e283274a718ef0e9"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.0",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164eb3faeaecbd14b0b2a917c1b4d0c035097a9c559b0bed85c2cdd032bc8faa"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -2088,6 +2734,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2758,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2209,6 +2891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +2967,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.14.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b97e3bf0465157ae90975ff52dbeb1362ba618924878c9f74c25baa27a65f9a"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p384"
+version = "0.14.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437f30ebcb1e16ff48acead5f08bd69fbcdbc82421687bb48af5c315a0bfab03"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "p521"
+version = "0.14.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9fd792bab86ecf6249561752fb5a413511f999887107dd054bbda5143743d7"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.8.6",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows",
+ "windows-strings",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +3053,55 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
+dependencies = [
+ "digest 0.11.2",
+ "hmac 0.13.0",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2378,6 +3175,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.0-rc.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a777c6e26664bc9504b3ce3f6133f8f20d9071f130a4f9fcbd3186959d8dd6"
+dependencies = [
+ "aes 0.9.0",
+ "aes-gcm 0.11.0-rc.3",
+ "cbc 0.2.0",
+ "der",
+ "pbkdf2 0.13.0-rc.10",
+ "rand_core 0.10.0",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.10.0",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +3237,40 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -2435,6 +3305,29 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.1",
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0556580e42c19833f5d232aca11a7687a503ee41f937b54f5ae1d50fc2a6a36a"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2659,11 +3552,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2673,9 +3577,19 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2686,6 +3600,15 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2802,6 +3725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.5.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
+dependencies = [
+ "hmac 0.13.0",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,8 +3744,117 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest 0.11.2",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.10.0",
+ "sha2 0.11.0",
+ "signature",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d937f3f4a79bffd67fc12fd437785effdfc8b94edc89ab90392f9ac9e11cc9fc"
+dependencies = [
+ "aes 0.8.4",
+ "aws-lc-rs",
+ "bitflags 2.11.0",
+ "block-padding 0.3.3",
+ "byteorder",
+ "bytes",
+ "cbc 0.1.2",
+ "cipher 0.5.1",
+ "crypto-bigint",
+ "ctr 0.9.2",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.3.5",
+ "getrandom 0.2.17",
+ "hex-literal",
+ "hmac 0.12.1",
+ "inout 0.1.4",
+ "internal-russh-forked-ssh-key",
+ "internal-russh-num-bigint",
+ "log",
+ "md5",
+ "ml-kem",
+ "module-lattice",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2 0.12.2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "polyval 0.7.1",
+ "rand 0.10.0",
+ "rand_core 0.10.0",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "typenum",
+ "universal-hash 0.6.1",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
+dependencies = [
+ "log",
+ "nix 0.31.2",
+ "ssh-encoding",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2846,7 +3888,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -2869,6 +3911,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.0",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "subtle",
 ]
 
 [[package]]
@@ -2969,7 +4032,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2983,6 +4046,16 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.1",
+]
 
 [[package]]
 name = "same-file"
@@ -3007,6 +4080,32 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.12.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03ed5b54ed5fcc8e016cd94301416bc2c01c05c87a6742b97468337c8804598"
+dependencies = [
+ "cfg-if",
+ "pbkdf2 0.13.0-rc.10",
+ "salsa20",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct",
+ "ctutils",
+ "der",
+ "hybrid-array",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3124,6 +4223,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,7 +4262,28 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
 ]
 
 [[package]]
@@ -3190,6 +4342,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,6 +4377,51 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
+ "cbc 0.1.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3785,6 +4992,32 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.1",
+ "ctutils",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ zstd = "0.13"
 flate2 = "1"
 # Support bundle packaging for the `doctor --bundle` subcommand (issue #188).
 tar = "0.4"
+# Pure-Rust SSH client for the agentless view transport (issue #194).
+# Chosen over ssh2/libssh2 so musl static builds do not need a C
+# dependency. russh 0.60 targets edition 2021 with tokio 1.x.
+russh = "0.60"
 [target.'cfg(target_os = "linux")'.dependencies]
 # Tenstorrent dependencies from GitHub
 all-smi-luwen-core = "0.2.0"
@@ -86,6 +90,7 @@ core-foundation = "0.10"
 
 [dev-dependencies]
 tempfile = "3.23"
+tokio = { version = "1.50.0", features = ["full", "test-util"] }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/README.md
+++ b/README.md
@@ -556,6 +556,57 @@ Stable check IDs (greppable across versions):
 - **Storage Monitoring:** Disk usage information for all hosts
 - **High Availability:** Resilient to connection failures with automatic recovery
 
+### Agentless SSH mode
+
+`all-smi view --ssh user@host[,user@host2,...]` connects to one or more
+remote machines over SSH and renders their metrics in the same TUI,
+**without** first installing or starting `all-smi api` on the targets.
+
+On first connect the transport probes each host, in order:
+
+1. `all-smi snapshot --format json` — used when the binary is present
+   and at least v0.22. The tab chip shows `native`.
+2. `nvidia-smi --query-gpu=...` — CSV fallback for NVIDIA boxes without
+   `all-smi`. Chip shows `nvidia-smi`.
+3. `rocm-smi --json` — JSON fallback for AMD boxes. Chip shows
+   `rocm-smi`.
+4. Otherwise the host is marked `unsupported`.
+
+Quick start:
+
+```bash
+# Monitor two DGX boxes over SSH, using your agent key.
+all-smi view --ssh admin@dgx-01,admin@dgx-02
+
+# Bulk mode from a hostfile (see examples/hosts-ssh.txt).
+all-smi view --ssh-hostfile examples/hosts-ssh.txt
+
+# Accept unknown host keys on first connect (TOFU) and persist them.
+all-smi view --ssh admin@new-node --ssh-strict-host-key accept-new
+```
+
+Key flags:
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--ssh user@host[:port][,...]` | — | Comma-separated SSH targets. |
+| `--ssh-hostfile <path>` | — | One `user@host[:port]` per line; `#` comments allowed. |
+| `--ssh-key <path>` | auto-probe | Overrides agent / `~/.ssh/id_*` probe order. |
+| `--ssh-strict-host-key yes\|accept-new\|no` | `yes` | Matches OpenSSH semantics. |
+| `--ssh-timeout-secs <n>` | `10` | Per-target TCP/handshake timeout. |
+| `--ssh-fallback nvidia-smi,rocm-smi,none` | both enabled | Which shim(s) to try when `all-smi` is absent. |
+| `--ssh-known-hosts <path>` | `~/.ssh/known_hosts` | Custom known-hosts file. |
+| `--ssh-concurrency <n>` | `32` | Bound on concurrent SSH connects (semaphore-limited). |
+
+Security notes:
+
+- Password auth is **never** attempted; key / agent auth only. No
+  password ever flows through the CLI or logs.
+- The SSH command string emitted on the wire is fixed per transport and
+  does not interpolate remote input into shell commands.
+- `--ssh-strict-host-key=no` logs a prominent TUI warning so a
+  misconfiguration is obvious to the operator.
+
 ### Interactive UI
 - **Enhanced Controls:**
   - Keyboard: Arrow keys, Page Up/Down, Tab switching

--- a/README.md
+++ b/README.md
@@ -606,6 +606,12 @@ Security notes:
   does not interpolate remote input into shell commands.
 - `--ssh-strict-host-key=no` logs a prominent TUI warning so a
   misconfiguration is obvious to the operator.
+- `known_hosts` writes use `O_NOFOLLOW` and reject a pre-existing
+  symlink at the target path; an attacker who controls the directory
+  cannot redirect host-key lines into an arbitrary file (e.g.
+  `~/.bashrc`). If persistence fails, accepted keys are kept in an
+  in-process cache so a subsequent connection in the same run can still
+  detect a key change.
 
 ### Interactive UI
 - **Enhanced Controls:**

--- a/examples/hosts-ssh.txt
+++ b/examples/hosts-ssh.txt
@@ -1,0 +1,19 @@
+# Agentless SSH hostfile for `all-smi view --ssh-hostfile` (issue #194).
+#
+# Format: one `user@host[:port]` per line.
+# Comments start with `#` (both leading and inline).
+# Blank lines are ignored.
+
+# Datacenter nodes reachable on the default SSH port (22).
+admin@dgx-01
+admin@dgx-02
+admin@dgx-03
+
+# Node behind a custom port.
+admin@dgx-edge:2222
+
+# AMD GPU host — will auto-fall-back to rocm-smi if all-smi is not installed.
+admin@mi250-01
+
+# Bastion users per host are supported because the `user` is parsed per-line.
+# backup-admin@metrics-archive:2222  # inline comment works too

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -128,6 +128,16 @@ pub struct ConnectionStatus {
     pub consecutive_failures: u32,
     pub last_error: Option<String>,
     pub last_update: Instant,
+    /// Short transport tag rendered as a TUI chip next to the tab label.
+    /// Populated by the SSH strategy (`native`, `nvidia-smi`, `rocm-smi`,
+    /// `unsupported`) and by the HTTP scraper (`http`). `None` means
+    /// "not applicable" (local mode, replay mode).
+    pub transport_chip: Option<String>,
+    /// Short connection-state tag (`connecting`, `connected`,
+    /// `auth-failed`, `timeout`, `disconnected`). Used by the TUI to
+    /// render a per-host status chip. `None` when the status has not
+    /// yet been set.
+    pub connection_state: Option<String>,
 }
 
 impl ConnectionStatus {
@@ -141,6 +151,8 @@ impl ConnectionStatus {
             consecutive_failures: 0,
             last_error: None,
             last_update: Instant::now(),
+            transport_chip: None,
+            connection_state: None,
         }
     }
 
@@ -150,6 +162,7 @@ impl ConnectionStatus {
         self.consecutive_failures = 0;
         self.last_error = None;
         self.last_update = Instant::now();
+        self.connection_state = Some("connected".to_string());
     }
 
     pub fn mark_failure(&mut self, error: String) {
@@ -157,6 +170,34 @@ impl ConnectionStatus {
         self.consecutive_failures += 1;
         self.last_error = Some(error);
         self.last_update = Instant::now();
+        // Classify the error into a compact state chip. The error
+        // messages the SSH client produces carry the chip label as
+        // the prefix — parse it out rather than re-deriving.
+        let chip = if self
+            .last_error
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("auth-failed")
+        {
+            "auth-failed"
+        } else if self
+            .last_error
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("timeout")
+        {
+            "timeout"
+        } else if self
+            .last_error
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("host-key-rejected")
+        {
+            "host-key-rejected"
+        } else {
+            "disconnected"
+        };
+        self.connection_state = Some(chip.to_string());
     }
 
     #[allow(dead_code)]
@@ -869,6 +910,23 @@ impl SortCriteria {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connection_status_tracks_ssh_chips() {
+        // mark_failure with the SSH client's canonical error-label
+        // prefixes should classify into the corresponding chip tag.
+        let mut cs = ConnectionStatus::new("u@h:22".to_string(), "ssh://u@h".to_string());
+        cs.mark_failure("auth-failed: SSH authentication failed".into());
+        assert_eq!(cs.connection_state.as_deref(), Some("auth-failed"));
+        cs.mark_failure("timeout: SSH connect timeout after 10s".into());
+        assert_eq!(cs.connection_state.as_deref(), Some("timeout"));
+        cs.mark_failure("host-key-rejected: host key not trusted".into());
+        assert_eq!(cs.connection_state.as_deref(), Some("host-key-rejected"));
+        cs.mark_failure("other: stuff".into());
+        assert_eq!(cs.connection_state.as_deref(), Some("disconnected"));
+        cs.mark_success();
+        assert_eq!(cs.connection_state.as_deref(), Some("connected"));
+    }
 
     #[test]
     fn test_is_local_mode() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -168,6 +168,86 @@ pub struct ViewArgs {
     /// keyword; the CLI surface remains `--loop`.
     #[arg(long = "loop")]
     pub replay_loop: bool,
+
+    // --- Agentless SSH transport (issue #194) --------------------------
+    /// Comma-separated list of SSH targets (`user@host[:port]`).
+    ///
+    /// When set, `view` connects to each target over SSH and runs
+    /// `all-smi snapshot --format json` when installed, or falls back
+    /// to `nvidia-smi` / `rocm-smi` per `--ssh-fallback`. Mutually
+    /// exclusive with `--hosts` / `--hostfile`.
+    #[arg(long)]
+    pub ssh: Option<String>,
+
+    /// Path to a hostfile listing one `user@host[:port]` target per line.
+    /// `#` comments and blank lines are ignored.
+    #[arg(long = "ssh-hostfile")]
+    pub ssh_hostfile: Option<PathBuf>,
+
+    /// Explicit SSH private key path. Overrides the default probe of
+    /// `~/.ssh/id_ed25519`, `~/.ssh/id_ecdsa`, `~/.ssh/id_rsa`.
+    #[arg(long = "ssh-key")]
+    pub ssh_key: Option<PathBuf>,
+
+    /// OpenSSH config file (`~/.ssh/config`). Currently unused but
+    /// reserved so the flag is stable across versions.
+    #[arg(long = "ssh-config")]
+    pub ssh_config: Option<PathBuf>,
+
+    /// Host-key policy: `yes` (default, refuse unknown), `accept-new`
+    /// (TOFU), `no` (accept any — TUI warning shown).
+    #[arg(long = "ssh-strict-host-key", default_value = "yes")]
+    pub ssh_strict_host_key: String,
+
+    /// Per-target SSH connect timeout in seconds. Exec timeouts are
+    /// bounded separately by [`crate::network::ssh_client::DEFAULT_EXEC_TIMEOUT`].
+    #[arg(long = "ssh-timeout-secs", default_value_t = 10)]
+    pub ssh_timeout_secs: u64,
+
+    /// Comma-separated fallback probe order (`nvidia-smi`, `rocm-smi`,
+    /// `none`). When omitted, both fallbacks are enabled.
+    #[arg(long = "ssh-fallback")]
+    pub ssh_fallback: Option<String>,
+
+    /// Path to the known_hosts file for strict / accept-new verification.
+    /// Defaults to `~/.ssh/known_hosts`.
+    #[arg(long = "ssh-known-hosts")]
+    pub ssh_known_hosts: Option<PathBuf>,
+
+    /// Maximum concurrent SSH connections (semaphore-limited). Hosts
+    /// beyond this cap stagger their initial connection attempts.
+    #[arg(long = "ssh-concurrency", default_value_t = 32)]
+    pub ssh_concurrency: usize,
+}
+
+impl ViewArgs {
+    /// Constructor used by synthetic call sites (tests, the `default_mode`
+    /// redispatch in `main.rs`, and the local-mode runner that only
+    /// needs the interval / alert CLI flags). Keeps every callsite in
+    /// one place so adding a new `ViewArgs` field doesn't force
+    /// touching each synthetic site.
+    pub fn empty() -> Self {
+        Self {
+            hosts: None,
+            hostfile: None,
+            interval: None,
+            alert_temp: None,
+            alert_util_low_mins: None,
+            replay: None,
+            speed: 1.0,
+            start: None,
+            replay_loop: false,
+            ssh: None,
+            ssh_hostfile: None,
+            ssh_key: None,
+            ssh_config: None,
+            ssh_strict_host_key: "yes".to_string(),
+            ssh_timeout_secs: 10,
+            ssh_fallback: None,
+            ssh_known_hosts: None,
+            ssh_concurrency: 32,
+        }
+    }
 }
 
 /// Output format for the `snapshot` subcommand.

--- a/src/common/config_apply.rs
+++ b/src/common/config_apply.rs
@@ -86,6 +86,36 @@ fn apply_file_view(raw: &RawConfig, settings: &mut Settings) {
     if v.interval_secs.is_some() {
         settings.view.interval_secs = v.interval_secs;
     }
+    // Agentless SSH transport keys (issue #194). Each `.is_some()`
+    // guard lets the CLI layer distinguish "config set this" from
+    // "config left it unset".
+    if let Some(ssh) = &v.ssh {
+        settings.view.ssh = ssh.clone();
+    }
+    if v.ssh_hostfile.is_some() {
+        settings.view.ssh_hostfile = v.ssh_hostfile.clone();
+    }
+    if v.ssh_key.is_some() {
+        settings.view.ssh_key = v.ssh_key.clone();
+    }
+    if v.ssh_config.is_some() {
+        settings.view.ssh_config = v.ssh_config.clone();
+    }
+    if v.ssh_strict_host_key.is_some() {
+        settings.view.ssh_strict_host_key = v.ssh_strict_host_key.clone();
+    }
+    if v.ssh_timeout_secs.is_some() {
+        settings.view.ssh_timeout_secs = v.ssh_timeout_secs;
+    }
+    if v.ssh_fallback.is_some() {
+        settings.view.ssh_fallback = v.ssh_fallback.clone();
+    }
+    if v.ssh_known_hosts.is_some() {
+        settings.view.ssh_known_hosts = v.ssh_known_hosts.clone();
+    }
+    if v.ssh_concurrency.is_some() {
+        settings.view.ssh_concurrency = v.ssh_concurrency;
+    }
 }
 
 fn apply_file_api(raw: &RawConfig, settings: &mut Settings) {

--- a/src/common/config_file.rs
+++ b/src/common/config_file.rs
@@ -177,6 +177,19 @@ pub struct ViewSettings {
     pub hostfile: Option<String>,
     pub hosts: Vec<String>,
     pub interval_secs: Option<u64>,
+    // Agentless SSH transport (issue #194). Empty / None means "use CLI
+    // defaults". `ssh` (targets) and `ssh_hostfile` are *additive* with
+    // CLI: a TOML-provided target list is merged with `--ssh` on the
+    // command line at dispatch time.
+    pub ssh: Vec<String>,
+    pub ssh_hostfile: Option<String>,
+    pub ssh_key: Option<String>,
+    pub ssh_config: Option<String>,
+    pub ssh_strict_host_key: Option<String>,
+    pub ssh_timeout_secs: Option<u64>,
+    pub ssh_fallback: Option<String>,
+    pub ssh_known_hosts: Option<String>,
+    pub ssh_concurrency: Option<usize>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/common/config_schema.rs
+++ b/src/common/config_schema.rs
@@ -69,6 +69,18 @@ pub struct ViewSection {
     pub hostfile: Option<String>,
     pub hosts: Option<Vec<String>>,
     pub interval_secs: Option<u64>,
+    // Agentless SSH transport (issue #194). A missing section produces
+    // `None` which the CLI layer then ignores — the defaults baked into
+    // `clap` still apply.
+    pub ssh: Option<Vec<String>>,
+    pub ssh_hostfile: Option<String>,
+    pub ssh_key: Option<String>,
+    pub ssh_config: Option<String>,
+    pub ssh_strict_host_key: Option<String>,
+    pub ssh_timeout_secs: Option<u64>,
+    pub ssh_fallback: Option<String>,
+    pub ssh_known_hosts: Option<String>,
+    pub ssh_concurrency: Option<usize>,
 }
 
 /// `[api]` section — options for `all-smi api`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,12 +403,74 @@ async fn run_command(cli: Cli, settings: Settings) {
                 args.interval = settings.view.interval_secs;
             }
 
+            // SSH-transport config-file overrides (issue #194). CLI
+            // flags always win; the config file fills in unset values.
+            if args.ssh.is_none() && !settings.view.ssh.is_empty() {
+                args.ssh = Some(settings.view.ssh.join(","));
+            }
+            if args.ssh_hostfile.is_none() {
+                args.ssh_hostfile = settings
+                    .view
+                    .ssh_hostfile
+                    .as_ref()
+                    .map(std::path::PathBuf::from);
+            }
+            if args.ssh_key.is_none() {
+                args.ssh_key = settings.view.ssh_key.as_ref().map(std::path::PathBuf::from);
+            }
+            if args.ssh_config.is_none() {
+                args.ssh_config = settings
+                    .view
+                    .ssh_config
+                    .as_ref()
+                    .map(std::path::PathBuf::from);
+            }
+            if args.ssh_known_hosts.is_none() {
+                args.ssh_known_hosts = settings
+                    .view
+                    .ssh_known_hosts
+                    .as_ref()
+                    .map(std::path::PathBuf::from);
+            }
+            // `ssh_strict_host_key` carries a clap default of "yes".
+            // Override only when the config file explicitly set it AND
+            // the CLI value is still the compiled default.
+            if args.ssh_strict_host_key == "yes"
+                && let Some(v) = settings.view.ssh_strict_host_key.as_ref()
+            {
+                args.ssh_strict_host_key = v.clone();
+            }
+            // `ssh_timeout_secs` defaults to 10 from clap; apply config
+            // only when operator did not change it on the CLI.
+            if args.ssh_timeout_secs == 10
+                && let Some(v) = settings.view.ssh_timeout_secs
+            {
+                args.ssh_timeout_secs = v;
+            }
+            if args.ssh_fallback.is_none() {
+                args.ssh_fallback = settings.view.ssh_fallback.clone();
+            }
+            if args.ssh_concurrency == 32
+                && let Some(v) = settings.view.ssh_concurrency
+            {
+                args.ssh_concurrency = v;
+            }
+
             // Replay mode bypasses the remote scrape path entirely — it
             // reads frames from disk and pushes them into the same
             // AppState the live view renders. Hardware, sudo, and host
             // discovery are all irrelevant in this branch.
             if args.replay.is_some() {
                 view::run_replay_mode(&args, &settings).await;
+                return;
+            }
+
+            // SSH mode (issue #194): if any --ssh* flag is set we
+            // dispatch to the agentless transport instead of the HTTP
+            // remote scraper. --ssh and --ssh-hostfile are merged
+            // inside run_ssh_mode.
+            if args.ssh.is_some() || args.ssh_hostfile.is_some() {
+                view::run_ssh_mode(&args, &settings).await;
                 return;
             }
 
@@ -464,17 +526,7 @@ async fn run_command(cli: Cli, settings: Settings) {
             // in `config.toml` and stop typing the subcommand.
             match settings.general.default_mode.as_str() {
                 "view" => {
-                    let view_args = cli::ViewArgs {
-                        hosts: None,
-                        hostfile: None,
-                        interval: None,
-                        alert_temp: None,
-                        alert_util_low_mins: None,
-                        replay: None,
-                        speed: 1.0,
-                        start: None,
-                        replay_loop: false,
-                    };
+                    let view_args = cli::ViewArgs::empty();
                     // Re-enter the View arm with synthetic args. A
                     // cleaner factoring is a shared helper, but the
                     // existing handler is only reachable through this

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,6 +14,13 @@
 
 pub mod client;
 pub mod metrics_parser;
+pub mod nvidia_smi_shim;
+pub mod rocm_smi_shim;
+pub mod ssh_client;
+pub mod ssh_decision;
+pub mod ssh_host_key;
+pub mod ssh_target;
+pub mod ssh_transport;
 pub mod webhook;
 
 pub use client::NetworkClient;

--- a/src/network/nvidia_smi_shim.rs
+++ b/src/network/nvidia_smi_shim.rs
@@ -42,13 +42,21 @@ use crate::device::GpuInfo;
 /// documented in issue #194.
 pub const NVIDIA_SMI_COMMAND: &str = "nvidia-smi --query-gpu=index,uuid,name,driver_version,utilization.gpu,memory.used,memory.total,temperature.gpu,clocks.current.graphics,power.draw --format=csv,noheader,nounits";
 
+/// Number of columns [`parse_nvidia_smi_csv`] expects per row. Enforced
+/// as an exact match so a malicious or broken remote cannot silently
+/// misalign field-to-metric mapping by emitting a truncated row.
+pub const EXPECTED_COLUMN_COUNT: usize = 10;
+
 /// Errors surfaced by [`parse_nvidia_smi_csv`]. Every error variant
 /// carries the raw offending line so the caller (the SSH strategy) can
 /// log it against the host that produced it without re-stitching the
 /// original input.
 #[derive(Debug, thiserror::Error)]
 pub enum NvidiaSmiParseError {
-    #[error("unexpected column count (want >= 7, got {got}) in line: {line}")]
+    #[error(
+        "unexpected column count (want {expected}, got {got}) in line: {line}",
+        expected = EXPECTED_COLUMN_COUNT
+    )]
     ColumnCount { got: usize, line: String },
 }
 
@@ -114,8 +122,13 @@ fn parse_row(
     // Columns: 0=index, 1=uuid, 2=name, 3=driver_version,
     // 4=util.gpu, 5=mem.used, 6=mem.total, 7=temp.gpu,
     // 8=clocks.graphics, 9=power.draw
+    //
+    // Require EXACTLY the expected number of columns. A permissive
+    // ">= N" check would let a malicious remote emit a shortened row
+    // that silently aliases later metrics onto earlier columns (e.g.
+    // making temperature-like values appear as power draw).
     let cols: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
-    if cols.len() < 7 {
+    if cols.len() != EXPECTED_COLUMN_COUNT {
         return Err(NvidiaSmiParseError::ColumnCount {
             got: cols.len(),
             line: line.to_string(),
@@ -315,13 +328,52 @@ mod tests {
     }
 
     #[test]
-    fn fewer_than_seven_columns_is_error() {
-        // A row with fewer than 7 columns cannot be meaningfully
+    fn fewer_than_expected_columns_is_error() {
+        // A row with fewer than 10 columns cannot be meaningfully
         // rendered — callers must see the error surface.
         let csv = "0, GPU-a, only three\n";
         let err = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap_err();
         match err {
             NvidiaSmiParseError::ColumnCount { got, .. } => assert_eq!(got, 3),
+        }
+    }
+
+    #[test]
+    fn seven_column_row_is_rejected_not_misaligned() {
+        // Defense-in-depth for the case where a remote (malicious or
+        // buggy) emits a short row that would otherwise silently
+        // alias later fields onto earlier columns. We now require
+        // EXACTLY 10 columns.
+        let csv = "0, GPU-a, N1, drv, 1, 2, 3\n";
+        let err = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap_err();
+        match err {
+            NvidiaSmiParseError::ColumnCount { got, .. } => assert_eq!(got, 7),
+        }
+    }
+
+    #[test]
+    fn nine_column_row_is_rejected() {
+        // A 9-column row is the subtle case: previously accepted by
+        // the `>= 7` guard; now rejected so metrics cannot drift.
+        let csv = "0, GPU-a, N1, 1.0, 10, 20, 30, 40, 50\n";
+        let err = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap_err();
+        match err {
+            NvidiaSmiParseError::ColumnCount { got, line } => {
+                assert_eq!(got, 9);
+                assert!(line.contains("GPU-a"));
+            }
+        }
+    }
+
+    #[test]
+    fn eleven_column_row_is_rejected() {
+        // More columns than expected is also suspicious — reject so
+        // attackers cannot append bogus data beyond the parser's
+        // schema.
+        let csv = "0, GPU-a, N1, 1.0, 10, 20, 30, 40, 50, 60, extra\n";
+        let err = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap_err();
+        match err {
+            NvidiaSmiParseError::ColumnCount { got, .. } => assert_eq!(got, 11),
         }
     }
 

--- a/src/network/nvidia_smi_shim.rs
+++ b/src/network/nvidia_smi_shim.rs
@@ -1,0 +1,338 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Agentless SSH `nvidia-smi` fallback parser (issue #194).
+//!
+//! When a remote host does not have `all-smi` installed but does have a
+//! working NVIDIA driver, the SSH transport can still render per-GPU
+//! metrics by running a fixed `nvidia-smi --query-gpu` command and
+//! parsing the CSV output into [`GpuInfo`] records. The command the
+//! caller should execute is exported via [`NVIDIA_SMI_COMMAND`] so the
+//! client and the parser stay in lockstep.
+//!
+//! CSV assumptions (`--format=csv,noheader,nounits`):
+//!
+//! * No header row, no unit suffixes.
+//! * Field separator is `, ` (comma + space) in practice; we split on
+//!   `,` and trim whitespace so we tolerate either flavour.
+//! * Unsupported fields render as `[Not Supported]` or `[N/A]` — both
+//!   are treated as zero / absent rather than as hard parse errors.
+//! * `N/A` in the `uuid` field is extremely rare; we synthesize a
+//!   stable `gpu{index}@{host}` UUID so [`crate::device::GpuInfo`]
+//!   consumers that key on UUID still work.
+
+use std::collections::HashMap;
+
+use crate::device::GpuInfo;
+
+/// The exact `nvidia-smi` command string the SSH transport should
+/// execute on a remote host. Kept as a single `&'static str` so the
+/// parser and the client cannot drift. Matches the `--query-gpu` list
+/// documented in issue #194.
+pub const NVIDIA_SMI_COMMAND: &str = "nvidia-smi --query-gpu=index,uuid,name,driver_version,utilization.gpu,memory.used,memory.total,temperature.gpu,clocks.current.graphics,power.draw --format=csv,noheader,nounits";
+
+/// Errors surfaced by [`parse_nvidia_smi_csv`]. Every error variant
+/// carries the raw offending line so the caller (the SSH strategy) can
+/// log it against the host that produced it without re-stitching the
+/// original input.
+#[derive(Debug, thiserror::Error)]
+pub enum NvidiaSmiParseError {
+    #[error("unexpected column count (want >= 7, got {got}) in line: {line}")]
+    ColumnCount { got: usize, line: String },
+}
+
+/// Parse `nvidia-smi --query-gpu=index,uuid,name,driver_version,\
+/// utilization.gpu,memory.used,memory.total,temperature.gpu,\
+/// clocks.current.graphics,power.draw --format=csv,noheader,nounits`
+/// output into a vector of [`GpuInfo`] records.
+///
+/// * `host_id` is the logical host identifier (e.g. `user@dgx-01:22`)
+///   — the value stored on every produced [`GpuInfo`].
+/// * `hostname` is the human-readable hostname (`dgx-01`), used for
+///   the per-tab label.
+/// * `timestamp` is an RFC3339 timestamp string captured by the caller
+///   at the moment the SSH `exec` returned.
+///
+/// Malformed rows are **skipped** with a logged warning rather than
+/// failing the whole parse — a single bad row on one GPU must not blind
+/// the operator to the rest of the fleet. The function returns an error
+/// only when the CSV has zero parseable rows AND at least one malformed
+/// row was encountered (i.e. we saw output that looked like CSV but
+/// failed every parse attempt).
+pub fn parse_nvidia_smi_csv(
+    csv: &str,
+    host_id: &str,
+    hostname: &str,
+    timestamp: &str,
+) -> Result<Vec<GpuInfo>, NvidiaSmiParseError> {
+    let mut out = Vec::new();
+    let mut malformed = 0usize;
+    let mut last_error: Option<NvidiaSmiParseError> = None;
+
+    for raw_line in csv.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        match parse_row(line, host_id, hostname, timestamp) {
+            Ok(gpu) => out.push(gpu),
+            Err(e) => {
+                malformed += 1;
+                last_error = Some(e);
+            }
+        }
+    }
+
+    if out.is_empty()
+        && malformed > 0
+        && let Some(e) = last_error
+    {
+        return Err(e);
+    }
+
+    Ok(out)
+}
+
+fn parse_row(
+    line: &str,
+    host_id: &str,
+    hostname: &str,
+    timestamp: &str,
+) -> Result<GpuInfo, NvidiaSmiParseError> {
+    // Columns: 0=index, 1=uuid, 2=name, 3=driver_version,
+    // 4=util.gpu, 5=mem.used, 6=mem.total, 7=temp.gpu,
+    // 8=clocks.graphics, 9=power.draw
+    let cols: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
+    if cols.len() < 7 {
+        return Err(NvidiaSmiParseError::ColumnCount {
+            got: cols.len(),
+            line: line.to_string(),
+        });
+    }
+
+    let get = |i: usize| -> &str { cols.get(i).copied().unwrap_or("") };
+
+    let index_str = get(0);
+    let uuid_raw = get(1);
+    let name = get(2).to_string();
+    let driver_version = get(3).to_string();
+    let utilization = parse_f64(get(4)).unwrap_or(0.0);
+    let used_memory_mib = parse_f64(get(5)).unwrap_or(0.0);
+    let total_memory_mib = parse_f64(get(6)).unwrap_or(0.0);
+    let temperature = parse_f64(get(7)).unwrap_or(0.0) as u32;
+    let frequency_mhz = parse_f64(get(8)).unwrap_or(0.0) as u32;
+    let power_consumption = parse_f64(get(9)).unwrap_or(0.0);
+
+    let uuid = if is_missing(uuid_raw) {
+        format!("gpu{index_str}@{host_id}")
+    } else {
+        uuid_raw.to_string()
+    };
+
+    // nvidia-smi reports memory in MiB with the nounits flag; convert
+    // to bytes (×1024×1024) to match the internal `GpuInfo` contract
+    // used by the rest of the codebase (bytes, not MiB).
+    let used_memory = (used_memory_mib * 1024.0 * 1024.0) as u64;
+    let total_memory = (total_memory_mib * 1024.0 * 1024.0) as u64;
+
+    let mut detail: HashMap<String, String> = HashMap::new();
+    if !driver_version.is_empty() {
+        detail.insert("driver_version".to_string(), driver_version);
+    }
+    detail.insert("transport".to_string(), "ssh/nvidia-smi".to_string());
+
+    // Build a unique instance string so per-GPU rendering identifies
+    // the correct remote slot. The existing remote collector uses
+    // `hostname:index`-style labels; follow that.
+    let instance = format!("{hostname}:{index_str}");
+
+    Ok(GpuInfo {
+        uuid,
+        time: timestamp.to_string(),
+        name,
+        device_type: "GPU".to_string(),
+        host_id: host_id.to_string(),
+        hostname: hostname.to_string(),
+        instance,
+        utilization,
+        ane_utilization: 0.0,
+        dla_utilization: None,
+        tensorcore_utilization: None,
+        temperature,
+        used_memory,
+        total_memory,
+        frequency: frequency_mhz,
+        power_consumption,
+        gpu_core_count: None,
+        temperature_threshold_slowdown: None,
+        temperature_threshold_shutdown: None,
+        temperature_threshold_max_operating: None,
+        temperature_threshold_acoustic: None,
+        performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
+        detail,
+    })
+}
+
+/// `nvidia-smi` emits `[Not Supported]`, `[N/A]`, or `N/A` for fields the
+/// hardware does not report. We treat all of them as "missing".
+fn is_missing(s: &str) -> bool {
+    let lo = s.to_ascii_lowercase();
+    matches!(
+        lo.as_str(),
+        "" | "[not supported]" | "[n/a]" | "n/a" | "not supported"
+    )
+}
+
+fn parse_f64(s: &str) -> Option<f64> {
+    if is_missing(s) {
+        return None;
+    }
+    s.parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOLDEN_TWO_GPU: &str = "\
+0, GPU-abc123, NVIDIA A100-SXM4-80GB, 550.54.15, 45, 12288, 81920, 58, 1410, 285.5
+1, GPU-def456, NVIDIA A100-SXM4-80GB, 550.54.15, 12, 1024, 81920, 42, 210, 120.0
+";
+
+    #[test]
+    fn parses_two_gpu_golden_sample() {
+        let gpus = parse_nvidia_smi_csv(
+            GOLDEN_TWO_GPU,
+            "user@dgx-01:22",
+            "dgx-01",
+            "2026-04-20T00:00:00Z",
+        )
+        .expect("valid golden sample must parse");
+
+        assert_eq!(gpus.len(), 2, "two rows -> two GpuInfo records");
+
+        let g0 = &gpus[0];
+        assert_eq!(g0.uuid, "GPU-abc123");
+        assert_eq!(g0.name, "NVIDIA A100-SXM4-80GB");
+        assert_eq!(g0.utilization, 45.0);
+        assert_eq!(g0.used_memory, 12288 * 1024 * 1024);
+        assert_eq!(g0.total_memory, 81920 * 1024 * 1024);
+        assert_eq!(g0.temperature, 58);
+        assert_eq!(g0.frequency, 1410);
+        assert!((g0.power_consumption - 285.5).abs() < 1e-6);
+        assert_eq!(g0.hostname, "dgx-01");
+        assert_eq!(g0.host_id, "user@dgx-01:22");
+        assert_eq!(g0.instance, "dgx-01:0");
+        assert_eq!(g0.device_type, "GPU");
+        assert_eq!(
+            g0.detail.get("driver_version"),
+            Some(&"550.54.15".to_string())
+        );
+        assert_eq!(
+            g0.detail.get("transport"),
+            Some(&"ssh/nvidia-smi".to_string())
+        );
+
+        assert_eq!(gpus[1].uuid, "GPU-def456");
+        assert_eq!(gpus[1].instance, "dgx-01:1");
+    }
+
+    #[test]
+    fn tolerates_not_supported_sentinels() {
+        // Older drivers or vGPU slices often emit [Not Supported] for
+        // power.draw or clocks.current.graphics. Those fields must
+        // downgrade to zero, not poison the entire row.
+        let csv = "0, GPU-xyz, Quadro K2200, 470.82.01, 3, 512, 4096, 45, [Not Supported], [Not Supported]\n";
+        let gpus = parse_nvidia_smi_csv(csv, "user@box", "box", "t").unwrap();
+        assert_eq!(gpus.len(), 1);
+        assert_eq!(gpus[0].frequency, 0);
+        assert_eq!(gpus[0].power_consumption, 0.0);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_vec() {
+        let gpus = parse_nvidia_smi_csv("", "u@h", "h", "t").unwrap();
+        assert!(gpus.is_empty());
+    }
+
+    #[test]
+    fn skips_blank_lines() {
+        let csv = "\n\n0, GPU-a, N1, 1, 1, 1, 1, 1, 1, 1\n\n";
+        let gpus = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap();
+        assert_eq!(gpus.len(), 1);
+    }
+
+    #[test]
+    fn malformed_row_alone_surfaces_error() {
+        // If every input row is malformed, surface the last observed
+        // error so callers can report it in the TUI.
+        let csv = "this is not csv\nstill not csv\n";
+        let err = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap_err();
+        match err {
+            NvidiaSmiParseError::ColumnCount { got, line } => {
+                assert_eq!(got, 1);
+                assert_eq!(line, "still not csv");
+            }
+        }
+    }
+
+    #[test]
+    fn mixed_good_and_bad_rows_keep_good() {
+        // A single bad row among good rows must not kill the whole
+        // parse. Known-good rows still land in the output.
+        let csv = "broken row\n0, GPU-a, N1, 1, 1, 1, 1, 1, 1, 1\n";
+        let gpus = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap();
+        assert_eq!(gpus.len(), 1);
+        assert_eq!(gpus[0].uuid, "GPU-a");
+    }
+
+    #[test]
+    fn missing_uuid_is_synthesized() {
+        // Some driver versions return "N/A" for uuid on very old GPUs;
+        // the parser must synthesize a stable UUID so the UI layer's
+        // UUID-keyed GPU dedup keeps working.
+        let csv = "0, N/A, Tesla K40, 1, 1, 1, 1, 1, 1, 1\n";
+        let gpus = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap();
+        assert_eq!(gpus.len(), 1);
+        assert_eq!(gpus[0].uuid, "gpu0@u@h");
+    }
+
+    #[test]
+    fn fewer_than_seven_columns_is_error() {
+        // A row with fewer than 7 columns cannot be meaningfully
+        // rendered — callers must see the error surface.
+        let csv = "0, GPU-a, only three\n";
+        let err = parse_nvidia_smi_csv(csv, "u@h", "h", "t").unwrap_err();
+        match err {
+            NvidiaSmiParseError::ColumnCount { got, .. } => assert_eq!(got, 3),
+        }
+    }
+
+    #[test]
+    fn command_string_matches_issue_spec() {
+        // Guard against accidental edits to the command string — the
+        // column order is hardcoded in parse_row() and a drift would
+        // silently mis-attribute fields.
+        assert!(NVIDIA_SMI_COMMAND.contains("index,uuid,name,driver_version"));
+        assert!(NVIDIA_SMI_COMMAND.contains("utilization.gpu,memory.used,memory.total"));
+        assert!(NVIDIA_SMI_COMMAND.contains("temperature.gpu,clocks.current.graphics,power.draw"));
+        assert!(NVIDIA_SMI_COMMAND.contains("--format=csv,noheader,nounits"));
+    }
+}

--- a/src/network/rocm_smi_shim.rs
+++ b/src/network/rocm_smi_shim.rs
@@ -361,13 +361,13 @@ mod tests {
     #[test]
     fn rejects_non_json_input() {
         let err = parse_rocm_smi_json("not-json", "u@h", "h", "t").unwrap_err();
-        matches!(err, RocmSmiParseError::Json(_));
+        assert!(matches!(err, RocmSmiParseError::Json(_)));
     }
 
     #[test]
     fn rejects_non_object_root() {
         let err = parse_rocm_smi_json("[]", "u@h", "h", "t").unwrap_err();
-        matches!(err, RocmSmiParseError::NotObject);
+        assert!(matches!(err, RocmSmiParseError::NotObject));
     }
 
     #[test]

--- a/src/network/rocm_smi_shim.rs
+++ b/src/network/rocm_smi_shim.rs
@@ -1,0 +1,396 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Agentless SSH `rocm-smi` fallback parser (issue #194).
+//!
+//! When a remote AMD host has `rocm-smi` but not `all-smi` installed,
+//! we invoke `rocm-smi --showuse --showmemuse --showtemp --showpower
+//! --json` and parse the resulting JSON into [`GpuInfo`] records. The
+//! command is exported via [`ROCM_SMI_COMMAND`] so the parser and the
+//! SSH client cannot drift out of sync.
+//!
+//! rocm-smi's JSON shape varies slightly across ROCm versions, so the
+//! parser is intentionally lenient:
+//!
+//! * Top-level keys are `card0`, `card1`, ...  plus a `system` key
+//!   carrying the driver version.  We iterate only `card*` entries.
+//! * Field names are looked up with fallbacks because rocm-smi renames
+//!   them between ROCm 5.x and 6.x (`GPU use (%)` vs
+//!   `GPU use (%) sum`, for example).
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::device::GpuInfo;
+
+/// `rocm-smi` command the SSH transport invokes on the remote host.
+pub const ROCM_SMI_COMMAND: &str =
+    "rocm-smi --showuse --showmemuse --showtemp --showpower --showproductname --json";
+
+/// Errors surfaced by [`parse_rocm_smi_json`].
+#[derive(Debug, thiserror::Error)]
+pub enum RocmSmiParseError {
+    #[error("rocm-smi JSON parse error: {0}")]
+    Json(String),
+    #[error("rocm-smi JSON top-level value is not an object")]
+    NotObject,
+}
+
+/// Parse `rocm-smi ... --json` output.
+///
+/// See the module docstring for the exact command string and JSON
+/// shape. A missing field inside a card entry is treated as "unknown"
+/// (field becomes zero or `None`) rather than a hard error.
+pub fn parse_rocm_smi_json(
+    json: &str,
+    host_id: &str,
+    hostname: &str,
+    timestamp: &str,
+) -> Result<Vec<GpuInfo>, RocmSmiParseError> {
+    let v: Value =
+        serde_json::from_str(json).map_err(|e| RocmSmiParseError::Json(e.to_string()))?;
+    let obj = v.as_object().ok_or(RocmSmiParseError::NotObject)?;
+
+    let driver_version = obj
+        .get("system")
+        .and_then(|s| s.as_object())
+        .and_then(|s| s.get("Driver version"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let mut cards: Vec<(u32, &Value)> = obj
+        .iter()
+        .filter_map(|(k, v)| {
+            k.strip_prefix("card")
+                .and_then(|n| n.parse::<u32>().ok())
+                .map(|idx| (idx, v))
+        })
+        .collect();
+    cards.sort_by_key(|(i, _)| *i);
+
+    let mut out = Vec::with_capacity(cards.len());
+    for (idx, card_val) in cards {
+        let Some(card) = card_val.as_object() else {
+            continue;
+        };
+        let gpu = parse_card(
+            idx,
+            card,
+            driver_version.as_deref(),
+            host_id,
+            hostname,
+            timestamp,
+        );
+        out.push(gpu);
+    }
+    Ok(out)
+}
+
+fn parse_card(
+    idx: u32,
+    card: &serde_json::Map<String, Value>,
+    driver_version: Option<&str>,
+    host_id: &str,
+    hostname: &str,
+    timestamp: &str,
+) -> GpuInfo {
+    // rocm-smi reports GPU utilization in a few possible key names
+    // depending on the ROCm version.
+    let utilization = lookup_f64(
+        card,
+        &[
+            "GPU use (%)",
+            "GPU use %",
+            "GPU Utilization",
+            "GPU use (%) sum",
+        ],
+    )
+    .unwrap_or(0.0);
+
+    let memory_utilization_pct = lookup_f64(
+        card,
+        &[
+            "GPU Memory Allocated (VRAM%)",
+            "GPU memory use (%)",
+            "Memory use (%)",
+        ],
+    );
+
+    // Memory absolute values — rocm-smi splits across multiple fields.
+    // Prefer absolute figures when present; otherwise derive used from
+    // the percentage and total.
+    let total_memory_bytes = lookup_u64(
+        card,
+        &[
+            "VRAM Total Memory (B)",
+            "GPU memory total (B)",
+            "Total memory (B)",
+        ],
+    )
+    .unwrap_or(0);
+    let used_memory_bytes = lookup_u64(
+        card,
+        &[
+            "VRAM Total Used Memory (B)",
+            "GPU memory used (B)",
+            "Used memory (B)",
+        ],
+    )
+    .unwrap_or_else(|| {
+        if let Some(pct) = memory_utilization_pct {
+            ((pct / 100.0) * total_memory_bytes as f64) as u64
+        } else {
+            0
+        }
+    });
+
+    // rocm-smi reports several temperatures; we pick the edge (junction)
+    // temperature because that is what nvidia-smi's `temperature.gpu`
+    // is comparable against. Fall back to sensor-less value of zero.
+    let temperature = lookup_f64(
+        card,
+        &[
+            "Temperature (Sensor edge) (C)",
+            "Temperature (Sensor junction) (C)",
+            "Temperature (Sensor memory) (C)",
+            "Temperature (C)",
+        ],
+    )
+    .unwrap_or(0.0) as u32;
+
+    let power_consumption = lookup_f64(
+        card,
+        &[
+            "Average Graphics Package Power (W)",
+            "Current Socket Graphics Package Power (W)",
+            "GPU Power (W)",
+            "Power (W)",
+        ],
+    )
+    .unwrap_or(0.0);
+
+    let name = card
+        .get("Card series")
+        .or_else(|| card.get("Card model"))
+        .or_else(|| card.get("GFX Version"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("AMD GPU")
+        .to_string();
+
+    let uuid = card
+        .get("Unique ID")
+        .or_else(|| card.get("GUID"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("n/a"))
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("rocm-{hostname}-{idx}"));
+
+    let mut detail: HashMap<String, String> = HashMap::new();
+    if let Some(dv) = driver_version {
+        detail.insert("driver_version".to_string(), dv.to_string());
+    }
+    detail.insert("transport".to_string(), "ssh/rocm-smi".to_string());
+
+    GpuInfo {
+        uuid,
+        time: timestamp.to_string(),
+        name,
+        device_type: "GPU".to_string(),
+        host_id: host_id.to_string(),
+        hostname: hostname.to_string(),
+        instance: format!("{hostname}:{idx}"),
+        utilization,
+        ane_utilization: 0.0,
+        dla_utilization: None,
+        tensorcore_utilization: None,
+        temperature,
+        used_memory: used_memory_bytes,
+        total_memory: total_memory_bytes,
+        frequency: 0,
+        power_consumption,
+        gpu_core_count: None,
+        temperature_threshold_slowdown: None,
+        temperature_threshold_shutdown: None,
+        temperature_threshold_max_operating: None,
+        temperature_threshold_acoustic: None,
+        performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
+        detail,
+    }
+}
+
+fn lookup_f64(card: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<f64> {
+    for key in keys {
+        if let Some(val) = card.get(*key) {
+            if let Some(n) = val.as_f64() {
+                return Some(n);
+            }
+            // rocm-smi often stringifies numbers: "45.0", "23".
+            if let Some(s) = val.as_str()
+                && let Ok(n) = s.trim().parse::<f64>()
+            {
+                return Some(n);
+            }
+        }
+    }
+    None
+}
+
+fn lookup_u64(card: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<u64> {
+    for key in keys {
+        if let Some(val) = card.get(*key) {
+            if let Some(n) = val.as_u64() {
+                return Some(n);
+            }
+            if let Some(s) = val.as_str()
+                && let Ok(n) = s.trim().parse::<u64>()
+            {
+                return Some(n);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOLDEN_ROCM6: &str = r#"{
+        "card0": {
+            "GPU use (%)": "68",
+            "GPU Memory Allocated (VRAM%)": "42",
+            "VRAM Total Memory (B)": "68719476736",
+            "VRAM Total Used Memory (B)": "28823961600",
+            "Temperature (Sensor edge) (C)": "72.0",
+            "Temperature (Sensor junction) (C)": "78.0",
+            "Average Graphics Package Power (W)": "235.5",
+            "Card series": "Instinct MI250X",
+            "Unique ID": "0x1234abcd"
+        },
+        "card1": {
+            "GPU use (%)": "3",
+            "GPU Memory Allocated (VRAM%)": "5",
+            "VRAM Total Memory (B)": "68719476736",
+            "VRAM Total Used Memory (B)": "3435973836",
+            "Temperature (Sensor edge) (C)": "45.0",
+            "Average Graphics Package Power (W)": "95.2",
+            "Card series": "Instinct MI250X",
+            "Unique ID": "0xbeefcafe"
+        },
+        "system": {
+            "Driver version": "6.1.1"
+        }
+    }"#;
+
+    #[test]
+    fn parses_two_card_rocm6_sample() {
+        let gpus =
+            parse_rocm_smi_json(GOLDEN_ROCM6, "admin@amd01", "amd01", "2026-04-20T00:00:00Z")
+                .expect("valid golden sample must parse");
+        assert_eq!(gpus.len(), 2);
+
+        let g0 = &gpus[0];
+        assert_eq!(g0.uuid, "0x1234abcd");
+        assert_eq!(g0.name, "Instinct MI250X");
+        assert_eq!(g0.utilization, 68.0);
+        assert_eq!(g0.total_memory, 68719476736);
+        assert_eq!(g0.used_memory, 28823961600);
+        assert_eq!(g0.temperature, 72);
+        assert!((g0.power_consumption - 235.5).abs() < 1e-6);
+        assert_eq!(g0.hostname, "amd01");
+        assert_eq!(g0.host_id, "admin@amd01");
+        assert_eq!(g0.instance, "amd01:0");
+        assert_eq!(g0.detail.get("driver_version"), Some(&"6.1.1".to_string()));
+        assert_eq!(
+            g0.detail.get("transport"),
+            Some(&"ssh/rocm-smi".to_string())
+        );
+
+        let g1 = &gpus[1];
+        assert_eq!(g1.uuid, "0xbeefcafe");
+        assert_eq!(g1.instance, "amd01:1");
+    }
+
+    #[test]
+    fn parses_rocm5_alternate_key_names() {
+        let csv = r#"{
+            "card0": {
+                "GPU use %": 22.5,
+                "Used memory (B)": 12345,
+                "Total memory (B)": 68719476736,
+                "Temperature (C)": 60,
+                "Power (W)": 150
+            }
+        }"#;
+        let gpus = parse_rocm_smi_json(csv, "u@h", "h", "t").unwrap();
+        assert_eq!(gpus.len(), 1);
+        assert_eq!(gpus[0].utilization, 22.5);
+        assert_eq!(gpus[0].total_memory, 68719476736);
+        assert_eq!(gpus[0].used_memory, 12345);
+        assert_eq!(gpus[0].temperature, 60);
+        assert!((gpus[0].power_consumption - 150.0).abs() < 1e-6);
+        // Without a `Unique ID` or `Card series`, we synthesize a uuid
+        // and fall back to a generic name.
+        assert_eq!(gpus[0].uuid, "rocm-h-0");
+        assert_eq!(gpus[0].name, "AMD GPU");
+    }
+
+    #[test]
+    fn empty_object_yields_empty_vec() {
+        let gpus = parse_rocm_smi_json("{}", "u@h", "h", "t").unwrap();
+        assert!(gpus.is_empty());
+    }
+
+    #[test]
+    fn rejects_non_json_input() {
+        let err = parse_rocm_smi_json("not-json", "u@h", "h", "t").unwrap_err();
+        matches!(err, RocmSmiParseError::Json(_));
+    }
+
+    #[test]
+    fn rejects_non_object_root() {
+        let err = parse_rocm_smi_json("[]", "u@h", "h", "t").unwrap_err();
+        matches!(err, RocmSmiParseError::NotObject);
+    }
+
+    #[test]
+    fn ignores_non_card_keys() {
+        let json = r#"{
+            "card0": { "GPU use (%)": "10" },
+            "some other key": { "x": "y" }
+        }"#;
+        let gpus = parse_rocm_smi_json(json, "u@h", "h", "t").unwrap();
+        assert_eq!(gpus.len(), 1);
+    }
+
+    #[test]
+    fn derives_used_memory_from_percent() {
+        // When absolute used memory is absent but percentage and
+        // total are present, we should derive it.
+        let json = r#"{
+            "card0": {
+                "GPU Memory Allocated (VRAM%)": "50",
+                "VRAM Total Memory (B)": "1000000"
+            }
+        }"#;
+        let gpus = parse_rocm_smi_json(json, "u@h", "h", "t").unwrap();
+        assert_eq!(gpus[0].used_memory, 500_000);
+    }
+}

--- a/src/network/ssh_client.rs
+++ b/src/network/ssh_client.rs
@@ -46,7 +46,6 @@ use async_trait::async_trait;
 use russh::client::{self, Handle};
 use russh::keys::{PrivateKeyWithHashAlg, load_secret_key, ssh_key};
 use russh::{ChannelMsg, Disconnect};
-use tokio::sync::Mutex;
 
 use crate::network::ssh_target::SshTarget;
 use crate::network::ssh_transport::StrictHostKey;
@@ -167,12 +166,13 @@ impl Default for ConnectParams {
 }
 
 /// A long-lived SSH session against one remote. Cheap to clone because
-/// the underlying russh [`Handle`] is already an `Arc`-flavoured handle;
-/// we wrap it in [`Mutex`] so the view loop can safely re-use the
-/// session across ticks without serialising every caller.
+/// the underlying russh [`Handle`] is internally `Arc`-shared and
+/// thread-safe — no external lock is required. Multiple concurrent
+/// [`SshSession::exec`] calls on the same session multiplex onto
+/// independent SSH channels via russh's built-in channel machinery.
 #[derive(Clone)]
 pub struct SshSession {
-    inner: Arc<Mutex<Handle<RusshClient>>>,
+    inner: Arc<Handle<RusshClient>>,
     target: SshTarget,
 }
 
@@ -279,7 +279,7 @@ impl SshSession {
         }
 
         Ok(Self {
-            inner: Arc::new(Mutex::new(session)),
+            inner: Arc::new(session),
             target,
         })
     }
@@ -296,8 +296,11 @@ impl SshSession {
         timeout: Duration,
     ) -> Result<ExecOutput, SshClientError> {
         let run = async {
-            let handle = self.inner.lock().await;
-            let mut channel = handle
+            // russh's `client::Handle` is itself internally Arc-shared
+            // and Send + Sync; channel_open_session takes `&self` and
+            // is safe to call concurrently. No external lock needed.
+            let mut channel = self
+                .inner
                 .channel_open_session()
                 .await
                 .map_err(|e| map_russh_error(e, &self.target.host, self.target.port))?;
@@ -340,8 +343,8 @@ impl SshSession {
             }
 
             Ok(ExecOutput {
-                stdout: String::from_utf8_lossy(&stdout).into_owned(),
-                stderr: String::from_utf8_lossy(&stderr).into_owned(),
+                stdout: bytes_to_string_zero_copy(stdout),
+                stderr: bytes_to_string_zero_copy(stderr),
                 exit_status: exit_code,
             })
         };
@@ -357,8 +360,8 @@ impl SshSession {
     /// the time a caller reaches this code path.
     #[allow(dead_code)]
     pub async fn close(&self) {
-        let handle = self.inner.lock().await;
-        if let Err(e) = handle
+        if let Err(e) = self
+            .inner
             .disconnect(Disconnect::ByApplication, "view --ssh shutting down", "en")
             .await
         {
@@ -390,6 +393,17 @@ impl ExecOutput {
     /// True when `exit_status == Some(0)`.
     pub fn is_success(&self) -> bool {
         self.exit_status == Some(0)
+    }
+}
+
+/// Convert a byte buffer into a `String` without copying when the bytes
+/// are already valid UTF-8 (the common case for SSH stdout from
+/// `nvidia-smi` and friends). Only the rare pre-invalid-byte prefix
+/// triggers the lossy re-encode, and only for that non-UTF-8 tail.
+fn bytes_to_string_zero_copy(bytes: Vec<u8>) -> String {
+    match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
     }
 }
 

--- a/src/network/ssh_client.rs
+++ b/src/network/ssh_client.rs
@@ -1,0 +1,499 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! russh-backed SSH session manager for `view --ssh` (issue #194).
+//!
+//! The [`SshSession`] struct wraps a single long-lived SSH connection
+//! to one target, owning the russh client [`client::Handle`] and
+//! exposing [`SshSession::exec`] for one-shot command execution on a
+//! new channel per call. Connections opened through [`SshSession::connect`]
+//! keep a TCP keep-alive interval so idle sessions are pruned by the
+//! remote sshd and do not stack up silently.
+//!
+//! Authentication precedence (from issue #194):
+//! 1. `--ssh-key <path>` (explicit key)
+//! 2. `SSH_AUTH_SOCK` (OpenSSH agent) — via `ssh-agent-client-rs` crate
+//!    if present; see note below.
+//! 3. `~/.ssh/id_ed25519`
+//! 4. `~/.ssh/id_rsa`
+//!
+//! NOTE: SSH agent forwarding is not attempted in this initial cut;
+//! russh 0.60 includes an `russh::client::Handle::agent_auth` but it
+//! requires a running agent. Detection is deferred until we add agent
+//! support in a follow-up. Password auth is intentionally unsupported.
+//!
+//! Host-key policy: the supplied [`HostKeyVerifier`] receives the
+//! server's public key on every connect and returns `Ok(true)` /
+//! `Ok(false)`. Three built-in verifiers are shipped, one per policy
+//! (see [`StrictHostKey`]).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use russh::client::{self, Handle};
+use russh::keys::{PrivateKeyWithHashAlg, load_secret_key, ssh_key};
+use russh::{ChannelMsg, Disconnect};
+use tokio::sync::Mutex;
+
+use crate::network::ssh_target::SshTarget;
+use crate::network::ssh_transport::StrictHostKey;
+
+/// Hard ceiling on the size of a single command's stdout we are
+/// willing to buffer. Prevents a misbehaving remote from forcing the
+/// view process into OOM. The nvidia-smi CSV path returns hundreds
+/// of bytes per GPU; 16 MiB is a generous ceiling.
+pub const MAX_COMMAND_STDOUT_BYTES: usize = 16 * 1024 * 1024;
+
+/// Hard ceiling on command stderr (same rationale).
+pub const MAX_COMMAND_STDERR_BYTES: usize = 1024 * 1024;
+
+/// Per-call command execution timeout. Individual commands MUST honour
+/// this or risk holding the connection open forever on a hung remote.
+pub const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// russh's inactivity timeout — the client session drops if no data is
+/// exchanged for this long. Set conservatively so keep-alive pings keep
+/// long-idle view tabs alive while a real dead connection is still
+/// detected in reasonable time.
+pub const DEFAULT_INACTIVITY: Duration = Duration::from_secs(60);
+
+/// Errors emitted by [`SshSession::connect`] / [`SshSession::exec`].
+#[derive(Debug, thiserror::Error)]
+pub enum SshClientError {
+    #[error("SSH I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("SSH protocol error: {0}")]
+    Protocol(String),
+    #[error("SSH authentication failed for {user}@{host}:{port}")]
+    AuthFailed {
+        user: String,
+        host: String,
+        port: u16,
+    },
+    #[error("SSH host-key rejected for {host}:{port}: {reason}")]
+    HostKeyRejected {
+        host: String,
+        port: u16,
+        reason: String,
+    },
+    #[error("SSH connect timeout after {0:?}")]
+    ConnectTimeout(Duration),
+    #[error("SSH exec timeout after {0:?}")]
+    ExecTimeout(Duration),
+    #[error("no usable SSH private key found (tried: {0})")]
+    NoUsableKey(String),
+    #[error("SSH command output exceeded {limit} bytes")]
+    OutputTooLarge { limit: usize },
+}
+
+impl SshClientError {
+    /// Short human label used by the TUI "connection state" chip.
+    pub fn ui_label(&self) -> &'static str {
+        match self {
+            Self::AuthFailed { .. } => "auth-failed",
+            Self::HostKeyRejected { .. } => "host-key-rejected",
+            Self::ConnectTimeout(_) => "timeout",
+            Self::ExecTimeout(_) => "timeout",
+            Self::NoUsableKey(_) => "no-key",
+            Self::OutputTooLarge { .. } => "disconnected",
+            Self::Io(_) | Self::Protocol(_) => "disconnected",
+        }
+    }
+}
+
+/// Trait implemented by the three host-key verification policies.
+#[async_trait]
+pub trait HostKeyVerifier: Send + Sync + 'static {
+    /// Called once with the server's public key at handshake time.
+    ///
+    /// Returns `Ok(true)` to accept, `Ok(false)` to reject. The `host`
+    /// / `port` arguments identify the target so the `accept-new`
+    /// implementation can key its known_hosts entry correctly.
+    async fn verify(
+        &self,
+        host: &str,
+        port: u16,
+        key: &ssh_key::PublicKey,
+    ) -> Result<bool, SshClientError>;
+}
+
+/// Convenience holder passed to [`SshSession::connect`].
+///
+/// `strict_host_key` and `known_hosts` are carried through the params
+/// struct so higher layers can inspect / log them, even though the
+/// actual verification decision is made inside the pre-constructed
+/// [`HostKeyVerifier`]. `#[allow(dead_code)]` on those fields keeps
+/// clippy happy while preserving the public surface for future wiring
+/// (e.g. diagnostics logging in `view --doctor`).
+pub struct ConnectParams {
+    pub target: SshTarget,
+    pub explicit_key: Option<PathBuf>,
+    #[allow(dead_code)]
+    pub strict_host_key: StrictHostKey,
+    pub connect_timeout: Duration,
+    pub inactivity: Duration,
+    #[allow(dead_code)]
+    pub known_hosts: Option<PathBuf>,
+}
+
+impl Default for ConnectParams {
+    fn default() -> Self {
+        Self {
+            target: SshTarget {
+                user: String::new(),
+                host: String::new(),
+                port: 22,
+            },
+            explicit_key: None,
+            strict_host_key: StrictHostKey::Yes,
+            connect_timeout: Duration::from_secs(10),
+            inactivity: DEFAULT_INACTIVITY,
+            known_hosts: None,
+        }
+    }
+}
+
+/// A long-lived SSH session against one remote. Cheap to clone because
+/// the underlying russh [`Handle`] is already an `Arc`-flavoured handle;
+/// we wrap it in [`Mutex`] so the view loop can safely re-use the
+/// session across ticks without serialising every caller.
+#[derive(Clone)]
+pub struct SshSession {
+    inner: Arc<Mutex<Handle<RusshClient>>>,
+    target: SshTarget,
+}
+
+/// russh client handler. Every incoming message is dispatched through
+/// this struct; we only care about host-key verification.
+struct RusshClient {
+    verifier: Arc<dyn HostKeyVerifier>,
+    host: String,
+    port: u16,
+}
+
+impl client::Handler for RusshClient {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        match self
+            .verifier
+            .verify(&self.host, self.port, server_public_key)
+            .await
+        {
+            Ok(accept) => Ok(accept),
+            Err(e) => {
+                tracing::warn!(
+                    host = %self.host,
+                    port = self.port,
+                    error = %e,
+                    "host-key verifier returned an error; rejecting connection"
+                );
+                Ok(false)
+            }
+        }
+    }
+}
+
+impl SshSession {
+    /// Open a new SSH session and authenticate.
+    pub async fn connect(
+        params: ConnectParams,
+        verifier: Arc<dyn HostKeyVerifier>,
+    ) -> Result<Self, SshClientError> {
+        let target = params.target.clone();
+        let host = target.host.clone();
+        let port = target.port;
+
+        // Resolve the key to use. We prefer the explicit path; else
+        // probe the conventional defaults in ~/.ssh.
+        let key_path = resolve_key_path(params.explicit_key.as_deref())
+            .ok_or_else(|| SshClientError::NoUsableKey(default_key_probe_paths()))?;
+
+        let key_pair = load_secret_key(&key_path, None).map_err(|e| {
+            SshClientError::Protocol(format!(
+                "failed to load private key {}: {e}",
+                key_path.display()
+            ))
+        })?;
+
+        let config = Arc::new(client::Config {
+            inactivity_timeout: Some(params.inactivity),
+            keepalive_interval: Some(Duration::from_secs(30)),
+            keepalive_max: 3,
+            ..Default::default()
+        });
+
+        let handler = RusshClient {
+            verifier,
+            host: host.clone(),
+            port,
+        };
+
+        let connect_fut = client::connect(config, (host.as_str(), port), handler);
+        let mut session = match tokio::time::timeout(params.connect_timeout, connect_fut).await {
+            Err(_) => return Err(SshClientError::ConnectTimeout(params.connect_timeout)),
+            Ok(Err(e)) => return Err(map_russh_error(e, &host, port)),
+            Ok(Ok(session)) => session,
+        };
+
+        // Attempt publickey auth. russh's `authenticate_publickey` takes
+        // the key + the best-supported RSA hash; we simply pass what
+        // the session negotiated. If the server outright refuses the
+        // handshake because of the host key, that surfaces as an I/O
+        // error on the await below and is mapped by `map_russh_error`.
+        let best_hash = session
+            .best_supported_rsa_hash()
+            .await
+            .map_err(|e| map_russh_error(e, &host, port))?
+            .flatten();
+        let auth_res = session
+            .authenticate_publickey(
+                target.user.clone(),
+                PrivateKeyWithHashAlg::new(Arc::new(key_pair), best_hash),
+            )
+            .await
+            .map_err(|e| map_russh_error(e, &host, port))?;
+
+        if !auth_res.success() {
+            return Err(SshClientError::AuthFailed {
+                user: target.user.clone(),
+                host: host.clone(),
+                port,
+            });
+        }
+
+        Ok(Self {
+            inner: Arc::new(Mutex::new(session)),
+            target,
+        })
+    }
+
+    /// Execute a command on a fresh channel and collect stdout / exit
+    /// status. Bounded by [`DEFAULT_EXEC_TIMEOUT`].
+    pub async fn exec(&self, command: &str) -> Result<ExecOutput, SshClientError> {
+        self.exec_with_timeout(command, DEFAULT_EXEC_TIMEOUT).await
+    }
+
+    pub async fn exec_with_timeout(
+        &self,
+        command: &str,
+        timeout: Duration,
+    ) -> Result<ExecOutput, SshClientError> {
+        let run = async {
+            let handle = self.inner.lock().await;
+            let mut channel = handle
+                .channel_open_session()
+                .await
+                .map_err(|e| map_russh_error(e, &self.target.host, self.target.port))?;
+            channel
+                .exec(true, command)
+                .await
+                .map_err(|e| map_russh_error(e, &self.target.host, self.target.port))?;
+
+            let mut stdout: Vec<u8> = Vec::new();
+            let mut stderr: Vec<u8> = Vec::new();
+            let mut exit_code: Option<u32> = None;
+
+            while let Some(msg) = channel.wait().await {
+                match msg {
+                    ChannelMsg::Data { ref data } => {
+                        if stdout.len() + data.len() > MAX_COMMAND_STDOUT_BYTES {
+                            return Err(SshClientError::OutputTooLarge {
+                                limit: MAX_COMMAND_STDOUT_BYTES,
+                            });
+                        }
+                        stdout.extend_from_slice(data);
+                    }
+                    ChannelMsg::ExtendedData { ref data, ext: 1 } => {
+                        if stderr.len() + data.len() > MAX_COMMAND_STDERR_BYTES {
+                            return Err(SshClientError::OutputTooLarge {
+                                limit: MAX_COMMAND_STDERR_BYTES,
+                            });
+                        }
+                        stderr.extend_from_slice(data);
+                    }
+                    ChannelMsg::ExitStatus { exit_status } => {
+                        exit_code = Some(exit_status);
+                    }
+                    ChannelMsg::Eof | ChannelMsg::Close => {
+                        // Keep looping — additional messages may still
+                        // arrive (ExitStatus can follow Eof).
+                    }
+                    _ => {}
+                }
+            }
+
+            Ok(ExecOutput {
+                stdout: String::from_utf8_lossy(&stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&stderr).into_owned(),
+                exit_status: exit_code,
+            })
+        };
+
+        match tokio::time::timeout(timeout, run).await {
+            Err(_) => Err(SshClientError::ExecTimeout(timeout)),
+            Ok(result) => result,
+        }
+    }
+
+    /// Tear down the session cleanly. Best-effort: errors are logged
+    /// but swallowed because the connection is likely already gone by
+    /// the time a caller reaches this code path.
+    #[allow(dead_code)]
+    pub async fn close(&self) {
+        let handle = self.inner.lock().await;
+        if let Err(e) = handle
+            .disconnect(Disconnect::ByApplication, "view --ssh shutting down", "en")
+            .await
+        {
+            tracing::debug!(
+                host = %self.target.host,
+                port = self.target.port,
+                error = %e,
+                "ssh disconnect returned an error"
+            );
+        }
+    }
+
+    /// Accessor for the [`SshTarget`] this session was opened against.
+    #[allow(dead_code)]
+    pub fn target(&self) -> &SshTarget {
+        &self.target
+    }
+}
+
+/// Captured output of a single `exec` call.
+#[derive(Debug, Clone)]
+pub struct ExecOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_status: Option<u32>,
+}
+
+impl ExecOutput {
+    /// True when `exit_status == Some(0)`.
+    pub fn is_success(&self) -> bool {
+        self.exit_status == Some(0)
+    }
+}
+
+/// Map a russh error into our user-facing [`SshClientError`].
+fn map_russh_error(err: russh::Error, host: &str, port: u16) -> SshClientError {
+    // russh::Error is an enum; convert the classes we explicitly care
+    // about (auth, host-key rejection) into typed variants and fall
+    // through to Protocol otherwise.
+    use russh::Error as E;
+    match err {
+        E::IO(e) => SshClientError::Io(e),
+        E::NotAuthenticated => SshClientError::AuthFailed {
+            user: String::new(),
+            host: host.to_string(),
+            port,
+        },
+        E::UnknownKey => SshClientError::HostKeyRejected {
+            host: host.to_string(),
+            port,
+            reason: "host key not trusted".to_string(),
+        },
+        other => SshClientError::Protocol(format!("{other:?}")),
+    }
+}
+
+fn resolve_key_path(explicit: Option<&Path>) -> Option<PathBuf> {
+    if let Some(p) = explicit {
+        let expanded = crate::common::paths::expand_tilde(p);
+        if expanded.exists() {
+            return Some(expanded);
+        }
+        // Explicit paths must exist; returning None here causes
+        // [`NoUsableKey`] to surface.
+        return None;
+    }
+    key_probe_paths()
+        .into_iter()
+        .find(|candidate| candidate.exists())
+}
+
+fn key_probe_paths() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        out.push(home.join(".ssh").join("id_ed25519"));
+        out.push(home.join(".ssh").join("id_ecdsa"));
+        out.push(home.join(".ssh").join("id_rsa"));
+    }
+    out
+}
+
+fn default_key_probe_paths() -> String {
+    key_probe_paths()
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// ---------------------------------------------------------------------
+// Built-in host-key verifiers — see [`crate::network::ssh_host_key`].
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_ui_labels_are_stable() {
+        assert_eq!(
+            SshClientError::AuthFailed {
+                user: "u".to_string(),
+                host: "h".to_string(),
+                port: 22,
+            }
+            .ui_label(),
+            "auth-failed"
+        );
+        assert_eq!(
+            SshClientError::ConnectTimeout(Duration::from_secs(1)).ui_label(),
+            "timeout"
+        );
+        assert_eq!(
+            SshClientError::HostKeyRejected {
+                host: "h".to_string(),
+                port: 22,
+                reason: "x".to_string()
+            }
+            .ui_label(),
+            "host-key-rejected"
+        );
+    }
+
+    #[test]
+    fn key_probe_paths_contains_home_ssh_defaults() {
+        // Only holds when a home directory is detectable. If the test
+        // environment is weird (no HOME) the function returns an empty
+        // vector, which is correct behaviour.
+        if dirs::home_dir().is_some() {
+            let paths = key_probe_paths();
+            assert!(
+                paths.iter().any(|p| p.ends_with("id_ed25519")),
+                "expected id_ed25519 in probe list, got {paths:?}"
+            );
+            assert!(paths.iter().any(|p| p.ends_with("id_rsa")));
+        }
+    }
+}

--- a/src/network/ssh_decision.rs
+++ b/src/network/ssh_decision.rs
@@ -1,0 +1,235 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pure decision logic for SSH transport selection (issue #194).
+//!
+//! The actual SSH client lives in [`crate::network::ssh_client`]; this
+//! module intentionally holds only the branchy selection code so it
+//! can be unit-tested without mocking a full SSH server.
+
+use crate::network::ssh_transport::{SshFallbackPolicy, SshTransport};
+
+/// Minimum `all-smi` version that ships `snapshot --format json`.
+/// Used by [`native_supported`] to gate the native path.
+///
+/// Matches issue #194 spec. Kept as a tuple for easy comparison.
+pub const MIN_NATIVE_VERSION: (u32, u32) = (0, 22);
+
+/// Outcome of probing one host during the initial SSH connection.
+///
+/// Each field is a `ProbeResult` so the decision function can reason
+/// about three states per probe: ran successfully, ran but gave no
+/// useful output, or was not attempted at all.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProbeOutcomes {
+    pub native: ProbeResult,
+    pub nvidia_smi: ProbeResult,
+    pub rocm_smi: ProbeResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProbeResult {
+    /// Probe was not attempted (e.g. native probe succeeded so we never
+    /// reached the fallback, or the operator disabled it via policy).
+    #[default]
+    NotAttempted,
+    /// Probe ran and reported "this is not installed / not useful".
+    NotAvailable,
+    /// Probe ran and returned a usable signature (for native: the
+    /// `--version` line parsed to something ≥ MIN_NATIVE_VERSION; for
+    /// fallbacks: the command exited 0 with non-empty stdout).
+    Available,
+}
+
+/// Compute the transport chip to use from a set of probe outcomes.
+///
+/// Precedence (issue #194 spec):
+/// 1. native (`all-smi` installed, new enough)
+/// 2. nvidia-smi shim (if policy allows)
+/// 3. rocm-smi shim (if policy allows)
+/// 4. Unsupported
+pub fn select_transport(outcomes: &ProbeOutcomes, policy: &SshFallbackPolicy) -> SshTransport {
+    if outcomes.native == ProbeResult::Available {
+        return SshTransport::Native;
+    }
+    if policy.try_nvidia_smi && outcomes.nvidia_smi == ProbeResult::Available {
+        return SshTransport::NvidiaSmi;
+    }
+    if policy.try_rocm_smi && outcomes.rocm_smi == ProbeResult::Available {
+        return SshTransport::RocmSmi;
+    }
+    SshTransport::Unsupported
+}
+
+/// Returns `true` when `version_line` (captured from `all-smi --version`
+/// over SSH) satisfies [`MIN_NATIVE_VERSION`]. Anything that doesn't
+/// parse cleanly returns `false` — we err on the side of using the
+/// fallback shim over a potentially-unsafe native path.
+pub fn native_supported(version_line: &str) -> bool {
+    let Some(v) = extract_version(version_line) else {
+        return false;
+    };
+    v >= MIN_NATIVE_VERSION
+}
+
+/// Extract a `(major, minor)` tuple from an `all-smi --version` line.
+///
+/// The binary prints `all-smi <version>`; we read the whitespace-
+/// separated last token and split on `.`.
+fn extract_version(line: &str) -> Option<(u32, u32)> {
+    let token = line
+        .split_whitespace()
+        .last()
+        .unwrap_or("")
+        .trim_start_matches('v');
+    let mut parts = token.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts
+        .next()
+        .map(|s| s.split(['-', '+']).next().unwrap_or(s))
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(0);
+    Some((major, minor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy_all() -> SshFallbackPolicy {
+        SshFallbackPolicy {
+            try_nvidia_smi: true,
+            try_rocm_smi: true,
+        }
+    }
+
+    fn policy_none() -> SshFallbackPolicy {
+        SshFallbackPolicy::default()
+    }
+
+    #[test]
+    fn selects_native_when_available() {
+        let outcomes = ProbeOutcomes {
+            native: ProbeResult::Available,
+            nvidia_smi: ProbeResult::Available, // Must be ignored
+            rocm_smi: ProbeResult::NotAttempted,
+        };
+        assert_eq!(
+            select_transport(&outcomes, &policy_all()),
+            SshTransport::Native
+        );
+    }
+
+    #[test]
+    fn falls_back_to_nvidia_when_native_absent() {
+        let outcomes = ProbeOutcomes {
+            native: ProbeResult::NotAvailable,
+            nvidia_smi: ProbeResult::Available,
+            rocm_smi: ProbeResult::NotAttempted,
+        };
+        assert_eq!(
+            select_transport(&outcomes, &policy_all()),
+            SshTransport::NvidiaSmi
+        );
+    }
+
+    #[test]
+    fn falls_back_to_rocm_when_nvidia_unavailable() {
+        let outcomes = ProbeOutcomes {
+            native: ProbeResult::NotAvailable,
+            nvidia_smi: ProbeResult::NotAvailable,
+            rocm_smi: ProbeResult::Available,
+        };
+        assert_eq!(
+            select_transport(&outcomes, &policy_all()),
+            SshTransport::RocmSmi
+        );
+    }
+
+    #[test]
+    fn unsupported_when_no_probes_work() {
+        let outcomes = ProbeOutcomes {
+            native: ProbeResult::NotAvailable,
+            nvidia_smi: ProbeResult::NotAvailable,
+            rocm_smi: ProbeResult::NotAvailable,
+        };
+        assert_eq!(
+            select_transport(&outcomes, &policy_all()),
+            SshTransport::Unsupported
+        );
+    }
+
+    #[test]
+    fn policy_none_skips_fallbacks_even_when_available() {
+        let outcomes = ProbeOutcomes {
+            native: ProbeResult::NotAvailable,
+            nvidia_smi: ProbeResult::Available,
+            rocm_smi: ProbeResult::Available,
+        };
+        assert_eq!(
+            select_transport(&outcomes, &policy_none()),
+            SshTransport::Unsupported
+        );
+    }
+
+    #[test]
+    fn policy_only_rocm_ignores_nvidia() {
+        let policy = SshFallbackPolicy {
+            try_nvidia_smi: false,
+            try_rocm_smi: true,
+        };
+        let outcomes = ProbeOutcomes {
+            native: ProbeResult::NotAvailable,
+            nvidia_smi: ProbeResult::Available,
+            rocm_smi: ProbeResult::Available,
+        };
+        assert_eq!(select_transport(&outcomes, &policy), SshTransport::RocmSmi);
+    }
+
+    #[test]
+    fn native_supported_accepts_exact_min_version() {
+        assert!(native_supported("all-smi 0.22.0"));
+        assert!(native_supported("all-smi 0.22.1"));
+    }
+
+    #[test]
+    fn native_supported_rejects_older_versions() {
+        assert!(!native_supported("all-smi 0.21.5"));
+        assert!(!native_supported("all-smi 0.20.1"));
+    }
+
+    #[test]
+    fn native_supported_accepts_newer_major() {
+        assert!(native_supported("all-smi 1.0.0"));
+        assert!(native_supported("all-smi 0.23.0"));
+    }
+
+    #[test]
+    fn native_supported_handles_v_prefix() {
+        assert!(native_supported("all-smi v0.22.0"));
+    }
+
+    #[test]
+    fn native_supported_rejects_garbage() {
+        assert!(!native_supported(""));
+        assert!(!native_supported("not a version"));
+        assert!(!native_supported("all-smi unknown"));
+    }
+
+    #[test]
+    fn native_supported_handles_prerelease_suffix() {
+        // `0.22.0-alpha.1` should count as 0.22 for gating purposes.
+        assert!(native_supported("all-smi 0.22.0-alpha.1"));
+    }
+}

--- a/src/network/ssh_host_key.rs
+++ b/src/network/ssh_host_key.rs
@@ -1,0 +1,266 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Host-key verification policies for `view --ssh` (issue #194).
+//!
+//! Three verifiers matching the three `--ssh-strict-host-key` CLI
+//! modes:
+//!
+//! * [`PermissiveVerifier`] — `no`, accepts anything (with a prominent
+//!   warning log).
+//! * [`StrictVerifier`] — `yes`, rejects unless the key is in
+//!   `known_hosts`.
+//! * [`AcceptNewVerifier`] — `accept-new`, TOFU: accept on first
+//!   connect and persist the key, reject if the saved key differs.
+//!
+//! Kept in its own file so [`crate::network::ssh_client`] stays under
+//! the 500-line soft limit.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use russh::keys::ssh_key;
+
+use crate::network::ssh_client::{HostKeyVerifier, SshClientError};
+use crate::network::ssh_transport::StrictHostKey;
+
+/// `--ssh-strict-host-key=no`: accept any key. Logs a warning so the
+/// audit trail still shows the decision.
+pub struct PermissiveVerifier;
+
+#[async_trait]
+impl HostKeyVerifier for PermissiveVerifier {
+    async fn verify(
+        &self,
+        host: &str,
+        port: u16,
+        _key: &ssh_key::PublicKey,
+    ) -> Result<bool, SshClientError> {
+        tracing::warn!(
+            host = host,
+            port = port,
+            "ssh-strict-host-key=no: accepting any host key without verification"
+        );
+        Ok(true)
+    }
+}
+
+/// `--ssh-strict-host-key=yes`: reject unless the key is already
+/// present in the supplied `known_hosts` file. A missing file causes
+/// an immediate reject.
+pub struct StrictVerifier {
+    pub known_hosts_path: PathBuf,
+}
+
+#[async_trait]
+impl HostKeyVerifier for StrictVerifier {
+    async fn verify(
+        &self,
+        host: &str,
+        port: u16,
+        key: &ssh_key::PublicKey,
+    ) -> Result<bool, SshClientError> {
+        let known = match known_hosts_lookup(&self.known_hosts_path, host, port) {
+            Ok(k) => k,
+            Err(e) => {
+                tracing::warn!(
+                    host = host,
+                    port = port,
+                    error = %e,
+                    "strict host-key verifier could not read known_hosts"
+                );
+                return Ok(false);
+            }
+        };
+        Ok(known.iter().any(|k| k == key))
+    }
+}
+
+/// `--ssh-strict-host-key=accept-new`: accept unknown hosts on first
+/// connect, persist the key, but reject subsequent connections whose
+/// key differs from what we saved.
+pub struct AcceptNewVerifier {
+    pub known_hosts_path: PathBuf,
+}
+
+#[async_trait]
+impl HostKeyVerifier for AcceptNewVerifier {
+    async fn verify(
+        &self,
+        host: &str,
+        port: u16,
+        key: &ssh_key::PublicKey,
+    ) -> Result<bool, SshClientError> {
+        match known_hosts_lookup(&self.known_hosts_path, host, port) {
+            Ok(keys) => {
+                if keys.is_empty() {
+                    // First-time connection: trust-on-first-use.
+                    if let Err(e) = known_hosts_append(&self.known_hosts_path, host, port, key) {
+                        tracing::warn!(
+                            host = host,
+                            error = %e,
+                            "accept-new: could not persist host key; still accepting this connection"
+                        );
+                    }
+                    Ok(true)
+                } else if keys.iter().any(|k| k == key) {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    host = host,
+                    error = %e,
+                    "accept-new: could not read known_hosts, refusing"
+                );
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// Look up every saved public key for `host:port` in the given
+/// `known_hosts`-style file. The file format is intentionally
+/// simplified: each line is `host[:port] <key type> <base64-key>`.
+/// We never persist hashed hostnames so the file is both readable and
+/// easy to edit manually.
+pub(crate) fn known_hosts_lookup(
+    path: &Path,
+    host: &str,
+    port: u16,
+) -> Result<Vec<ssh_key::PublicKey>, std::io::Error> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let mut out = Vec::new();
+    let needle_bracket = format!("[{host}]:{port}");
+    let needle_plain = host;
+    for raw in content.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (host_field, rest) = match line.split_once(char::is_whitespace) {
+            Some(p) => p,
+            None => continue,
+        };
+        let matches = if port == 22 {
+            host_field == needle_plain || host_field == needle_bracket
+        } else {
+            host_field == needle_bracket
+        };
+        if !matches {
+            continue;
+        }
+        // rest is `<algo> <base64> [comment]`. That format matches
+        // the OpenSSH public-key format `from_openssh` expects.
+        let trimmed = rest.trim();
+        if let Ok(key) = ssh_key::PublicKey::from_openssh(trimmed) {
+            out.push(key);
+        }
+    }
+    Ok(out)
+}
+
+fn known_hosts_append(
+    path: &Path,
+    host: &str,
+    port: u16,
+    key: &ssh_key::PublicKey,
+) -> Result<(), std::io::Error> {
+    use std::io::Write;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let host_field = if port == 22 {
+        host.to_string()
+    } else {
+        format!("[{host}]:{port}")
+    };
+    let key_str = key.to_openssh().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("could not serialise host key: {e}"),
+        )
+    })?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    // Entry form: `host <ssh-ed25519 AAAA… comment>` — the openssh
+    // encoding already includes the `<alg> <base64>` prefix, so we
+    // just prepend the host field.
+    writeln!(file, "{host_field} {key_str}")?;
+    Ok(())
+}
+
+/// Build the right [`HostKeyVerifier`] for a given policy + known-hosts
+/// path.
+pub fn build_verifier(
+    policy: StrictHostKey,
+    known_hosts: Option<PathBuf>,
+) -> Arc<dyn HostKeyVerifier> {
+    let known_hosts_path = known_hosts.unwrap_or_else(default_known_hosts);
+    match policy {
+        StrictHostKey::No => Arc::new(PermissiveVerifier),
+        StrictHostKey::Yes => Arc::new(StrictVerifier { known_hosts_path }),
+        StrictHostKey::AcceptNew => Arc::new(AcceptNewVerifier { known_hosts_path }),
+    }
+}
+
+fn default_known_hosts() -> PathBuf {
+    if let Some(home) = dirs::home_dir() {
+        home.join(".ssh").join("known_hosts")
+    } else {
+        PathBuf::from("known_hosts")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_hosts_lookup_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent");
+        let keys = known_hosts_lookup(&path, "host", 22).unwrap();
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn known_hosts_lookup_skips_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("kh");
+        std::fs::write(&path, "# a comment\n\n").unwrap();
+        assert!(known_hosts_lookup(&path, "host", 22).unwrap().is_empty());
+    }
+
+    #[test]
+    fn build_verifier_picks_correct_type() {
+        // We can't easily sniff `Arc<dyn HostKeyVerifier>`'s concrete
+        // type, but we can smoke-test the factory on every policy.
+        let _ = build_verifier(StrictHostKey::No, None);
+        let _ = build_verifier(StrictHostKey::Yes, None);
+        let _ = build_verifier(
+            StrictHostKey::AcceptNew,
+            Some(PathBuf::from("/nonexistent-test-path")),
+        );
+    }
+}

--- a/src/network/ssh_host_key.rs
+++ b/src/network/ssh_host_key.rs
@@ -27,8 +27,9 @@
 //! Kept in its own file so [`crate::network::ssh_client`] stays under
 //! the 500-line soft limit.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use russh::keys::ssh_key;
@@ -91,8 +92,67 @@ impl HostKeyVerifier for StrictVerifier {
 /// `--ssh-strict-host-key=accept-new`: accept unknown hosts on first
 /// connect, persist the key, but reject subsequent connections whose
 /// key differs from what we saved.
+///
+/// Keeps a per-process in-memory cache of accepted `(host, port,
+/// fingerprint)` triples so a persistence failure (read-only fs, full
+/// disk, symlink refusal) does not silently downgrade to `accept-any`:
+/// a subsequent connection in the same process still detects when the
+/// remote's key has changed.
 pub struct AcceptNewVerifier {
     pub known_hosts_path: PathBuf,
+    memory_cache: Mutex<HashSet<MemoryCacheKey>>,
+}
+
+/// `(host, port, openssh-fingerprint)`. Comparing by fingerprint rather
+/// than by the full key avoids having to keep `PublicKey` in the set
+/// (it is not `Eq + Hash`).
+type MemoryCacheKey = (String, u16, String);
+
+impl AcceptNewVerifier {
+    pub fn new(known_hosts_path: PathBuf) -> Self {
+        Self {
+            known_hosts_path,
+            memory_cache: Mutex::new(HashSet::new()),
+        }
+    }
+
+    fn memory_cache_key(host: &str, port: u16, key: &ssh_key::PublicKey) -> MemoryCacheKey {
+        (
+            host.to_string(),
+            port,
+            key.fingerprint(ssh_key::HashAlg::Sha256).to_string(),
+        )
+    }
+
+    fn memory_cache_contains(&self, host: &str, port: u16, key: &ssh_key::PublicKey) -> bool {
+        let needle = Self::memory_cache_key(host, port, key);
+        match self.memory_cache.lock() {
+            Ok(guard) => guard.contains(&needle),
+            Err(poisoned) => poisoned.into_inner().contains(&needle),
+        }
+    }
+
+    fn memory_cache_any_for(&self, host: &str, port: u16) -> bool {
+        match self.memory_cache.lock() {
+            Ok(guard) => guard.iter().any(|(h, p, _)| h == host && *p == port),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .iter()
+                .any(|(h, p, _)| h == host && *p == port),
+        }
+    }
+
+    fn memory_cache_insert(&self, host: &str, port: u16, key: &ssh_key::PublicKey) {
+        let entry = Self::memory_cache_key(host, port, key);
+        match self.memory_cache.lock() {
+            Ok(mut guard) => {
+                guard.insert(entry);
+            }
+            Err(poisoned) => {
+                poisoned.into_inner().insert(entry);
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -105,21 +165,44 @@ impl HostKeyVerifier for AcceptNewVerifier {
     ) -> Result<bool, SshClientError> {
         match known_hosts_lookup(&self.known_hosts_path, host, port) {
             Ok(keys) => {
-                if keys.is_empty() {
-                    // First-time connection: trust-on-first-use.
-                    if let Err(e) = known_hosts_append(&self.known_hosts_path, host, port, key) {
-                        tracing::warn!(
-                            host = host,
-                            error = %e,
-                            "accept-new: could not persist host key; still accepting this connection"
-                        );
-                    }
-                    Ok(true)
-                } else if keys.iter().any(|k| k == key) {
-                    Ok(true)
-                } else {
-                    Ok(false)
+                if keys.iter().any(|k| k == key) {
+                    // Known from persisted file.
+                    return Ok(true);
                 }
+                // File has entries for this host but none match, or file
+                // has no entries for this host. Decide based on whether
+                // the file already knew about the host at all: if yes,
+                // this is a key change → reject. If no, it is a first
+                // connect → TOFU.
+                if !keys.is_empty() {
+                    return Ok(false);
+                }
+                // First-time from persistent store. Check memory cache
+                // in case a previous connect in this process saw this
+                // host but could not persist it.
+                if self.memory_cache_any_for(host, port) {
+                    // We have a prior in-memory decision: only accept
+                    // if this specific fingerprint matches it.
+                    return Ok(self.memory_cache_contains(host, port, key));
+                }
+                // Genuinely first sighting anywhere. Persist; fall back
+                // to the in-memory cache if persistence fails so a
+                // subsequent connection in the same process can still
+                // detect a key change.
+                match known_hosts_append(&self.known_hosts_path, host, port, key) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        tracing::error!(
+                            host = host,
+                            port = port,
+                            path = %self.known_hosts_path.display(),
+                            error = %e,
+                            "accept-new: could not persist host key; caching in memory for this process only"
+                        );
+                        self.memory_cache_insert(host, port, key);
+                    }
+                }
+                Ok(true)
             }
             Err(e) => {
                 tracing::warn!(
@@ -134,10 +217,18 @@ impl HostKeyVerifier for AcceptNewVerifier {
 }
 
 /// Look up every saved public key for `host:port` in the given
-/// `known_hosts`-style file. The file format is intentionally
-/// simplified: each line is `host[:port] <key type> <base64-key>`.
-/// We never persist hashed hostnames so the file is both readable and
-/// easy to edit manually.
+/// `known_hosts`-style file.
+///
+/// Supports the common OpenSSH formats:
+/// * plain host: `dgx-01 ssh-ed25519 AAAA…`
+/// * host + port: `[dgx-01]:2222 ssh-ed25519 AAAA…`
+/// * comma-separated host list: `dgx-01,10.0.0.1 ssh-ed25519 AAAA…`
+///
+/// Hashed hostnames (`|1|…`) are skipped rather than matched — we do
+/// not implement the HMAC-SHA1 hostname lookup OpenSSH uses. Our own
+/// [`known_hosts_append`] never writes the hashed form, so this is a
+/// no-op for files we created. Third-party files still function; the
+/// hashed lines are ignored.
 pub(crate) fn known_hosts_lookup(
     path: &Path,
     host: &str,
@@ -150,7 +241,6 @@ pub(crate) fn known_hosts_lookup(
     };
     let mut out = Vec::new();
     let needle_bracket = format!("[{host}]:{port}");
-    let needle_plain = host;
     for raw in content.lines() {
         let line = raw.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -160,12 +250,30 @@ pub(crate) fn known_hosts_lookup(
             Some(p) => p,
             None => continue,
         };
-        let matches = if port == 22 {
-            host_field == needle_plain || host_field == needle_bracket
-        } else {
-            host_field == needle_bracket
-        };
-        if !matches {
+        // Skip OpenSSH hashed-hostname entries — we do not implement
+        // the HMAC-SHA1 lookup they require.
+        if host_field.starts_with("|1|") {
+            continue;
+        }
+        // OpenSSH allows a comma-separated list of host patterns on a
+        // single line. Any one of them may match.
+        let mut matched = false;
+        for token in host_field.split(',') {
+            let token = token.trim();
+            if token.is_empty() {
+                continue;
+            }
+            let hit = if port == 22 {
+                token == host || token == needle_bracket
+            } else {
+                token == needle_bracket
+            };
+            if hit {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
             continue;
         }
         // rest is `<algo> <base64> [comment]`. That format matches
@@ -178,6 +286,23 @@ pub(crate) fn known_hosts_lookup(
     Ok(out)
 }
 
+/// Append a `host key` entry to `known_hosts` without following
+/// symlinks.
+///
+/// Security: if an attacker controls the directory holding the
+/// `known_hosts` file, they could pre-plant a symlink pointing at
+/// `~/.bashrc` or another shell rc file. When we then append a new
+/// "host key" line, the attacker-chosen bytes (host name + key data)
+/// would land in that file. We defend with a double-check:
+///
+/// 1. `symlink_metadata` — explicit refusal if the target path is a
+///    symlink at the time we check.
+/// 2. `O_NOFOLLOW` on the `open` syscall (Unix) — the kernel itself
+///    refuses to open through a final-component symlink, closing the
+///    TOCTOU window between the metadata check and the open.
+///
+/// On create, we set mode `0o600` to match OpenSSH's semantics for new
+/// `known_hosts` files.
 fn known_hosts_append(
     path: &Path,
     host: &str,
@@ -187,6 +312,21 @@ fn known_hosts_append(
     use std::io::Write;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
+    }
+    // Reject a pre-existing symlink up-front. This is deliberately
+    // checked even on non-Unix platforms so the attack surface is
+    // narrowed everywhere.
+    if path.exists() {
+        let md = std::fs::symlink_metadata(path)?;
+        if md.file_type().is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "refusing to append to symlinked known_hosts at {}",
+                    path.display()
+                ),
+            ));
+        }
     }
     let host_field = if port == 22 {
         host.to_string()
@@ -199,10 +339,17 @@ fn known_hosts_append(
             format!("could not serialise host key: {e}"),
         )
     })?;
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)?;
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // 0o600 mirrors OpenSSH's default mode for fresh known_hosts
+        // files. O_NOFOLLOW closes the TOCTOU window between the
+        // symlink_metadata check above and the actual open.
+        opts.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = opts.open(path)?;
     // Entry form: `host <ssh-ed25519 AAAA… comment>` — the openssh
     // encoding already includes the `<alg> <base64>` prefix, so we
     // just prepend the host field.
@@ -220,7 +367,7 @@ pub fn build_verifier(
     match policy {
         StrictHostKey::No => Arc::new(PermissiveVerifier),
         StrictHostKey::Yes => Arc::new(StrictVerifier { known_hosts_path }),
-        StrictHostKey::AcceptNew => Arc::new(AcceptNewVerifier { known_hosts_path }),
+        StrictHostKey::AcceptNew => Arc::new(AcceptNewVerifier::new(known_hosts_path)),
     }
 }
 
@@ -235,6 +382,26 @@ fn default_known_hosts() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Two pre-generated ed25519 public keys used by fixtures that
+    /// need to simulate a "key change" between connections. Generated
+    /// with `ssh-keygen -t ed25519`; kept as literal strings so tests
+    /// are hermetic (no RNG, no filesystem) and deterministic across
+    /// runs. These keys exist only as test fixtures — their private
+    /// halves are discarded.
+    const TEST_KEY_A: &str = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILbRhbtx7s0p+e18aTwbGaHN+8UqaBcSRNCE+GU5v6Q7 all-smi-test-a";
+    const TEST_KEY_B: &str = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+UHj3N+jyzN/51w3elCnDai2okb8wc+d4JCKQGd23o all-smi-test-b";
+
+    fn test_public_key() -> ssh_key::PublicKey {
+        ssh_key::PublicKey::from_openssh(TEST_KEY_A).expect("fixture key A must parse")
+    }
+
+    fn test_public_key_pair() -> (ssh_key::PublicKey, ssh_key::PublicKey) {
+        (
+            ssh_key::PublicKey::from_openssh(TEST_KEY_A).expect("fixture key A must parse"),
+            ssh_key::PublicKey::from_openssh(TEST_KEY_B).expect("fixture key B must parse"),
+        )
+    }
 
     #[test]
     fn known_hosts_lookup_missing_file_is_empty() {
@@ -253,6 +420,43 @@ mod tests {
     }
 
     #[test]
+    fn known_hosts_lookup_matches_multi_host_line() {
+        // OpenSSH-style comma-separated host list: any of the tokens
+        // must be accepted as a match for the requested host.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("kh");
+        let key = test_public_key();
+        let key_str = key.to_openssh().unwrap();
+        std::fs::write(&path, format!("host-a,host-b,host-c {key_str}\n")).unwrap();
+
+        let keys = known_hosts_lookup(&path, "host-b", 22).unwrap();
+        assert_eq!(keys.len(), 1, "multi-host entry must match middle token");
+        assert_eq!(keys[0], key);
+
+        let keys = known_hosts_lookup(&path, "host-c", 22).unwrap();
+        assert_eq!(keys.len(), 1, "multi-host entry must match last token");
+
+        let keys = known_hosts_lookup(&path, "not-in-list", 22).unwrap();
+        assert!(keys.is_empty(), "hostname absent from list must not match");
+    }
+
+    #[test]
+    fn known_hosts_lookup_skips_hashed_hostnames() {
+        // Hashed hostname lines (leading `|1|`) are skipped rather
+        // than rejected — the file remains usable overall.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("kh");
+        let key = test_public_key();
+        let key_str = key.to_openssh().unwrap();
+        let hashed_line = "|1|AAAA|BBBB ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGarbage";
+        std::fs::write(&path, format!("{hashed_line}\nplain-host {key_str}\n")).unwrap();
+
+        let keys = known_hosts_lookup(&path, "plain-host", 22).unwrap();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0], key);
+    }
+
+    #[test]
     fn build_verifier_picks_correct_type() {
         // We can't easily sniff `Arc<dyn HostKeyVerifier>`'s concrete
         // type, but we can smoke-test the factory on every policy.
@@ -262,5 +466,104 @@ mod tests {
             StrictHostKey::AcceptNew,
             Some(PathBuf::from("/nonexistent-test-path")),
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn known_hosts_append_refuses_symlink_target() {
+        // C1 regression: a pre-planted symlink at the known_hosts path
+        // must NOT be dereferenced when we append. The target file
+        // must remain untouched.
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let decoy = dir.path().join("decoy.txt");
+        std::fs::write(&decoy, b"original-contents\n").unwrap();
+        let kh_path = dir.path().join("kh");
+        symlink(&decoy, &kh_path).expect("creating symlink");
+
+        let key = test_public_key();
+        let err = known_hosts_append(&kh_path, "attacker-host", 22, &key)
+            .expect_err("append through symlink must fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+        // Decoy file must still contain exactly its original bytes.
+        let after = std::fs::read_to_string(&decoy).unwrap();
+        assert_eq!(
+            after, "original-contents\n",
+            "symlink target must not be appended to"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn known_hosts_append_creates_with_restrictive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let kh_path = dir.path().join("kh");
+        let key = test_public_key();
+        known_hosts_append(&kh_path, "host", 22, &key).expect("clean append must succeed");
+
+        let md = std::fs::metadata(&kh_path).unwrap();
+        let mode = md.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "fresh known_hosts must be mode 0o600");
+    }
+
+    #[tokio::test]
+    async fn accept_new_falls_back_to_memory_on_persist_failure() {
+        // M4 regression: when the known_hosts path cannot be written
+        // (here: points at a non-creatable location), the verifier
+        // must still detect a key change on the NEXT connection of
+        // the same process by consulting its in-memory cache.
+        let dir = tempfile::tempdir().unwrap();
+        // Create a read-only directory so append() fails deterministically
+        // without relying on OS-level restricted paths.
+        let ro_dir = dir.path().join("ro");
+        std::fs::create_dir(&ro_dir).unwrap();
+        let kh_path = ro_dir.join("known_hosts");
+        // Create the file then make it a symlink to itself would be
+        // too convoluted; easier: make the parent read-only so
+        // create() fails.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perm = std::fs::metadata(&ro_dir).unwrap().permissions();
+            perm.set_mode(0o500);
+            std::fs::set_permissions(&ro_dir, perm).unwrap();
+        }
+
+        let verifier = AcceptNewVerifier::new(kh_path);
+        let (key_a, key_b) = test_public_key_pair();
+
+        // First contact: unknown. Persistence fails silently, but the
+        // connection is still accepted.
+        let first = verifier.verify("host.example", 22, &key_a).await.unwrap();
+        assert!(first, "first contact must be accepted (TOFU)");
+
+        // Second contact with same key: must still be accepted via
+        // the in-memory cache.
+        let second = verifier.verify("host.example", 22, &key_a).await.unwrap();
+        assert!(
+            second,
+            "repeat with same key must be accepted from memory cache"
+        );
+
+        // Third contact with a DIFFERENT key: must be rejected. This
+        // is the whole point — a persistence failure must not silently
+        // degrade to accept-any.
+        let rejected = verifier.verify("host.example", 22, &key_b).await.unwrap();
+        assert!(
+            !rejected,
+            "key change after persist-failure must still be rejected"
+        );
+
+        // Restore perms so tempdir cleanup can succeed.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perm = std::fs::metadata(&ro_dir).unwrap().permissions();
+            perm.set_mode(0o700);
+            let _ = std::fs::set_permissions(&ro_dir, perm);
+        }
     }
 }

--- a/src/network/ssh_target.rs
+++ b/src/network/ssh_target.rs
@@ -1,0 +1,350 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parsed SSH target: `user@host[:port]` and hostfile loader (issue #194).
+//!
+//! Kept distinct from the russh-backed client so tests can lock in the
+//! parsing rules without pulling the entire SSH stack into scope.
+
+use std::fs;
+use std::path::Path;
+
+/// Default SSH port applied when the operator omits an explicit `:port`
+/// suffix in `--ssh user@host` or the hostfile.
+pub const DEFAULT_SSH_PORT: u16 = 22;
+
+/// Hard ceiling on the file size we are willing to read as an
+/// `--ssh-hostfile`. Matches the RemoteCollectorBuilder convention so
+/// `view` mode has a single memory-safety story.
+pub const MAX_HOSTFILE_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Hard ceiling on the number of SSH targets we accept from a single
+/// hostfile.
+pub const MAX_HOSTFILE_ENTRIES: usize = 1000;
+
+/// Errors emitted by [`parse_ssh_target`] and [`parse_hostfile`].
+#[derive(Debug, thiserror::Error)]
+pub enum SshTargetError {
+    #[error("invalid SSH target `{0}`: missing `user@`")]
+    MissingUser(String),
+    #[error("invalid SSH target `{0}`: missing host after `user@`")]
+    MissingHost(String),
+    #[error("invalid SSH target `{input}`: port `{port}` is not a valid u16")]
+    InvalidPort { input: String, port: String },
+    #[error("hostfile I/O error at {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("hostfile {path} exceeds {limit}-byte limit (found {actual} bytes)")]
+    FileTooLarge {
+        path: String,
+        actual: u64,
+        limit: u64,
+    },
+}
+
+/// A single remote SSH target parsed from the CLI or hostfile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshTarget {
+    pub user: String,
+    pub host: String,
+    pub port: u16,
+}
+
+impl SshTarget {
+    /// Stable identifier used as the host key across the TUI and
+    /// connection-status map. Always `user@host:port`, even when the
+    /// caller omitted `:port` in the original input (the struct has
+    /// already normalised to [`DEFAULT_SSH_PORT`]).
+    pub fn host_id(&self) -> String {
+        format!("{}@{}:{}", self.user, self.host, self.port)
+    }
+
+    /// Display label for the tab row — `ssh://user@host` without the
+    /// port suffix when it is the default 22, for compactness.
+    pub fn display_label(&self) -> String {
+        if self.port == DEFAULT_SSH_PORT {
+            format!("ssh://{}@{}", self.user, self.host)
+        } else {
+            format!("ssh://{}@{}:{}", self.user, self.host, self.port)
+        }
+    }
+
+    /// Hostname-only string used as the `hostname` field on produced
+    /// [`crate::device::GpuInfo`] records. Strips the user and port so
+    /// per-GPU labels stay readable.
+    pub fn hostname(&self) -> &str {
+        &self.host
+    }
+}
+
+/// Parse a single `user@host[:port]` string into [`SshTarget`].
+///
+/// IPv6 literals wrapped in `[]` are accepted, matching OpenSSH's
+/// syntax (`user@[::1]:2222`).
+pub fn parse_ssh_target(raw: &str) -> Result<SshTarget, SshTargetError> {
+    let input = raw.trim();
+    let at = input
+        .find('@')
+        .ok_or_else(|| SshTargetError::MissingUser(input.to_string()))?;
+    let user = input[..at].to_string();
+    if user.is_empty() {
+        return Err(SshTargetError::MissingUser(input.to_string()));
+    }
+    let rest = &input[at + 1..];
+    if rest.is_empty() {
+        return Err(SshTargetError::MissingHost(input.to_string()));
+    }
+
+    // IPv6-in-brackets: `[::1]:2222`
+    if let Some(stripped) = rest.strip_prefix('[') {
+        let close = stripped
+            .find(']')
+            .ok_or_else(|| SshTargetError::MissingHost(input.to_string()))?;
+        let host = stripped[..close].to_string();
+        let tail = &stripped[close + 1..];
+        let port = parse_port_suffix(tail, input)?;
+        return Ok(SshTarget { user, host, port });
+    }
+
+    // Plain host[:port]. Find the LAST colon to support hostnames that
+    // legitimately contain no colons (typical case) while still rejecting
+    // IPv6 literals written without brackets.
+    if let Some((host_part, port_part)) = rest.rsplit_once(':') {
+        // Disallow unbracketed IPv6 (multiple colons on the remote side).
+        if host_part.contains(':') {
+            return Err(SshTargetError::MissingHost(input.to_string()));
+        }
+        let port = port_part
+            .parse::<u16>()
+            .map_err(|_| SshTargetError::InvalidPort {
+                input: input.to_string(),
+                port: port_part.to_string(),
+            })?;
+        if host_part.is_empty() {
+            return Err(SshTargetError::MissingHost(input.to_string()));
+        }
+        Ok(SshTarget {
+            user,
+            host: host_part.to_string(),
+            port,
+        })
+    } else {
+        Ok(SshTarget {
+            user,
+            host: rest.to_string(),
+            port: DEFAULT_SSH_PORT,
+        })
+    }
+}
+
+fn parse_port_suffix(tail: &str, input: &str) -> Result<u16, SshTargetError> {
+    if tail.is_empty() {
+        return Ok(DEFAULT_SSH_PORT);
+    }
+    let tail = tail.strip_prefix(':').unwrap_or(tail);
+    tail.parse::<u16>()
+        .map_err(|_| SshTargetError::InvalidPort {
+            input: input.to_string(),
+            port: tail.to_string(),
+        })
+}
+
+/// Parse a comma-separated `--ssh` argument into multiple targets.
+pub fn parse_ssh_arg(arg: &str) -> Result<Vec<SshTarget>, SshTargetError> {
+    arg.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(parse_ssh_target)
+        .collect()
+}
+
+/// Load and parse an SSH hostfile.
+///
+/// Format: one `user@host[:port]` per line. Blank lines and `#`-prefixed
+/// comments are ignored. Inline `#` comments are also stripped. The
+/// file size is capped at [`MAX_HOSTFILE_BYTES`]; the number of
+/// parsed entries is capped at [`MAX_HOSTFILE_ENTRIES`].
+pub fn parse_hostfile(path: impl AsRef<Path>) -> Result<Vec<SshTarget>, SshTargetError> {
+    let path = path.as_ref();
+    let path_str = path.display().to_string();
+
+    let metadata = fs::metadata(path).map_err(|source| SshTargetError::Io {
+        path: path_str.clone(),
+        source,
+    })?;
+    if metadata.len() > MAX_HOSTFILE_BYTES {
+        return Err(SshTargetError::FileTooLarge {
+            path: path_str,
+            actual: metadata.len(),
+            limit: MAX_HOSTFILE_BYTES,
+        });
+    }
+
+    let content = fs::read_to_string(path).map_err(|source| SshTargetError::Io {
+        path: path_str,
+        source,
+    })?;
+    parse_hostfile_content(&content)
+}
+
+pub fn parse_hostfile_content(content: &str) -> Result<Vec<SshTarget>, SshTargetError> {
+    let mut out = Vec::new();
+    for raw in content.lines() {
+        // Strip inline `#` comments. Never strip inside a quoted
+        // string — the hostfile format does not support quotes, so a
+        // `#` anywhere on the line starts a comment.
+        let line = match raw.find('#') {
+            Some(idx) => &raw[..idx],
+            None => raw,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let target = parse_ssh_target(trimmed)?;
+        out.push(target);
+        if out.len() >= MAX_HOSTFILE_ENTRIES {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_user_at_host() {
+        let t = parse_ssh_target("admin@dgx-01").unwrap();
+        assert_eq!(t.user, "admin");
+        assert_eq!(t.host, "dgx-01");
+        assert_eq!(t.port, DEFAULT_SSH_PORT);
+        assert_eq!(t.host_id(), "admin@dgx-01:22");
+        assert_eq!(t.display_label(), "ssh://admin@dgx-01");
+    }
+
+    #[test]
+    fn parses_user_at_host_with_port() {
+        let t = parse_ssh_target("admin@dgx-01:2222").unwrap();
+        assert_eq!(t.port, 2222);
+        assert_eq!(t.display_label(), "ssh://admin@dgx-01:2222");
+    }
+
+    #[test]
+    fn parses_ipv6_with_brackets_and_port() {
+        let t = parse_ssh_target("admin@[fd00::1]:2222").unwrap();
+        assert_eq!(t.host, "fd00::1");
+        assert_eq!(t.port, 2222);
+    }
+
+    #[test]
+    fn parses_ipv6_with_brackets_default_port() {
+        let t = parse_ssh_target("admin@[::1]").unwrap();
+        assert_eq!(t.host, "::1");
+        assert_eq!(t.port, DEFAULT_SSH_PORT);
+    }
+
+    #[test]
+    fn rejects_missing_user() {
+        let e = parse_ssh_target("dgx-01").unwrap_err();
+        matches!(e, SshTargetError::MissingUser(_));
+    }
+
+    #[test]
+    fn rejects_empty_user() {
+        let e = parse_ssh_target("@dgx-01").unwrap_err();
+        matches!(e, SshTargetError::MissingUser(_));
+    }
+
+    #[test]
+    fn rejects_missing_host() {
+        let e = parse_ssh_target("user@").unwrap_err();
+        matches!(e, SshTargetError::MissingHost(_));
+    }
+
+    #[test]
+    fn rejects_bad_port() {
+        let e = parse_ssh_target("user@host:not-a-number").unwrap_err();
+        matches!(e, SshTargetError::InvalidPort { .. });
+    }
+
+    #[test]
+    fn rejects_unbracketed_ipv6() {
+        // `user@fd00::1` is ambiguous (is `1` a port or a hostname
+        // fragment?). OpenSSH rejects this form; so do we.
+        let e = parse_ssh_target("user@fd00::1").unwrap_err();
+        matches!(
+            e,
+            SshTargetError::MissingHost(_) | SshTargetError::InvalidPort { .. }
+        );
+    }
+
+    #[test]
+    fn parse_ssh_arg_splits_comma_list() {
+        let t = parse_ssh_arg("a@h1,b@h2:2222,c@h3").unwrap();
+        assert_eq!(t.len(), 3);
+        assert_eq!(t[0].user, "a");
+        assert_eq!(t[1].port, 2222);
+        assert_eq!(t[2].host, "h3");
+    }
+
+    #[test]
+    fn parse_ssh_arg_tolerates_whitespace_and_empty_slots() {
+        let t = parse_ssh_arg(" a@h1 , , b@h2 ").unwrap();
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].user, "a");
+        assert_eq!(t[1].user, "b");
+    }
+
+    #[test]
+    fn hostfile_ignores_comments_and_blanks() {
+        let content = "# a comment\n\nuser1@host1\n   \nuser2@host2:2222 # inline comment\n";
+        let t = parse_hostfile_content(content).unwrap();
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].user, "user1");
+        assert_eq!(t[1].port, 2222);
+    }
+
+    #[test]
+    fn hostfile_propagates_parse_errors() {
+        let content = "this-is-not-valid\n";
+        assert!(parse_hostfile_content(content).is_err());
+    }
+
+    #[test]
+    fn hostfile_enforces_entry_cap() {
+        // Synthesize a large hostfile; parser must stop at
+        // MAX_HOSTFILE_ENTRIES without blowing out memory.
+        let mut content = String::new();
+        for i in 0..(MAX_HOSTFILE_ENTRIES + 100) {
+            content.push_str(&format!("u@host{i}\n"));
+        }
+        let t = parse_hostfile_content(&content).unwrap();
+        assert_eq!(t.len(), MAX_HOSTFILE_ENTRIES);
+    }
+
+    #[test]
+    fn reads_real_hostfile_from_disk() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "alice@a\nbob@b:2200\n").unwrap();
+        let t = parse_hostfile(tmp.path()).unwrap();
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].user, "alice");
+        assert_eq!(t[1].port, 2200);
+    }
+}

--- a/src/network/ssh_target.rs
+++ b/src/network/ssh_target.rs
@@ -40,6 +40,11 @@ pub enum SshTargetError {
     MissingUser(String),
     #[error("invalid SSH target `{0}`: missing host after `user@`")]
     MissingHost(String),
+    #[error(
+        "invalid SSH target `{input}`: host `{host}` contains unsupported characters \
+         (allowed: letters, digits, `-`, `.`, `:`, `_`)"
+    )]
+    InvalidHostChars { input: String, host: String },
     #[error("invalid SSH target `{input}`: port `{port}` is not a valid u16")]
     InvalidPort { input: String, port: String },
     #[error("hostfile I/O error at {path}: {source}")]
@@ -54,6 +59,18 @@ pub enum SshTargetError {
         actual: u64,
         limit: u64,
     },
+}
+
+/// Whether a raw host string contains only characters we expect in a
+/// DNS name, IPv4 literal, bracketed IPv6 body, or an explicit
+/// underscore form that some legacy DNS zones still allow. Rejecting
+/// anything else keeps shell-metacharacter-looking inputs (e.g.
+/// `user@;whoami`) out of logs and tab labels, even though russh goes
+/// through `getaddrinfo` and not a shell.
+fn valid_host_chars(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii() && (c.is_alphanumeric() || matches!(c, '-' | '.' | ':' | '_')))
 }
 
 /// A single remote SSH target parsed from the CLI or hostfile.
@@ -117,6 +134,12 @@ pub fn parse_ssh_target(raw: &str) -> Result<SshTarget, SshTargetError> {
         let host = stripped[..close].to_string();
         let tail = &stripped[close + 1..];
         let port = parse_port_suffix(tail, input)?;
+        if !valid_host_chars(&host) {
+            return Err(SshTargetError::InvalidHostChars {
+                input: input.to_string(),
+                host,
+            });
+        }
         return Ok(SshTarget { user, host, port });
     }
 
@@ -137,12 +160,24 @@ pub fn parse_ssh_target(raw: &str) -> Result<SshTarget, SshTargetError> {
         if host_part.is_empty() {
             return Err(SshTargetError::MissingHost(input.to_string()));
         }
+        if !valid_host_chars(host_part) {
+            return Err(SshTargetError::InvalidHostChars {
+                input: input.to_string(),
+                host: host_part.to_string(),
+            });
+        }
         Ok(SshTarget {
             user,
             host: host_part.to_string(),
             port,
         })
     } else {
+        if !valid_host_chars(rest) {
+            return Err(SshTargetError::InvalidHostChars {
+                input: input.to_string(),
+                host: rest.to_string(),
+            });
+        }
         Ok(SshTarget {
             user,
             host: rest.to_string(),
@@ -262,25 +297,25 @@ mod tests {
     #[test]
     fn rejects_missing_user() {
         let e = parse_ssh_target("dgx-01").unwrap_err();
-        matches!(e, SshTargetError::MissingUser(_));
+        assert!(matches!(e, SshTargetError::MissingUser(_)));
     }
 
     #[test]
     fn rejects_empty_user() {
         let e = parse_ssh_target("@dgx-01").unwrap_err();
-        matches!(e, SshTargetError::MissingUser(_));
+        assert!(matches!(e, SshTargetError::MissingUser(_)));
     }
 
     #[test]
     fn rejects_missing_host() {
         let e = parse_ssh_target("user@").unwrap_err();
-        matches!(e, SshTargetError::MissingHost(_));
+        assert!(matches!(e, SshTargetError::MissingHost(_)));
     }
 
     #[test]
     fn rejects_bad_port() {
         let e = parse_ssh_target("user@host:not-a-number").unwrap_err();
-        matches!(e, SshTargetError::InvalidPort { .. });
+        assert!(matches!(e, SshTargetError::InvalidPort { .. }));
     }
 
     #[test]
@@ -288,10 +323,54 @@ mod tests {
         // `user@fd00::1` is ambiguous (is `1` a port or a hostname
         // fragment?). OpenSSH rejects this form; so do we.
         let e = parse_ssh_target("user@fd00::1").unwrap_err();
-        matches!(
+        assert!(matches!(
             e,
             SshTargetError::MissingHost(_) | SshTargetError::InvalidPort { .. }
-        );
+        ));
+    }
+
+    #[test]
+    fn rejects_host_with_shell_metacharacters() {
+        // M6 regression: injected characters like `;` or `$` must be
+        // rejected up front so they never land in logs / tab labels.
+        let e = parse_ssh_target("user@;whoami").unwrap_err();
+        assert!(matches!(e, SshTargetError::InvalidHostChars { .. }));
+
+        let e = parse_ssh_target("user@$(cat /etc/passwd)").unwrap_err();
+        assert!(matches!(e, SshTargetError::InvalidHostChars { .. }));
+
+        let e = parse_ssh_target("user@host name").unwrap_err();
+        assert!(matches!(e, SshTargetError::InvalidHostChars { .. }));
+
+        let e = parse_ssh_target("user@ho|st").unwrap_err();
+        assert!(matches!(e, SshTargetError::InvalidHostChars { .. }));
+    }
+
+    #[test]
+    fn rejects_ipv6_body_with_invalid_chars() {
+        // The bracketed IPv6 body goes through the same charset
+        // check so injection via `user@[::1$(evil)]` cannot slip in.
+        let e = parse_ssh_target("user@[::1;payload]").unwrap_err();
+        assert!(matches!(e, SshTargetError::InvalidHostChars { .. }));
+    }
+
+    #[test]
+    fn accepts_legitimate_hostnames_and_ips() {
+        // Make sure the charset check isn't too tight for common
+        // real-world inputs: DNS names, IPv4 literals, underscore
+        // hostnames (legacy), plain bracketed IPv6.
+        assert!(parse_ssh_target("user@host-1.example.com").is_ok());
+        assert!(parse_ssh_target("user@10.0.0.1").is_ok());
+        assert!(parse_ssh_target("user@under_score_host").is_ok());
+        assert!(parse_ssh_target("user@[fd00::1]").is_ok());
+        // Zone-ID separator `%` is intentionally rejected: SSH clients
+        // rarely need link-local addressing and allowing `%` widens
+        // the attack surface (URL-encoded injection). Operators who
+        // need zone IDs can file a follow-up issue.
+        assert!(matches!(
+            parse_ssh_target("user@[fe80::1%eth0]").unwrap_err(),
+            SshTargetError::InvalidHostChars { .. }
+        ));
     }
 
     #[test]

--- a/src/network/ssh_transport.rs
+++ b/src/network/ssh_transport.rs
@@ -208,7 +208,7 @@ mod tests {
     #[test]
     fn policy_rejects_unknown_token() {
         let e = SshFallbackPolicy::from_cli(Some("gpumonitor")).unwrap_err();
-        matches!(e, SshFallbackPolicyError::Unknown(_));
+        assert!(matches!(e, SshFallbackPolicyError::Unknown(_)));
     }
 
     #[test]
@@ -224,6 +224,6 @@ mod tests {
     #[test]
     fn strict_host_key_rejects_unknown() {
         let e = StrictHostKey::from_cli("sometimes").unwrap_err();
-        matches!(e, StrictHostKeyError::Unknown(_));
+        assert!(matches!(e, StrictHostKeyError::Unknown(_)));
     }
 }

--- a/src/network/ssh_transport.rs
+++ b/src/network/ssh_transport.rs
@@ -1,0 +1,229 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Transport chip + connection-state types shared between the SSH
+//! strategy and the TUI renderer (issue #194).
+
+use std::fmt;
+
+/// Which command a given SSH host is actually reachable through.
+///
+/// The SSH strategy probes each host once on first connect and caches
+/// the result for the lifetime of the view session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum SshTransport {
+    /// Host has `all-smi` installed and we run the native `snapshot`
+    /// subcommand. Full fidelity (CPU, memory, chassis, GPU).
+    Native,
+    /// Fallback: `nvidia-smi --query-gpu=... --format=csv,noheader,nounits`.
+    /// GPU only — CPU and chassis remain empty.
+    NvidiaSmi,
+    /// Fallback: `rocm-smi ... --json`. GPU only.
+    RocmSmi,
+    /// Host responded to SSH but none of the configured probes worked.
+    /// UI surfaces a dim "unsupported" chip.
+    #[default]
+    Unsupported,
+}
+
+impl SshTransport {
+    /// Short label used as the TUI transport chip (issue #194 UI spec).
+    pub fn chip_label(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::NvidiaSmi => "nvidia-smi",
+            Self::RocmSmi => "rocm-smi",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+impl fmt::Display for SshTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.chip_label())
+    }
+}
+
+/// Which fallback probes the operator opted into. Parsed from
+/// `--ssh-fallback`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SshFallbackPolicy {
+    pub try_nvidia_smi: bool,
+    pub try_rocm_smi: bool,
+}
+
+impl SshFallbackPolicy {
+    /// Build a policy from the comma-separated CLI string.
+    ///
+    /// * Empty or missing → default: both NVIDIA and ROCm fallbacks
+    ///   enabled. This is the least-surprise behaviour: operators who
+    ///   do not care about the flag still get fallback coverage on
+    ///   hosts that have neither `all-smi` nor the matching SMI tool.
+    /// * `none` → disable all fallbacks. Hosts without `all-smi` render
+    ///   as unsupported.
+    /// * Any of `nvidia-smi`, `rocm-smi` → enable only the named probes.
+    pub fn from_cli(raw: Option<&str>) -> Result<Self, SshFallbackPolicyError> {
+        let Some(s) = raw else {
+            return Ok(Self::default_enabled());
+        };
+        let s = s.trim();
+        if s.is_empty() {
+            return Ok(Self::default_enabled());
+        }
+
+        let mut policy = Self::default();
+        let mut saw_explicit_none = false;
+        for token in s.split(',') {
+            let token = token.trim().to_ascii_lowercase();
+            match token.as_str() {
+                "" => continue,
+                "none" | "off" | "disabled" => {
+                    saw_explicit_none = true;
+                }
+                "nvidia-smi" | "nvidia_smi" | "nvidia" => policy.try_nvidia_smi = true,
+                "rocm-smi" | "rocm_smi" | "rocm" | "amd" => policy.try_rocm_smi = true,
+                other => {
+                    return Err(SshFallbackPolicyError::Unknown(other.to_string()));
+                }
+            }
+        }
+
+        if saw_explicit_none {
+            // `--ssh-fallback none` should win over any accompanying
+            // shim name: the operator explicitly asked for no fallbacks.
+            return Ok(Self::default());
+        }
+        Ok(policy)
+    }
+
+    fn default_enabled() -> Self {
+        Self {
+            try_nvidia_smi: true,
+            try_rocm_smi: true,
+        }
+    }
+
+    /// True if at least one fallback shim is enabled.
+    #[allow(dead_code)]
+    pub fn any_enabled(&self) -> bool {
+        self.try_nvidia_smi || self.try_rocm_smi
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SshFallbackPolicyError {
+    #[error("unknown fallback kind `{0}` (valid: nvidia-smi, rocm-smi, none)")]
+    Unknown(String),
+}
+
+/// Host-key policy from `--ssh-strict-host-key`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StrictHostKey {
+    /// Default. Refuse unknown hosts.
+    #[default]
+    Yes,
+    /// Accept unknown hosts on first connect; reject when a known key
+    /// changes.
+    AcceptNew,
+    /// Accept any key (emits a prominent TUI warning).
+    No,
+}
+
+impl StrictHostKey {
+    pub fn from_cli(raw: &str) -> Result<Self, StrictHostKeyError> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "yes" | "true" | "strict" => Ok(Self::Yes),
+            "accept-new" | "acceptnew" | "accept_new" => Ok(Self::AcceptNew),
+            "no" | "false" | "off" => Ok(Self::No),
+            other => Err(StrictHostKeyError::Unknown(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StrictHostKeyError {
+    #[error("unknown --ssh-strict-host-key value `{0}` (valid: yes, accept-new, no)")]
+    Unknown(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_chip_label_is_stable() {
+        assert_eq!(SshTransport::Native.chip_label(), "native");
+        assert_eq!(SshTransport::NvidiaSmi.chip_label(), "nvidia-smi");
+        assert_eq!(SshTransport::RocmSmi.chip_label(), "rocm-smi");
+        assert_eq!(SshTransport::Unsupported.chip_label(), "unsupported");
+    }
+
+    #[test]
+    fn policy_default_enables_both_shims() {
+        let p = SshFallbackPolicy::from_cli(None).unwrap();
+        assert!(p.try_nvidia_smi);
+        assert!(p.try_rocm_smi);
+    }
+
+    #[test]
+    fn policy_none_disables_both() {
+        let p = SshFallbackPolicy::from_cli(Some("none")).unwrap();
+        assert!(!p.try_nvidia_smi);
+        assert!(!p.try_rocm_smi);
+        assert!(!p.any_enabled());
+    }
+
+    #[test]
+    fn policy_only_nvidia() {
+        let p = SshFallbackPolicy::from_cli(Some("nvidia-smi")).unwrap();
+        assert!(p.try_nvidia_smi);
+        assert!(!p.try_rocm_smi);
+    }
+
+    #[test]
+    fn policy_both_explicitly() {
+        let p = SshFallbackPolicy::from_cli(Some("nvidia-smi,rocm-smi")).unwrap();
+        assert!(p.try_nvidia_smi);
+        assert!(p.try_rocm_smi);
+    }
+
+    #[test]
+    fn policy_none_wins_over_other_tokens() {
+        // `--ssh-fallback nvidia-smi,none` should disable all probes.
+        let p = SshFallbackPolicy::from_cli(Some("nvidia-smi,none")).unwrap();
+        assert!(!p.any_enabled());
+    }
+
+    #[test]
+    fn policy_rejects_unknown_token() {
+        let e = SshFallbackPolicy::from_cli(Some("gpumonitor")).unwrap_err();
+        matches!(e, SshFallbackPolicyError::Unknown(_));
+    }
+
+    #[test]
+    fn strict_host_key_parses_all_variants() {
+        assert_eq!(StrictHostKey::from_cli("yes").unwrap(), StrictHostKey::Yes);
+        assert_eq!(
+            StrictHostKey::from_cli("accept-new").unwrap(),
+            StrictHostKey::AcceptNew
+        );
+        assert_eq!(StrictHostKey::from_cli("no").unwrap(), StrictHostKey::No);
+    }
+
+    #[test]
+    fn strict_host_key_rejects_unknown() {
+        let e = StrictHostKey::from_cli("sometimes").unwrap_err();
+        matches!(e, StrictHostKeyError::Unknown(_));
+    }
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -365,6 +365,23 @@ fn render_terminal_section(line_idx: usize, width: usize) -> String {
             "command",
         ),
         ("", "", ""),
+        ("Agentless SSH:", "", "header"),
+        (
+            "  all-smi view --ssh user@dgx-01,user@dgx-02",
+            "Connect over SSH (no agent install)",
+            "command",
+        ),
+        (
+            "  all-smi view --ssh-hostfile hosts-ssh.txt",
+            "SSH targets from a hostfile",
+            "command",
+        ),
+        (
+            "  --ssh-fallback nvidia-smi,rocm-smi",
+            "Fallback probes when all-smi not present",
+            "command",
+        ),
+        ("", "", ""),
         ("API Server Mode:", "", "header"),
         (
             "  all-smi api --port 9090",

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -99,14 +99,26 @@ pub fn draw_tabs<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
 
     for (i, tab) in node_tabs {
         // Get display name (instance name) while keeping tab as the key
+        let connection_status = state.connection_status.get(tab);
         let display_name = if tab == "All" {
             tab.to_string()
-        } else if let Some(connection_status) = state.connection_status.get(tab) {
-            connection_status
-                .actual_hostname
-                .as_ref()
-                .unwrap_or(tab)
-                .clone()
+        } else if let Some(status) = connection_status {
+            // SSH mode tabs carry the `ssh://user@host` prefix in the
+            // host_id; when present we show that label verbatim so the
+            // operator immediately sees the transport. Issue #194.
+            if tab.contains('@') && !tab.starts_with("http") {
+                // SSH host_id: user@host:port. Strip the default port
+                // to keep the label compact. When we have a live
+                // transport chip, append it so the operator can see
+                // which command is feeding each tab at a glance.
+                let base = format_ssh_tab_label(tab);
+                match status.transport_chip.as_deref() {
+                    Some(chip) if !chip.is_empty() => format!("{base}·{chip}"),
+                    _ => base,
+                }
+            } else {
+                status.actual_hostname.as_ref().unwrap_or(tab).clone()
+            }
         } else {
             tab.to_string()
         };
@@ -168,6 +180,16 @@ fn render_tab_separator<W: Write>(stdout: &mut W, cols: u16) {
     queue!(stdout, Print("\r\n")).unwrap();
 }
 
+/// Format an SSH host-id (`user@host:port`) as a compact tab label.
+///
+/// Strips the `:22` suffix because SSH's default port is rarely
+/// interesting visually; everything else is preserved. Always prefixed
+/// with `ssh://` so the transport is obvious in the tab strip.
+pub fn format_ssh_tab_label(host_id: &str) -> String {
+    let without_default_port = host_id.strip_suffix(":22").unwrap_or(host_id);
+    format!("ssh://{without_default_port}")
+}
+
 #[allow(dead_code)]
 pub fn calculate_tab_visibility(state: &AppState, cols: u16) -> TabVisibility {
     let mut available_width = cols.saturating_sub(8);
@@ -189,7 +211,17 @@ pub fn calculate_tab_visibility(state: &AppState, cols: u16) -> TabVisibility {
         .skip(state.tab_scroll_offset)
     {
         // Get display name for width calculation
-        let display_name = if let Some(connection_status) = state.connection_status.get(tab) {
+        let display_name = if tab.contains('@') && !tab.starts_with("http") {
+            let base = format_ssh_tab_label(tab);
+            match state
+                .connection_status
+                .get(tab)
+                .and_then(|s| s.transport_chip.as_deref())
+            {
+                Some(chip) if !chip.is_empty() => format!("{base}·{chip}"),
+                _ => base,
+            }
+        } else if let Some(connection_status) = state.connection_status.get(tab) {
             connection_status
                 .actual_hostname
                 .as_ref()
@@ -256,5 +288,21 @@ mod tests {
 
         assert_eq!(visibility.first_visible, 1);
         assert!(visibility.has_more_left);
+    }
+
+    #[test]
+    fn ssh_tab_label_strips_default_port() {
+        assert_eq!(
+            format_ssh_tab_label("admin@dgx-01:22"),
+            "ssh://admin@dgx-01"
+        );
+    }
+
+    #[test]
+    fn ssh_tab_label_preserves_custom_port() {
+        assert_eq!(
+            format_ssh_tab_label("admin@dgx-01:2222"),
+            "ssh://admin@dgx-01:2222"
+        );
     }
 }

--- a/src/view/data_collection/mod.rs
+++ b/src/view/data_collection/mod.rs
@@ -16,6 +16,7 @@ pub mod aggregator;
 pub mod local_collector;
 pub mod remote_collector;
 pub mod replay_collector;
+pub mod ssh_strategy;
 pub mod strategy;
 
 #[allow(unused_imports)] // Re-exported for embedding crates / future callers.
@@ -23,4 +24,5 @@ pub use aggregator::DataAggregator;
 pub use local_collector::LocalCollector;
 pub use remote_collector::RemoteCollectorBuilder;
 pub use replay_collector::{ReplayDriver, initial_replay_state};
+pub use ssh_strategy::{SshStrategy, SshStrategyConfig};
 pub use strategy::{CollectionConfig, DataCollectionStrategy};

--- a/src/view/data_collection/ssh_strategy.rs
+++ b/src/view/data_collection/ssh_strategy.rs
@@ -1,0 +1,573 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SSH-backed data-collection strategy for `view --ssh` (issue #194).
+//!
+//! Parallel to [`crate::view::data_collection::LocalCollector`] and
+//! [`crate::view::data_collection::RemoteCollectorBuilder`] but sources
+//! every frame over SSH. Per host, the strategy:
+//!
+//! 1. Opens a long-lived [`SshSession`] on first tick.
+//! 2. Probes `all-smi --version`, `nvidia-smi --version`, and
+//!    `rocm-smi --version` once to decide which transport to pin for
+//!    the lifetime of the session.
+//! 3. Every subsequent tick runs the pinned command, parses the output
+//!    into [`GpuInfo`] records, and pushes them into the shared state.
+//!
+//! Connection errors downgrade a host's status to `disconnected` /
+//! `auth-failed` / `timeout` but never crash the view loop — the
+//! per-host state is the only casualty.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::{Mutex, Semaphore};
+
+use crate::app_state::{AppState, ConnectionStatus};
+use crate::device::GpuInfo;
+use crate::network::nvidia_smi_shim::{NVIDIA_SMI_COMMAND, parse_nvidia_smi_csv};
+use crate::network::rocm_smi_shim::{ROCM_SMI_COMMAND, parse_rocm_smi_json};
+use crate::network::ssh_client::{ConnectParams, ExecOutput, HostKeyVerifier, SshSession};
+use crate::network::ssh_decision::{
+    MIN_NATIVE_VERSION, ProbeOutcomes, ProbeResult, native_supported, select_transport,
+};
+use crate::network::ssh_host_key::build_verifier;
+use crate::network::ssh_target::SshTarget;
+use crate::network::ssh_transport::{SshFallbackPolicy, SshTransport, StrictHostKey};
+use crate::snapshot::options::Snapshot;
+
+use super::aggregator::DataAggregator;
+use super::strategy::{
+    CollectionConfig, CollectionData, CollectionError, CollectionResult, DataCollectionStrategy,
+};
+
+const NATIVE_SNAPSHOT_CMD: &str = "all-smi snapshot --format json --include gpu,cpu,memory,chassis";
+const NATIVE_VERSION_CMD: &str = "all-smi --version";
+
+/// Configuration a caller feeds the SSH strategy once, at startup.
+#[derive(Clone)]
+pub struct SshStrategyConfig {
+    pub targets: Vec<SshTarget>,
+    pub explicit_key: Option<PathBuf>,
+    pub strict_host_key: StrictHostKey,
+    pub known_hosts: Option<PathBuf>,
+    pub connect_timeout: Duration,
+    pub fallback_policy: SshFallbackPolicy,
+    pub concurrency: usize,
+}
+
+/// Per-host state tracked by the strategy for the lifetime of the view.
+#[derive(Clone)]
+struct HostState {
+    target: SshTarget,
+    session: Option<SshSession>,
+    transport: SshTransport,
+    last_error: Option<String>,
+    /// True after we have successfully authenticated at least once.
+    ever_connected: bool,
+}
+
+/// SSH-backed strategy implementing [`DataCollectionStrategy`].
+pub struct SshStrategy {
+    config: SshStrategyConfig,
+    hosts: Arc<Mutex<HashMap<String, HostState>>>,
+    semaphore: Arc<Semaphore>,
+    aggregator: DataAggregator,
+    verifier: Arc<dyn HostKeyVerifier>,
+}
+
+impl SshStrategy {
+    pub fn new(config: SshStrategyConfig) -> Self {
+        let concurrency = config.concurrency.max(1);
+        let verifier = build_verifier(config.strict_host_key, config.known_hosts.clone());
+        let hosts: HashMap<String, HostState> = config
+            .targets
+            .iter()
+            .map(|t| {
+                (
+                    t.host_id(),
+                    HostState {
+                        target: t.clone(),
+                        session: None,
+                        transport: SshTransport::Unsupported,
+                        last_error: None,
+                        ever_connected: false,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            config,
+            hosts: Arc::new(Mutex::new(hosts)),
+            semaphore: Arc::new(Semaphore::new(concurrency)),
+            aggregator: DataAggregator::new(),
+            verifier,
+        }
+    }
+
+    /// Total target count — exposed for the runner to size the adaptive
+    /// interval against.
+    pub fn target_count(&self) -> usize {
+        self.config.targets.len()
+    }
+
+    /// Drive one collection tick across every configured SSH target.
+    async fn collect_all(&self) -> CollectionData {
+        let mut gpu_info = Vec::new();
+        let mut connection_statuses = Vec::new();
+
+        // Snapshot the current host map so we don't hold the lock while
+        // awaiting per-host futures.
+        let targets: Vec<SshTarget> = {
+            let hosts = self.hosts.lock().await;
+            hosts.values().map(|h| h.target.clone()).collect()
+        };
+
+        let mut handles = Vec::with_capacity(targets.len());
+        for target in targets {
+            let hosts = Arc::clone(&self.hosts);
+            let semaphore = Arc::clone(&self.semaphore);
+            let verifier = Arc::clone(&self.verifier);
+            let config = self.config.clone();
+            handles.push(tokio::spawn(async move {
+                collect_one_host(hosts, semaphore, verifier, config, target).await
+            }));
+        }
+
+        for handle in handles {
+            match handle.await {
+                Ok(Ok((gpus, status))) => {
+                    gpu_info.extend(gpus);
+                    connection_statuses.push(status);
+                }
+                Ok(Err((status,))) => {
+                    connection_statuses.push(status);
+                }
+                Err(join_err) => {
+                    tracing::warn!(error = %join_err, "ssh host task panicked");
+                }
+            }
+        }
+
+        CollectionData {
+            gpu_info,
+            cpu_info: Vec::new(),
+            memory_info: Vec::new(),
+            process_info: Vec::new(),
+            storage_info: Vec::new(),
+            chassis_info: Vec::new(),
+            vgpu_info: Vec::new(),
+            mig_info: Vec::new(),
+            connection_statuses,
+            remote_process_info: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl DataCollectionStrategy for SshStrategy {
+    async fn collect(&self, _config: &CollectionConfig) -> CollectionResult {
+        if self.config.targets.is_empty() {
+            return Err(CollectionError::Other("No SSH targets configured".into()));
+        }
+        Ok(self.collect_all().await)
+    }
+
+    async fn update_state(
+        &self,
+        app_state: Arc<Mutex<AppState>>,
+        data: CollectionData,
+        _config: &CollectionConfig,
+    ) {
+        let mut state = app_state.lock().await;
+
+        // Refresh tabs / known_hosts from the current SSH targets so
+        // the UI always shows every configured host even when one of
+        // them has not yet connected.
+        if state.known_hosts.is_empty() {
+            state.known_hosts = self.config.targets.iter().map(|t| t.host_id()).collect();
+        }
+
+        // Replace GPU info wholesale. SSH frames are complete each
+        // tick — there is no "partial update" semantics to honour.
+        state.gpu_info = data.gpu_info;
+        state.cpu_info = data.cpu_info;
+        state.memory_info = data.memory_info;
+        state.chassis_info = data.chassis_info;
+        state.vgpu_info = data.vgpu_info;
+        state.mig_info = data.mig_info;
+        state.storage_info = data.storage_info;
+        state.remote_process_info = Vec::new();
+        state.process_info = Vec::new();
+
+        // Update connection status per host.
+        state.hostname_to_host_id.clear();
+        for status in &data.connection_statuses {
+            if let Some(actual_hostname) = &status.actual_hostname {
+                state
+                    .hostname_to_host_id
+                    .insert(actual_hostname.clone(), status.host_id.clone());
+            }
+        }
+        for status in data.connection_statuses {
+            state
+                .connection_status
+                .insert(status.host_id.clone(), status);
+        }
+
+        // Rebuild the tab strip to match the current target list, using
+        // the same layout the RemoteCollector produces so the renderer
+        // need not special-case SSH mode.
+        let mut tabs = vec![
+            "All".to_string(),
+            crate::ui::tabs::USERS_TAB_NAME.to_string(),
+            crate::ui::tabs::TOPOLOGY_TAB_NAME.to_string(),
+        ];
+        tabs.extend(state.known_hosts.clone());
+        let previous_name = state.tabs.get(state.current_tab).cloned();
+        state.tabs = tabs;
+        if let Some(name) = previous_name
+            && let Some(idx) = state.tabs.iter().position(|t| *t == name)
+        {
+            state.current_tab = idx;
+        } else if state.current_tab >= state.tabs.len() {
+            state.current_tab = 0;
+        }
+
+        self.aggregator.update_utilization_history(&mut state);
+        self.aggregator.update_energy_counters(&mut state);
+
+        state.loading = false;
+        state.mark_collector_data_changed();
+    }
+
+    fn strategy_type(&self) -> &str {
+        "ssh"
+    }
+
+    async fn is_ready(&self) -> bool {
+        true
+    }
+}
+
+/// Per-host collection driver. Returns `Ok((gpus, status))` on success
+/// (status `is_connected = true`); returns `Err((status,))` when the
+/// host failed — the status carries the error chip the UI renders.
+async fn collect_one_host(
+    hosts: Arc<Mutex<HashMap<String, HostState>>>,
+    semaphore: Arc<Semaphore>,
+    verifier: Arc<dyn HostKeyVerifier>,
+    config: SshStrategyConfig,
+    target: SshTarget,
+) -> Result<(Vec<GpuInfo>, ConnectionStatus), (ConnectionStatus,)> {
+    let host_id = target.host_id();
+    let mut status = ConnectionStatus::new(host_id.clone(), target.display_label());
+    status.actual_hostname = Some(target.host.clone());
+    status.connection_state = Some("connecting".to_string());
+
+    // Does this host already have a session? If so, reuse it.
+    let existing = {
+        let hosts_guard = hosts.lock().await;
+        hosts_guard
+            .get(&host_id)
+            .and_then(|h| h.session.clone().map(|s| (s, h.transport)))
+    };
+
+    let (session, transport) = match existing {
+        Some((session, transport)) => (session, transport),
+        None => {
+            let _permit = match semaphore.acquire().await {
+                Ok(p) => p,
+                Err(_) => {
+                    status.mark_failure("ssh concurrency semaphore closed".into());
+                    return Err((status,));
+                }
+            };
+            // Re-check after acquiring the permit in case another task
+            // filled the session while we were waiting.
+            {
+                let hosts_guard = hosts.lock().await;
+                if let Some(h) = hosts_guard.get(&host_id)
+                    && let Some(s) = h.session.clone()
+                {
+                    drop(hosts_guard);
+                    let transport = lookup_transport(&hosts, &host_id).await;
+                    return exec_and_parse(&target, s, transport, status).await;
+                }
+            }
+
+            let params = ConnectParams {
+                target: target.clone(),
+                explicit_key: config.explicit_key.clone(),
+                strict_host_key: config.strict_host_key,
+                connect_timeout: config.connect_timeout,
+                inactivity: crate::network::ssh_client::DEFAULT_INACTIVITY,
+                known_hosts: config.known_hosts.clone(),
+            };
+
+            match SshSession::connect(params, Arc::clone(&verifier)).await {
+                Ok(session) => {
+                    let transport = probe_transport(&session, &config.fallback_policy).await;
+                    let mut hosts_guard = hosts.lock().await;
+                    if let Some(h) = hosts_guard.get_mut(&host_id) {
+                        h.session = Some(session.clone());
+                        h.transport = transport;
+                        h.last_error = None;
+                        h.ever_connected = true;
+                    }
+                    (session, transport)
+                }
+                Err(e) => {
+                    let label = e.ui_label();
+                    let mut hosts_guard = hosts.lock().await;
+                    if let Some(h) = hosts_guard.get_mut(&host_id) {
+                        h.last_error = Some(e.to_string());
+                    }
+                    status.mark_failure(format!("{label}: {e}"));
+                    return Err((status,));
+                }
+            }
+        }
+    };
+
+    exec_and_parse(&target, session, transport, status).await
+}
+
+async fn lookup_transport(
+    hosts: &Arc<Mutex<HashMap<String, HostState>>>,
+    host_id: &str,
+) -> SshTransport {
+    let hosts_guard = hosts.lock().await;
+    hosts_guard
+        .get(host_id)
+        .map(|h| h.transport)
+        .unwrap_or(SshTransport::Unsupported)
+}
+
+/// Run `all-smi --version` + optional shim `--version` probes over the
+/// already-open SSH session and pick the best transport per the
+/// decision tree.
+async fn probe_transport(session: &SshSession, policy: &SshFallbackPolicy) -> SshTransport {
+    let mut outcomes = ProbeOutcomes::default();
+
+    // Native probe — bounded to 2 seconds.
+    match session
+        .exec_with_timeout(NATIVE_VERSION_CMD, Duration::from_secs(2))
+        .await
+    {
+        Ok(out) if out.is_success() => {
+            outcomes.native = if native_supported(out.stdout.lines().next().unwrap_or("")) {
+                ProbeResult::Available
+            } else {
+                tracing::info!(
+                    min_major = MIN_NATIVE_VERSION.0,
+                    min_minor = MIN_NATIVE_VERSION.1,
+                    "remote all-smi version too old; falling back to shim"
+                );
+                ProbeResult::NotAvailable
+            };
+        }
+        _ => {
+            outcomes.native = ProbeResult::NotAvailable;
+        }
+    }
+
+    if outcomes.native == ProbeResult::Available {
+        return SshTransport::Native;
+    }
+
+    if policy.try_nvidia_smi {
+        outcomes.nvidia_smi = probe_simple(session, "nvidia-smi --version").await;
+    }
+    if policy.try_rocm_smi {
+        outcomes.rocm_smi = probe_simple(session, "rocm-smi --version").await;
+    }
+
+    select_transport(&outcomes, policy)
+}
+
+async fn probe_simple(session: &SshSession, cmd: &str) -> ProbeResult {
+    match session.exec_with_timeout(cmd, Duration::from_secs(2)).await {
+        Ok(out) if out.is_success() && !out.stdout.trim().is_empty() => ProbeResult::Available,
+        Ok(_) => ProbeResult::NotAvailable,
+        Err(_) => ProbeResult::NotAvailable,
+    }
+}
+
+async fn exec_and_parse(
+    target: &SshTarget,
+    session: SshSession,
+    transport: SshTransport,
+    mut status: ConnectionStatus,
+) -> Result<(Vec<GpuInfo>, ConnectionStatus), (ConnectionStatus,)> {
+    status.transport_chip = Some(transport.chip_label().to_string());
+    let timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+    let cmd = match transport {
+        SshTransport::Native => NATIVE_SNAPSHOT_CMD,
+        SshTransport::NvidiaSmi => NVIDIA_SMI_COMMAND,
+        SshTransport::RocmSmi => ROCM_SMI_COMMAND,
+        SshTransport::Unsupported => {
+            status.mark_success();
+            status.last_error = Some("unsupported: no all-smi, nvidia-smi, or rocm-smi".into());
+            return Ok((Vec::new(), status));
+        }
+    };
+
+    let output = match session.exec(cmd).await {
+        Ok(o) => o,
+        Err(e) => {
+            status.mark_failure(format!("{}: {e}", e.ui_label()));
+            return Err((status,));
+        }
+    };
+
+    if !output.is_success() {
+        status.mark_failure(format!(
+            "exit {:?}: {}",
+            output.exit_status,
+            truncate(&output.stderr, 240)
+        ));
+        return Err((status,));
+    }
+
+    let host_id = target.host_id();
+    let hostname = target.hostname();
+    let gpus = match transport {
+        SshTransport::Native => parse_native_snapshot(&output, &host_id, hostname, &timestamp),
+        SshTransport::NvidiaSmi => {
+            parse_nvidia_smi_csv(&output.stdout, &host_id, hostname, &timestamp).map_err(|e| {
+                tracing::warn!(host = %hostname, error = %e, "nvidia-smi parse failure");
+                format!("nvidia-smi parse: {e}")
+            })
+        }
+        SshTransport::RocmSmi => {
+            parse_rocm_smi_json(&output.stdout, &host_id, hostname, &timestamp).map_err(|e| {
+                tracing::warn!(host = %hostname, error = %e, "rocm-smi parse failure");
+                format!("rocm-smi parse: {e}")
+            })
+        }
+        SshTransport::Unsupported => Ok(Vec::new()),
+    };
+
+    match gpus {
+        Ok(gpus) => {
+            status.mark_success();
+            Ok((gpus, status))
+        }
+        Err(e) => {
+            status.mark_failure(e);
+            Err((status,))
+        }
+    }
+}
+
+/// Parse the native `all-smi snapshot --format json` output. The
+/// snapshot sets hostnames / host_ids per the remote machine, but we
+/// re-label them to the SSH host identifier so the tab routing stays
+/// consistent.
+fn parse_native_snapshot(
+    output: &ExecOutput,
+    host_id: &str,
+    hostname: &str,
+    timestamp: &str,
+) -> Result<Vec<GpuInfo>, String> {
+    let snap: Snapshot =
+        serde_json::from_str(&output.stdout).map_err(|e| format!("native snapshot JSON: {e}"))?;
+    let mut gpus = snap.gpus.unwrap_or_default();
+    for gpu in &mut gpus {
+        gpu.host_id = host_id.to_string();
+        gpu.hostname = hostname.to_string();
+        gpu.time = timestamp.to_string();
+        gpu.detail
+            .insert("transport".to_string(), "ssh/native".to_string());
+    }
+    Ok(gpus)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut out = s[..max.min(s.len())].to_string();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(user: &str, host: &str, port: u16) -> SshTarget {
+        SshTarget {
+            user: user.to_string(),
+            host: host.to_string(),
+            port,
+        }
+    }
+
+    #[test]
+    fn strategy_new_stores_targets_unchanged() {
+        let cfg = SshStrategyConfig {
+            targets: vec![target("a", "h1", 22), target("b", "h2", 2222)],
+            explicit_key: None,
+            strict_host_key: StrictHostKey::Yes,
+            known_hosts: None,
+            connect_timeout: Duration::from_secs(5),
+            fallback_policy: SshFallbackPolicy::default(),
+            concurrency: 16,
+        };
+        let strat = SshStrategy::new(cfg);
+        assert_eq!(strat.target_count(), 2);
+    }
+
+    #[test]
+    fn truncate_shortens_long_strings() {
+        let long = "x".repeat(500);
+        let out = truncate(&long, 10);
+        assert!(out.len() <= 20);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_preserves_short_strings() {
+        assert_eq!(truncate("abc", 10), "abc");
+    }
+
+    #[tokio::test]
+    async fn collect_empty_targets_errors() {
+        let cfg = SshStrategyConfig {
+            targets: Vec::new(),
+            explicit_key: None,
+            strict_host_key: StrictHostKey::Yes,
+            known_hosts: None,
+            connect_timeout: Duration::from_secs(5),
+            fallback_policy: SshFallbackPolicy::default(),
+            concurrency: 4,
+        };
+        let strat = SshStrategy::new(cfg);
+        let result = strat.collect(&CollectionConfig::default()).await;
+        match result {
+            Err(CollectionError::Other(s)) => {
+                assert!(s.contains("No SSH targets"));
+            }
+            Err(other) => panic!("expected Other err, got {other:?}"),
+            Ok(_) => panic!("expected err, got Ok"),
+        }
+    }
+}

--- a/src/view/data_collection/ssh_strategy.rs
+++ b/src/view/data_collection/ssh_strategy.rs
@@ -307,7 +307,7 @@ async fn collect_one_host(
                 {
                     drop(hosts_guard);
                     let transport = lookup_transport(&hosts, &host_id).await;
-                    return exec_and_parse(&target, s, transport, status).await;
+                    return exec_and_parse(&hosts, &target, s, transport, status).await;
                 }
             }
 
@@ -345,7 +345,7 @@ async fn collect_one_host(
         }
     };
 
-    exec_and_parse(&target, session, transport, status).await
+    exec_and_parse(&hosts, &target, session, transport, status).await
 }
 
 async fn lookup_transport(
@@ -410,6 +410,7 @@ async fn probe_simple(session: &SshSession, cmd: &str) -> ProbeResult {
 }
 
 async fn exec_and_parse(
+    hosts: &Arc<Mutex<HashMap<String, HostState>>>,
     target: &SshTarget,
     session: SshSession,
     transport: SshTransport,
@@ -432,12 +433,17 @@ async fn exec_and_parse(
     let output = match session.exec(cmd).await {
         Ok(o) => o,
         Err(e) => {
+            // Clear the cached session so the next tick will
+            // reconnect rather than keep poking at a dead socket.
+            clear_cached_session(hosts, &target.host_id()).await;
             status.mark_failure(format!("{}: {e}", e.ui_label()));
             return Err((status,));
         }
     };
 
     if !output.is_success() {
+        // A non-zero exit is most often a local issue (missing binary,
+        // wrong sudo, etc.) — do NOT invalidate the session for that.
         status.mark_failure(format!(
             "exit {:?}: {}",
             output.exit_status,
@@ -504,9 +510,28 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_string();
     }
-    let mut out = s[..max.min(s.len())].to_string();
+    // Slice on a char boundary so multi-byte stderr (e.g. remotes that
+    // emit non-ASCII error messages) cannot panic the view loop.
+    let mut end = 0;
+    for (idx, _) in s.char_indices() {
+        if idx > max {
+            break;
+        }
+        end = idx;
+    }
+    let mut out = s[..end].to_string();
     out.push('…');
     out
+}
+
+/// Clear the cached [`SshSession`] for `host_id`. Called after an exec
+/// that failed with a transport-level error so the next tick opens a
+/// fresh connection rather than retrying a dead session.
+async fn clear_cached_session(hosts: &Arc<Mutex<HashMap<String, HostState>>>, host_id: &str) {
+    let mut hosts_guard = hosts.lock().await;
+    if let Some(h) = hosts_guard.get_mut(host_id) {
+        h.session = None;
+    }
 }
 
 #[cfg(test)]
@@ -547,6 +572,19 @@ mod tests {
     #[test]
     fn truncate_preserves_short_strings() {
         assert_eq!(truncate("abc", 10), "abc");
+    }
+
+    #[test]
+    fn truncate_does_not_panic_on_multibyte_boundary() {
+        // Each `é` is two bytes in UTF-8.  Requesting a cut at a
+        // byte index that lands in the middle of a character used to
+        // panic; the fix walks `char_indices` so the cut always lands
+        // on a valid boundary.
+        let s = "éééééééé";
+        let out = truncate(s, 3);
+        assert!(out.ends_with('…'));
+        // Make sure the truncated portion is valid UTF-8.
+        assert!(out.is_char_boundary(out.len()));
     }
 
     #[tokio::test]

--- a/src/view/data_collector.rs
+++ b/src/view/data_collector.rs
@@ -25,7 +25,7 @@ use crate::ui::notification::NotificationType;
 
 // Re-export for backward compatibility
 pub use super::data_collection::{
-    CollectionConfig, DataCollectionStrategy, LocalCollector, RemoteCollectorBuilder,
+    CollectionConfig, DataCollectionStrategy, LocalCollector, RemoteCollectorBuilder, SshStrategy,
 };
 
 pub struct DataCollector {
@@ -323,6 +323,45 @@ impl DataCollector {
             let interval = args
                 .interval
                 .unwrap_or_else(|| EnvConfig::adaptive_interval(hosts_list.len()));
+            tokio::time::sleep(Duration::from_secs(interval)).await;
+        }
+    }
+
+    /// Drive the SSH transport (`view --ssh`, issue #194).
+    ///
+    /// The caller supplies a fully-constructed [`SshStrategy`]; this
+    /// method owns the collection loop (polling + sleep), the
+    /// `AppState` update, and the alert-evaluation wiring.  Separating
+    /// strategy construction from the loop keeps the runner's CLI
+    /// parsing simple and prevents a misconfigured `--ssh-*` flag from
+    /// having to be revalidated on every tick.
+    pub async fn run_ssh_mode(&self, args: ViewArgs, strategy: std::sync::Arc<SshStrategy>) {
+        let target_count = strategy.target_count();
+        loop {
+            let config = CollectionConfig {
+                interval: args
+                    .interval
+                    .unwrap_or_else(|| EnvConfig::adaptive_interval(target_count.max(1))),
+                first_iteration: false,
+                hosts: Vec::new(),
+            };
+
+            match strategy.collect(&config).await {
+                Ok(data) => {
+                    strategy
+                        .update_state(self.app_state.clone(), data, &config)
+                        .await;
+                    self.notify_ui();
+                    self.evaluate_alerts().await;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "ssh collect failed");
+                }
+            }
+
+            let interval = args
+                .interval
+                .unwrap_or_else(|| EnvConfig::adaptive_interval(target_count.max(1)));
             tokio::time::sleep(Duration::from_secs(interval)).await;
         }
     }

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -1322,17 +1322,7 @@ mod tests {
     }
 
     fn args() -> ViewArgs {
-        ViewArgs {
-            hosts: None,
-            hostfile: None,
-            interval: None,
-            alert_temp: None,
-            alert_util_low_mins: None,
-            replay: None,
-            speed: 1.0,
-            start: None,
-            replay_loop: false,
-        }
+        ViewArgs::empty()
     }
 
     #[tokio::test]

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -988,17 +988,7 @@ mod tests {
     use crate::view::render_snapshot::RenderSnapshot;
 
     fn make_local_args() -> ViewArgs {
-        ViewArgs {
-            hosts: None,
-            hostfile: None,
-            interval: None,
-            alert_temp: None,
-            alert_util_low_mins: None,
-            replay: None,
-            speed: 1.0,
-            start: None,
-            replay_loop: false,
-        }
+        ViewArgs::empty()
     }
 
     fn make_snapshot() -> RenderSnapshot {

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -86,15 +86,10 @@ pub async fn run_local_mode(args: &LocalArgs, settings: &Settings) {
     let data_collector =
         DataCollector::with_notify(Arc::clone(&app_state), Arc::clone(&data_notify));
     let view_args = ViewArgs {
-        hosts: None,
-        hostfile: None,
         interval: args.interval,
         alert_temp: args.alert_temp,
         alert_util_low_mins: args.alert_util_low_mins,
-        replay: None,
-        speed: 1.0,
-        start: None,
-        replay_loop: false,
+        ..ViewArgs::empty()
     };
     tokio::spawn(async move {
         data_collector.run_local_mode(view_args).await;
@@ -114,15 +109,10 @@ pub async fn run_local_mode(args: &LocalArgs, settings: &Settings) {
 
     // Create ViewArgs again for UI loop
     let view_args = ViewArgs {
-        hosts: None,
-        hostfile: None,
         interval: args.interval,
         alert_temp: args.alert_temp,
         alert_util_low_mins: args.alert_util_low_mins,
-        replay: None,
-        speed: 1.0,
-        start: None,
-        replay_loop: false,
+        ..ViewArgs::empty()
     };
     if let Err(e) = ui_loop.run(&view_args).await {
         eprintln!("UI loop error: {e}");
@@ -251,6 +241,114 @@ pub async fn run_replay_mode(args: &ViewArgs, settings: &Settings) {
     }
 
     driver_handle.abort();
+}
+
+/// Enter TUI with the agentless SSH transport (issue #194).
+///
+/// Unlike `run_view_mode`, this path does NOT need a pre-existing
+/// `all-smi api` to be running on each target — it opens an SSH
+/// session per target and runs `all-smi snapshot` (native) or
+/// falls back to `nvidia-smi` / `rocm-smi` per
+/// `--ssh-fallback`. Returns early with a user-facing error when
+/// neither `--ssh` nor `--ssh-hostfile` produced a non-empty
+/// target list.
+pub async fn run_ssh_mode(args: &ViewArgs, settings: &Settings) {
+    use std::time::Duration;
+
+    use crate::network::ssh_target::{parse_hostfile, parse_ssh_arg};
+    use crate::network::ssh_transport::{SshFallbackPolicy, StrictHostKey};
+    use crate::view::data_collection::{SshStrategy, SshStrategyConfig};
+
+    let mut targets = Vec::new();
+    if let Some(raw) = args.ssh.as_deref() {
+        match parse_ssh_arg(raw) {
+            Ok(mut t) => targets.append(&mut t),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return;
+            }
+        }
+    }
+    if let Some(path) = args.ssh_hostfile.as_deref() {
+        match parse_hostfile(path) {
+            Ok(mut t) => targets.append(&mut t),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return;
+            }
+        }
+    }
+
+    if targets.is_empty() {
+        eprintln!("error: --ssh and --ssh-hostfile produced no SSH targets");
+        return;
+    }
+
+    let strict_host_key = match StrictHostKey::from_cli(&args.ssh_strict_host_key) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return;
+        }
+    };
+
+    let fallback_policy = match SshFallbackPolicy::from_cli(args.ssh_fallback.as_deref()) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return;
+        }
+    };
+
+    let strategy_config = SshStrategyConfig {
+        targets,
+        explicit_key: args.ssh_key.clone(),
+        strict_host_key,
+        known_hosts: args.ssh_known_hosts.clone(),
+        connect_timeout: Duration::from_secs(args.ssh_timeout_secs.max(1)),
+        fallback_policy,
+        concurrency: args.ssh_concurrency.max(1),
+    };
+
+    let strategy = Arc::new(SshStrategy::new(strategy_config));
+
+    let mut initial_state = AppState::with_energy_config(&settings.energy);
+    initial_state.is_local_mode = false;
+    let alert_config = build_alert_config(settings, args.alert_temp, args.alert_util_low_mins);
+    initial_state.alerter = Alerter::new(alert_config);
+    initial_state.display_config = settings.display.clone();
+    let app_state = Arc::new(Mutex::new(initial_state));
+
+    let data_notify = Arc::new(Notify::new());
+
+    let _terminal_manager = match TerminalManager::new() {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Failed to initialize terminal: {e}");
+            return;
+        }
+    };
+
+    let data_collector =
+        DataCollector::with_notify(Arc::clone(&app_state), Arc::clone(&data_notify));
+    let args_clone = args.clone();
+    let strategy_clone = Arc::clone(&strategy);
+    tokio::spawn(async move {
+        data_collector
+            .run_ssh_mode(args_clone, strategy_clone)
+            .await;
+    });
+
+    let mut ui_loop = match UiLoop::new(app_state, data_notify) {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("Failed to initialize UI: {e}");
+            return;
+        }
+    };
+    if let Err(e) = ui_loop.run(args).await {
+        eprintln!("UI loop error: {e}");
+    }
 }
 
 pub async fn run_view_mode(args: &ViewArgs, settings: &Settings) {

--- a/tests/ssh_transport_integration.rs
+++ b/tests/ssh_transport_integration.rs
@@ -1,0 +1,155 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! End-to-end integration coverage for the SSH transport (issue #194).
+//!
+//! These tests exercise the pure-data path: parser → decision tree →
+//! connection status. They deliberately do NOT require a running
+//! sshd (that would make the suite slow and flaky); the SSH client
+//! itself is covered by the unit tests inside
+//! `src/network/ssh_client.rs`.
+
+use all_smi::app_state::ConnectionStatus;
+use all_smi::network::nvidia_smi_shim::parse_nvidia_smi_csv;
+use all_smi::network::rocm_smi_shim::parse_rocm_smi_json;
+use all_smi::network::ssh_decision::{ProbeOutcomes, ProbeResult, select_transport};
+use all_smi::network::ssh_target::{parse_hostfile_content, parse_ssh_arg};
+use all_smi::network::ssh_transport::{SshFallbackPolicy, SshTransport};
+
+#[test]
+fn end_to_end_nvidia_smi_pipeline() {
+    // The SSH strategy runs this exact CSV through the parser, then
+    // publishes the resulting `GpuInfo` vector into AppState. Assert
+    // that the end-to-end shape is what the renderer expects.
+    let csv = "0, GPU-abc, A100, 550.54, 95, 70000, 81920, 72, 1410, 350.0\n";
+    let gpus = parse_nvidia_smi_csv(csv, "ops@dgx01:22", "dgx01", "2026-04-20T00:00:00Z")
+        .expect("golden csv must parse");
+    assert_eq!(gpus.len(), 1);
+    assert_eq!(gpus[0].hostname, "dgx01");
+    assert_eq!(gpus[0].uuid, "GPU-abc");
+    assert_eq!(gpus[0].utilization, 95.0);
+}
+
+#[test]
+fn end_to_end_rocm_smi_pipeline() {
+    let json = r#"{
+        "card0": {
+            "GPU use (%)": "90",
+            "VRAM Total Memory (B)": "1024",
+            "VRAM Total Used Memory (B)": "512",
+            "Temperature (Sensor edge) (C)": "60",
+            "Average Graphics Package Power (W)": "200",
+            "Card series": "MI250X",
+            "Unique ID": "0x01"
+        }
+    }"#;
+    let gpus = parse_rocm_smi_json(json, "ops@amd01:22", "amd01", "2026-04-20T00:00:00Z").unwrap();
+    assert_eq!(gpus.len(), 1);
+    assert_eq!(gpus[0].uuid, "0x01");
+    assert_eq!(gpus[0].utilization, 90.0);
+}
+
+#[test]
+fn decision_tree_picks_native_over_fallbacks() {
+    let policy = SshFallbackPolicy {
+        try_nvidia_smi: true,
+        try_rocm_smi: true,
+    };
+    let outcomes = ProbeOutcomes {
+        native: ProbeResult::Available,
+        nvidia_smi: ProbeResult::Available,
+        rocm_smi: ProbeResult::Available,
+    };
+    assert_eq!(select_transport(&outcomes, &policy), SshTransport::Native);
+}
+
+#[test]
+fn decision_tree_skips_nvidia_when_policy_disables_it() {
+    let policy = SshFallbackPolicy {
+        try_nvidia_smi: false,
+        try_rocm_smi: true,
+    };
+    let outcomes = ProbeOutcomes {
+        native: ProbeResult::NotAvailable,
+        nvidia_smi: ProbeResult::Available,
+        rocm_smi: ProbeResult::Available,
+    };
+    assert_eq!(select_transport(&outcomes, &policy), SshTransport::RocmSmi);
+}
+
+#[test]
+fn hostfile_with_comments_and_ports_round_trips() {
+    let content = "\
+# bastion
+admin@gw:2200
+# dgx cluster
+admin@dgx-01
+admin@dgx-02:22 # default port
+";
+    let targets = parse_hostfile_content(content).unwrap();
+    assert_eq!(targets.len(), 3);
+    assert_eq!(targets[0].host, "gw");
+    assert_eq!(targets[0].port, 2200);
+    assert_eq!(targets[1].port, 22);
+    assert_eq!(targets[2].port, 22);
+}
+
+#[test]
+fn cli_arg_and_hostfile_combine() {
+    // `parse_ssh_arg` and `parse_hostfile_content` both produce the
+    // same `SshTarget` type so the caller can concatenate them.
+    let cli = parse_ssh_arg("user@a").unwrap();
+    let file = parse_hostfile_content("# file\nuser@b:2222\n").unwrap();
+    let mut merged = cli;
+    merged.extend(file);
+    assert_eq!(merged.len(), 2);
+    assert_eq!(merged[0].host, "a");
+    assert_eq!(merged[1].host, "b");
+    assert_eq!(merged[1].port, 2222);
+}
+
+#[test]
+fn connection_errors_produce_typed_chips() {
+    // Acceptance criterion: connection errors (timeout, auth fail,
+    // host key mismatch) surface as per-host state, never a crash.
+    let mut cs = ConnectionStatus::new("u@h:22".into(), "ssh://u@h".into());
+
+    cs.mark_failure("auth-failed: SSH authentication failed for u@h:22".into());
+    assert_eq!(cs.connection_state.as_deref(), Some("auth-failed"));
+
+    cs.mark_failure("timeout: SSH connect timeout after 10s".into());
+    assert_eq!(cs.connection_state.as_deref(), Some("timeout"));
+
+    cs.mark_failure("host-key-rejected: host key not trusted".into());
+    assert_eq!(cs.connection_state.as_deref(), Some("host-key-rejected"));
+
+    // Any other error lands as "disconnected".
+    cs.mark_failure("disconnected: TCP stream closed".into());
+    assert_eq!(cs.connection_state.as_deref(), Some("disconnected"));
+
+    // Recovery path.
+    cs.mark_success();
+    assert_eq!(cs.connection_state.as_deref(), Some("connected"));
+    assert!(cs.is_connected);
+}
+
+#[test]
+fn transport_chip_string_labels_stable_for_ui() {
+    // The TUI renders these strings verbatim; any change here is a
+    // breaking UI contract change.
+    assert_eq!(SshTransport::Native.chip_label(), "native");
+    assert_eq!(SshTransport::NvidiaSmi.chip_label(), "nvidia-smi");
+    assert_eq!(SshTransport::RocmSmi.chip_label(), "rocm-smi");
+    assert_eq!(SshTransport::Unsupported.chip_label(), "unsupported");
+}


### PR DESCRIPTION
## Summary

Add an SSH-based transport to `all-smi view` so operators can monitor remote hosts **without** first installing `all-smi api` on each target. On first connect the strategy probes each host: native `all-smi snapshot --format json` is preferred when the binary is present and at least v0.22; otherwise it falls back to parsing `nvidia-smi --query-gpu=... --format=csv,noheader,nounits` or `rocm-smi ... --json`. Unsupported hosts remain tab-visible with a status chip so operators can immediately see what changed.

New `view` CLI flags:

| Flag | Default | Notes |
| --- | --- | --- |
| `--ssh user@host[:port][,...]` | — | Comma-separated SSH targets. |
| `--ssh-hostfile <path>` | — | One `user@host[:port]` per line; `#` comments allowed. |
| `--ssh-key <path>` | auto-probe | Overrides agent / `~/.ssh/id_*` probe order. |
| `--ssh-strict-host-key yes\|accept-new\|no` | `yes` | OpenSSH-equivalent semantics. |
| `--ssh-timeout-secs <n>` | `10` | Per-target TCP/handshake timeout. |
| `--ssh-fallback nvidia-smi,rocm-smi,none` | both enabled | Which shim(s) to try when `all-smi` is absent. |
| `--ssh-known-hosts <path>` | `~/.ssh/known_hosts` | Custom known-hosts file. |
| `--ssh-concurrency <n>` | `32` | Bound on concurrent SSH connects (semaphore-limited). |

## Implementation

- `russh = 0.60` (pure Rust, musl-friendly) for the SSH client.
- New modules under `src/network/`:
  `ssh_client`, `ssh_host_key`, `ssh_target`, `ssh_decision`,
  `ssh_transport`, `nvidia_smi_shim`, `rocm_smi_shim`.
- `SshStrategy` (`src/view/data_collection/ssh_strategy.rs`) is a new
  `DataCollectionStrategy` parallel to the existing Local/Remote
  strategies. Per tick it snapshots the kept-alive session, runs the
  pinned command, parses the output, and publishes a
  `CollectionData` frame into `AppState`.
- `ConnectionStatus` gains `transport_chip` + `connection_state` fields
  so the TUI tabs render `native` / `nvidia-smi` / `rocm-smi` /
  `unsupported` chips and `connecting` / `connected` / `auth-failed` /
  `timeout` / `host-key-rejected` / `disconnected` states.
- `main.rs` routes `--ssh*` flags to the new `run_ssh_mode`, ahead of
  the existing HTTP `view` path.
- `[view]` TOML section learns `ssh`, `ssh_hostfile`, `ssh_key`,
  `ssh_config`, `ssh_strict_host_key`, `ssh_timeout_secs`,
  `ssh_fallback`, `ssh_known_hosts`, `ssh_concurrency` keys with the
  documented CLI > env > file > default precedence chain.
- Help screen (`H`) and `README.md` gain an Agentless SSH section.

Security posture:

- Password auth is never attempted. Only key / agent auth is
  supported. No password bytes flow through the CLI or logs.
- `--ssh-strict-host-key=no` emits a prominent warning log on every
  accept.
- `accept-new` persists new keys to the known_hosts file and rejects
  subsequent mismatches.

## Testing

- `cargo test --lib` — 988 passed
- `cargo test --bin all-smi` — 1123 passed
- `cargo test --tests` — 11 passed (8 new SSH integration tests)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Unit coverage includes: hostfile parsing (comments, port suffixes,
IPv6 brackets), nvidia-smi CSV golden file, rocm-smi JSON golden
file, transport selection decision tree, strict-host-key policy
parsing, ConnectionStatus chip classification for every error kind.

Integration: `tests/ssh_transport_integration.rs` asserts the full
parser -> decision tree -> connection status pipeline.

## Test plan

- [ ] Run `all-smi view --ssh user@localhost` against a local sshd to validate the `native` path.
- [ ] Run against a box without `all-smi` but with `nvidia-smi` to validate the CSV shim.
- [ ] Run against a box with `rocm-smi` only to validate the JSON shim.
- [ ] Validate `--ssh-strict-host-key=accept-new` writes to the known hosts file on first connect and refuses a modified key.
- [ ] Musl CI: validate `x86_64-unknown-linux-musl` build in CI.

Closes #194