### PR TITLE
fix(tui): restore terminal cursor on exit (Linux/tmux)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,8 @@ static NATIVE_METRICS_INITIALIZED: AtomicBool = AtomicBool::new(false);
 static HLSMI_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 fn main() {
-    // Set up panic handler for cleanup
-    #[cfg(target_os = "macos")]
-    setup_panic_handler();
+    // Set up panic handler for cleanup (cross-platform)
+    setup_panic_handlers();
 
     // Best-effort one-time migration of legacy `~/.cache/all-smi/...`
     // data to the platform-correct cache dir (issue #229). Runs before
@@ -191,6 +190,9 @@ async fn run_command(cli: Cli, settings: Settings) {
         // Set up signal handler for clean shutdown
         tokio::spawn(async {
             signal::ctrl_c().await.expect("Failed to listen for Ctrl+C");
+            // Restore terminal state before exit so the parent shell is usable
+            // (issue #235). No-op when no TUI was running.
+            view::terminal_manager::restore_terminal();
             #[cfg(target_os = "macos")]
             {
                 // Cleanup native metrics manager on signal
@@ -210,6 +212,9 @@ async fn run_command(cli: Cli, settings: Settings) {
             let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
                 .expect("Failed to listen for SIGTERM");
             sigterm.recv().await;
+            // Restore terminal state before exit so the parent shell is usable
+            // (issue #235). No-op when no TUI was running.
+            view::terminal_manager::restore_terminal();
             #[cfg(target_os = "macos")]
             {
                 // Cleanup native metrics manager on signal
@@ -651,12 +656,17 @@ async fn run_command(cli: Cli, settings: Settings) {
     }
 }
 
-// Set up a panic handler to ensure cleanup
-#[cfg(target_os = "macos")]
-fn setup_panic_handler() {
+// Set up a panic handler to ensure cleanup.
+// Cross-platform: the macOS native-metrics shutdown is gated behind
+// `#[cfg(target_os = "macos")]`. The terminal-restoration hook is installed
+// separately inside `TerminalManager::new()` via `PANIC_HOOK_INSTALLED` —
+// it layers on top of whatever hook this function installs, so the terminal
+// is always restored before this hook's body runs.
+fn setup_panic_handlers() {
     let default_panic = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
-        // Cleanup native metrics manager before panicking
+        // Cleanup native metrics manager before panicking (macOS only)
+        #[cfg(target_os = "macos")]
         device::macos_native::shutdown_native_metrics_manager();
         default_panic(panic_info);
     }));

--- a/src/view/terminal_manager.rs
+++ b/src/view/terminal_manager.rs
@@ -13,14 +13,32 @@
 // limitations under the License.
 
 use std::io::stdout;
+use std::sync::{
+    Once,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crossterm::{
+    cursor,
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{
         ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     },
 };
+
+/// Process-global flag: `true` when the terminal has been set to alternate-screen /
+/// raw mode and the cursor has been hidden. Any exit path — normal `q`, SIGINT,
+/// SIGTERM, or panic — must call `restore_terminal()` to clear this flag and
+/// emit the cleanup escape sequences.
+///
+/// Initialised `false` so `restore_terminal()` is a no-op for subcommands that
+/// never touch the TUI (e.g., `snapshot`, `doctor`).
+static TERMINAL_NEEDS_RESTORE: AtomicBool = AtomicBool::new(false);
+
+/// `Once` guard that ensures the panic hook is installed exactly once, even if
+/// `TerminalManager::new()` were called multiple times within the same process.
+static PANIC_HOOK_INSTALLED: Once = Once::new();
 
 pub struct TerminalManager {
     initialized: bool,
@@ -51,6 +69,17 @@ impl TerminalManager {
             return Err("Failed to initialize terminal display".into());
         }
 
+        // Mark the terminal as needing restoration on every exit path.
+        // This must be set before `self.initialized = true` so that if any
+        // subsequent initialisation step panics the flag is already live.
+        TERMINAL_NEEDS_RESTORE.store(true, Ordering::SeqCst);
+
+        // Install the panic hook exactly once. `take_hook` captures whatever is
+        // on top of the panic-hook stack at this point — which may be the macOS
+        // native-metrics hook installed earlier by `setup_panic_handlers` in
+        // main.rs — so the chain is preserved correctly.
+        PANIC_HOOK_INSTALLED.call_once(install_panic_hook);
+
         self.initialized = true;
         Ok(())
     }
@@ -64,11 +93,12 @@ impl TerminalManager {
 impl Drop for TerminalManager {
     fn drop(&mut self) {
         if self.initialized {
-            let mut stdout = stdout();
-            // Leave alternate screen and restore terminal state
-            let _ = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture);
-            let _ = disable_raw_mode();
-            // No "Terminating..." message needed - native APIs don't require cleanup
+            // Restore cursor visibility in addition to leaving the alternate screen.
+            // `LeaveAlternateScreen` alone does NOT guarantee cursor visibility on
+            // Linux terminals (VTE family, tmux, kitty, …) that track cursor state
+            // independently of the alternate-screen mode — hence the explicit
+            // `cursor::Show` (issue #235).
+            restore_terminal();
         }
     }
 }
@@ -76,5 +106,94 @@ impl Drop for TerminalManager {
 impl Default for TerminalManager {
     fn default() -> Self {
         Self::new().unwrap_or_else(|_| Self { initialized: false })
+    }
+}
+
+/// Restore the terminal to a usable state: show the cursor, leave the alternate
+/// screen, disable mouse capture, and disable raw mode.
+///
+/// This function is **idempotent**: the first call after `TerminalManager::new()`
+/// performs the cleanup; any subsequent call is a silent no-op. It is therefore
+/// safe to call from `Drop`, from SIGINT/SIGTERM handlers, and from a panic hook
+/// simultaneously without double-emitting escape sequences.
+///
+/// All errors are intentionally ignored with `let _ = ...`. At cleanup time we
+/// cannot meaningfully recover from a write failure (the terminal may already be
+/// in a broken state), and panicking inside a signal handler or a panic hook
+/// would abort the process uncleanly.
+pub fn restore_terminal() {
+    // Atomically clear the flag. If it was already `false` (either because the
+    // terminal was never initialised, or because a concurrent call got here
+    // first), return immediately — nothing to do.
+    if !TERMINAL_NEEDS_RESTORE.swap(false, Ordering::SeqCst) {
+        return;
+    }
+
+    // Use `std::io::stdout()` directly — no locks, no shared state — so this
+    // function is safe to call from a panic hook context, from a tokio task, and
+    // from `Drop`.
+    let mut stdout = std::io::stdout();
+    let _ = execute!(
+        stdout,
+        cursor::Show,
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    );
+    let _ = disable_raw_mode();
+}
+
+/// Install a panic hook that calls `restore_terminal()` before delegating to
+/// whatever hook was previously installed (either the default backtrace hook, or
+/// the macOS native-metrics hook set up by `setup_panic_handlers` in main.rs).
+///
+/// Layering via `take_hook` / `set_hook` is the idiomatic Rust pattern for
+/// composing panic hooks; the terminal hook is always outermost after this call
+/// so it runs first and the terminal is usable when the inner hook prints its
+/// backtrace.
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        // Restore the terminal first so the panic backtrace is readable.
+        restore_terminal();
+        previous(panic_info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Calling `restore_terminal()` when the flag is `false` must be a no-op and
+    /// must not panic. We reset the flag explicitly at the start so parallel test
+    /// runs (cargo parallelises tests within a binary) see a consistent baseline.
+    #[test]
+    fn restore_terminal_is_noop_when_flag_unset() {
+        TERMINAL_NEEDS_RESTORE.store(false, Ordering::SeqCst);
+        // Neither call should panic.
+        restore_terminal();
+        restore_terminal();
+        assert!(!TERMINAL_NEEDS_RESTORE.load(Ordering::SeqCst));
+    }
+
+    /// Manually setting the flag to `true` and then calling `restore_terminal()`
+    /// must atomically clear it to `false`. We do not assert on the IO output
+    /// (escape codes go to stdout and may not be readable in a test context).
+    #[test]
+    fn restore_terminal_clears_flag() {
+        TERMINAL_NEEDS_RESTORE.store(true, Ordering::SeqCst);
+        restore_terminal();
+        assert!(!TERMINAL_NEEDS_RESTORE.load(Ordering::SeqCst));
+    }
+
+    /// Calling `restore_terminal()` repeatedly with the flag initially `true`
+    /// must be idempotent: the first call clears the flag, subsequent calls are
+    /// silent no-ops, and no call panics.
+    #[test]
+    fn restore_terminal_is_idempotent() {
+        TERMINAL_NEEDS_RESTORE.store(true, Ordering::SeqCst);
+        restore_terminal();
+        restore_terminal();
+        restore_terminal();
+        assert!(!TERMINAL_NEEDS_RESTORE.load(Ordering::SeqCst));
     }
 }

--- a/src/view/terminal_manager.rs
+++ b/src/view/terminal_manager.rs
@@ -129,9 +129,10 @@ pub fn restore_terminal() {
         return;
     }
 
-    // Use `std::io::stdout()` directly — no locks, no shared state — so this
-    // function is safe to call from a panic hook context, from a tokio task, and
-    // from `Drop`.
+    // Use `std::io::stdout()` directly. No *application-owned* locks are held
+    // across this call — `execute!` acquires the stdlib stdout mutex internally
+    // and releases it before returning, which is fine in every context this
+    // function can be called from (panic hook, tokio task, `Drop`).
     let mut stdout = std::io::stdout();
     let _ = execute!(
         stdout,
@@ -161,13 +162,21 @@ fn install_panic_hook() {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    // All three tests mutate the process-global `TERMINAL_NEEDS_RESTORE` flag.
+    // Cargo may run tests in parallel within a binary, so we serialize them with
+    // an in-module mutex rather than adding a new dev-dependency.
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     /// Calling `restore_terminal()` when the flag is `false` must be a no-op and
     /// must not panic. We reset the flag explicitly at the start so parallel test
     /// runs (cargo parallelises tests within a binary) see a consistent baseline.
     #[test]
     fn restore_terminal_is_noop_when_flag_unset() {
+        let _guard = TEST_MUTEX.lock().unwrap();
         TERMINAL_NEEDS_RESTORE.store(false, Ordering::SeqCst);
         // Neither call should panic.
         restore_terminal();
@@ -180,6 +189,7 @@ mod tests {
     /// (escape codes go to stdout and may not be readable in a test context).
     #[test]
     fn restore_terminal_clears_flag() {
+        let _guard = TEST_MUTEX.lock().unwrap();
         TERMINAL_NEEDS_RESTORE.store(true, Ordering::SeqCst);
         restore_terminal();
         assert!(!TERMINAL_NEEDS_RESTORE.load(Ordering::SeqCst));
@@ -190,6 +200,7 @@ mod tests {
     /// silent no-ops, and no call panics.
     #[test]
     fn restore_terminal_is_idempotent() {
+        let _guard = TEST_MUTEX.lock().unwrap();
         TERMINAL_NEEDS_RESTORE.store(true, Ordering::SeqCst);
         restore_terminal();
         restore_terminal();

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -102,8 +102,9 @@ impl UiLoop {
         // Start the background terminal event reader
         self.event_coordinator.spawn_terminal_reader();
 
-        // Hide cursor once at session start. The cursor is restored in
-        // TerminalManager::drop() (LeaveAlternateScreen resets it).
+        // Hide cursor once at session start. The cursor is restored on every
+        // exit path (normal q, panic, SIGINT/SIGTERM) by terminal_manager —
+        // see Drop and restore_terminal() (issue #235).
         // This avoids per-frame Hide/Show churn.
         {
             let mut stdout = std::io::stdout();


### PR DESCRIPTION
## Summary

On Linux terminals (VTE family, tmux, kitty) cursor visibility is tracked independently of the alternate-screen mode. Leaving the alternate screen does **not** automatically restore a hidden cursor — so after pressing `q`, Ctrl-C, or a panic the shell cursor remained invisible, requiring the user to run `reset`.

## Root cause

Two independent failure modes:
1. `TerminalManager::Drop` emitted `LeaveAlternateScreen` but not `cursor::Show`, so the normal `q`-exit path left the cursor hidden on non-Apple terminals.
2. The SIGINT/SIGTERM handlers called `std::process::exit(0)` directly, which **bypasses all `Drop` impls** — so even adding `cursor::Show` to `Drop` alone would not fix Ctrl-C. (See issue #235 for full analysis.)

## Changes

- **`src/view/terminal_manager.rs`**: Added `TERMINAL_NEEDS_RESTORE` (`AtomicBool`) static flag and a public `restore_terminal()` function. The flag is set in `initialize()` after the alternate screen is entered and cleared atomically in `restore_terminal()`. The function is idempotent — safe to call concurrently from `Drop`, signal handlers, and a panic hook. Added `PANIC_HOOK_INSTALLED` (`Once`) to install a panic hook exactly once; the hook calls `restore_terminal()` before delegating to the previous hook so panic backtraces render on a usable terminal. `TerminalManager::Drop` now delegates to `restore_terminal()` (including explicit `cursor::Show`). Added 3 unit tests for the swap semantics and idempotency.
- **`src/main.rs`**: Added `view::terminal_manager::restore_terminal()` calls at the start of both the SIGINT and SIGTERM handlers, before `std::process::exit(0)`. Renamed `setup_panic_handler` to `setup_panic_handlers` and removed the `#[cfg(target_os = "macos")]` gate on the function definition; the macOS-specific native-metrics shutdown remains gated inside the closure. The call site in `main()` is now unconditional.
- **`src/view/ui_loop.rs`**: Updated stale comment that claimed `LeaveAlternateScreen` resets cursor visibility — which was precisely the bug.

## Verification

Automated checks run:

| Command | Result |
|---|---|
| `cargo check --features cli --lib` | passed |
| `cargo check --features cli --lib --tests` | passed |
| `cargo clippy --features cli --lib --tests -- -D warnings` | passed |
| `cargo test --features cli --bin all-smi -- view::terminal_manager::tests` | 3/3 passed |
| `cargo fmt --check` | passed |

Acceptance criteria requiring **manual verification** by the reviewer:

- Press `q` on Linux (TTY + VTE terminal) — cursor must be visible in the shell afterward.
- Press `q` inside tmux — cursor must be visible.
- Press Ctrl-C — cursor must be visible and terminal must be out of raw mode / alt-screen.
- Induce a panic in the view loop — terminal must be restored without needing `reset`.

The macOS / iTerm2 regression check (idempotent `cursor::Show` is safe when cursor already visible) does not require separate verification — the escape sequence is a no-op when the cursor is already shown.

Closes #235
