### PR TITLE
fix(view): correct remote-mode node counter, spacing, and Topology alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # all-smi
 
 [![Crates.io version](https://img.shields.io/crates/v/all-smi.svg?style=flat-square)](https://crates.io/crates/all-smi)
-[![Crates.io downloads](https://img.shields.io/crates/d/all-smi.svg?style=flat-square)](https://crates.io/crates/all-smi)
-![GitHub Downloads](https://img.shields.io/github/downloads/lablup/all-smi/total?style=flat-square&label=downloads)
+[![Crates.io downloads](https://img.shields.io/crates/d/all-smi.svg?style=flat-square&label=crates.io%20downloads)](https://crates.io/crates/all-smi)
+![GitHub Downloads](https://img.shields.io/github/downloads/lablup/all-smi/total?style=flat-square&label=GitHub%20downloads)
 ![CI](https://github.com/lablup/all-smi/workflows/CI/badge.svg)
 [![dependency status](https://deps.rs/repo/github/lablup/all-smi/status.svg)](https://deps.rs/repo/github/lablup/all-smi)
 

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -30,7 +30,10 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
     let total_nodes = if is_local_mode {
         1 // Local mode has 1 node
     } else {
-        state.tabs.len().saturating_sub(1) // Exclude "All" tab in remote mode
+        // Count only host tabs — `state.tabs` also carries the reserved
+        // cluster-level entries (All, Users, Topology). Counting them as
+        // nodes is what caused `50/52` on a 50-host cluster.
+        crate::ui::tabs::host_tab_count(&state.tabs)
     };
     let live_nodes = if is_local_mode {
         1 // Local node is always considered live

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -50,7 +50,7 @@ impl LayoutCalculator {
 
             // Live statistics section (remote sparkline panel)
             if !state.utilization_history.is_empty() || !state.cpu_utilization_history.is_empty() {
-                lines += 5; // Separator + header + 3 sparkline rows
+                lines += 6; // Separator + header + 3 sparkline rows + spacer
             }
 
             // Tabs section

--- a/src/ui/remote_sparkline_panel.rs
+++ b/src/ui/remote_sparkline_panel.rs
@@ -131,6 +131,11 @@ pub fn draw_remote_sparkline_panel<W: Write>(stdout: &mut W, state: &AppState, c
         },
     );
     queue!(stdout, Print("\r\n")).unwrap();
+
+    // Spacer row so the Tabs strip below isn't visually glued to the
+    // last sparkline row. The matching header-line budget lives in
+    // `layout::calculate_header_lines` — keep the two in sync.
+    queue!(stdout, Print("\r\n")).unwrap();
 }
 
 struct SparklinePairParams<'a> {

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -65,6 +65,25 @@ pub fn is_topology_tab_active(state: &AppState) -> bool {
     topology_tab_index(&state.tabs).is_some_and(|i| i == state.current_tab)
 }
 
+/// True when `name` is a reserved cluster-level tab ("All", Users,
+/// Topology) rather than a per-host tab. Used by callers that want to
+/// count or iterate only the host tabs without hard-coding the reserved
+/// names at the call site (see issue raised when 50 hosts displayed as
+/// `50/52` because the dashboard counted reserved tabs as nodes).
+#[inline]
+pub fn is_reserved_tab(name: &str) -> bool {
+    matches!(name, "All" | USERS_TAB_NAME | TOPOLOGY_TAB_NAME)
+}
+
+/// Count host tabs in `tabs`, excluding the reserved cluster-level tabs
+/// ("All", Users, Topology). The dashboard's `live/total nodes` figure
+/// uses this so newly added cluster-level tabs cannot inflate the
+/// denominator again.
+#[inline]
+pub fn host_tab_count(tabs: &[String]) -> usize {
+    tabs.iter().filter(|t| !is_reserved_tab(t)).count()
+}
+
 pub fn draw_tabs<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
     // Print tabs
     let mut labels: Vec<(String, Color)> = Vec::new();
@@ -304,5 +323,36 @@ mod tests {
             format_ssh_tab_label("admin@dgx-01:2222"),
             "ssh://admin@dgx-01:2222"
         );
+    }
+
+    #[test]
+    fn host_tab_count_excludes_reserved_tabs() {
+        // Mirrors the real remote-mode layout from
+        // `remote_collector.rs`: [All, Users, Topology, host1, host2, ...]
+        // 50 hosts must register as 50, not 52 (issue: `50/52`).
+        let mut tabs = vec![
+            "All".to_string(),
+            USERS_TAB_NAME.to_string(),
+            TOPOLOGY_TAB_NAME.to_string(),
+        ];
+        for i in 0..50 {
+            tabs.push(format!("host-{i}"));
+        }
+        assert_eq!(host_tab_count(&tabs), 50);
+
+        // Local mode style: only "All" — zero hosts.
+        assert_eq!(host_tab_count(&["All".to_string()]), 0);
+
+        // Defensive: empty tab list returns 0.
+        assert_eq!(host_tab_count(&[]), 0);
+    }
+
+    #[test]
+    fn is_reserved_tab_matches_cluster_level_tabs() {
+        assert!(is_reserved_tab("All"));
+        assert!(is_reserved_tab(USERS_TAB_NAME));
+        assert!(is_reserved_tab(TOPOLOGY_TAB_NAME));
+        assert!(!is_reserved_tab("dgx-01"));
+        assert!(!is_reserved_tab("admin@dgx-01:22"));
     }
 }

--- a/src/ui/topology/graph_render.rs
+++ b/src/ui/topology/graph_render.rs
@@ -254,12 +254,24 @@ fn render_footer(out: &mut String, model: &TopologyModel) {
     }
 }
 
+/// Centre `s` in a field `w` cells wide.
+///
+/// Uses `chars().count()` for the width measurement so multi-byte box-
+/// drawing characters (e.g. `─`, U+2500, 3 bytes / 1 cell) are sized
+/// correctly. The previous `s.len()` (byte length) implementation
+/// under-padded edge labels like `── NV ──`, which collapsed cells below
+/// `cell_width` and broke the box borders in the Topology tab.
+///
+/// Every label this module emits is composed of ASCII + single-cell
+/// box-drawing characters, so character count equals display width here.
+/// If anyone adds wide (East Asian) or zero-width (combining) glyphs to
+/// edge labels in the future, swap this for `unicode_width::UnicodeWidthStr`.
 fn center(s: &str, w: usize) -> String {
-    if s.len() >= w {
-        let trimmed: String = s.chars().take(w).collect();
-        return trimmed;
+    let visible = s.chars().count();
+    if visible >= w {
+        return s.chars().take(w).collect();
     }
-    let total = w - s.len();
+    let total = w - visible;
     let left = total / 2;
     let right = total - left;
     format!("{}{s}{}", " ".repeat(left), " ".repeat(right))
@@ -398,5 +410,53 @@ mod tests {
         let model = TopologyModel::from_host("h", &gpus);
         let out = render_graph(&model, 200);
         assert!(out.contains("nvsw"), "{out}");
+    }
+
+    #[test]
+    fn center_uses_display_width_not_byte_length() {
+        // Regression: `center` previously measured with `str::len()` so
+        // multi-byte box-drawing chars (3 bytes / 1 cell) under-padded
+        // and the right border `│` slipped left. All cells must report
+        // exactly the requested column width.
+        let width = 13;
+        for label in [
+            "[GPU 0]",    // pure ASCII baseline
+            "──",         // self-cell marker
+            "── NV ──",   // NvLink without generation
+            "── NV5 ──",  // NvLink with generation
+            "── NSW ──",  // NvSwitch
+            "── PXB ──",  // PCIe bridge
+            "── NODE ──", // same NUMA, no NvLink
+            "── SYS ──",  // across NUMA
+        ] {
+            let out = center(label, width);
+            assert_eq!(
+                out.chars().count(),
+                width,
+                "label {label:?} produced {out:?} ({} cells, want {width})",
+                out.chars().count()
+            );
+        }
+    }
+
+    #[test]
+    fn render_numa_box_keeps_borders_aligned_with_unicode_edge_labels() {
+        // 2 GPUs in one NUMA -> 1 row, 2 columns, 1 edge cell carrying
+        // the unicode-laden NvLink label. Every rendered line must have
+        // identical display width, otherwise the right border zig-zags.
+        let gpus = vec![mk_gpu(0, Some(0), 4, false), mk_gpu(1, Some(0), 4, false)];
+        let model = TopologyModel::from_host("h", &gpus);
+        let out = render_graph(&model, 200);
+        let body_lines: Vec<&str> = out
+            .lines()
+            .filter(|l| l.contains('│') || l.starts_with('┌') || l.starts_with('└'))
+            .collect();
+        assert!(!body_lines.is_empty(), "{out}");
+        let widths: Vec<usize> = body_lines.iter().map(|l| l.chars().count()).collect();
+        let first = widths[0];
+        assert!(
+            widths.iter().all(|&w| w == first),
+            "box lines have mismatched widths {widths:?}:\n{out}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three remote-mode `all-smi view` bugs from this session, plus a small README polish.

### 1. Node counter inflated by reserved tabs

The dashboard derived `total_nodes` as `state.tabs.len() - 1`, only subtracting `"All"`. The real remote-mode tab layout is `[All, Users, Topology, host1, …]` (set in `remote_collector`, `ssh_strategy`, `replay_collector`, `runner`, and `event_handler`), so a 50-host cluster rendered as **`50/52`**.

Fix: added `is_reserved_tab` / `host_tab_count` helpers in `src/ui/tabs.rs` and switched `draw_system_view` to count only host tabs. The helper centralizes the reserved-tab list so future cluster-level tabs can't silently inflate the denominator again.

### 2. Live Statistics ↔ Tabs collision

The remote sparkline panel's last row sat directly above the tab strip, hurting readability. Added one spacer line at the tail of `draw_remote_sparkline_panel` (inside the empty-history early-return so it only emits when the panel actually renders) and bumped `LayoutCalculator::calculate_header_lines` from 5 to 6 to keep the content-area math in sync.

### 3. Topology tab box borders zig-zagging

`center()` in `topology::graph_render` measured field width with `str::len()`, but every edge label uses `─` (U+2500 — 3 bytes / 1 cell). For `center("── NV ──", 13)` it saw `len == 16 ≥ 13` and returned the label untouched at 8 visible cells — 5 short of the cell width. The right `│` border then slipped left and the NUMA box looked broken.

Fix: switched to `s.chars().count()`, which equals display width for the ASCII + single-cell box-drawing characters this module emits, and documented the assumption.

Sample render after the fix (all four lines 54 cells):

```
┌────────────────────── NUMA 0 ──────────────────────┐
│   [GPU 0]      [GPU 1]      [GPU 2]      [GPU 3]   │
│  ── NV5 ──    ── NV5 ──    ── NV5 ──               │
└────────────────────────────────────────────────────┘
```

### 4. README download shields

Both Crates.io and GitHub badges rendered as bare `downloads | N`, giving no visual cue which count came from which source. They now read `crates.io downloads` and `GitHub downloads`.

## Tests

- `cargo test --lib` — 1033 passed, 0 failed.
- `cargo clippy --lib --tests -- -D warnings` — clean.

Regression coverage added in this PR:

- `ui::tabs::tests::host_tab_count_excludes_reserved_tabs` — asserts the real `[All, Users, Topology, host-0..host-49]` shape counts as 50.
- `ui::tabs::tests::is_reserved_tab_matches_cluster_level_tabs` — pins the reserved-tab list.
- `ui::topology::graph_render::tests::center_uses_display_width_not_byte_length` — pins every edge label (`──`, `── NV ──`, `── NV5 ──`, `── NSW ──`, `── PXB ──`, `── NODE ──`, `── SYS ──`) to its requested cell width.
- `ui::topology::graph_render::tests::render_numa_box_keeps_borders_aligned_with_unicode_edge_labels` — integration check that every border-bearing line of a rendered box has identical visible width.

## Risk

Low. Pure rendering / arithmetic fixes; no behavior change for local mode or for the data pipeline. Header-line budget bumped by 1 row so the content area shrinks by one row when Live Statistics is visible.
