### PR TITLE
fix: pin libamdgpu_top to =0.11.4 and rename get_all_proc_usage call (#205)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,9 +2426,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libamdgpu_top"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b5ef5a4117127f6e5b608426f067d124cde754b07127e1fd4199f22deb5041"
+checksum = "767e7df82c1bba462f6093a4b611ac59b33a768290cd8c7fdb32a5b8cb8ec013"
 dependencies = [
  "libdrm_amdgpu_sys",
  "nix 0.31.2",
@@ -2443,9 +2443,9 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libdrm_amdgpu_sys"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f473858086180a3190991b49129a459b038494f1d4886c9a464d55b2fe1b3a21"
+checksum = "380c3cfe531e0237f58a16c75710b17eaa006614c6ab115efa921ac8b019c25b"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,9 @@ libloading = "0.9"
 
 # AMD GPU support (glibc only, not compatible with musl static linking)
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
-libamdgpu_top = "0.11.3"
+# Pinned exactly: 0.11.4 renamed get_all_proc_usage → update_proc_usage in a
+# patch bump (issue #205). Re-evaluate when bumping.
+libamdgpu_top = "=0.11.4"
 
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl = { version = "0.10.75", features = ["vendored"] }

--- a/src/device/readers/amd.rs
+++ b/src/device/readers/amd.rs
@@ -569,7 +569,7 @@ impl GpuReader for AmdGpuReader {
 
             // Get fdinfo usage for all processes
             let mut fdinfo = FdInfoStat::default();
-            fdinfo.get_all_proc_usage(&proc_index);
+            fdinfo.update_proc_usage(&proc_index);
 
             // Collect process data
             for proc_usage in fdinfo.proc_usage {


### PR DESCRIPTION
## Summary

Fixes build failure caused by `libamdgpu_top` 0.11.4 renaming
`FdInfoStat::get_all_proc_usage` → `FdInfoStat::update_proc_usage` in a
patch release. Cargo's caret resolution for `"0.11.3"` silently picks up
0.11.4, breaking all Linux glibc fresh builds.

Closes #205

## Changes

1. **`Cargo.toml`**: Changed `libamdgpu_top = "0.11.3"` to
   `libamdgpu_top = "=0.11.4"` (exact pin) under the Linux-glibc target
   table, with a comment explaining the reason for pinning.
2. **`src/device/readers/amd.rs` line 572**: Renamed
   `fdinfo.get_all_proc_usage(&proc_index)` →
   `fdinfo.update_proc_usage(&proc_index)` — the only call site.
3. **`Cargo.lock`**: Regenerated via
   `cargo update -p libamdgpu_top --precise 0.11.4`.

## Verification Results

| Check | Result |
|-------|--------|
| `cargo build --release` | PASSED (macOS) |
| `cargo fmt --check` | PASSED |
| `cargo clippy --all-targets -- -D warnings` | Pre-existing failures in `src/doctor/checks/{amd,furiosa,gaudi,privileges}.rs` — 7 unused-import warnings exist identically on `main` before this PR; not introduced by this change. |
| `cargo test` | PASSED (21 passed, 14 ignored) |
| `grep -rn get_all_proc_usage src/` | Returns zero matches — call site fully renamed |
| Linux `cargo check` (AMD target) | Requires CI — AMD reader is gated by `cfg(all(target_os = "linux", not(target_env = "musl")))` and cannot compile on macOS. Final AMD-target verification depends on CI. |

## Notes

- The exact-pin (`=0.11.4`) prevents future upstream patch surprises from
  silently breaking the build again. Re-evaluate the pin when bumping to a
  new `libamdgpu_top` minor and verifying the API surface.
- A patch release (e.g., `0.20.2`) should follow merge so downstream
  library consumers can pick up the fix without waiting for the next minor
  release.