### PR TITLE
docs: document Energy Session config in TUI help, --help, and manpage

### DIFF
--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -233,6 +233,54 @@ http://node002:9090
 https://node003:9443
 .fi
 .RE
+.SH ENERGY ACCOUNTING
+The Energy Session panel integrates instantaneous power draw over time
+to report cumulative energy consumption (kWh) and an optional cost
+estimate ($/kWh) for the current run. The session counter starts when
+the process launches and can be reset with the
+.B R
+key in the TUI; the underlying Prometheus
+.B all_smi_energy_joules_total
+counter is monotonic and is never reset.
+.PP
+Display behaviour is controlled via the
+.B [energy]
+section of the TOML config file (see
+.B all-smi config init
+for the canonical path) or the following environment variables, which
+take precedence over the file:
+.TP
+.B ALL_SMI_ENERGY_PRICE
+Electricity price per kWh as a decimal number (e.g.
+.IR 0.12 ).
+A non-positive or non-finite value silently hides the cost column instead
+of surfacing
+.IR $NaN .
+Default: 0.12.
+.TP
+.B ALL_SMI_ENERGY_CURRENCY
+Display-only currency code (e.g.
+.IR USD ", " KRW ", " EUR ).
+Default: USD.
+.TP
+.B ALL_SMI_ENERGY_NO_COST
+When set to any value, suppresses the monetary cost column. The kWh
+total and average power are still rendered.
+.TP
+.B ALL_SMI_ENERGY_WAL_PATH
+Path to the disk-backed write-ahead log used to persist the cumulative
+joules counter across restarts. Default:
+.IR ~/.cache/all-smi/energy-wal.bin .
+.TP
+.B ALL_SMI_ENERGY_NO_WAL
+When set to any value, disables the disk-backed WAL — counters are
+in-memory only. Useful for ephemeral hosts.
+.TP
+.B ALL_SMI_ENERGY_GAP_SECONDS
+Sample-gap threshold in seconds (range
+.IR [1,\ 3600] )
+above which the integrator switches from trapezoidal to hold-last
+integration. Default: 10.
 .SH ENVIRONMENT
 .TP
 .B RUST_LOG

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,8 +22,22 @@ pub use crate::cli_config::{
     ConfigAction, ConfigArgs, ConfigPrintArgs, ConfigPrintFormat, ConfigValidateArgs,
 };
 
+const ENERGY_HELP: &str = "Energy Session (TUI):
+  Shows accumulated energy (kWh), avg power, and estimated cost since the
+  process started. Press R in the TUI to reset the session counter (the
+  Prometheus all_smi_energy_joules_total counter is unaffected).
+
+  Configure via [energy] in the TOML config (see `all-smi config init`)
+  or these environment variables (override the config file):
+    ALL_SMI_ENERGY_PRICE         $/kWh price (default 0.12; invalid hides cost)
+    ALL_SMI_ENERGY_CURRENCY      Display currency code (default USD)
+    ALL_SMI_ENERGY_NO_COST=1     Hide cost column; still show kWh
+    ALL_SMI_ENERGY_WAL_PATH      WAL file path (default ~/.cache/all-smi/energy-wal.bin)
+    ALL_SMI_ENERGY_NO_WAL=1      Disable disk WAL (in-memory counters only)
+    ALL_SMI_ENERGY_GAP_SECONDS   Gap threshold for trapezoid→hold-last (1..=3600, default 10)";
+
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, after_help = ENERGY_HELP)]
 pub struct Cli {
     /// Override the default TOML config file path. When omitted the loader
     /// probes the platform-appropriate locations (see `all-smi config init`

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -294,6 +294,28 @@ fn render_shortcuts_section(
             "membar",
         ),
         ("", "", ""),
+        ("Energy Session:", "", "header"),
+        (
+            "  Shows",
+            "kWh accumulated since session start, avg W, est. cost",
+            "legend",
+        ),
+        ("  R key", "Resets the kWh/cost session counter", "legend"),
+        (
+            "  Price",
+            "$/kWh from [energy] TOML or ALL_SMI_ENERGY_PRICE",
+            "legend",
+        ),
+        (
+            "  Currency",
+            "ALL_SMI_ENERGY_CURRENCY (default USD)",
+            "legend",
+        ),
+        (
+            "  Hide cost",
+            "ALL_SMI_ENERGY_NO_COST=1 (kWh still shown)",
+            "legend",
+        ),
         ("", "", ""),
         ("Current Status:", "", "header"),
     ];


### PR DESCRIPTION
## Summary

Document the Energy Session feature (kWh accumulation + \$/kWh cost
estimate, added in #201) across all three help surfaces so users can
discover and configure it without reading source.

## Changes

- **TUI help (\`h\` key)** — \`src/ui/help.rs\`: new \"Energy Session\" subsection in the right column explaining what the panel shows, the \`R\` reset shortcut, and the price/currency/no-cost env overrides.
- **\`all-smi --help\`** — \`src/cli.rs\`: added \`after_help\` text on the top-level \`Cli\` listing the \`[energy]\` TOML section and all six \`ALL_SMI_ENERGY_*\` environment variables.
- **manpage** — \`docs/man/all-smi.1\`: new \`ENERGY ACCOUNTING\` section documenting the integrator semantics (kWh from time-integrated power, monotonic Prometheus counter vs. resettable session counter) and every supported override.

## Test plan

- [x] \`cargo build --release\` succeeds (the 7 \"unused import\" warnings are unrelated; fix in flight as #208).
- [x] \`./target/release/all-smi --help\` shows the new \"Energy Session\" trailer.
- [x] \`mandoc -T ascii docs/man/all-smi.1\` renders the new section without errors.
- [ ] Visually inspect the \`h\` overlay in a TUI session.