### PR TITLE
fix: realign Rust MSRV to 1.93 for Launchpad PPA builds

### DIFF
--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -25,14 +25,14 @@ jobs:
       matrix:
         include:
           - distro: jammy
-            vendor_rust: "1.95.0"
-            toolchain_source: "Requires Rust 1.95+ from ~lablup/+archive/ubuntu/rustc-release"
+            vendor_rust: "1.93.0"
+            toolchain_source: "Requires Rust 1.93+ from ~lablup/+archive/ubuntu/rustc-release"
           - distro: noble
-            vendor_rust: "1.95.0"
-            toolchain_source: "Requires Rust 1.95+ from ~lablup/+archive/ubuntu/rustc-release"
+            vendor_rust: "1.93.0"
+            toolchain_source: "Requires Rust 1.93+ from ~lablup/+archive/ubuntu/rustc-release"
           - distro: resolute
-            vendor_rust: "1.95.0"
-            toolchain_source: "Requires a Rust 1.95+ toolchain"
+            vendor_rust: "1.93.0"
+            toolchain_source: "Requires a Rust 1.93+ toolchain"
 
     steps:
     - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,16 +1266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,39 +2701,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
 ]
 
 [[package]]
@@ -2754,17 +2717,6 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-open-directory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
 ]
 
 [[package]]
@@ -4353,16 +4305,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "objc2-open-directory",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["cli", "rust"]
 categories = ["command-line-utilities"]
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.93"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -28,7 +28,7 @@ reqwest = { version = "0.13", features = ["json"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 regex = "1.12.2"
-sysinfo = "0.39"
+sysinfo = "0.38"
 anyhow = { version = "1.0.100", optional = true }
 hyper = { version = "1.9.0", features = ["full"], optional = true }
 hyper-util = { version = "0.1.18", features = ["full"], optional = true }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for optimal image size
-FROM rust:1.95-slim AS builder
+FROM rust:1.93-slim AS builder
 
 # Install system dependencies for cross-compilation
 RUN apt-get update && apt-get install -y \

--- a/debian/README.packaging
+++ b/debian/README.packaging
@@ -10,8 +10,8 @@ Launchpad build environments do NOT have internet access. This means:
 
 ### Build Dependencies
 The following packages are required and must be available in the Ubuntu repository:
-- `rustc-1.95 | rustc (>= 1.95)` - Rust compiler for the current dependency set
-- `cargo-1.95 | cargo (>= 1.95)` - Cargo for the current lockfile/dependency set
+- `rustc-1.93 | rustc-1.94 | rustc-1.95 | rustc (>= 1.93)` - Rust compiler for the current dependency set
+- `cargo-1.93 | cargo-1.94 | cargo-1.95 | cargo (>= 1.93)` - Cargo for the current lockfile/dependency set
 - `pkg-config` - For finding system libraries
 - `libssl-dev` - OpenSSL development files
 - `protobuf-compiler` - Protocol buffer compiler
@@ -19,15 +19,15 @@ The following packages are required and must be available in the Ubuntu reposito
 - `cmake` - Build system
 
 ### Rust Version Requirements
-This project currently requires Rust 1.95 or newer. This means:
-- Ubuntu 22.04 (Jammy): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA
-- Ubuntu 24.04 (Noble): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA
-- Ubuntu 26.04 (Resolute): needs any archive/PPA Rust 1.95+ toolchain
+This project currently requires Rust 1.93 or newer. This means:
+- Ubuntu 22.04 (Jammy): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA (provides `rustc-1.93`)
+- Ubuntu 24.04 (Noble): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA (provides `rustc-1.93`)
+- Ubuntu 26.04 (Resolute): ships `rustc`/`cargo` 1.93 in the archive — no extra PPA required
 
 ### Build Process
 1. The GitHub Actions workflow vendors dependencies into `vendor/`
 2. `debian/sanitize-vendor.py` removes hidden/orig checksum entries that break Launchpad source tarballs
-3. The debian/rules file uses system-provided `rustc-1.95` / `cargo-1.95` when present
+3. The debian/rules file auto-detects the newest available toolchain among `rustc-1.95` / `rustc-1.94` / `rustc-1.93`, falling back to the unversioned `rustc` (a `>= 1.93` guard validates whichever is selected)
 4. The project is built with `cargo build --release --frozen`
 5. The binary is installed to `/usr/bin/all-smi`
 
@@ -36,7 +36,7 @@ If the build fails on Launchpad:
 1. Check the build log for the exact error
 2. Common issues:
    - Missing build dependencies: Add them to debian/control
-   - Rust version incompatibility: Ensure Rust 1.95+ is available
+   - Rust version incompatibility: Ensure Rust 1.93+ is available
    - Network access attempts: Remove any code that downloads dependencies
    - Vendored checksum mismatch: Re-run the vendor sanitization step
    - Permission issues: Ensure proper file permissions in debian/rules

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.95 | rustc (>= 1.95),
-               cargo-1.95 | cargo (>= 1.95),
+               rustc-1.93 | rustc-1.94 | rustc-1.95 | rustc (>= 1.93),
+               cargo-1.93 | cargo-1.94 | cargo-1.95 | cargo (>= 1.93),
                pkg-config,
                libssl-dev,
                protobuf-compiler,

--- a/debian/control.source
+++ b/debian/control.source
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.95 | rustc (>= 1.95),
-               cargo-1.95 | cargo (>= 1.95),
+               rustc-1.93 | rustc-1.94 | rustc-1.95 | rustc (>= 1.93),
+               cargo-1.93 | cargo-1.94 | cargo-1.95 | cargo (>= 1.93),
                libssl-dev,
                pkg-config,
                protobuf-compiler,

--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
+RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
-		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
+		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
-		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
+		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad
+++ b/debian/rules.launchpad
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
+RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
-		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
+		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
-		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
+		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad-simple
+++ b/debian/rules.launchpad-simple
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
+RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@

--- a/debian/rules.source
+++ b/debian/rules.source
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
+RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
-		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
+		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
-		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
+		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 


### PR DESCRIPTION
## Problem

`sysinfo 0.39` (pulled in by #228) raised the effective MSRV to **1.95**, and #233 propagated `rustc-1.95` into the Debian packaging. But **no Rust 1.95 toolchain is actually available** for the target Ubuntu series:

| Series | Available rustc |
|--------|-----------------|
| resolute (26.04) | archive `rustc`/`cargo` **1.93.1**, versioned up to `rustc-1.93` |
| jammy / noble | lablup `rustc-release` PPA tops out at **`rustc-1.94`** |
| anywhere | **no `rustc-1.95`** |

So the build-dep `rustc-1.95 | rustc (>= 1.95)` is unsatisfiable and the Launchpad PPA build would fail (dep-wait) on all three series.

## Fix

**Lower the baseline to Rust 1.93** (what resolute ships natively and what the PPA can provide via `rustc-1.93`):

- Revert `sysinfo` `0.39 → 0.38` (resolves to `0.38.4`, MSRV **1.88**). After this the highest dependency MSRV is 1.88, so nothing needs more than 1.93. The 0.39-only `objc2`/`dispatch2` subtree is dropped from `Cargo.lock`.
- Set `rust-version = "1.93"`; align `Dockerfile` (`rust:1.93-slim`) and all debian packaging.

**Make toolchain selection forward-compatible** so future PPA bumps don't need packaging edits:

- Build-deps widened to `rustc-1.93 | rustc-1.94 | rustc-1.95 | rustc (>= 1.93)` (cargo likewise). APT picks the first installable alternative.
- `debian/rules` auto-detects the newest available toolchain (`rustc-1.95` → `1.94` → `1.93` → unversioned `rustc`), keeping the `>= 1.93` guard that validates whichever is selected.

> Note: versioned package names are matched literally by APT, so `rustc-1.93` would **not** be satisfied by a `rustc-1.95` package. Listing the alternatives explicitly (control) plus newest-available detection (rules) is what makes any `>= 1.93` toolchain build cleanly.

## Verification

- `cargo check --all-targets --locked` on **Rust 1.88.0** (the strict dependency floor) passes — confirms sysinfo 0.38 API compatibility and that the code builds well below 1.93.
- `debian/rules` detection exercised through `make` for the fallback / 1.93 / 1.95-preferred cases (correct selection in all three).

## Files

`Cargo.toml`, `Cargo.lock`, `Dockerfile`, `.github/workflows/launchpad_ppa.yml`, `debian/control`(`.source`), `debian/rules`(`.source`, `.launchpad`, `.launchpad-simple`), `debian/README.packaging`.
