### PR TITLE
fix: remove unused imports in doctor checks modules

### DIFF
--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -14,6 +14,11 @@
 
 //! `amd.*` checks — ROCm, libamdgpu_top, DRI access, musl-build gating.
 
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use crate::doctor::exec::try_exec;
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&ROCM_VERSION, &LIBAMDGPU_TOP_ABI, &DRI_PERMS, &MUSL_GATE];

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -14,9 +14,6 @@
 
 //! `amd.*` checks — ROCm, libamdgpu_top, DRI access, musl-build gating.
 
-use std::time::Duration;
-
-use crate::doctor::exec::try_exec;
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&ROCM_VERSION, &LIBAMDGPU_TOP_ABI, &DRI_PERMS, &MUSL_GATE];

--- a/src/doctor/checks/furiosa.rs
+++ b/src/doctor/checks/furiosa.rs
@@ -14,6 +14,8 @@
 
 //! `furiosa.*` checks — feature flag enabled, furiosa-smi binary.
 
+#[cfg(target_os = "linux")]
+use crate::doctor::exec::which;
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&FEATURE, &SMI];

--- a/src/doctor/checks/furiosa.rs
+++ b/src/doctor/checks/furiosa.rs
@@ -14,7 +14,6 @@
 
 //! `furiosa.*` checks — feature flag enabled, furiosa-smi binary.
 
-use crate::doctor::exec::which;
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&FEATURE, &SMI];

--- a/src/doctor/checks/gaudi.rs
+++ b/src/doctor/checks/gaudi.rs
@@ -14,9 +14,6 @@
 
 //! `gaudi.*` checks — hl-smi presence, HL device nodes, driver version.
 
-use std::time::Duration;
-
-use crate::doctor::exec::{try_exec, which};
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&HLSMI_BINARY, &DEVICE_NODES, &DRIVER];

--- a/src/doctor/checks/gaudi.rs
+++ b/src/doctor/checks/gaudi.rs
@@ -14,6 +14,11 @@
 
 //! `gaudi.*` checks — hl-smi presence, HL device nodes, driver version.
 
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use crate::doctor::exec::{try_exec, which};
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&HLSMI_BINARY, &DEVICE_NODES, &DRIVER];

--- a/src/doctor/checks/privileges.rs
+++ b/src/doctor/checks/privileges.rs
@@ -16,9 +16,6 @@
 //! node access. Windows is a structural skip because the UNIX uid/gid
 //! model does not translate.
 
-use std::time::Duration;
-
-use crate::doctor::exec::try_exec;
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&USER, &ROOT, &VIDEO_RENDER, &DEV_DRI, &DEV_TENSTORRENT];

--- a/src/doctor/checks/privileges.rs
+++ b/src/doctor/checks/privileges.rs
@@ -16,6 +16,11 @@
 //! node access. Windows is a structural skip because the UNIX uid/gid
 //! model does not translate.
 
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use crate::doctor::exec::try_exec;
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
 static CHECKS: &[&Check] = &[&USER, &ROOT, &VIDEO_RENDER, &DEV_DRI, &DEV_TENSTORRENT];


### PR DESCRIPTION
## Summary

- Remove unused imports across doctor check modules to silence build warnings
- Affects `amd.rs`, `furiosa.rs`, `gaudi.rs`, and `privileges.rs`

## Removed Imports

- `src/doctor/checks/amd.rs`: `std::time::Duration`, `crate::doctor::exec::try_exec`
- `src/doctor/checks/furiosa.rs`: `crate::doctor::exec::which`
- `src/doctor/checks/gaudi.rs`: `std::time::Duration`, `crate::doctor::exec::{try_exec, which}`
- `src/doctor/checks/privileges.rs`: `std::time::Duration`, `crate::doctor::exec::try_exec`

## Test plan

- [x] `cargo build --release` produces no warnings
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes