### PR TITLE
docs: gate unreleased subcommands with v0.21.0+ availability notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ The PPA provides automatic updates and is maintained for Ubuntu 22.04 (Jammy) an
 
 ### Option 3: Install via Debian Package
 
-For Debian and other Debian-based distributions, download the `.deb` package from the [releases page](https://github.com/inureyes/all-smi/releases):
+For Debian and other Debian-based distributions, download the `.deb` package from the [releases page](https://github.com/lablup/all-smi/releases):
 
 ```bash
 # Download the latest .deb package (replace VERSION with the actual version)
-wget https://github.com/inureyes/all-smi/releases/download/vVERSION/all-smi_VERSION_OS_ARCH.deb
+wget https://github.com/lablup/all-smi/releases/download/vVERSION/all-smi_VERSION_OS_ARCH.deb
 # Example: all-smi_0.7.0_ubuntu24.04.noble_amd64.deb
 
 # Install the package
@@ -63,9 +63,9 @@ sudo apt-get install -f
 
 ### Option 4: Download Pre-built Binary
 
-Download the latest release from the [GitHub releases page](https://github.com/inureyes/all-smi/releases):
+Download the latest release from the [GitHub releases page](https://github.com/lablup/all-smi/releases):
 
-1. Go to https://github.com/inureyes/all-smi/releases
+1. Go to https://github.com/lablup/all-smi/releases
 2. Download the appropriate binary for your platform
 3. Extract the archive and place the binary in your `$PATH`
 
@@ -97,6 +97,13 @@ See [Building from Source](DEVELOPERS.md#building-from-source) in the developer 
 
 ### Command Overview
 
+> **Note:** This README tracks the `main` branch. Subcommands tagged
+> **Availability: v0.21.0+** below (`snapshot`, `record`, `view --replay`,
+> `config`, `doctor`) are not present in the current published release
+> (v0.20.1) and will ship with v0.21.0. See the [Changelog](#changelog) for
+> what is in each release. To run the latest features today, build from
+> source ([Option 6](#option-6-build-from-source)).
+
 ```bash
 # Show help
 all-smi --help
@@ -112,13 +119,13 @@ all-smi view --hostfile hosts.csv
 # API mode (expose metrics server)
 all-smi api --port 9090
 
-# One-shot JSON/CSV/Prometheus dump for scripts
+# One-shot JSON/CSV/Prometheus dump for scripts (Availability: v0.21.0+)
 all-smi snapshot
 
-# Capture a stream to disk for later replay
+# Capture a stream to disk for later replay (Availability: v0.21.0+)
 all-smi record --output trace.ndjson.zst --duration 1h
 
-# Replay a captured stream in the TUI
+# Replay a captured stream in the TUI (Availability: v0.21.0+)
 all-smi view --replay trace.ndjson.zst
 ```
 
@@ -157,6 +164,13 @@ http://gpu-node3:9090
 ```
 
 ## Configuration
+
+> **Availability: v0.21.0+.** The `config` subcommand (`config init`, `config
+> print`, `config validate`) and the TOML config-file loader described below
+> are not present in v0.20.1; they are scheduled for v0.21.0. Environment
+> variables documented in the schema tables (e.g., `ALL_SMI_API_PORT`,
+> `ALL_SMI_ALERTS_TEMP_WARN_C`) continue to work in v0.20.1 where they were
+> already supported. To use `config` today, build from source.
 
 `all-smi` reads optional settings from a TOML config file. Every field has a compiled default, so a fresh install requires no file; operators only create one when they want persistent overrides (hostfile path, update interval, alert thresholds, `$/kWh`, etc.).
 
@@ -319,6 +333,9 @@ Older releases introduced environment variables with different naming. All alias
   - For best temperature monitoring on Windows, install and run LibreHardwareMonitor in the background
 
 ## Diagnostics
+
+> **Availability: v0.21.0+.** The `doctor` subcommand is not present in
+> v0.20.1; it is scheduled for v0.21.0. To run it today, build from source.
 
 The `all-smi doctor` subcommand runs a read-only suite of environment checks and
 prints a PASS/WARN/FAIL report covering platform, privileges, container
@@ -968,6 +985,9 @@ blocking collect rather than each spawning their own reader set.
 
 ### Scripting / CI (Snapshot Mode)
 
+> **Availability: v0.21.0+.** The `snapshot` subcommand is not present in
+> v0.20.1; it is scheduled for v0.21.0. To use it today, build from source.
+
 The `snapshot` subcommand emits a single, one-shot machine-readable dump of
 the current hardware state to stdout (or a file) and exits. It is designed
 for shell piping, CI probes, Slurm prolog/epilog hooks, and any tool that
@@ -1049,6 +1069,10 @@ all-smi snapshot --format csv --include gpu --query utilization \
 | `--output` / `-o` | stdout                            | Write to this path (`-` also means stdout). On Unix: created with mode `0600` (owner-only), symlinks refused, atomic write via sibling `.tmp` + rename. |
 
 ### Recording & Replay
+
+> **Availability: v0.21.0+.** The `record` subcommand and `view --replay` are
+> not present in v0.20.1; they are scheduled for v0.21.0. To use them today,
+> build from source.
 
 The `record` subcommand captures a live metric stream to disk as NDJSON, and
 `view --replay <file>` plays it back through the same TUI the operator would


### PR DESCRIPTION
## Summary

Resolves the README inconsistency reported in #214: the body presented `config`, `doctor`, `snapshot`, `record`, and `view --replay` as currently-shipped features, while the Changelog correctly listed them under "v0.21.0 (upcoming)". A Windows 11 user on v0.20.1 followed the README, ran `all-smi.exe config`, hit `error: unrecognized subcommand 'config'`, and reasonably concluded the bug was Windows-specific — it is not; these subcommands are absent on every platform in v0.20.1 because they post-date the tag.

This PR takes option 2 from the issue ("version-gate the docs"). Option 1 (cutting v0.21.0) is out of scope for `/auto-impl`.

## Changes

`README.md` only — no source changes; the subcommands already exist on `main` and ship as documented in v0.21.0.

- **Command Overview** — added a top-of-section banner noting the README tracks `main` and tagging each of the four unreleased examples (`snapshot`, `record`, `view --replay`) with `(Availability: v0.21.0+)` inline.
- **Configuration** — added an "Availability: v0.21.0+" banner covering the `config init / print / validate` helpers and the TOML loader, explicitly calling out that pre-existing environment variables (e.g., `ALL_SMI_API_PORT`, `ALL_SMI_ALERTS_TEMP_WARN_C`) continue to work in v0.20.1 so users do not assume those regressed.
- **Diagnostics** — added an "Availability: v0.21.0+" banner for the `doctor` subcommand.
- **Scripting / CI (Snapshot Mode)** — added an "Availability: v0.21.0+" banner for the `snapshot` subcommand.
- **Recording & Replay** — added an "Availability: v0.21.0+" banner for `record` and `view --replay`.
- **Install URLs** — reconciled four `github.com/inureyes/all-smi/...` links in the Debian package and pre-built binary install sections to the canonical `lablup/all-smi` repository (secondary cleanup noted in the issue).

Wording was kept consistent with the Changelog's existing "v0.21.0 (upcoming)" entry so the two sources of truth agree.

## Test plan

- [x] `cargo check --lib --tests` passes (docs-only change; verifies no inadvertent breakage)
- [x] `grep -n "Availability: v0.21" README.md` shows 8 hits (1 banner + 3 inline tags in Command Overview, plus 1 banner each in Configuration, Diagnostics, Snapshot, and Recording & Replay)
- [x] `grep -n "inureyes/all-smi" README.md` returns empty (no residual upstream URL drift)
- [x] Internal consistency: every body section that mentions `config`, `doctor`, `snapshot`, `record`, or `view --replay` now agrees with the Changelog's "v0.21.0 (upcoming)" entry

Closes #214