### PR TITLE
refactor: resolve clippy lints in mock server and example

### DIFF
--- a/examples/library_usage.rs
+++ b/examples/library_usage.rs
@@ -300,8 +300,8 @@ fn main() -> Result<()> {
         let original_index = held_cpu.index;
         if smi.refresh_cpu(&mut held_cpu) {
             println!(
-                "  CPU index {} ({}) refreshed in place: util now {:.1}%",
-                original_index, held_cpu.cpu_model, held_cpu.utilization
+                "  CPU index {original_index} ({}) refreshed in place: util now {:.1}%",
+                held_cpu.cpu_model, held_cpu.utilization
             );
         }
     }
@@ -312,8 +312,8 @@ fn main() -> Result<()> {
         if smi.refresh_memory(&mut held_mem) {
             let total_gb = held_mem.total_bytes as f64 / 1024.0 / 1024.0 / 1024.0;
             println!(
-                "  Memory index {} refreshed in place: util now {:.1}% (total {:.1} GB)",
-                original_index, held_mem.utilization, total_gb
+                "  Memory index {original_index} refreshed in place: util now {:.1}% (total {total_gb:.1} GB)",
+                held_mem.utilization
             );
         }
     }

--- a/src/mock/server.rs
+++ b/src/mock/server.rs
@@ -202,7 +202,6 @@ pub async fn start_servers(args: Args) -> Result<()> {
     let platform_type = PlatformType::from_str(&args.platform);
     let nodes = Arc::new(Mutex::new(HashMap::new()));
     let mut file = File::create(&args.o)?;
-    let mut instance_counter = args.start_index;
 
     // Use appropriate GPU/NPU name based on platform
     let device_name = if args.gpu_name == crate::mock::constants::DEFAULT_NVIDIA_GPU_NAME {
@@ -220,12 +219,11 @@ pub async fn start_servers(args: Args) -> Result<()> {
     };
 
     // Initialize nodes
-    for port in port_range.clone() {
+    for (instance_counter, port) in (args.start_index..).zip(port_range.clone()) {
         let instance_name = format!("node-{instance_counter:04}");
         let node = MockNode::new(instance_name, device_name.clone(), platform_type.clone());
         nodes.lock().unwrap().insert(port, node);
         writeln!(file, "localhost:{port}").unwrap();
-        instance_counter += 1;
     }
 
     println!("Outputting server list to {}", args.o);


### PR DESCRIPTION
## Summary

Resolves pre-existing clippy lints in the mock server and the library-usage example. These were surfaced by `cargo clippy --all-targets --features mock` (run by the local pre-commit hook) but are **not** caught by CI's default-target `cargo clippy`, so they had gone unnoticed. Discovered while working on #238.

## Changes

- **`src/mock/server.rs`** — `explicit_counter_loop`: replace the manual `let mut instance_counter` / `instance_counter += 1` with `for (instance_counter, port) in (args.start_index..).zip(port_range.clone())`. Same numbering (starts at `args.start_index`, +1 per node), no behavior change.
- **`examples/library_usage.rs`** — `uninlined_format_args`: inline the simple identifiers `original_index` and `total_gb` into the `println!` format strings. Field-access args (e.g. `held_cpu.cpu_model`) stay positional since Rust inline format only supports bare identifiers.

## Verification

- `cargo clippy --all-targets --features mock -- -D warnings` → **clean (exit 0, 0 warnings)**.
- `cargo fmt --check` → clean.
- No behavior change (pure lint/style fixes).
