### PR TITLE
fix: harden PR 221-227 follow-up issues

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -606,7 +606,7 @@ pub struct DoctorArgs {
 ///   Override path with --config <PATH>.
 /// ```
 pub fn config_help_block() -> String {
-    let resolved = paths::default_config_path();
+    let resolved = paths::active_config_path();
     let line = paths::format_path_with_existence(resolved.as_deref());
     format!(
         "Configuration file:\n  \

--- a/src/common/paths.rs
+++ b/src/common/paths.rs
@@ -164,6 +164,21 @@ pub fn discover_existing_config() -> Option<PathBuf> {
     candidate_config_paths().into_iter().find(|p| p.exists())
 }
 
+/// Path the implicit loader would treat as active for user-facing
+/// discovery: the first existing candidate if one is present, otherwise
+/// the platform-canonical default path where a new config would be
+/// created.
+///
+/// This keeps `all-smi --help` and `all-smi config path` aligned with
+/// [`crate::common::config_file::load`]. On macOS in particular, the
+/// loader accepts `~/.config/all-smi/config.toml` as a fallback; if that
+/// file exists while the Apple-canonical path does not, this function
+/// reports the fallback as active instead of incorrectly labelling the
+/// missing canonical path as the active one.
+pub fn active_config_path() -> Option<PathBuf> {
+    discover_existing_config().or_else(default_config_path)
+}
+
 /// Render a candidate config path together with an `(active)` or
 /// `(not found)` existence marker for display in `--help` and the
 /// `config path` subcommand. Both surfaces share this so the marker
@@ -255,6 +270,12 @@ mod tests {
             let paths = candidate_config_paths();
             assert!(!paths.is_empty());
         }
+    }
+
+    #[test]
+    fn active_config_path_matches_loader_resolution() {
+        let expected = discover_existing_config().or_else(default_config_path);
+        assert_eq!(active_config_path(), expected);
     }
 
     #[test]

--- a/src/config_cmd/path.rs
+++ b/src/config_cmd/path.rs
@@ -71,7 +71,7 @@ fn write_text<W: Write>(out: &mut W, explicit: Option<&Path>) -> io::Result<()> 
         return Ok(());
     }
 
-    let active = paths::default_config_path();
+    let active = paths::active_config_path();
     writeln!(
         out,
         "{}",
@@ -107,7 +107,8 @@ fn write_text<W: Write>(out: &mut W, explicit: Option<&Path>) -> io::Result<()> 
 /// ```
 ///
 /// * `active` is the path the loader would actually open (either the
-///   `--config` override or the canonical default for the platform).
+///   `--config` override, the first existing implicit candidate, or the
+///   canonical default path where a new config would be created).
 ///   `null` only when no home directory can be resolved.
 /// * `exists` reflects `Path::exists()` for `active`.
 /// * `overridden` is `true` when `--config` was supplied.
@@ -118,7 +119,7 @@ fn write_json<W: Write>(out: &mut W, explicit: Option<&Path>) -> io::Result<()> 
     let overridden = explicit.is_some();
     let active_path: Option<std::path::PathBuf> = match explicit {
         Some(p) => Some(p.to_path_buf()),
-        None => paths::default_config_path(),
+        None => paths::active_config_path(),
     };
     let exists = active_path.as_deref().map(Path::exists).unwrap_or(false);
     let search_order: Vec<String> = if overridden {

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -100,6 +100,11 @@ impl RecorderOptions {
     /// * Final fallback: [`DEFAULT_BASENAME`] in the current working
     ///   directory (when no home-like directory is available — bare
     ///   CI shells, containers without `$HOME`).
+    ///
+    /// The CLI binary passes `Settings::default().record` when no
+    /// config file exists; its empty `output_dir` intentionally
+    /// delegates to the same platform cache tier, keeping `record
+    /// --help`, README text, and resolver behavior aligned.
     pub fn from_args_with_settings(
         args: &RecordArgs,
         settings: Option<&RecordSettings>,
@@ -608,6 +613,23 @@ mod tests {
         let args = record_args(None);
         let opts = RecorderOptions::from_args_with_settings(&args, None).unwrap();
         assert_eq!(opts.output, cache.join("records").join(DEFAULT_BASENAME));
+    }
+
+    /// No `-o` in the real CLI binary: main loads compiled defaults
+    /// into `Settings` even when no config file exists, so the
+    /// user-facing default still delegates to the platform cache helper.
+    /// This guards `record --help`, README, and resolver behaviour from
+    /// drifting apart again.
+    #[test]
+    fn resolve_output_no_cli_with_compiled_record_settings_uses_cache_dir() {
+        let args = record_args(None);
+        let settings = crate::common::config_file::Settings::default().record;
+        let opts = RecorderOptions::from_args_with_settings(&args, Some(&settings)).unwrap();
+        let expected = match crate::common::paths::cache_dir() {
+            Some(c) => c.join("records").join(DEFAULT_BASENAME),
+            None => PathBuf::from(DEFAULT_BASENAME),
+        };
+        assert_eq!(opts.output, expected);
     }
 
     /// No `-o`, config `output_dir` set: the default basename should be

--- a/src/ui/renderers/memory_renderer.rs
+++ b/src/ui/renderers/memory_renderer.rs
@@ -263,6 +263,12 @@ mod tests {
         out
     }
 
+    fn foreground_sgr(color: Color) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        queue!(buf, crossterm::style::SetForegroundColor(color)).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
     fn make_memory_info(hostname: &str) -> MemoryInfo {
         MemoryInfo {
             index: 0,
@@ -395,9 +401,10 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         print_memory_info(&mut buf, 0, &info, 120, 0, false);
         let raw = String::from_utf8_lossy(&buf);
+        let red_sgr = foreground_sgr(Color::Red);
         assert!(
-            raw.contains("\x1b[38;5;9m") || raw.contains("\x1b[31m"),
-            "Active swap row should be colored red; raw output did not contain a red SGR"
+            raw.contains(&red_sgr),
+            "Active swap row should be colored red; raw output did not contain {red_sgr:?}"
         );
     }
 

--- a/tests/config_path_help_test.rs
+++ b/tests/config_path_help_test.rs
@@ -23,6 +23,7 @@
 //! spawning a child process for each assertion.
 
 use all_smi::cli::{build_command_with_runtime_help, config_help_block};
+use all_smi::common::paths;
 
 /// `--help` must render the runtime-composed "Configuration file"
 /// block. Without this, a fresh user who reaches for `-h` has no way
@@ -75,6 +76,26 @@ fn help_active_path_carries_existence_marker() {
         has_marker,
         "config_help_block must carry an existence marker.\n--- block ---\n{block}"
     );
+}
+
+/// The help block must report the same active path the implicit loader
+/// would use: first existing candidate if present, otherwise the
+/// platform-canonical default. This matters on macOS, where the loader
+/// accepts `~/.config/all-smi/config.toml` as a fallback.
+#[test]
+fn help_active_path_uses_loader_resolution() {
+    let block = config_help_block();
+    match paths::active_config_path() {
+        Some(path) => assert!(
+            block.contains(&path.display().to_string()),
+            "help must contain loader-active path {}.\n--- block ---\n{block}",
+            path.display()
+        ),
+        None => assert!(
+            block.contains("no config path"),
+            "help must explain missing config path.\n--- block ---\n{block}"
+        ),
+    }
 }
 
 /// The `--config` flag's own help text must guide users toward a


### PR DESCRIPTION
## Summary

Follow-up hardening for the already-merged PRs #221, #222, #224, #225, #226, and #227 after reading each PR body and the linked original issue bodies. This PR fixes the remaining gaps found during that review and was rebased after #230 so record-path documentation and tests now match the platform-aware cache-directory behavior from #229/#230.

## Target PRs Reviewed

- #221 docs: gate unreleased subcommands with v0.21.0+ availability notes
- #222 fix(view): drop non-Press key events to fix Windows TUI double-dispatch
- #224 feat: surface active TOML config path in --help and add `config path` subcommand
- #225 feat(lib): targeted device refresh and stable correlation IDs for AllSmi
- #226 feat: display system swap usage in the TUI memory section
- #227 fix: resolve record default output path consistently

## Linked Original Issues Reviewed

- #214 README documents unreleased subcommands absent from v0.20.1
- #212 Windows key press/release double-dispatch in the TUI
- #213 Surface active TOML config file location in help and add read-only `config path`
- #211 Targeted device refresh and stable correlation IDs for the AllSmi API
- #220 Display system swap usage in the TUI memory section
- #223 Record default output path inconsistently documented/resolved

## Review Findings

- Correctness: #224 used `default_config_path()` for help and `config path` active output, while the loader uses the first existing implicit candidate before falling back to the canonical default. On macOS this could show the Apple-canonical path as “not found” even when the loader would actually read `~/.config/all-smi/config.toml`.
- Correctness/docs: #227 fixed the explicit-output sentinel bug, and #230 later moved implicit record output to `paths::cache_dir()`. The follow-up risk was drift between `record --help`, `RecorderOptions` docs, compiled `Settings::default().record`, and resolver tests. This PR keeps those surfaces aligned with the platform-aware cache helper and final CWD fallback only when no home-like cache directory is resolvable.
- Test reliability: #226’s active-swap color test assumed specific Red escape sequences. After #228 updated dependencies, full `cargo test` exposed that the test was brittle even though the renderer still uses `Color::Red`.
- No additional correctness gaps were found in #221 availability gating, #222 key-kind filtering, or #225 targeted refresh/index APIs after comparing against the linked issue acceptance criteria.

## Fixes

- Added `paths::active_config_path()` and reused it in top-level help plus `all-smi config path` text/JSON output so the displayed active path matches implicit loader semantics.
- Added regression coverage that the help block contains the loader-active path.
- Added `RecorderOptions` documentation and regression coverage proving the real CLI default, represented by compiled `Settings::default().record`, delegates to `paths::cache_dir().join("records")` and falls back to `DEFAULT_BASENAME` only when cache-dir discovery returns `None`.
- Updated the swap-color regression test to derive crossterm’s current `Color::Red` SGR sequence rather than hard-coding specific terminal encodings.

## Security Review

No authentication, authorization, SQL, shell execution, deserialization, SSRF, or network surface was changed by this follow-up. The `config path` change remains read-only and only calls bounded path discovery plus `Path::exists()`. The record-path change is documentation/test alignment around existing resolver behavior; it does not relax writer symlink refusal or file-mode hardening. No sensitive config values are printed or newly exposed.

## Performance And Reliability Review

The new active-path helper performs the same bounded candidate path scan the config loader already performs and is only used in help/config-path discovery surfaces. There is no hot-path TUI, API, parser, or hardware reader overhead. The swap test update improves CI reliability across crossterm versions without changing rendering behavior.

## Validation

- `rustup update stable` to Rust 1.95.0 so local validation matches the post-#228 dependency MSRV.
- Local system lacked `libdrm-dev`; because sudo was unavailable, validation used `target/local-lib` symlinks to the installed runtime `libdrm.so.2` and `libdrm_amdgpu.so.1` via `LIBRARY_PATH` for linking only.
- `cargo fmt --check`
- `git diff --check`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo test --bin all-smi record::tests::resolve_output`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo test --test config_path_help_test`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo test --lib ui::renderers::memory_renderer::tests::test_swap_row_active_uses_red_color`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo clippy -- -D warnings`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo test`

Refs #221, #222, #224, #225, #226, #227, #211, #212, #213, #214, #220, #223.
