### PR TITLE
fix: upgrade libamdgpu_top to 0.11.5 to fix AMD GPU file descriptor leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,9 +2426,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libamdgpu_top"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767e7df82c1bba462f6093a4b611ac59b33a768290cd8c7fdb32a5b8cb8ec013"
+checksum = "20e9cb5c980bdf72b4b5e8dc3efb186749ceaa9b527b91ec388c6e1d95b58012"
 dependencies = [
  "libdrm_amdgpu_sys",
  "nix 0.31.2",
@@ -2443,9 +2443,9 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libdrm_amdgpu_sys"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380c3cfe531e0237f58a16c75710b17eaa006614c6ab115efa921ac8b019c25b"
+checksum = "3b63f219bdee8484c65e0f54f81b6c671f1ab433f460e40c3174dea688abf31b"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,7 @@ libloading = "0.9"
 
 # AMD GPU support (glibc only, not compatible with musl static linking)
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
-# Pinned exactly: 0.11.4 renamed get_all_proc_usage → update_proc_usage in a
-# patch bump (issue #205). Re-evaluate when bumping.
-libamdgpu_top = "=0.11.4"
+libamdgpu_top = "0.11.5"
 
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl = { version = "0.10.75", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,11 @@ libloading = "0.9"
 
 # AMD GPU support (glibc only, not compatible with musl static linking)
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
-libamdgpu_top = "0.11.5"
+# Pinned exactly: this crate has shipped semver-violating breaking changes in
+# patch releases (0.11.4 renamed get_all_proc_usage → update_proc_usage, #205).
+# 0.11.5 fixes a file-descriptor leak (#218). Re-evaluate the exact version on
+# each bump.
+libamdgpu_top = "=0.11.5"
 
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl = { version = "0.10.75", features = ["vendored"] }


### PR DESCRIPTION
As reported in my issue https://github.com/Umio-Yasuno/amdgpu_top/issues/163 libamdgpu_top has a file descriptor leak that's fixed in their 0.11.5 now released.

This PR unpins libamdgpu_top and brings it up to 0.11.5. I confirmed with [my bug repro repository](https://github.com/joshhansen/allsmi-libamdgpu_top-bug) that this change resolves the FD leak coming from all-smi.

---

_Maintainer note: merged with `libamdgpu_top` kept **exact-pinned** at `=0.11.5` (rather than unpinned to a caret range) to preserve the semver-break protection added in #207 — this crate has renamed public APIs in patch releases before. See the review comment for details._

Closes #218
