### PR TITLE
feat: display system swap usage in the TUI memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,8 +436,18 @@ Stable check IDs (greppable across versions):
 - **System Memory Tracking:**
   - Total, used, available, and free memory
   - Memory utilization percentage
-  - Swap space monitoring
   - Linux: Buffer and cache memory tracking
+- **Swap Space Monitoring:**
+  - A dedicated `Swap` bar is rendered directly under the `Mem` bar in the
+    TUI memory section whenever the host has swap configured
+    (`swap_total_bytes > 0`)
+  - Hosts without swap (`swap_total_bytes == 0`) automatically hide the
+    swap row so the layout stays compact — most relevant on Apple Silicon
+    before macOS' `dynamic_pager` allocates a swap file
+  - The swap bar segment is colored **red** when `swap_used_bytes > 0`
+    to flag active swapping at a glance — the primary signal needed for
+    AI inference workloads on Apple Silicon, where over-sized models
+    spill unified memory into swap and silently degrade throughput
 - **Visual Indicators:** Color-coded memory usage bars
 
 ### Process Monitoring

--- a/src/mock/templates/apple_silicon.rs
+++ b/src/mock/templates/apple_silicon.rs
@@ -260,6 +260,37 @@ impl AppleSiliconMockGenerator {
             "all_smi_memory_pressure{{instance=\"{}\"}} {{{{MEM_PRESSURE}}}}\n",
             self.instance_name
         ));
+
+        // Swap metrics (issue #220 — demoable swap row).
+        // Emitted only when `swap_total_bytes > 0`, matching the real
+        // `MemoryMetricExporter::export_swap_metrics` guard at
+        // `src/api/metrics/memory.rs:76`. Apple Silicon's
+        // `dynamic_pager` may legitimately report 0 until a swap file
+        // exists; the mock seeds a non-zero value so the swap UI is
+        // always demoable, but the conditional is kept here so the
+        // mock stays faithful to the API contract.
+        if memory.swap_total_bytes > 0 {
+            template.push_str("# HELP all_smi_swap_total_bytes Total swap space in bytes\n");
+            template.push_str("# TYPE all_smi_swap_total_bytes gauge\n");
+            template.push_str(&format!(
+                "all_smi_swap_total_bytes{{instance=\"{}\"}} {}\n",
+                self.instance_name, memory.swap_total_bytes
+            ));
+
+            template.push_str("# HELP all_smi_swap_used_bytes Used swap space in bytes\n");
+            template.push_str("# TYPE all_smi_swap_used_bytes gauge\n");
+            template.push_str(&format!(
+                "all_smi_swap_used_bytes{{instance=\"{}\"}} {{{{SWAP_USED}}}}\n",
+                self.instance_name
+            ));
+
+            template.push_str("# HELP all_smi_swap_free_bytes Free swap space in bytes\n");
+            template.push_str("# TYPE all_smi_swap_free_bytes gauge\n");
+            template.push_str(&format!(
+                "all_smi_swap_free_bytes{{instance=\"{}\"}} {{{{SWAP_FREE}}}}\n",
+                self.instance_name
+            ));
+        }
     }
 
     /// Render dynamic values for Apple Silicon
@@ -352,6 +383,12 @@ impl AppleSiliconMockGenerator {
         let mem_pressure = (memory.used_bytes as f64 / memory.total_bytes as f64) * 100.0;
         response = response.replace("{{MEM_PRESSURE}}", &format!("{mem_pressure:.2}"));
 
+        // Swap metrics (issue #220). Only present in the template when
+        // `swap_total_bytes > 0`; the replace calls are no-ops otherwise.
+        response = response
+            .replace("{{SWAP_USED}}", &memory.swap_used_bytes.to_string())
+            .replace("{{SWAP_FREE}}", &memory.swap_free_bytes.to_string());
+
         // Replace Apple chassis metrics
         response = crate::mock::templates::common::render_apple_chassis_metrics(response, gpus);
 
@@ -406,6 +443,15 @@ impl MockGenerator for AppleSiliconMockGenerator {
             per_core_utilization: vec![],
         };
 
+        // Apple Silicon (macOS) manages swap dynamically via `dynamic_pager`,
+        // which creates a swap file the moment unified memory comes under
+        // pressure. Seed the mock with a realistic 4 GB swap file and a
+        // small but non-zero `swap_used` value so that:
+        //   1. The TUI's new swap row (issue #220) is demoable end-to-end
+        //      against `all-smi-mock-server` without needing real macOS.
+        //   2. The amber/red "active swap" emphasis path actually fires.
+        let swap_total: u64 = 4_294_967_296; // 4 GB
+        let swap_used = rng.random_range(256_000_000..1_500_000_000);
         let memory = MemoryMetrics {
             total_bytes: 68_719_476_736, // 64GB unified memory
             used_bytes: rng.random_range(10_000_000_000..60_000_000_000),
@@ -413,9 +459,9 @@ impl MockGenerator for AppleSiliconMockGenerator {
             free_bytes: rng.random_range(5_000_000_000..50_000_000_000),
             cached_bytes: rng.random_range(1_000_000_000..10_000_000_000),
             buffers_bytes: rng.random_range(100_000_000..1_000_000_000),
-            swap_total_bytes: 0,
-            swap_used_bytes: 0,
-            swap_free_bytes: 0,
+            swap_total_bytes: swap_total,
+            swap_used_bytes: swap_used,
+            swap_free_bytes: swap_total.saturating_sub(swap_used),
             utilization: rng.random_range(10.0..90.0),
         };
 

--- a/src/mock/templates/nvidia.rs
+++ b/src/mock/templates/nvidia.rs
@@ -490,6 +490,36 @@ impl NvidiaMockGenerator {
             "all_smi_memory_total_bytes{{instance=\"{}\"}} {}\n",
             self.instance_name, memory.total_bytes
         ));
+
+        // Swap metrics (issue #220 — demoable swap row).
+        // Emitted only when `swap_total_bytes > 0`, matching the real
+        // `MemoryMetricExporter::export_swap_metrics` guard at
+        // `src/api/metrics/memory.rs:76`. Templates generated with
+        // zero swap therefore omit these series, preserving the
+        // exporter contract that swap series only appear on hosts
+        // with swap actually configured.
+        if memory.swap_total_bytes > 0 {
+            template.push_str("# HELP all_smi_swap_total_bytes Total swap space in bytes\n");
+            template.push_str("# TYPE all_smi_swap_total_bytes gauge\n");
+            template.push_str(&format!(
+                "all_smi_swap_total_bytes{{instance=\"{}\"}} {}\n",
+                self.instance_name, memory.swap_total_bytes
+            ));
+
+            template.push_str("# HELP all_smi_swap_used_bytes Used swap space in bytes\n");
+            template.push_str("# TYPE all_smi_swap_used_bytes gauge\n");
+            template.push_str(&format!(
+                "all_smi_swap_used_bytes{{instance=\"{}\"}} {{{{SWAP_USED}}}}\n",
+                self.instance_name
+            ));
+
+            template.push_str("# HELP all_smi_swap_free_bytes Free swap space in bytes\n");
+            template.push_str("# TYPE all_smi_swap_free_bytes gauge\n");
+            template.push_str(&format!(
+                "all_smi_swap_free_bytes{{instance=\"{}\"}} {{{{SWAP_FREE}}}}\n",
+                self.instance_name
+            ));
+        }
     }
 
     /// Render dynamic values for NVIDIA GPUs
@@ -549,6 +579,14 @@ impl NvidiaMockGenerator {
         response = response
             .replace("{{CPU_UTIL}}", &format!("{:.2}", cpu.utilization))
             .replace("{{MEM_USED}}", &memory.used_bytes.to_string());
+
+        // Swap metrics (issue #220). Placeholders are only present in
+        // the template when `swap_total_bytes > 0`; the replaces are
+        // no-ops otherwise so this stays safe for the zero-swap
+        // `generate_template` path.
+        response = response
+            .replace("{{SWAP_USED}}", &memory.swap_used_bytes.to_string())
+            .replace("{{SWAP_FREE}}", &memory.swap_free_bytes.to_string());
 
         // Replace chassis metrics
         response = crate::mock::templates::common::render_chassis_metrics(response, gpus);
@@ -612,6 +650,12 @@ impl MockGenerator for NvidiaMockGenerator {
             per_core_utilization: vec![],
         };
 
+        // Linux servers typically configure a swap partition or zram
+        // device alongside large physical RAM. Seed a realistic 32 GB
+        // swap area with a modest current usage so the TUI swap row
+        // (issue #220) renders end-to-end against the NVIDIA mock.
+        let swap_total: u64 = 34_359_738_368; // 32 GB
+        let swap_used = rng.random_range(0..8_000_000_000);
         let memory = MemoryMetrics {
             total_bytes: 1099511627776, // 1TB
             used_bytes: rng.random_range(10_000_000_000..500_000_000_000),
@@ -619,9 +663,9 @@ impl MockGenerator for NvidiaMockGenerator {
             free_bytes: rng.random_range(50_000_000_000..400_000_000_000),
             cached_bytes: rng.random_range(10_000_000_000..100_000_000_000),
             buffers_bytes: rng.random_range(1_000_000_000..10_000_000_000),
-            swap_total_bytes: 0,
-            swap_used_bytes: 0,
-            swap_free_bytes: 0,
+            swap_total_bytes: swap_total,
+            swap_used_bytes: swap_used,
+            swap_free_bytes: swap_total.saturating_sub(swap_used),
             utilization: rng.random_range(10.0..90.0),
         };
 
@@ -756,6 +800,87 @@ mod tests {
             swap_free_bytes: 0,
             utilization: 50.0,
         }
+    }
+
+    /// Memory fixture with a configured swap area, used by the
+    /// issue #220 swap-emission tests.
+    fn make_memory_metrics_with_swap() -> MemoryMetrics {
+        MemoryMetrics {
+            total_bytes: 1024,
+            used_bytes: 512,
+            available_bytes: 512,
+            free_bytes: 512,
+            cached_bytes: 0,
+            buffers_bytes: 0,
+            swap_total_bytes: 4_294_967_296,
+            swap_used_bytes: 536_870_912,
+            swap_free_bytes: 3_758_096_384,
+            utilization: 50.0,
+        }
+    }
+
+    // --- swap metrics (issue #220) ---
+
+    #[test]
+    fn mock_template_omits_swap_metrics_when_swap_total_is_zero() {
+        // Mirrors the real API exporter behaviour: when the host has
+        // no swap, `all_smi_swap_*` series are not emitted at all.
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_gpu_metrics();
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &make_memory_metrics());
+
+        for metric in &[
+            "all_smi_swap_total_bytes",
+            "all_smi_swap_used_bytes",
+            "all_smi_swap_free_bytes",
+        ] {
+            assert!(
+                !tpl.contains(metric),
+                "swap metric {metric:?} should be absent when swap_total_bytes == 0"
+            );
+        }
+    }
+
+    #[test]
+    fn mock_template_emits_swap_metrics_when_swap_total_is_nonzero() {
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_gpu_metrics();
+        let memory = make_memory_metrics_with_swap();
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &memory);
+
+        for metric in &[
+            "all_smi_swap_total_bytes",
+            "all_smi_swap_used_bytes",
+            "all_smi_swap_free_bytes",
+        ] {
+            assert!(
+                tpl.contains(metric),
+                "swap metric {metric:?} should be present when swap_total_bytes > 0"
+            );
+        }
+        // The total is a literal in the template; used/free are placeholders
+        // resolved by `render_nvidia_response`.
+        assert!(
+            tpl.contains("{{SWAP_USED}}") && tpl.contains("{{SWAP_FREE}}"),
+            "swap value placeholders missing from template"
+        );
+    }
+
+    #[test]
+    fn mock_render_resolves_swap_placeholders() {
+        let gen_ = NvidiaMockGenerator::new(None, "mock-node".to_string());
+        let gpus = make_gpu_metrics();
+        let memory = make_memory_metrics_with_swap();
+        let tpl = gen_.build_nvidia_template(&gpus, &make_cpu_metrics(), &memory);
+        let rendered = gen_.render_nvidia_response(&tpl, &gpus, &make_cpu_metrics(), &memory);
+
+        assert!(
+            !rendered.contains("{{SWAP_USED}}") && !rendered.contains("{{SWAP_FREE}}"),
+            "swap placeholders should be resolved after render; got:\n{rendered}"
+        );
+        // Used / free byte counts should appear verbatim in the rendered output.
+        assert!(rendered.contains(&memory.swap_used_bytes.to_string()));
+        assert!(rendered.contains(&memory.swap_free_bytes.to_string()));
     }
 
     // Process-global mutex that serialises every test in this module which

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -198,7 +198,12 @@ impl MetricsParser {
                             host,
                         );
                     }
-                } else if metric_name.starts_with("memory_") {
+                } else if metric_name.starts_with("memory_") || metric_name.starts_with("swap_") {
+                    // Swap metrics share the same per-host accumulator as
+                    // memory — they carry identical `instance`/`hostname`/`index`
+                    // labels and are conceptually a property of the host's
+                    // memory subsystem (issue #220). Routing them together
+                    // keeps the `MemoryInfo` row populated consistently.
                     if memory_info_map.len() < MAX_DEVICES_PER_TYPE {
                         self.process_memory_metrics(
                             &mut memory_info_map,
@@ -900,7 +905,15 @@ impl MetricsParser {
             "memory_available_bytes" => available_bytes as u64,
             "memory_buffers_bytes" => buffers_bytes as u64,
             "memory_cached_bytes" => cached_bytes as u64,
-            "memory_utilization" => utilization as f64
+            "memory_utilization" => utilization as f64,
+            // Swap metrics (issue #220). The API exporter only emits
+            // these series when `swap_total_bytes > 0`, so absent
+            // metrics leave the corresponding fields at their default
+            // zero — which is exactly what the renderer needs to
+            // decide whether to show the Swap row.
+            "swap_total_bytes" => swap_total_bytes as u64,
+            "swap_used_bytes" => swap_used_bytes as u64,
+            "swap_free_bytes" => swap_free_bytes as u64
         });
     }
 
@@ -1802,6 +1815,40 @@ all_smi_memory_utilization{instance="node-0058", hostname="node-0058", index="0"
         assert_eq!(memory.used_bytes, 68719476736);
         assert_eq!(memory.available_bytes, 68719476736);
         assert_eq!(memory.utilization, 50.0);
+        // Swap fields default to zero when the exporter omits them
+        // (the API guard at `src/api/metrics/memory.rs:76` skips swap
+        // series on hosts where `swap_total_bytes == 0`).
+        assert_eq!(memory.swap_total_bytes, 0);
+        assert_eq!(memory.swap_used_bytes, 0);
+        assert_eq!(memory.swap_free_bytes, 0);
+    }
+
+    #[test]
+    fn test_parse_swap_metrics() {
+        // Issue #220: swap series share the per-host memory accumulator.
+        // The parser routes `swap_*` lines into the same `MemoryInfo`
+        // row that the matching `memory_*` lines populate.
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10058";
+
+        let test_data = r#"
+all_smi_memory_total_bytes{instance="node-0058", hostname="node-0058", index="0"} 137438953472
+all_smi_memory_used_bytes{instance="node-0058", hostname="node-0058", index="0"} 68719476736
+all_smi_swap_total_bytes{instance="node-0058", hostname="node-0058", index="0"} 4294967296
+all_smi_swap_used_bytes{instance="node-0058", hostname="node-0058", index="0"} 536870912
+all_smi_swap_free_bytes{instance="node-0058", hostname="node-0058", index="0"} 3758096384
+"#;
+
+        let parsed = parser.parse_metrics(test_data, host, &re);
+
+        assert_eq!(parsed.memory_info.len(), 1);
+        let memory = &parsed.memory_info[0];
+        assert_eq!(memory.total_bytes, 137438953472);
+        assert_eq!(memory.used_bytes, 68719476736);
+        assert_eq!(memory.swap_total_bytes, 4294967296);
+        assert_eq!(memory.swap_used_bytes, 536870912);
+        assert_eq!(memory.swap_free_bytes, 3758096384);
     }
 
     #[test]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -293,6 +293,11 @@ fn render_shortcuts_section(
             "[used/buffers/cache                    used%]",
             "membar",
         ),
+        (
+            "  Swap gauge:",
+            "[swap                                   GB] (red = active)",
+            "swapbar",
+        ),
         ("", "", ""),
         ("Energy Session:", "", "header"),
         (
@@ -478,6 +483,14 @@ fn format_shortcut_line(key: &str, desc: &str, style: &str, width: usize) -> Str
                 .replace("used", &"used".green().to_string())
                 .replace("buffers", &"buffers".blue().to_string())
                 .replace("cache", &"cache".yellow().to_string());
+            format!(" {key:<10} {colored_desc}")
+        }
+        "swapbar" => {
+            // Mirror "membar" styling for the swap row added in issue
+            // #220. The bar text is colored red to convey "active
+            // swapping = bad"; the parenthetical clarifier stays in
+            // the default text color so the legend remains readable.
+            let colored_desc = desc.replace("swap", &"swap".red().to_string());
             format!(" {key:<10} {colored_desc}")
         }
         _ => String::new(),

--- a/src/ui/renderers/memory_renderer.rs
+++ b/src/ui/renderers/memory_renderer.rs
@@ -54,7 +54,19 @@ fn format_hostname_with_scroll(hostname: &str, scroll_offset: usize) -> String {
     }
 }
 
-/// Render memory information including total, used, available, and utilization
+/// Render memory information including total, used, available, and utilization.
+///
+/// When `info.swap_total_bytes > 0`, a second bar (`Swap`) is rendered
+/// directly below the `Mem` bar. The swap segment color flips from
+/// magenta (idle: swap space exists but is unused) to red (active:
+/// `swap_used_bytes > 0`) so users can immediately spot swap pressure,
+/// which is the primary signal requested in issue #220 — particularly
+/// important on Apple Silicon where unified-memory spillover into swap
+/// silently degrades AI inference throughput.
+///
+/// Hosts with no swap configured (`swap_total_bytes == 0`) skip the
+/// swap row entirely, matching the API exporter guard at
+/// `src/api/metrics/memory.rs:76`.
 pub fn print_memory_info<W: Write>(
     stdout: &mut W,
     _index: usize,
@@ -116,7 +128,9 @@ pub fn print_memory_info<W: Write>(
     // Calculate actual space used and dynamic right padding
     let total_gauge_width = gauge_width;
     let left_padding = 5;
-    let right_padding = width - left_padding - total_gauge_width;
+    let right_padding = width
+        .saturating_sub(left_padding)
+        .saturating_sub(total_gauge_width);
 
     print_colored_text(stdout, "     ", Color::White, None, None); // 5 char left padding
 
@@ -162,12 +176,92 @@ pub fn print_memory_info<W: Write>(
 
     print_colored_text(stdout, &" ".repeat(right_padding), Color::White, None, None);
     queue!(stdout, Print("\r\n")).unwrap();
+
+    // Render the Swap row only when swap space exists on the host. Mirrors
+    // the API exporter guard at `src/api/metrics/memory.rs:76` so non-swap
+    // hosts (e.g., Apple Silicon before `dynamic_pager` allocates a swap
+    // file) stay visually uncluttered. The row appears the moment macOS
+    // creates a swap file, which is exactly when the user wants to see it.
+    if info.swap_total_bytes > 0 {
+        print_swap_bar(stdout, info, width, gauge_width, left_padding);
+    }
+}
+
+/// Render the swap bar row that sits directly below the memory bar.
+///
+/// Layout mirrors the `Mem` row: 5-char left pad, full-width
+/// `draw_bar_multi` gauge, trailing pad to the right edge. The bar
+/// label is `Swap` and the overlay text shows `<used>GB` to match
+/// the memory bar's `<total_used>GB` convention.
+fn print_swap_bar<W: Write>(
+    stdout: &mut W,
+    info: &MemoryInfo,
+    width: usize,
+    gauge_width: usize,
+    left_padding: usize,
+) {
+    let swap_total_gb = info.swap_total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    let swap_used_gb = info.swap_used_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+    // Right padding mirrors the Mem row so the trailing edges line up.
+    let right_padding = width
+        .saturating_sub(left_padding)
+        .saturating_sub(gauge_width);
+
+    print_colored_text(stdout, &" ".repeat(left_padding), Color::White, None, None);
+
+    let mut segments = Vec::new();
+    if info.swap_used_bytes > 0 {
+        // Emphasize active swapping in red — the core signal from #220.
+        segments.push(BarSegment::swap_used_active(swap_used_gb));
+    }
+
+    // Overlay text is always `<used>GB` so the column reads at a glance
+    // alongside the Mem row's `<total_used>GB`. When idle (used == 0)
+    // this naturally prints `0.0GB` over an empty bar, signaling
+    // "swap is available but unused."
+    let display_text = format!("{swap_used_gb:.1}GB");
+
+    draw_bar_multi(
+        stdout,
+        "Swap",
+        &segments,
+        swap_total_gb,
+        gauge_width,
+        Some(display_text),
+    );
+
+    print_colored_text(stdout, &" ".repeat(right_padding), Color::White, None, None);
+    queue!(stdout, Print("\r\n")).unwrap();
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::device::MemoryInfo;
+
+    /// Strip ANSI CSI sequences (ESC [ ... letter) so tests can inspect
+    /// the visible characters that end up on the terminal.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                // Consume "[" and then everything up to the final byte
+                // (any ASCII letter terminates a CSI sequence).
+                if chars.next() == Some('[') {
+                    for nc in chars.by_ref() {
+                        if nc.is_ascii_alphabetic() {
+                            break;
+                        }
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
 
     fn make_memory_info(hostname: &str) -> MemoryInfo {
         MemoryInfo {
@@ -224,5 +318,101 @@ mod tests {
         // Should not panic with a narrow terminal width
         print_memory_info(&mut buf, 0, &info, 30, 0, false);
         assert!(!buf.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Swap row rendering (issue #220)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_swap_row_renders_when_swap_total_nonzero() {
+        // Default fixture has swap_total_bytes > 0 and swap_used_bytes > 0,
+        // so the Swap row must appear.
+        let info = make_memory_info("host");
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 120, 0, false);
+        let visible = strip_ansi(&String::from_utf8_lossy(&buf));
+        assert!(
+            visible.contains("Swap"),
+            "Swap row should appear when swap_total_bytes > 0; got: {visible:?}"
+        );
+        // The label has its own line (newline separates Mem and Swap rows).
+        let row_count = visible.matches("\r\n").count();
+        assert!(
+            row_count >= 3,
+            "Expected at least 3 newlines (info + Mem + Swap), got {row_count} in: {visible:?}"
+        );
+    }
+
+    #[test]
+    fn test_swap_row_hidden_when_swap_total_zero() {
+        let mut info = make_memory_info("host");
+        info.swap_total_bytes = 0;
+        info.swap_used_bytes = 0;
+        info.swap_free_bytes = 0;
+
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 120, 0, false);
+        let visible = strip_ansi(&String::from_utf8_lossy(&buf));
+        assert!(
+            !visible.contains("Swap"),
+            "Swap row should NOT appear when swap_total_bytes == 0; got: {visible:?}"
+        );
+    }
+
+    #[test]
+    fn test_swap_row_renders_when_total_present_but_unused() {
+        // Apple Silicon's `dynamic_pager` can create a swap file with
+        // zero usage; the row should still appear so the user knows
+        // swap exists, but in the idle (non-emphasized) state.
+        let mut info = make_memory_info("host");
+        info.swap_used_bytes = 0;
+        info.swap_free_bytes = info.swap_total_bytes;
+
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 120, 0, false);
+        let visible = strip_ansi(&String::from_utf8_lossy(&buf));
+        assert!(
+            visible.contains("Swap"),
+            "Swap row should still appear when swap_used_bytes == 0 but swap_total_bytes > 0; got: {visible:?}"
+        );
+        // Used = 0 bytes -> overlay text "0.0GB" must appear.
+        assert!(
+            visible.contains("0.0GB"),
+            "Idle swap row should show '0.0GB' overlay text; got: {visible:?}"
+        );
+    }
+
+    #[test]
+    fn test_swap_row_active_uses_red_color() {
+        // When swap is actively in use, the rendered output should
+        // contain the red ANSI color SGR for the active swap segment.
+        // crossterm Color::Red maps to SGR "31".
+        let info = make_memory_info("host");
+        assert!(info.swap_used_bytes > 0, "fixture precondition");
+
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 120, 0, false);
+        let raw = String::from_utf8_lossy(&buf);
+        assert!(
+            raw.contains("\x1b[38;5;9m") || raw.contains("\x1b[31m"),
+            "Active swap row should be colored red; raw output did not contain a red SGR"
+        );
+    }
+
+    #[test]
+    fn test_swap_row_renders_at_narrow_width() {
+        // Narrow widths should not panic and the Swap row should still
+        // render. The bar's left padding and gauge_width are derived
+        // via saturating arithmetic so this exercises the underflow
+        // guard added alongside the swap row.
+        let info = make_memory_info("host");
+        let mut buf: Vec<u8> = Vec::new();
+        print_memory_info(&mut buf, 0, &info, 30, 0, false);
+        let visible = strip_ansi(&String::from_utf8_lossy(&buf));
+        assert!(
+            visible.contains("Swap"),
+            "Swap row should appear even at narrow width; got: {visible:?}"
+        );
     }
 }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -291,6 +291,28 @@ impl BarSegment {
     pub fn memory_cache(value: f64) -> Self {
         Self::new(value, Color::Yellow).with_label("cache")
     }
+
+    /// Swap-used segment in its idle color (Magenta).
+    ///
+    /// Use this when `swap_total_bytes > 0` but no swap is currently in
+    /// use; renderers should call [`Self::swap_used_active`] when
+    /// `swap_used_bytes > 0` to emphasize the pressure signal. Kept
+    /// public alongside `swap_used_active` so external renderers can
+    /// distinguish "swap configured" from "swap pressure" without
+    /// re-implementing the color choice.
+    #[allow(dead_code)]
+    pub fn swap_used(value: f64) -> Self {
+        Self::new(value, Color::Magenta).with_label("swap")
+    }
+
+    /// Swap-used segment in its emphasized color (Red).
+    ///
+    /// Renderers should switch to this variant whenever
+    /// `swap_used_bytes > 0` so that active swapping is visually
+    /// distinct from a host that merely has swap space configured.
+    pub fn swap_used_active(value: f64) -> Self {
+        Self::new(value, Color::Red).with_label("swap")
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Surface system swap usage in the TUI memory section so users can spot swap pressure at a glance. Most important on Apple Silicon, where over-sized models spill unified memory into swap and silently degrade AI inference throughput. The data was already collected and exported on every platform; this PR is the long-missing rendering and end-to-end demoability work.

## What changed

- `src/ui/renderers/memory_renderer.rs`: added `print_swap_bar` and conditional rendering. The swap row is drawn directly below the Mem bar only when `swap_total_bytes > 0` (mirrors `src/api/metrics/memory.rs:76`); the bar segment color flips from magenta (idle) to red (active swap pressure) when `swap_used_bytes > 0`.
- `src/ui/widgets.rs`: new `BarSegment::swap_used` and `BarSegment::swap_used_active` helpers alongside `memory_used`/`memory_buffers`/`memory_cache`.
- `src/ui/help.rs`: documented the new swap row in the resource-gauge legend using the same colored-keyword styling as the memory row.
- `src/network/metrics_parser.rs`: extended the per-host memory accumulator to route `swap_*` lines into the same `MemoryInfo` row as `memory_*` lines, populating `swap_{total,used,free}_bytes`. Without this, cluster/remote mode would silently drop every swap series and the new UI would render inert against real remote hosts.
- `src/mock/templates/apple_silicon.rs` and `src/mock/templates/nvidia.rs`: replaced hardcoded zero swap with realistic non-zero values (4 GB on Apple Silicon, 32 GB on NVIDIA) and now emit `all_smi_swap_{total,used,free}_bytes` series guarded by the same `swap_total_bytes > 0` condition as the real exporter. Lets reviewers exercise the new UI end-to-end against `all-smi-mock-server`.
- `README.md`: documented the new swap row, the hide-when-zero behaviour, and the active-swap red emphasis under the Memory Monitoring section.

## Test plan

- [x] `cargo check --lib --tests` (clean)
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `cargo test --lib ui::renderers::memory_renderer` (9 tests pass — includes 5 new tests for swap-row visible/hidden/idle/active/narrow-width)
- [x] `cargo test --lib network::metrics_parser` (48 tests pass — includes new `test_parse_swap_metrics`)
- [x] `cargo test --features mock --bin all-smi-mock-server mock::templates::nvidia` (12 tests pass — includes 3 new tests for swap emission/omission/render)

Closes #220
