### PR TITLE
fix: align Docker Rust toolchain with MSRV

### DIFF
--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -25,14 +25,14 @@ jobs:
       matrix:
         include:
           - distro: jammy
-            vendor_rust: "1.92.0"
-            toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
+            vendor_rust: "1.95.0"
+            toolchain_source: "Requires Rust 1.95+ from ~lablup/+archive/ubuntu/rustc-release"
           - distro: noble
-            vendor_rust: "1.92.0"
-            toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
+            vendor_rust: "1.95.0"
+            toolchain_source: "Requires Rust 1.95+ from ~lablup/+archive/ubuntu/rustc-release"
           - distro: resolute
-            vendor_rust: "1.92.0"
-            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.92+ toolchain"
+            vendor_rust: "1.95.0"
+            toolchain_source: "Requires a Rust 1.95+ toolchain"
 
     steps:
     - name: Checkout code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["cli", "rust"]
 categories = ["command-line-utilities"]
 edition = "2024"
+rust-version = "1.95"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for optimal image size
-FROM rust:1.88-slim as builder
+FROM rust:1.95-slim AS builder
 
 # Install system dependencies for cross-compilation
 RUN apt-get update && apt-get install -y \

--- a/debian/README.packaging
+++ b/debian/README.packaging
@@ -10,8 +10,8 @@ Launchpad build environments do NOT have internet access. This means:
 
 ### Build Dependencies
 The following packages are required and must be available in the Ubuntu repository:
-- `rustc-1.92 | rustc (>= 1.92)` - Rust compiler for the current dependency set
-- `cargo-1.92 | cargo (>= 1.92)` - Cargo for the current lockfile/dependency set
+- `rustc-1.95 | rustc (>= 1.95)` - Rust compiler for the current dependency set
+- `cargo-1.95 | cargo (>= 1.95)` - Cargo for the current lockfile/dependency set
 - `pkg-config` - For finding system libraries
 - `libssl-dev` - OpenSSL development files
 - `protobuf-compiler` - Protocol buffer compiler
@@ -19,15 +19,15 @@ The following packages are required and must be available in the Ubuntu reposito
 - `cmake` - Build system
 
 ### Rust Version Requirements
-This project currently requires Rust 1.92 or newer. This means:
+This project currently requires Rust 1.95 or newer. This means:
 - Ubuntu 22.04 (Jammy): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA
 - Ubuntu 24.04 (Noble): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA
-- Ubuntu 26.04 (Resolute): uses the official Ubuntu archive Rust toolchain
+- Ubuntu 26.04 (Resolute): needs any archive/PPA Rust 1.95+ toolchain
 
 ### Build Process
 1. The GitHub Actions workflow vendors dependencies into `vendor/`
 2. `debian/sanitize-vendor.py` removes hidden/orig checksum entries that break Launchpad source tarballs
-3. The debian/rules file uses system-provided `rustc-1.92` / `cargo-1.92` when present
+3. The debian/rules file uses system-provided `rustc-1.95` / `cargo-1.95` when present
 4. The project is built with `cargo build --release --frozen`
 5. The binary is installed to `/usr/bin/all-smi`
 
@@ -36,7 +36,7 @@ If the build fails on Launchpad:
 1. Check the build log for the exact error
 2. Common issues:
    - Missing build dependencies: Add them to debian/control
-   - Rust version incompatibility: Ensure Rust 1.92+ is available
+   - Rust version incompatibility: Ensure Rust 1.95+ is available
    - Network access attempts: Remove any code that downloads dependencies
    - Vendored checksum mismatch: Re-run the vendor sanitization step
    - Permission issues: Ensure proper file permissions in debian/rules

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.92 | rustc (>= 1.92),
-               cargo-1.92 | cargo (>= 1.92),
+               rustc-1.95 | rustc (>= 1.95),
+               cargo-1.95 | cargo (>= 1.95),
                pkg-config,
                libssl-dev,
                protobuf-compiler,

--- a/debian/control.source
+++ b/debian/control.source
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.92 | rustc (>= 1.92),
-               cargo-1.92 | cargo (>= 1.92),
+               rustc-1.95 | rustc (>= 1.95),
+               cargo-1.95 | cargo (>= 1.95),
                libssl-dev,
                pkg-config,
                protobuf-compiler,

--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad
+++ b/debian/rules.launchpad
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad-simple
+++ b/debian/rules.launchpad-simple
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@

--- a/debian/rules.source
+++ b/debian/rules.source
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 


### PR DESCRIPTION
## Summary

Fix the Docker Build Check failure introduced after the dependency refresh to `sysinfo 0.39.2`, which requires Rust 1.95 while the Docker builder image was still pinned to Rust 1.88.

## Changes

- Update the Docker builder image from `rust:1.88-slim` to `rust:1.95-slim`.
- Fix the Dockerfile `FROM ... AS` casing warning reported by buildx.
- Declare the crate MSRV explicitly with `rust-version = "1.95"`.
- Align Debian/Launchpad packaging Rust and Cargo requirements from 1.92 to 1.95 so packaging paths fail early with the correct requirement instead of reaching dependency resolution failures later.

## Build Check Note

The regular CI `Build Check` runs `cargo build --release --bin all-smi` first and then `cargo build --no-default-features --lib`. Those two can fail independently because the library-only build compiles a different feature set. The current Docker failure is separate: the Dockerfile only runs the binary release build, and it failed before compilation because Cargo rejected `sysinfo 0.39.2` on rustc 1.88.

## Validation

- `cargo metadata --format-version 1 --locked --no-deps`
- `cargo fmt --check`
- `git diff --check`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo build --release --bin all-smi`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo build --no-default-features --lib`
- `LIBRARY_PATH=/home/inureyes/Development/backend.ai/all-smi/target/local-lib cargo clippy -- -D warnings`

Local Docker validation was attempted with `docker build --progress=plain --target builder -t all-smi-builder-msrv-check .`, but this environment cannot access `/var/run/docker.sock`, so the Docker-specific verification must be provided by GitHub Actions after merge.
