### PR TITLE
fix: stabilize GPU Freq display on idle Apple Silicon (#216)

### DIFF
--- a/src/device/macos_native/ioreport.rs
+++ b/src/device/macos_native/ioreport.rs
@@ -877,6 +877,15 @@ impl IOReportMetrics {
 
         let avg_freq = if active_residency > 0 {
             (weighted_freq / active_residency as f64) as u32
+        } else if !freq_table.is_empty() {
+            // The GPU is present (total_residency > 0) but spent the entire
+            // sampling window in IDLE/OFF/DOWN states. It is not running at
+            // 0 Hz — it is parked at its lowest P-state. Report the lowest
+            // entry of the IOKit pmgr frequency table (sorted ascending) so
+            // the renderer shows a truthful idle clock instead of letting
+            // the Freq field flicker between a real value and 0 every
+            // refresh cycle.
+            freq_table[0]
         } else {
             0
         };
@@ -891,6 +900,11 @@ impl IOReportMetrics {
         let mut total_residency: i64 = 0;
         let mut weighted_freq: i64 = 0;
         let mut active_residency: i64 = 0;
+        // Track the lowest parseable active-state frequency seen during the
+        // scan. Used as the idle fallback when the cluster is present
+        // (total_residency > 0) but spent the entire window in IDLE/OFF/DOWN
+        // states — that's its parked P-state, not 0 Hz.
+        let mut min_active_freq: Option<i64> = None;
 
         for (name, residency) in residencies {
             total_residency += residency;
@@ -905,6 +919,7 @@ impl IOReportMetrics {
             // Parse frequency from state name (e.g., "2064" for 2064 MHz)
             if let Ok(freq) = name.trim().parse::<i64>() {
                 weighted_freq += freq * residency;
+                min_active_freq = Some(min_active_freq.map_or(freq, |m| m.min(freq)));
             }
         }
 
@@ -915,7 +930,13 @@ impl IOReportMetrics {
         let avg_freq = if active_residency > 0 {
             (weighted_freq / active_residency) as u32
         } else {
-            0
+            // Cluster is present but parked at its lowest P-state for the
+            // entire window. Report the minimum active-state frequency we
+            // saw (the parked P-state) rather than masquerading as no data.
+            // This applies to both the GPU fallback path (no IOKit pmgr
+            // table available) and CPU clusters, which both call this
+            // helper via process_cpu_channel.
+            min_active_freq.unwrap_or(0) as u32
         };
 
         let residency_pct = (active_residency as f64 / total_residency as f64) * 100.0;
@@ -1017,5 +1038,68 @@ mod tests {
 
         // No frequency data available
         assert_eq!(freq, 0);
+    }
+
+    #[test]
+    fn test_calc_freq_from_residencies_all_idle() {
+        // Cluster is present and idle, but there are no parseable active
+        // state names available to fall back on. Expected: (0, 0.0) —
+        // truly no usable signal.
+        let residencies = vec![("IDLE".to_string(), 500)];
+
+        let (freq, residency) = IOReportMetrics::calc_freq_from_residencies(&residencies);
+
+        assert_eq!(freq, 0);
+        assert!((residency - 0.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_calc_freq_from_residencies_idle_with_known_states() {
+        // Cluster spent the whole window in IDLE, but the residency map
+        // still enumerates the (zero-residency) active P-states. The
+        // function should report the minimum parseable active frequency
+        // as the parked clock with 0% active residency, rather than 0 Hz.
+        let residencies = vec![
+            ("IDLE".to_string(), 500),
+            ("600".to_string(), 0),
+            ("1200".to_string(), 0),
+        ];
+
+        let (freq, residency) = IOReportMetrics::calc_freq_from_residencies(&residencies);
+
+        assert_eq!(freq, 600);
+        assert!((residency - 0.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_calc_gpu_freq_with_table_idle() {
+        // GPU is present (residency > 0) but every state is idle/off.
+        // With a non-empty IOKit pmgr freq_table, the function should
+        // return the lowest entry — the parked P-state — instead of 0.
+        let residencies = vec![("OFF".to_string(), 200), ("IDLE".to_string(), 800)];
+
+        let freq_table = [396, 720, 1398];
+
+        let (freq, residency) =
+            IOReportMetrics::calc_gpu_freq_with_table(&residencies, &freq_table);
+
+        assert_eq!(freq, 396);
+        assert!((residency - 0.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_calc_gpu_freq_with_table_empty_table_idle() {
+        // GPU is present but idle, and the IOKit pmgr table is empty so
+        // there is no idle-state P-state to fall back on. Expected:
+        // (0, 0.0). The renderer will substitute N/A.
+        let residencies = vec![("OFF".to_string(), 200), ("IDLE".to_string(), 800)];
+
+        let freq_table: [u32; 0] = [];
+
+        let (freq, residency) =
+            IOReportMetrics::calc_gpu_freq_with_table(&residencies, &freq_table);
+
+        assert_eq!(freq, 0);
+        assert!((residency - 0.0).abs() < 0.1);
     }
 }

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -311,26 +311,32 @@ pub fn print_gpu_info<W: Write>(
 
     print_colored_text(stdout, &temp_display, temp_color, None, None);
 
-    // Display GPU frequency
-    if info.frequency > 0 {
-        print_colored_text(stdout, " Freq:", Color::Magenta, None, None);
-        if info.frequency >= 1000 {
-            print_colored_text(
-                stdout,
-                &format!("{:.2}GHz", info.frequency as f64 / 1000.0),
-                Color::White,
-                None,
-                None,
-            );
-        } else {
-            print_colored_text(
-                stdout,
-                &format!("{}MHz", info.frequency),
-                Color::White,
-                None,
-                None,
-            );
-        }
+    // Display GPU frequency. Always render the label so the row layout stays
+    // stable across refreshes; substitute N/A when the value is missing, the
+    // same way Util/VRAM/Temp above handle their missing-data cases. Readers
+    // that statically report `frequency: 0` (Rebellions, Intel Gaudi, AMD via
+    // WMI, and any platform that genuinely lacks a frequency probe) will show
+    // ` Freq:     N/A` instead of letting the field — and every field after
+    // it — vanish for the duration of that sample.
+    print_colored_text(stdout, " Freq:", Color::Magenta, None, None);
+    if info.frequency == 0 {
+        print_colored_text(stdout, &format!("{:>7}", "N/A"), Color::White, None, None);
+    } else if info.frequency >= 1000 {
+        print_colored_text(
+            stdout,
+            &format!("{:.2}GHz", info.frequency as f64 / 1000.0),
+            Color::White,
+            None,
+            None,
+        );
+    } else {
+        print_colored_text(
+            stdout,
+            &format!("{}MHz", info.frequency),
+            Color::White,
+            None,
+            None,
+        );
     }
 
     print_colored_text(stdout, " Pwr:", Color::Red, None, None);


### PR DESCRIPTION
## Summary

Closes #216. The \`Freq:\` field in the \`view\` TUI's GPU List row was flickering on near-idle Apple Silicon Macs, vanishing for a refresh cycle and shifting every field after it (\`Pwr:\` etc.) left. Two compounding bugs were at play; this PR fixes both.

### Bug A — data layer (Apple Silicon)

\`src/device/macos_native/ioreport.rs\`. \`calc_gpu_freq_with_table\` and \`calc_freq_from_residencies\` were returning \`(0, 0.0)\` whenever the GPU/cluster was present (\`total_residency > 0\`) but spent the entire 100ms sampling window in \`IDLE\`/\`OFF\`/\`DOWN\` states — the normal condition for an idle Apple GPU. That 0 propagated all the way to \`GpuInfo.frequency\`. An idle Apple GPU is not running at 0 Hz; it is parked at its lowest P-state (~350 MHz on M1).

Fix: when active residency is zero but the cluster is present, fall back to the parked clock instead of 0.
- \`calc_gpu_freq_with_table\` uses \`freq_table[0]\` — the lowest entry of the IOKit pmgr table, which is sorted ascending.
- \`calc_freq_from_residencies\` tracks the minimum parseable active-state frequency during its scan and uses it as the idle fallback. This covers both the GPU fallback path (no pmgr table available) and CPU clusters via \`process_cpu_channel\`.
- When neither signal is available (\`freq_table\` empty AND no parseable active states), \`(0, 0.0)\` is still returned and the renderer substitutes N/A.

**OpenMetrics side effect:** The \`all_smi_gpu_frequency_mhz\` gauge for idle Apple Silicon will now export the parked P-state clock (e.g. ~350 MHz on M1) instead of 0, eliminating misleading zero-gaps in Prometheus/Grafana dashboards during idle periods.

### Bug B — render layer (cross-platform)

\`src/ui/renderers/gpu_renderer.rs\`. The entire \`Freq:\` label+value block was gated on \`info.frequency > 0\`. Any refresh where Bug A produced 0 made the field — and therefore every field after it on the row — vanish.

Fix: mirror the existing \`Util:\` / \`VRAM:\` / \`Temp:\` patterns in the same function. Always render the \`Freq:\` label, substitute \`N/A\` (right-aligned at width 7, matching \`Temp:\`'s N/A width) when the value is 0.

This change is intentionally cross-platform. Readers that statically report \`frequency: 0\` (Rebellions, Intel Gaudi, AMD via WMI) will now show \` Freq:     N/A\` instead of hiding the field, making row layout consistent across all device types. NVIDIA / Jetson rarely hit 0 (NVML reports a stable idle graphics clock; sysfs \`cur_freq\` is always readable when accessible), so they are unaffected in practice — no spurious N/A.

### Out of scope

Per the issue's "What NOT to change" section, this PR deliberately does NOT change \`GpuInfo.frequency\` from \`u32\` to \`Option<u32>\`. After Fix A, the only way \`frequency == 0\` reaches the renderer is genuine "no data", which the renderer now handles via N/A. Changing the type would have touched every reader, the JSON API, and the OpenMetrics exporter — out of scope here.

## Test plan

- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — no warnings
- [x] \`cargo test\` — all existing tests pass; existing \`test_calc_freq_from_residencies\` and \`test_calc_gpu_freq_with_table\` (active path) still pass unchanged
- [x] \`cargo build --release\` — succeeds on Linux (CI host); the Apple-specific code path remains gated behind \`#[cfg(target_os = "macos")]\`
- [x] Four new unit tests cover the new idle-state behaviour:
  - \`test_calc_freq_from_residencies_all_idle\` — all-idle, no parseable states → \`(0, 0.0)\`
  - \`test_calc_freq_from_residencies_idle_with_known_states\` — idle plus known states at zero residency → returns the min parsed frequency at 0% active residency
  - \`test_calc_gpu_freq_with_table_idle\` — fully-idle GPU with non-empty freq table → returns \`freq_table[0]\`
  - \`test_calc_gpu_freq_with_table_empty_table_idle\` — fully-idle GPU with empty freq table → \`(0, 0.0)\`
- [ ] Runtime check on an idle Apple Silicon Mac: \`sudo ./target/release/all-smi view\`, watch the GPU row over 20-30s. Expected: \`Freq:\` stays visible at a stable idle clock (e.g. 350-400 MHz on M1) across refresh cycles; no field-shift on idle. Under load, the field still reports the weighted active frequency.
- [ ] Runtime check on NVIDIA / Jetson: no spurious N/A in the \`Freq:\` column.

## Files touched

- \`src/ui/renderers/gpu_renderer.rs\` (renderer: always render Freq, show N/A on 0)
- \`src/device/macos_native/ioreport.rs\` (data layer: idle Apple GPU/cluster falls back to parked clock; four new unit tests)