### PR TITLE
feat: surface active TOML config path in --help (issue #213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ http://gpu-node3:9090
 | macOS    | `~/Library/Application Support/all-smi/config.toml` (also accepts `~/.config/all-smi/config.toml`) |
 | Windows  | `%APPDATA%\all-smi\config.toml` |
 
-Pass `--config <PATH>` to any subcommand to override the discovery and force a specific file. A missing or malformed `--config` target is a hard error (exit 2); implicit discovery silently falls back to defaults when no candidate file exists.
+Pass `--config <PATH>` to any subcommand to override the discovery and force a specific file. A missing or malformed `--config` target is a hard error (exit 2); implicit discovery silently falls back to defaults when no candidate file exists. To print the active path for the current user without writing any file, run `all-smi config path` (also surfaced in `all-smi --help` under the "Configuration file" section).
 
 ### Precedence
 
@@ -179,6 +179,7 @@ Highest to lowest: **CLI flag > environment variable > config file > compiled de
 - `all-smi config init [--force]` writes a commented example config to the platform-canonical path. Refuses to overwrite without `--force`. The file is created with `O_NOFOLLOW` and mode `0o600` on Unix.
 - `all-smi config print [--format toml|json] [--show-secrets]` prints the fully merged effective configuration. `webhook_url` is redacted unless `--show-secrets` is passed.
 - `all-smi config validate [<path>] [--strict]` parses a config file and reports any errors (with line/column on parse failures). Exit 0 valid, 2 invalid. `--strict` rejects unknown keys.
+- `all-smi config path [--json]` prints the active config-file path with an `(active)` / `(not found)` marker, plus the candidate search order. Read-only — no file is created. The same active path is shown in `all-smi --help` under the "Configuration file" block.
 
 ### Reload
 

--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -45,6 +45,23 @@ Does not require sudo permissions.
 Run in API mode, exposing metrics in Prometheus format via HTTP endpoint.
 No sudo required on macOS (uses native APIs).
 .TP
+.B config \fISUBCOMMAND\fR
+Manage the optional TOML configuration file. Subcommands:
+.RS
+.IP \(bu 3
+.B init
+\(em write a commented example config to the platform-canonical path.
+.IP \(bu 3
+.B print
+\(em print the merged effective configuration (TOML or JSON).
+.IP \(bu 3
+.B validate
+\(em parse a config file and report errors (exit 0 valid, 2 invalid).
+.IP \(bu 3
+.B path
+\(em print the active config-file path and the candidate search order. Read-only; supports \fB--json\fR for scripts.
+.RE
+.TP
 .B help
 Display help information about all-smi or a specific command.
 .SH OPTIONS
@@ -233,6 +250,39 @@ http://node002:9090
 https://node003:9443
 .fi
 .RE
+.TP
+.I config.toml
+Optional TOML configuration file. Per-platform canonical paths:
+.RS
+.IP \(bu 3
+Linux: \fI$XDG_CONFIG_HOME/all-smi/config.toml\fR (fallback \fI~/.config/all-smi/config.toml\fR)
+.IP \(bu 3
+macOS: \fI~/Library/Application Support/all-smi/config.toml\fR (also accepts \fI~/.config/all-smi/config.toml\fR)
+.IP \(bu 3
+Windows: \fI%APPDATA%\\all-smi\\config.toml\fR
+.RE
+.RS
+The active path for the current user is printed by
+.B all-smi --help
+(under "Configuration file") and by
+.B all-smi config path
+(read-only; supports
+.B --json
+for scripts). Override the discovery with
+.B --config \fIPATH\fR\fR.
+A missing or malformed
+.B --config
+target is a hard error (exit 2); implicit discovery silently falls back
+to compiled defaults plus env vars when no candidate file exists.
+.RE
+.TP
+.I energy-wal.bin
+Disk-backed write-ahead log persisting the cumulative joules counter
+across restarts. Default: \fI~/.cache/all-smi/energy-wal.bin\fR.
+See
+.B ENERGY ACCOUNTING
+below for the \fBALL_SMI_ENERGY_WAL_PATH\fR / \fBALL_SMI_ENERGY_NO_WAL\fR
+overrides.
 .SH ENERGY ACCOUNTING
 The Energy Session panel integrates instantaneous power draw over time
 to report cumulative energy consumption (kWh) and an optional cost
@@ -245,10 +295,12 @@ counter is monotonic and is never reset.
 .PP
 Display behaviour is controlled via the
 .B [energy]
-section of the TOML config file (see
-.B all-smi config init
-for the canonical path) or the following environment variables, which
-take precedence over the file:
+section of the TOML config file (run
+.B all-smi config path
+to print the active location, or see
+.B FILES
+above) or the following environment variables, which take precedence
+over the file:
 .TP
 .B ALL_SMI_ENERGY_PRICE
 Electricity price per kWh as a decimal number (e.g.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,21 +14,31 @@
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+
+use crate::common::paths;
 
 // Config subcommand argument types live in a sibling module so the main
 // CLI file stays within the 500-line soft limit.
 pub use crate::cli_config::{
-    ConfigAction, ConfigArgs, ConfigPrintArgs, ConfigPrintFormat, ConfigValidateArgs,
+    ConfigAction, ConfigArgs, ConfigPathArgs, ConfigPrintArgs, ConfigPrintFormat,
+    ConfigValidateArgs,
 };
 
-const ENERGY_HELP: &str = "Energy Session (TUI):
+/// Energy Session help block — appended at the end of `--help`.
+///
+/// Public because `main.rs` composes it with the dynamic
+/// "Configuration file" block (which has to be built at runtime to print
+/// the resolved per-user config path) before injecting the combined
+/// string via `Command::after_help`. See [`build_command_with_runtime_help`].
+pub const ENERGY_HELP: &str = "Energy Session (TUI):
   Shows accumulated energy (kWh), avg power, and estimated cost since the
   process started. Press R in the TUI to reset the session counter (the
   Prometheus all_smi_energy_joules_total counter is unaffected).
 
-  Configure via [energy] in the TOML config (see `all-smi config init`)
-  or these environment variables (override the config file):
+  Configure via [energy] in the TOML config (see `all-smi config path`
+  for the active path) or these environment variables (override the
+  config file):
     ALL_SMI_ENERGY_PRICE         $/kWh price (default 0.12; invalid hides cost)
     ALL_SMI_ENERGY_CURRENCY      Display currency code (default USD)
     ALL_SMI_ENERGY_NO_COST=1     Hide cost column; still show kWh
@@ -37,12 +47,14 @@ const ENERGY_HELP: &str = "Energy Session (TUI):
     ALL_SMI_ENERGY_GAP_SECONDS   Gap threshold for trapezoid→hold-last (1..=3600, default 10)";
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None, after_help = ENERGY_HELP)]
+#[command(author, version, about, long_about = None)]
 pub struct Cli {
-    /// Override the default TOML config file path. When omitted the loader
-    /// probes the platform-appropriate locations (see `all-smi config init`
-    /// for the canonical path). When given, a missing or malformed file
-    /// produces a hard error; no silent fallback.
+    /// Override the default TOML config file path. When omitted, the loader
+    /// probes the platform-appropriate locations (run `all-smi config path`
+    /// to print the resolved location, or see the "Configuration file"
+    /// block at the bottom of this help text). A missing or malformed file
+    /// passed explicitly here is a hard error; implicit discovery silently
+    /// falls back to defaults.
     #[arg(long, global = true, value_name = "PATH")]
     pub config: Option<PathBuf>,
 
@@ -566,6 +578,46 @@ pub struct DoctorArgs {
     pub only: Vec<String>,
 }
 
+/// Render the runtime "Configuration file" help block. Resolved at
+/// invocation time because the canonical path embeds `$HOME` /
+/// `$XDG_CONFIG_HOME` / `%APPDATA%`, which are user-specific and not
+/// known at compile time. Issue #213.
+///
+/// Shape (intentionally short — `after_help` is shown for both `-h` and
+/// `--help`, so we keep it scannable):
+///
+/// ```text
+/// Configuration file:
+///   Optional TOML file. Precedence: CLI flags > env vars > config file > built-in defaults.
+///   Active path (this platform):
+///     <resolved-path>   (active | not found)
+///   Inspect:  all-smi config path   Init:  all-smi config init   Print merged:  all-smi config print
+///   Override path with --config <PATH>.
+/// ```
+pub fn config_help_block() -> String {
+    let resolved = paths::default_config_path();
+    let line = paths::format_path_with_existence(resolved.as_deref());
+    format!(
+        "Configuration file:\n  \
+        Optional TOML file. Precedence: CLI flags > env vars > config file > built-in defaults.\n  \
+        Active path (this platform):\n    \
+        {line}\n  \
+        Inspect:  all-smi config path   Init:  all-smi config init   Print merged:  all-smi config print\n  \
+        Override path with --config <PATH>."
+    )
+}
+
+/// Build the top-level [`clap::Command`] with the runtime-composed
+/// `after_help` text injected. Callers should parse via
+/// `Cli::from_arg_matches(&Self::build_command_with_runtime_help().get_matches())`
+/// rather than `Cli::parse()` so the dynamic Configuration file block
+/// reaches `--help` output.
+pub fn build_command_with_runtime_help() -> clap::Command {
+    let config_block = config_help_block();
+    let after = format!("{config_block}\n\n{ENERGY_HELP}");
+    Cli::command().after_help(after)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -631,5 +683,63 @@ mod tests {
         assert_eq!(SnapshotFormat::Json.to_string(), "json");
         assert_eq!(SnapshotFormat::Csv.to_string(), "csv");
         assert_eq!(SnapshotFormat::Prometheus.to_string(), "prometheus");
+    }
+
+    // ---- Issue #213: help output exposes the active config path. ----
+
+    /// The runtime-built command must surface the new "Configuration
+    /// file" block in `--help`, plus the existing Energy Session block.
+    /// Regression guard: nobody can drop the runtime `after_help`
+    /// injection without breaking this test.
+    #[test]
+    fn help_text_contains_config_and_energy_blocks() {
+        let mut cmd = build_command_with_runtime_help();
+        let help = cmd.render_help().to_string();
+        assert!(
+            help.contains("Configuration file:"),
+            "help must contain the Configuration file block, got:\n{help}"
+        );
+        assert!(
+            help.contains("Active path (this platform):"),
+            "help must label the active path, got:\n{help}"
+        );
+        assert!(
+            help.contains("all-smi config path"),
+            "help must point at `all-smi config path`, got:\n{help}"
+        );
+        assert!(
+            help.contains("Energy Session"),
+            "existing Energy Session block must still render, got:\n{help}"
+        );
+    }
+
+    /// The `--config` flag's own docstring must no longer redirect users
+    /// to a side-effecting command (`config init`); it points at the
+    /// read-only `config path` or the inline block.
+    #[test]
+    fn config_flag_help_no_longer_only_points_at_init() {
+        let mut cmd = build_command_with_runtime_help();
+        let help = cmd.render_help().to_string();
+        // The new wording mentions `config path` somewhere in the help
+        // surface (either in the flag doc or the Configuration block).
+        assert!(
+            help.contains("config path"),
+            "help should mention `config path`, got:\n{help}"
+        );
+    }
+
+    /// `config_help_block()` must annotate the resolved path with an
+    /// existence marker — either `(active)` when present or
+    /// `(not found)` when absent. Without a marker the user cannot
+    /// tell from `--help` whether the file is there.
+    #[test]
+    fn config_help_block_carries_existence_marker() {
+        let block = config_help_block();
+        assert!(
+            block.contains("(active)")
+                || block.contains("(not found)")
+                || block.contains("no config path"),
+            "config_help_block must carry an existence marker, got:\n{block}"
+        );
     }
 }

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -37,6 +37,9 @@ pub struct ConfigArgs {
 ///   `--show-secrets` is set.
 /// - `config validate [<path>] [--strict]` parses the given (or default)
 ///   file and reports any errors, exiting 0 on valid and 2 on invalid.
+/// - `config path [--json]` (issue #213) prints the active config path
+///   plus the candidate search order, with no file writes — strictly
+///   read-only for discovery and scripting.
 #[derive(Subcommand, Clone, Debug)]
 pub enum ConfigAction {
     /// Write a commented example config.toml at the default location.
@@ -47,6 +50,10 @@ pub enum ConfigAction {
     /// Parse a config file and report any errors. Exit 0 on valid, 2
     /// on invalid.
     Validate(ConfigValidateArgs),
+    /// Print the active config-file path and the candidate search
+    /// order. Read-only — performs no file writes. Pass `--json` for
+    /// scripts. (Issue #213.)
+    Path(ConfigPathArgs),
 }
 
 #[derive(Args, Clone, Debug)]
@@ -93,4 +100,21 @@ pub struct ConfigValidateArgs {
     /// error, so the config remains forward-compatible.
     #[arg(long)]
     pub strict: bool,
+}
+
+/// Arguments for `all-smi config path` (issue #213).
+///
+/// Read-only discovery — the runner only reads `paths::*` helpers and
+/// `Path::exists()`, never writes to disk. Honours the global
+/// `--config <PATH>` override: when set, that path becomes the
+/// "active" line and the candidate-search list is suppressed (it would
+/// be misleading — discovery never runs when `--config` is explicit).
+#[derive(Args, Clone, Debug)]
+pub struct ConfigPathArgs {
+    /// Emit a machine-readable JSON object instead of the human-readable
+    /// text format. The schema is `{ active: string|null, exists: bool,
+    /// overridden: bool, search_order: [string] }` — `active` is `null`
+    /// only when no home directory can be resolved for this platform.
+    #[arg(long)]
+    pub json: bool,
 }

--- a/src/common/paths.rs
+++ b/src/common/paths.rs
@@ -141,6 +141,26 @@ pub fn discover_existing_config() -> Option<PathBuf> {
     candidate_config_paths().into_iter().find(|p| p.exists())
 }
 
+/// Render a candidate config path together with an `(active)` or
+/// `(not found)` existence marker for display in `--help` and the
+/// `config path` subcommand. Both surfaces share this so the marker
+/// vocabulary stays consistent.
+///
+/// * `Some(path)` whose target exists → `"<path>   (active)"`
+/// * `Some(path)` whose target is missing → `"<path>   (not found)"`
+/// * `None` (no resolvable home directory) → a clear inline message
+///   instead of an empty string, so operators on bare/CI shells
+///   immediately understand why no path was printed.
+pub fn format_path_with_existence(path: Option<&Path>) -> String {
+    match path {
+        Some(p) => {
+            let marker = if p.exists() { "active" } else { "not found" };
+            format!("{}   ({marker})", p.display())
+        }
+        None => "(no config path resolvable — set $HOME or $XDG_CONFIG_HOME)".to_string(),
+    }
+}
+
 /// Return the parent directory of `path`, creating intermediate
 /// directories when needed. Matches `fs::create_dir_all` semantics.
 pub fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
@@ -205,5 +225,36 @@ mod tests {
             let paths = candidate_config_paths();
             assert!(!paths.is_empty());
         }
+    }
+
+    #[test]
+    fn format_path_with_existence_marks_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("config.toml");
+        std::fs::write(&file, b"# stub").unwrap();
+        let rendered = format_path_with_existence(Some(&file));
+        assert!(
+            rendered.contains("(active)"),
+            "expected (active) marker, got: {rendered}"
+        );
+        assert!(rendered.contains(&file.display().to_string()));
+    }
+
+    #[test]
+    fn format_path_with_existence_marks_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let absent = dir.path().join("nope.toml");
+        let rendered = format_path_with_existence(Some(&absent));
+        assert!(
+            rendered.contains("(not found)"),
+            "expected (not found) marker, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn format_path_with_existence_handles_none() {
+        let rendered = format_path_with_existence(None);
+        assert!(rendered.contains("no config path"));
+        assert!(rendered.contains("HOME"));
     }
 }

--- a/src/config_cmd/mod.rs
+++ b/src/config_cmd/mod.rs
@@ -31,6 +31,7 @@ use crate::common::paths;
 use crate::common::secure_write;
 
 mod example;
+mod path;
 mod render;
 
 pub use example::EXAMPLE_TOML;
@@ -48,6 +49,10 @@ pub fn run(explicit_config_path: Option<&Path>, action: &ConfigAction) -> i32 {
         ConfigAction::Init(args) => run_init(explicit_config_path, args.force),
         ConfigAction::Print(args) => run_print(explicit_config_path, args),
         ConfigAction::Validate(args) => run_validate(explicit_config_path, args),
+        // `config path` is read-only and never writes to disk; it
+        // honours `--config <path>` by reporting that override as the
+        // active path. (Issue #213.)
+        ConfigAction::Path(args) => path::run_path(explicit_config_path, args),
     }
 }
 

--- a/src/config_cmd/path.rs
+++ b/src/config_cmd/path.rs
@@ -1,0 +1,265 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of `all-smi config path` (issue #213).
+//!
+//! Strictly read-only — never opens a file for write, never creates a
+//! directory. Resolves the same path helpers the loader uses
+//! ([`paths::default_config_path`] / [`paths::candidate_config_paths`])
+//! and prints them in either a scannable text format or a stable JSON
+//! schema for shell scripts.
+//!
+//! The printed absolute path embeds the local username; per the issue
+//! body that is acceptable (it is the operator's own machine, and
+//! every other path-printing CLI tool — `cargo`, `rustup`, `npm` —
+//! does the same). We never print secrets such as `webhook_url`; that
+//! redaction lives in [`config_cmd::redact_secrets`] and is enforced
+//! by the renderers used by `config print`.
+
+use std::io::{self, Write};
+use std::path::Path;
+
+use serde_json::json;
+
+use crate::cli::ConfigPathArgs;
+use crate::common::paths;
+
+/// Entry point for `all-smi config path`. Returns a process exit code
+/// (0 on success, 1 only on writer failure — we never produce an error
+/// for an absent config file, since the whole point of this command is
+/// to *tell* the user the file is absent).
+///
+/// * `explicit` mirrors the global `--config <PATH>` argument. When
+///   `Some`, the override path is reported as the active path and the
+///   candidate-search list is suppressed (search-order is irrelevant
+///   when discovery is bypassed). When `None`, the platform-canonical
+///   path is reported and the full ordered candidate list is printed.
+/// * `args.json` selects the machine-readable JSON output.
+pub fn run_path(explicit: Option<&Path>, args: &ConfigPathArgs) -> i32 {
+    let mut stdout = io::stdout().lock();
+    let mut stderr = io::stderr().lock();
+    let result = if args.json {
+        write_json(&mut stdout, explicit)
+    } else {
+        write_text(&mut stdout, explicit)
+    };
+    if let Err(e) = result {
+        let _ = writeln!(stderr, "error: failed to write config path: {e}");
+        return 1;
+    }
+    0
+}
+
+/// Render the human-readable form to `out`. Format mirrors the issue
+/// spec verbatim so operators copying from the issue body can paste
+/// the output and recognise it.
+fn write_text<W: Write>(out: &mut W, explicit: Option<&Path>) -> io::Result<()> {
+    if let Some(p) = explicit {
+        writeln!(out, "{}", paths::format_path_with_existence(Some(p)))?;
+        writeln!(out, "source: --config override (discovery bypassed)")?;
+        return Ok(());
+    }
+
+    let active = paths::default_config_path();
+    writeln!(
+        out,
+        "{}",
+        paths::format_path_with_existence(active.as_deref())
+    )?;
+
+    let candidates = paths::candidate_config_paths();
+    if candidates.is_empty() {
+        // Already covered by the `(no config path…)` message in the
+        // first line; nothing further to print.
+        return Ok(());
+    }
+    writeln!(out, "search order:")?;
+    for (i, candidate) in candidates.iter().enumerate() {
+        writeln!(out, "  {}. {}", i + 1, candidate.display())?;
+    }
+    Ok(())
+}
+
+/// Render the machine-readable JSON form to `out`.
+///
+/// Schema (stable as of issue #213):
+/// ```json
+/// {
+///   "active": "/Users/you/Library/Application Support/all-smi/config.toml",
+///   "exists": false,
+///   "overridden": false,
+///   "search_order": [
+///     "/Users/you/Library/Application Support/all-smi/config.toml",
+///     "/Users/you/.config/all-smi/config.toml"
+///   ]
+/// }
+/// ```
+///
+/// * `active` is the path the loader would actually open (either the
+///   `--config` override or the canonical default for the platform).
+///   `null` only when no home directory can be resolved.
+/// * `exists` reflects `Path::exists()` for `active`.
+/// * `overridden` is `true` when `--config` was supplied.
+/// * `search_order` is the ordered list the loader would probe;
+///   suppressed (empty) when `overridden` is `true` because discovery
+///   never runs in that case.
+fn write_json<W: Write>(out: &mut W, explicit: Option<&Path>) -> io::Result<()> {
+    let overridden = explicit.is_some();
+    let active_path: Option<std::path::PathBuf> = match explicit {
+        Some(p) => Some(p.to_path_buf()),
+        None => paths::default_config_path(),
+    };
+    let exists = active_path.as_deref().map(Path::exists).unwrap_or(false);
+    let search_order: Vec<String> = if overridden {
+        Vec::new()
+    } else {
+        paths::candidate_config_paths()
+            .into_iter()
+            .map(|p| p.display().to_string())
+            .collect()
+    };
+    let value = json!({
+        "active": active_path.as_deref().map(|p| p.display().to_string()),
+        "exists": exists,
+        "overridden": overridden,
+        "search_order": search_order,
+    });
+    let rendered = serde_json::to_string_pretty(&value).map_err(io::Error::other)?;
+    writeln!(out, "{rendered}")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The text output must always begin with a marker line and never
+    /// be empty even when there is no resolvable home directory.
+    #[test]
+    fn text_output_never_empty_with_default_resolution() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&mut buf, None).expect("write must succeed");
+        let s = String::from_utf8(buf).unwrap();
+        assert!(!s.trim().is_empty(), "text output must not be empty");
+    }
+
+    /// With `--config <path>` the text output reports the override and
+    /// suppresses the candidate-search list (discovery doesn't run).
+    #[test]
+    fn text_output_with_explicit_reports_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, b"# stub").unwrap();
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&mut buf, Some(&path)).expect("write must succeed");
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains(&path.display().to_string()));
+        assert!(
+            s.contains("(active)"),
+            "existing override file must be marked (active), got: {s}"
+        );
+        assert!(
+            s.contains("--config override"),
+            "override sourcing must be disclosed, got: {s}"
+        );
+        assert!(
+            !s.contains("search order:"),
+            "search order must be suppressed when overridden, got: {s}"
+        );
+    }
+
+    /// Without an override the text output prints the default path and
+    /// the ordered candidate list (where one is resolvable).
+    #[test]
+    fn text_output_prints_search_order_when_not_overridden() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&mut buf, None).expect("write must succeed");
+        let s = String::from_utf8(buf).unwrap();
+        if paths::candidate_config_paths().is_empty() {
+            // No home dir resolvable on this host; the first line
+            // already covers the no-config case, so search order is
+            // expected to be omitted.
+            assert!(s.contains("no config path"));
+        } else {
+            assert!(s.contains("search order:"));
+        }
+    }
+
+    /// The JSON output must always parse and carry the documented
+    /// fields. Missing fields would break scripts depending on the
+    /// schema.
+    #[test]
+    fn json_output_has_stable_schema() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_json(&mut buf, None).expect("write must succeed");
+        let s = String::from_utf8(buf).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        assert!(value.get("active").is_some(), "missing `active`");
+        assert!(value.get("exists").is_some(), "missing `exists`");
+        assert!(value.get("overridden").is_some(), "missing `overridden`");
+        assert!(
+            value.get("search_order").is_some(),
+            "missing `search_order`"
+        );
+        assert_eq!(value["overridden"], false);
+    }
+
+    /// JSON output with an explicit override reflects the override and
+    /// reports an empty `search_order` (discovery is bypassed).
+    #[test]
+    fn json_output_reflects_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, b"# stub").unwrap();
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_json(&mut buf, Some(&path)).expect("write must succeed");
+        let s = String::from_utf8(buf).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        assert_eq!(value["overridden"], true);
+        assert_eq!(value["exists"], true);
+        assert_eq!(value["active"], path.display().to_string());
+        let order = value["search_order"]
+            .as_array()
+            .expect("search_order must be array");
+        assert!(
+            order.is_empty(),
+            "search_order must be empty when overridden, got: {order:?}"
+        );
+    }
+
+    /// The runner is read-only: it MUST NOT create the file even when
+    /// `Path::exists()` returns false. Regression guard against a
+    /// future refactor that accidentally calls
+    /// `secure_write::create_new_secure` from this path.
+    #[test]
+    fn run_path_does_not_create_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let absent = dir.path().join("never-written.toml");
+        assert!(!absent.exists(), "precondition: file must not exist");
+
+        // Direct call to the JSON writer so we don't print to stdout
+        // during tests, but the JSON path is the strictest — if any
+        // future regression were to add a write, it would happen
+        // inside the resolver helpers shared with the text path too.
+        let mut buf: Vec<u8> = Vec::new();
+        write_json(&mut buf, Some(&absent)).expect("write must succeed");
+
+        // Critical assertion — the runner must NOT have touched disk.
+        assert!(
+            !absent.exists(),
+            "config path runner must NOT create the file"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ mod utils;
 mod view;
 
 use api::run_api_mode;
-use clap::Parser;
+use clap::FromArgMatches;
 use cli::{Cli, Commands, LocalArgs};
 use common::config_file::{self, Settings, SocketSetting};
 use tokio::signal;
@@ -68,7 +68,17 @@ fn main() {
     #[cfg(target_os = "macos")]
     setup_panic_handler();
 
-    let cli = Cli::parse();
+    // Build the top-level command with the runtime-composed help
+    // blocks injected (issue #213). The "Configuration file" block has
+    // to resolve `$HOME` / `$XDG_CONFIG_HOME` / `%APPDATA%` at process
+    // start, which a static `#[command(after_help = ...)]` cannot do.
+    let matches = cli::build_command_with_runtime_help().get_matches();
+    let cli = match Cli::from_arg_matches(&matches) {
+        Ok(c) => c,
+        Err(e) => {
+            e.exit();
+        }
+    };
 
     // Handle the `config` subcommand synchronously — it never starts a
     // Tokio runtime and its I/O is purely local filesystem work.

--- a/tests/config_path_help_test.rs
+++ b/tests/config_path_help_test.rs
@@ -1,0 +1,137 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for issue #213 — `--help` exposes the active TOML
+//! config file location, and the `--config` flag's own help text no
+//! longer requires the user to run a side-effecting command
+//! (`config init`) to discover the default path.
+//!
+//! These tests intentionally exercise the lib-level API
+//! (`all_smi::cli::build_command_with_runtime_help`) rather than
+//! shelling out to the compiled binary so they stay fast and avoid
+//! spawning a child process for each assertion.
+
+use all_smi::cli::{build_command_with_runtime_help, config_help_block};
+
+/// `--help` must render the runtime-composed "Configuration file"
+/// block. Without this, a fresh user who reaches for `-h` has no way
+/// to know a TOML config exists or where it lives.
+#[test]
+fn help_shows_configuration_file_block() {
+    let mut cmd = build_command_with_runtime_help();
+    let help = cmd.render_help().to_string();
+    assert!(
+        help.contains("Configuration file:"),
+        "help must contain `Configuration file:` block.\n--- help ---\n{help}"
+    );
+    assert!(
+        help.contains("Active path (this platform):"),
+        "help must label the active path.\n--- help ---\n{help}"
+    );
+    assert!(
+        help.contains("Override path with --config"),
+        "help must document the --config override.\n--- help ---\n{help}"
+    );
+}
+
+/// The composed help text must keep the existing Energy Session block
+/// in place. Regression guard against the runtime-composition refactor
+/// accidentally dropping the static block.
+#[test]
+fn help_preserves_existing_energy_block() {
+    let mut cmd = build_command_with_runtime_help();
+    let help = cmd.render_help().to_string();
+    assert!(
+        help.contains("Energy Session"),
+        "Energy Session block must still be rendered.\n--- help ---\n{help}"
+    );
+    assert!(
+        help.contains("ALL_SMI_ENERGY_PRICE"),
+        "Energy env-var docs must still be rendered.\n--- help ---\n{help}"
+    );
+}
+
+/// The active path line must carry an existence marker — either
+/// `(active)`, `(not found)`, or the no-config explainer. Without a
+/// marker, the user cannot tell from `--help` whether the file exists.
+#[test]
+fn help_active_path_carries_existence_marker() {
+    let block = config_help_block();
+    let has_marker = block.contains("(active)")
+        || block.contains("(not found)")
+        || block.contains("no config path");
+    assert!(
+        has_marker,
+        "config_help_block must carry an existence marker.\n--- block ---\n{block}"
+    );
+}
+
+/// The `--config` flag's own help text must guide users toward a
+/// read-only discovery path (`config path` or the inline help block)
+/// rather than only `config init`, which has the side effect of
+/// writing a file.
+#[test]
+fn config_flag_help_points_at_readonly_discovery() {
+    let mut cmd = build_command_with_runtime_help();
+    let help = cmd.render_help().to_string();
+    // Anywhere in the rendered help, the read-only discovery command
+    // must be mentioned — either in the flag docstring or in the
+    // Configuration file block.
+    assert!(
+        help.contains("config path"),
+        "help must mention the read-only `config path` command.\n--- help ---\n{help}"
+    );
+}
+
+/// `--version` must still render through the runtime-composed command.
+/// Regression guard for the clap derive vs. runtime mutation interaction.
+#[test]
+fn version_flag_still_renders() {
+    let cmd = build_command_with_runtime_help();
+    let version = cmd.render_version().to_string();
+    assert!(
+        !version.trim().is_empty(),
+        "render_version must produce non-empty text"
+    );
+}
+
+/// The `config path` subcommand must be reachable from the
+/// runtime-composed command tree — i.e. clap parses it as a known
+/// subcommand. Regression guard: future edits to `ConfigAction` that
+/// drop the variant would surface as a parse failure here.
+#[test]
+fn config_path_subcommand_is_reachable() {
+    let cmd = build_command_with_runtime_help();
+    let matches = cmd
+        .try_get_matches_from(["all-smi", "config", "path"])
+        .expect("`config path` must parse cleanly");
+    let (sub_name, sub_matches) = matches
+        .subcommand()
+        .expect("config subcommand must be present");
+    assert_eq!(sub_name, "config");
+    let (inner_name, _) = sub_matches
+        .subcommand()
+        .expect("config sub-subcommand must be present");
+    assert_eq!(inner_name, "path");
+}
+
+/// `config path --json` is also reachable; verifies the `--json` flag
+/// is wired through.
+#[test]
+fn config_path_accepts_json_flag() {
+    let cmd = build_command_with_runtime_help();
+    let _matches = cmd
+        .try_get_matches_from(["all-smi", "config", "path", "--json"])
+        .expect("`config path --json` must parse cleanly");
+}


### PR DESCRIPTION
## Summary

Closes #213.

Adds the resolved TOML config file location to `all-smi --help`, introduces a strictly read-only `all-smi config path` subcommand for scripting/discovery, and fills the config-path gap in the man page `FILES` section.

### Before
`all-smi --help` did not reveal where the config file lives. The only pointer was the `--config <PATH>` flag description, which redirected to `all-smi config init` — a command that **writes a file** as a side effect. A new user had no way, from `-h` / `--help` alone, to know a config file even existed or where it would go.

### After
- `all-smi --help` and `all-smi -h` show a new "Configuration file" section with the resolved per-user path (`$HOME` / `$XDG_CONFIG_HOME` / `%APPDATA%` aware) plus an `(active)` / `(not found)` marker.
- `all-smi config path [--json]` prints the active path + ordered candidate search list with **no file writes**. The JSON form has a stable schema (`active`, `exists`, `overridden`, `search_order`).
- `--config <PATH>` is honoured by `config path` (reports the override + suppresses the search list).
- Man page `FILES` enumerates per-platform `config.toml` paths and points at the new discovery surface.
- README adds `config path` to the helpers list and tightens the `--config` flag wording.

### Implementation notes
- Dynamic `after_help` is composed at runtime in `cli::build_command_with_runtime_help()` because the resolved path embeds the user's `$HOME` / `$XDG_CONFIG_HOME`, which a static `#[command(after_help = ...)]` cannot do.
- `main.rs` parses via `Cli::from_arg_matches` so the runtime composition reaches `--help`.
- Shared `paths::format_path_with_existence()` keeps the existence marker vocabulary consistent between `--help` and `config path`.
- Read-only guarantee for `config path` is regression-tested (`run_path_does_not_create_file`).
- No-home-directory case is handled with a clear inline message (`(no config path resolvable — set $HOME or $XDG_CONFIG_HOME)`).

### Files changed
- `src/cli.rs` — dynamic `after_help` builder; reworded `--config` doc.
- `src/cli_config.rs` — new `ConfigAction::Path(ConfigPathArgs)`.
- `src/config_cmd/mod.rs` + `src/config_cmd/path.rs` — read-only runner with text + JSON output.
- `src/common/paths.rs` — shared existence-marker formatter.
- `src/main.rs` — parse via `Cli::from_arg_matches` after runtime composition.
- `docs/man/all-smi.1` — `config` subcommand in COMMANDS; per-platform paths in FILES; ENERGY ACCOUNTING points at `config path`.
- `README.md` — `config path` helper entry; tightened `--config` wording.
- `tests/config_path_help_test.rs` (integration) + inline unit tests in `paths.rs`, `cli.rs`, `config_cmd/path.rs`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo test --test config_path_help_test` (7 new integration tests)
- [x] `cargo test --lib common::paths::tests` (3 new + 7 existing pass)
- [x] `cargo test --bin all-smi config_cmd::path` (6 new tests pass)
- [x] `cargo test --bin all-smi cli::tests` (3 new + 5 existing pass)
- [x] `cargo test --bin all-smi config_cmd` (existing render tests still pass)
- [x] `cargo test --test config_file_integration_test` (existing 14 tests still pass)
- [x] Manual: `./target/debug/all-smi --help` shows Configuration file + Energy Session blocks
- [x] Manual: `./target/debug/all-smi config path` prints active path + search order
- [x] Manual: `./target/debug/all-smi config path --json` emits stable JSON schema
- [x] Manual: confirmed `config path` does NOT create the file (no `~/.config/all-smi/` after invocation; no `/tmp/explicit_nope.toml` after `--config` override)
- [x] Manual: `groff -Tutf8 -man docs/man/all-smi.1` renders cleanly; new FILES entries display correctly