### PR TITLE
fix: resolve record default output path consistently (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,7 +1102,7 @@ operator can filter the visible GPUs mid-playback.
 
 | Flag              | Default                           | Description                                      |
 |-------------------|-----------------------------------|--------------------------------------------------|
-| `--output` / `-o` | `all-smi-record.ndjson.zst`       | Output path. Extension picks the codec.          |
+| `--output` / `-o` | `~/.cache/all-smi/records/all-smi-record.ndjson.zst` (override via `record.output_dir` config, or `-o` flag) | Output path. Extension picks the codec. |
 | `--interval` / `-i` | `3`                             | Seconds between frames.                          |
 | `--duration`      | `0` (= record until SIGTERM)      | Accepts `30s`, `5m`, `1h`, `1d`, or bare seconds. |
 | `--source`        | `local`                           | `local` (hardware readers) or `remote` (HTTP scrape). |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -438,12 +438,20 @@ impl std::fmt::Display for RecordCompression {
 #[derive(Parser, Clone, Debug)]
 pub struct RecordArgs {
     /// Output path for the NDJSON stream.
-    ///
-    /// Extension drives compression: `.ndjson.zst` → zstd,
-    /// `.ndjson.gz` → gzip, anything else → plain NDJSON. Use
-    /// `--compress` to override detection.
-    #[arg(long, short = 'o', default_value = "all-smi-record.ndjson.zst")]
-    pub output: PathBuf,
+    #[arg(
+        long,
+        short = 'o',
+        long_help = "Output path for the NDJSON stream.\n\n\
+            When omitted, the file lands under the `record.output_dir` config \
+            value (default `~/.cache/all-smi/records/`) with basename \
+            `all-smi-record.ndjson.zst`. If no config file is present, the \
+            file is written to the current working directory as \
+            `all-smi-record.ndjson.zst`.\n\n\
+            Extension drives compression: `.ndjson.zst` → zstd, \
+            `.ndjson.gz` → gzip, anything else → plain NDJSON. Use \
+            `--compress` to override detection."
+    )]
+    pub output: Option<PathBuf>,
 
     /// Interval in seconds between frames.
     #[arg(long, short = 'i', default_value_t = 3)]

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -52,6 +52,11 @@ use writer::{Codec, RotatingWriter};
 /// walk index frames.
 const INDEX_EVERY_N_FRAMES: u64 = 1000;
 
+/// Default basename used for the recorder's NDJSON stream when the
+/// operator does not pass `-o`. Defined once here so the CLI layer,
+/// resolver, doc comments, and tests stay aligned (see issue #223).
+pub const DEFAULT_BASENAME: &str = "all-smi-record.ndjson.zst";
+
 /// Resolved, validated options for a recording run.
 pub struct RecorderOptions {
     pub output: PathBuf,
@@ -80,15 +85,19 @@ impl RecorderOptions {
     /// Merged CLI + `[record]` config constructor. Precedence
     /// (highest → lowest):
     ///
-    /// * CLI flag (`--output`, `--compress`)
+    /// * Explicit CLI flag (`-o <path>` / `--compress`) — always
+    ///   honored verbatim, including when the path happens to equal
+    ///   [`DEFAULT_BASENAME`].
     /// * Config file (`record.output_dir`, `record.compress`)
-    /// * Compiled default (`./all-smi-record.ndjson.zst`, codec zstd)
+    /// * Compiled default ([`DEFAULT_BASENAME`] in the current working
+    ///   directory, codec zstd)
     ///
-    /// `record.output_dir` is treated as the *directory* the default
-    /// basename is placed under — the operator can always pass `-o
-    /// /some/file.ndjson` to bypass it. Tilde expansion is applied so
+    /// When `-o` is omitted, [`DEFAULT_BASENAME`] is placed under
+    /// `record.output_dir` (tilde-expanded so
     /// `output_dir = "~/.cache/all-smi/records"` resolves to the
-    /// user's home at record time.
+    /// user's home at record time). If no config is supplied,
+    /// the default resolves to just [`DEFAULT_BASENAME`] in the
+    /// current working directory.
     pub fn from_args_with_settings(
         args: &RecordArgs,
         settings: Option<&RecordSettings>,
@@ -124,21 +133,21 @@ impl RecorderOptions {
             })
         });
 
-        // Resolve the output path. clap hands us a default basename; if
-        // the operator did not pass `-o` AND the config supplied an
-        // `output_dir`, redirect the default basename under that dir.
-        // Detecting "operator did not pass -o" relies on the clap
-        // default being exactly the documented value — if that ever
-        // changes, update this guard.
-        let default_basename: std::path::PathBuf =
-            std::path::PathBuf::from("all-smi-record.ndjson.zst");
-        let output = if args.output == default_basename
-            && let Some(dir) = settings.map(|s| s.output_dir.as_str())
-            && !dir.is_empty()
-        {
-            crate::common::paths::expand_tilde(std::path::Path::new(dir)).join(&default_basename)
-        } else {
-            args.output.clone()
+        // Resolve the output path. Precedence: explicit `-o` >
+        // `record.output_dir` config + `DEFAULT_BASENAME` >
+        // `DEFAULT_BASENAME` in the current working directory.
+        let output = match &args.output {
+            Some(p) => p.clone(),
+            None => {
+                let dir = settings
+                    .map(|s| s.output_dir.as_str())
+                    .filter(|s| !s.is_empty());
+                match dir {
+                    Some(d) => crate::common::paths::expand_tilde(std::path::Path::new(d))
+                        .join(DEFAULT_BASENAME),
+                    None => std::path::PathBuf::from(DEFAULT_BASENAME),
+                }
+            }
         };
 
         let codec = Codec::detect(&output, compress_override);
@@ -529,5 +538,94 @@ mod tests {
         assert_eq!(parse_byte_size("1K").unwrap(), 1024);
         assert_eq!(parse_byte_size("1M").unwrap(), 1 << 20);
         assert_eq!(parse_byte_size("2G").unwrap(), 2 << 30);
+    }
+
+    /// Build a minimal valid `RecordArgs` for resolver tests. Defaults
+    /// match the clap-compiled defaults (`--source=local`,
+    /// `--include=gpu,cpu,memory,chassis`, etc.) so
+    /// `from_args_with_settings` passes its hosts and includes checks
+    /// without further setup. Callers tweak `output` to exercise the
+    /// path-resolution precedence.
+    fn record_args(output: Option<PathBuf>) -> RecordArgs {
+        RecordArgs {
+            output,
+            interval: 3,
+            duration: "0".to_string(),
+            source: RecordSource::Local,
+            hosts: None,
+            hostfile: None,
+            include: vec![
+                "gpu".to_string(),
+                "cpu".to_string(),
+                "memory".to_string(),
+                "chassis".to_string(),
+            ],
+            max_size: "100M".to_string(),
+            max_files: 10,
+            compress: None,
+        }
+    }
+
+    /// No `-o`, no config: the default basename should resolve to just
+    /// `DEFAULT_BASENAME` in the current working directory (no
+    /// directory prefix). This is the fallback when no config file is
+    /// loaded at all.
+    #[test]
+    fn resolve_output_no_cli_no_config() {
+        let args = record_args(None);
+        let opts = RecorderOptions::from_args_with_settings(&args, None).unwrap();
+        assert_eq!(opts.output, PathBuf::from(DEFAULT_BASENAME));
+    }
+
+    /// No `-o`, config `output_dir` set: the default basename should be
+    /// placed under the configured directory. Uses an absolute path so
+    /// tilde expansion is a no-op and the assertion is portable.
+    #[test]
+    fn resolve_output_no_cli_with_config_dir() {
+        let args = record_args(None);
+        let settings = RecordSettings {
+            output_dir: "/tmp/all-smi-records".to_string(),
+            compress: "zstd".to_string(),
+        };
+        let opts = RecorderOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
+        assert_eq!(
+            opts.output,
+            PathBuf::from("/tmp/all-smi-records/all-smi-record.ndjson.zst")
+        );
+    }
+
+    /// Regression guard for the silent-redirect bug fixed in #223:
+    /// explicit `-o all-smi-record.ndjson.zst` (a path that happens to
+    /// equal `DEFAULT_BASENAME`) must be honored verbatim, even when
+    /// the config has `output_dir` set. The previous string-sentinel
+    /// resolver silently redirected this path under the cache dir.
+    #[test]
+    fn resolve_output_explicit_matching_basename_is_honored() {
+        let args = record_args(Some(PathBuf::from(DEFAULT_BASENAME)));
+        let settings = RecordSettings {
+            output_dir: "/tmp/all-smi-records".to_string(),
+            compress: "zstd".to_string(),
+        };
+        let opts = RecorderOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
+        assert_eq!(opts.output, PathBuf::from(DEFAULT_BASENAME));
+    }
+
+    /// Explicit `-o /var/log/cluster.ndjson.zst` must always be honored
+    /// verbatim, regardless of whether a config layer is present.
+    #[test]
+    fn resolve_output_explicit_absolute_path_is_honored() {
+        let explicit = PathBuf::from("/var/log/cluster.ndjson.zst");
+        // Without config.
+        let args = record_args(Some(explicit.clone()));
+        let opts = RecorderOptions::from_args_with_settings(&args, None).unwrap();
+        assert_eq!(opts.output, explicit);
+        // And with config that sets `output_dir` — explicit `-o` still wins.
+        let args = record_args(Some(explicit.clone()));
+        let settings = RecordSettings {
+            output_dir: "/tmp/all-smi-records".to_string(),
+            compress: "zstd".to_string(),
+        };
+        let opts = RecorderOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
+        assert_eq!(opts.output, explicit);
     }
 }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -628,4 +628,23 @@ mod tests {
         let opts = RecorderOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
         assert_eq!(opts.output, explicit);
     }
+
+    /// No `-o`, config `output_dir` contains a tilde prefix: the resolver
+    /// must call `expand_tilde` so `~/my-records` resolves to the user's
+    /// home directory rather than a literal `~/my-records` path. The expected
+    /// value is computed by calling the same `expand_tilde` helper the
+    /// resolver uses, so the assertion is portable across environments where
+    /// `$HOME` may or may not be set.
+    #[test]
+    fn resolve_output_no_cli_with_tilde_config_dir() {
+        let args = record_args(None);
+        let settings = RecordSettings {
+            output_dir: "~/my-records".to_string(),
+            compress: "zstd".to_string(),
+        };
+        let opts = RecorderOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
+        let expected = crate::common::paths::expand_tilde(std::path::Path::new("~/my-records"))
+            .join(DEFAULT_BASENAME);
+        assert_eq!(opts.output, expected);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the inconsistency between what `all-smi record --help`, the source doc comment on `RecorderOptions::from_args_with_settings`, and the README each claimed as the default output path, and removes the brittle string-sentinel resolver that silently redirected an explicit `-o all-smi-record.ndjson.zst` under the cache directory.

## Behaviour change

Before this PR, the resolver detected "operator did not pass `-o`" by string-comparing `args.output` against the magic basename `all-smi-record.ndjson.zst`. As a side effect, an operator who passed `-o all-smi-record.ndjson.zst` explicitly was silently redirected under `record.output_dir` (the cache dir) instead of having their flag honoured verbatim. After this PR, `-o <path>` is always honoured exactly as passed — including when `<path>` happens to equal the default basename. There is no change to where files land when `-o` is omitted.

## What changed

- `src/cli.rs` — `RecordArgs::output` is now `Option<PathBuf>` with no clap `default_value`. The doc comment is rewritten as a clap `long_help` so `-h` stays terse and `--help` describes the actual resolution rules (config `record.output_dir` default `~/.cache/all-smi/records/`, basename `all-smi-record.ndjson.zst`, or just the basename in CWD when no config is loaded).
- `src/record/mod.rs` — adds a shared `pub const DEFAULT_BASENAME: &str = "all-smi-record.ndjson.zst"` next to `INDEX_EVERY_N_FRAMES`. Rewrites the output-resolution block in `from_args_with_settings` to `match &args.output`: `Some(p)` is honoured verbatim; `None` joins `DEFAULT_BASENAME` under the (tilde-expanded) config `output_dir`, or falls back to `DEFAULT_BASENAME` in CWD. The old `args.output == default_basename && let Some(dir)...` guard (and its self-deprecating "if that ever changes, update this guard" comment) is gone. The precedence doc block on `from_args_with_settings` is rewritten to match.
- `README.md` — the `record` options-summary table now shows the actual default for `--output` as `~/.cache/all-smi/records/all-smi-record.ndjson.zst` with the override hints inline. This folds in the README correction originally proposed in #210 by @victorhooi; that PR could not be merged directly due to an unsigned CLA, so the fix is reapplied here with credit.

## Tests

Four unit tests added to `record::tests` cover all four acceptance-criteria branches of the resolver:

- `resolve_output_no_cli_no_config` — no `-o`, no config → just `DEFAULT_BASENAME` in CWD.
- `resolve_output_no_cli_with_config_dir` — no `-o`, config `output_dir = /tmp/all-smi-records` → `/tmp/all-smi-records/all-smi-record.ndjson.zst`.
- `resolve_output_explicit_matching_basename_is_honored` — regression guard for the silent-redirect bug: `-o all-smi-record.ndjson.zst` with config `output_dir` set is honoured verbatim, not redirected under the cache dir.
- `resolve_output_explicit_absolute_path_is_honored` — `-o /var/log/cluster.ndjson.zst` is honoured verbatim, with or without config.

## Scope B is intentionally deferred

The issue defines a Scope B (derive the cache base from `dirs::cache_dir()` so Windows / macOS land in their platform-correct cache directories instead of `~/.cache/...`) and recommends "land Scope A first; treat Scope B as a separate decision/PR to keep changes focused." This PR follows that recommendation and does not touch `src/common/config_file.rs`, `src/common/paths.rs`, `src/metrics/energy_wal.rs`, or `src/view/event_handler.rs`. A follow-up issue could track the platform-aware cache work, which is a behaviour change that moves existing files on macOS, Windows, and Linux-with-`$XDG_CACHE_HOME`-set and warrants its own migration / changelog note.

## Test plan

- [x] `cargo check --lib --tests` passes.
- [x] `cargo test --bin all-smi record::` — 33 passed, including the 4 new resolver tests (the `record` module lives under the `all-smi` binary target, not the library).
- [x] `cargo clippy --bin all-smi --tests -- -D warnings` passes.
- [x] `cargo fmt --check` passes.

Credit to @victorhooi for the original README correction in #210.

Closes #223
