### PR TITLE
feat: add Intel client GPU reader (Arc/Iris/Xe) for Windows and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![dependency status](https://deps.rs/repo/github/lablup/all-smi/status.svg)](https://deps.rs/repo/github/lablup/all-smi)
 
 
-`all-smi` is a command-line utility for monitoring GPU and NPU hardware across multiple systems. It provides a real-time view of accelerator utilization, memory usage, temperature, power consumption, and other metrics. The tool is designed to be a cross-platform alternative to `nvidia-smi`, with support for NVIDIA GPUs, AMD GPUs, NVIDIA Jetson platforms, Apple Silicon GPUs, Intel Gaudi NPUs, Google Cloud TPUs, Tenstorrent NPUs, Rebellions NPUs, and Furiosa NPUs.
+`all-smi` is a command-line utility for monitoring GPU and NPU hardware across multiple systems. It provides a real-time view of accelerator utilization, memory usage, temperature, power consumption, and other metrics. The tool is designed to be a cross-platform alternative to `nvidia-smi`, with support for NVIDIA GPUs, AMD GPUs, NVIDIA Jetson platforms, Apple Silicon GPUs, Intel Arc/Iris Xe/Xe client GPUs, Intel Gaudi NPUs, Google Cloud TPUs, Tenstorrent NPUs, Rebellions NPUs, and Furiosa NPUs.
 
 The application presents a terminal-based user interface with cluster overview, interactive sorting, and both local and remote monitoring capabilities. It also provides an API mode for Prometheus metrics integration.
 
@@ -557,6 +557,10 @@ Stable check IDs (greppable across versions):
     - GPU process detection with memory usage tracking
     - Temperature, power consumption, frequency, and fan speed metrics
     - Requires sudo access to /dev/dri devices (glibc builds only)
+  - Intel Arc / Iris Xe / Xe client GPUs (Arc A/B-series, Core Ultra iGPU, Iris Xe) via i915/xe sysfs
+    - Architecture classification (Alchemist, Battlemage, Xe-LPG, Iris Xe) with SYCL/oneAPI capability flag
+    - Discrete VRAM tracking (i915 `mem_info_vram_total` and xe `tile0/vram0/total_bytes`)
+    - Frequency, temperature (hwmon), and power (hwmon) metrics
   - CPU monitoring via /proc filesystem
   - Memory monitoring with detailed statistics
   - Intel Gaudi NPUs (Gaudi 1/2/3) via hl-smi with background process monitoring
@@ -862,7 +866,7 @@ threshold}` JSON with a 2-second timeout, fire-and-forget.
   - Simulates realistic GPU clusters with 8 GPUs per node
   - Configurable port ranges for multiple instances
   - Failure simulation for resilience testing
-  - Platform-specific metric generation (NVIDIA, AMD, Apple Silicon, Jetson, Intel Gaudi, Google TPU, Tenstorrent, Rebellions, Furiosa)
+  - Platform-specific metric generation (NVIDIA, AMD, Apple Silicon, Jetson, Intel client GPU, Intel Gaudi, Google TPU, Tenstorrent, Rebellions, Furiosa)
   - Background metric updates with realistic variations
   - Set `ALL_SMI_MOCK_VGPU=1` to simulate NVIDIA vGPU SR-IOV data without real vGPU hardware
   - Set `ALL_SMI_MOCK_MIG=1` to simulate NVIDIA MIG (Multi-Instance GPU) data without MIG hardware
@@ -903,7 +907,7 @@ curl --unix-socket /tmp/all-smi.sock http://localhost/metrics
 - Currently Unix-only (Linux, macOS); Windows support pending Rust ecosystem maturity
 
 Metrics are available at `http://localhost:9090/metrics` (TCP) or via Unix socket and include comprehensive hardware monitoring for:
-- **GPUs:** Utilization, memory, temperature, power, frequency (NVIDIA, AMD, Apple Silicon, Intel Gaudi, Google TPU, Tenstorrent)
+- **GPUs:** Utilization, memory, temperature, power, frequency (NVIDIA, AMD, Apple Silicon, Intel Arc/Iris Xe client GPU, Intel Gaudi, Google TPU, Tenstorrent)
 - **NVIDIA hardware details:** NUMA node ID, GSP firmware mode and version, NvLink remote endpoint type per active link, GPM SM occupancy and memory bandwidth utilization (all omitted when the driver does not support the underlying API)
 - **NVIDIA vGPUs:** Per-vGPU utilization, framebuffer memory, scheduler state, and SR-IOV host mode (emitted only on vGPU-enabled hosts)
 - **NVIDIA MIG:** Per-GPU MIG mode status and per-MIG-instance utilization, framebuffer memory used/total (emitted only on MIG-enabled hosts)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-All-SMI is a unified GPU/NPU monitoring tool that provides both terminal UI (TUI) and Prometheus metrics interface for monitoring local and remote accelerator resources. Built with a modular, event-driven architecture on async Rust patterns, it supports multiple platforms (NVIDIA GPU, AMD GPU, Apple Silicon, Jetson, Intel Gaudi, Tenstorrent, Rebellions, Furiosa) and enables distributed monitoring across multiple nodes.
+All-SMI is a unified GPU/NPU monitoring tool that provides both terminal UI (TUI) and Prometheus metrics interface for monitoring local and remote accelerator resources. Built with a modular, event-driven architecture on async Rust patterns, it supports multiple platforms (NVIDIA GPU, AMD GPU, Apple Silicon, Jetson, Intel Arc/Iris Xe client GPU, Intel Gaudi, Tenstorrent, Rebellions, Furiosa) and enables distributed monitoring across multiple nodes.
 
 ## Table of Contents
 
@@ -206,6 +206,13 @@ pub trait MetricsExporter: Send + Sync {
 - Specialized for Tegra platforms
 - DLA (Deep Learning Accelerator) support
 - Integrated memory architecture handling
+
+#### Intel Arc / Iris Xe client GPU (Linux: `src/device/readers/intel_gpu_linux.rs`, Windows: `src/device/readers/intel_gpu_windows.rs`)
+- Linux: sysfs discovery under `/sys/class/drm/card*`, vendor `0x8086`, driver `i915` or `xe`
+- Windows: WMI `Win32_VideoController` query filtered to Intel graphics adapter names
+- PCI device-ID to marketing-name table in `src/device/readers/intel_gpu_names.rs` covering Arc A/B-series, Iris Xe, Xe-LPG (Core Ultra / Meteor Lake), and Xe2 (Lunar Lake)
+- Architecture classification (Alchemist, Battlemage, XeLpg, XeLpgPlus, IrisXe, OlderIntegrated) with SYCL/oneAPI capability flag
+- Discrete VRAM tracking via i915 `mem_info_vram_total` or xe `tile0/vram0/total_bytes`; integrated GPUs report zero
 
 #### Intel Gaudi (`src/device/readers/gaudi.rs`, `src/device/hlsmi/`)
 - Uses `hl-smi` command running as a background process

--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -17,7 +17,7 @@ all-smi \- Command-line utility for monitoring GPU hardware
 .B all-smi
 is a comprehensive hardware monitoring tool that provides real-time information about GPU/NPU utilization,
 memory usage, temperature, power consumption, chassis-level metrics, and other system information. It supports various hardware platforms
-including NVIDIA GPUs, AMD GPUs, Apple Silicon, NVIDIA Jetson, Google Cloud TPUs, Tenstorrent NPUs, Rebellions NPUs, and Furiosa NPUs.
+including NVIDIA GPUs, AMD GPUs, Apple Silicon, NVIDIA Jetson, Intel Arc/Iris Xe client GPUs, Google Cloud TPUs, Tenstorrent NPUs, Rebellions NPUs, and Furiosa NPUs.
 Chassis monitoring provides node-level power consumption tracking (CPU+GPU+ANE), thermal pressure monitoring (Apple Silicon),
 and BMC sensor integration for inlet/outlet temperatures and fan speeds on server systems.
 
@@ -173,6 +173,9 @@ Full support via nvidia-smi, including CUDA information, PCIe status, and perfor
 .TP
 .B AMD GPUs
 Support for Radeon and Instinct GPUs via ROCm/libamdgpu_top, including VRAM/GTT memory tracking and fdinfo-based process monitoring
+.TP
+.B Intel Arc / Iris Xe / Xe client GPUs
+Support for Arc A/B-series discrete GPUs and Iris Xe/Xe-LPG integrated GPUs via i915/xe sysfs (Linux) and WMI (Windows), including architecture classification and SYCL/oneAPI capability detection
 .TP
 .B Apple Silicon
 Native support for M1/M2/M3/M4 series with Metal API integration, ANE power monitoring, and thermal pressure tracking

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -119,6 +119,41 @@ pub fn has_amd() -> bool {
     *CACHE.get_or_init(detect_amd)
 }
 
+/// Check whether at least one Intel **client** GPU (Arc / Iris / Xe /
+/// integrated graphics) is present.
+///
+/// Linux: delegates to [`crate::device::readers::intel_gpu_linux::has_intel_client_gpu`]
+/// which walks `/sys/class/drm/card*` and falls back to `lspci -n`.
+///
+/// Windows: delegates to
+/// [`crate::device::readers::intel_gpu_windows::has_intel_gpu_windows`]
+/// which uses a WMI query against `Win32_VideoController`.
+///
+/// On other platforms (macOS, BSD) Intel client GPUs are not in scope —
+/// returns `false` unconditionally so the rest of the detection
+/// machinery short-circuits. Result is cached in a `OnceLock` like
+/// every other `has_*` detector since hardware doesn't change at
+/// runtime.
+pub fn has_intel_gpu() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(detect_intel_gpu)
+}
+
+fn detect_intel_gpu() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        crate::device::readers::intel_gpu_linux::has_intel_client_gpu()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        crate::device::readers::intel_gpu_windows::has_intel_gpu_windows()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        false
+    }
+}
+
 #[cfg(all(target_os = "linux", not(target_env = "musl")))]
 fn detect_amd() -> bool {
     // On Linux, check for AMD GPUs
@@ -554,6 +589,11 @@ pub mod introspection {
         pub tenstorrent: bool,
         pub rebellions: bool,
         pub furiosa: bool,
+        /// `true` when an Intel **client** GPU (Arc / Iris / Xe /
+        /// integrated graphics) is detected. Reported on both Linux
+        /// (i915 / xe drivers) and Windows (WMI). Distinct from
+        /// `gaudi`, which is the Intel datacenter HPU.
+        pub intel_gpu: bool,
     }
 
     /// Produce a fresh [`PlatformSnapshot`] from the cached detectors.
@@ -569,6 +609,7 @@ pub mod introspection {
             tenstorrent: detect_tenstorrent(),
             rebellions: super::has_rebellions(),
             furiosa: super::has_furiosa(),
+            intel_gpu: super::has_intel_gpu(),
         }
     }
 
@@ -619,6 +660,10 @@ pub mod introspection {
             let empty = PlatformSnapshot::default();
             assert_eq!(empty.os, "");
             assert!(!empty.nvidia);
+            // Intel client GPU detection (issue #244) must default to
+            // `false` so unconfigured mock/test scenarios don't
+            // accidentally claim Intel hardware.
+            assert!(!empty.intel_gpu);
         }
     }
 }

--- a/src/device/reader_factory.rs
+++ b/src/device/reader_factory.rs
@@ -14,7 +14,7 @@
 
 use crate::device::{
     platform_detection::{
-        get_os_type, has_furiosa, has_gaudi, has_nvidia, has_rebellions, is_jetson,
+        get_os_type, has_furiosa, has_gaudi, has_intel_gpu, has_nvidia, has_rebellions, is_jetson,
     },
     readers::{furiosa, gaudi, nvidia, nvidia_jetson, rebellions},
     traits::{CpuReader, GpuReader, MemoryReader},
@@ -40,6 +40,12 @@ use crate::device::{cpu_windows, memory_windows};
 
 #[cfg(target_os = "windows")]
 use crate::device::readers::amd_windows;
+
+#[cfg(target_os = "linux")]
+use crate::device::readers::intel_gpu_linux;
+
+#[cfg(target_os = "windows")]
+use crate::device::readers::intel_gpu_windows;
 
 #[cfg(all(target_os = "linux", not(target_env = "musl")))]
 use crate::device::platform_detection::has_amd;
@@ -99,6 +105,14 @@ pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
             if has_amd() {
                 readers.push(Box::new(amd::AmdGpuReader::new()));
             }
+
+            // Check for Intel client GPU (Arc / Iris / Xe). Unlike
+            // `libamdgpu_top`, the Intel sysfs reader has no glibc
+            // constraint and works on both glibc and musl targets.
+            #[cfg(target_os = "linux")]
+            if has_intel_gpu() {
+                readers.push(Box::new(intel_gpu_linux::IntelGpuReader::new()));
+            }
         }
         "macos" => {
             #[cfg(target_os = "macos")]
@@ -120,6 +134,12 @@ pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
                 // Check for AMD GPU on Windows (including APU)
                 if amd_windows::has_amd_gpu_windows() {
                     readers.push(Box::new(amd_windows::AmdWindowsGpuReader::new()));
+                }
+
+                // Check for Intel client GPU (Arc / Iris / Xe) on
+                // Windows via WMI.
+                if intel_gpu_windows::has_intel_gpu_windows() {
+                    readers.push(Box::new(intel_gpu_windows::IntelWindowsGpuReader::new()));
                 }
             }
         }

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -44,7 +44,9 @@
 use crate::device::GpuReader;
 use crate::device::common::execute_command_default;
 use crate::device::readers::common_cache::{DeviceStaticInfo, MAX_DEVICES};
-use crate::device::readers::intel_gpu_names::{classify_intel_architecture, resolve_intel_gpu_name};
+use crate::device::readers::intel_gpu_names::{
+    classify_intel_architecture, resolve_intel_gpu_name,
+};
 use crate::device::readers::intel_gpu_sysfs::{
     MemoryVariant, has_nonzero_u64, read_frequency_mhz, read_memory_bytes, read_power_watts,
     read_temperature_celsius,

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -1,0 +1,473 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Intel client GPU reader for Linux using sysfs
+//!
+//! Enumerates Intel **client** GPUs — both discrete Intel Arc (A-series /
+//! B-series "Battlemage") and integrated graphics (Iris Xe, Xe-LPG, Arc iGPU
+//! on Core Ultra / Meteor Lake) — by walking `/sys/class/drm/card*` for
+//! devices whose vendor is `0x8086` and whose driver is `i915` or `xe`.
+//!
+//! ## Scope (v1)
+//!
+//! This implementation surfaces device identity (name, PCI device ID),
+//! memory totals and used bytes where the driver exposes them, current
+//! frequency, temperature, and instantaneous power. Engine-busy utilization
+//! (the `engine/*/busy` perf counters) requires sampling deltas across
+//! polling intervals and is **deferred** — `utilization` is reported as
+//! `0.0` and the `detail` map carries a `"Utilization"` note pointing the
+//! user at `intel_gpu_top` for live engine-busy figures. Intel client GPUs
+//! have no MIG/vGPU equivalent so the `GpuReader` default `Vec::new()`
+//! returns apply unchanged.
+//!
+//! ## Memory semantics
+//!
+//! Discrete GPUs report dedicated VRAM via `device/mem_info_vram_total`
+//! (i915) or `device/tile0/vram0/total_bytes` (xe). Integrated GPUs have
+//! no dedicated VRAM — the reader records `total_memory = 0` and writes a
+//! `"Memory"` detail explaining the value is shared system memory. The
+//! reader never fabricates a number from `MemTotal` because that
+//! misrepresents the actual GPU memory budget (the kernel allocates GTT
+//! pages on demand and the budget is a soft cap, not a fixed reservation).
+
+use crate::device::GpuReader;
+use crate::device::common::execute_command_default;
+use crate::device::readers::common_cache::{DeviceStaticInfo, MAX_DEVICES};
+use crate::device::readers::intel_gpu_names::resolve_intel_gpu_name;
+use crate::device::readers::intel_gpu_sysfs::{
+    MemoryVariant, has_nonzero_u64, read_frequency_mhz, read_memory_bytes, read_power_watts,
+    read_temperature_celsius,
+};
+use crate::device::types::{GpuInfo, ProcessInfo};
+use crate::utils::get_hostname;
+use chrono::Local;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+// GPU metric validation constants — Intel client GPUs are smaller than
+// datacenter accelerators, so we use tighter caps than the AMD reader.
+// These prevent obviously bogus driver values (e.g. an integer parse
+// glitch returning u32::MAX) from poisoning consumers.
+const MAX_GPU_POWER_WATTS: f64 = 750.0; // largest Arc Pro variants stay <250W
+const MAX_GPU_TEMP_CELSIUS: u32 = 125; // package max across i915/xe
+const MAX_GPU_FREQ_MHZ: u32 = 5000;
+const MAX_GPU_MEMORY_BYTES: u64 = 96 * 1024 * 1024 * 1024; // 96GB headroom
+
+// Per-card sysfs anchor.  We hold the absolute card path (e.g.
+// `/sys/class/drm/card0`) plus a one-time-cached identity (the name and
+// `detail` map) so subsequent refreshes only re-read the dynamic counters.
+struct IntelGpuCard {
+    /// Card index as exposed by the kernel (`0` for `card0`, …). Used for
+    /// stable UUIDs when no PCI bus identifier is available.
+    index: u32,
+    /// Absolute path to `/sys/class/drm/cardN`.
+    card_path: PathBuf,
+    /// Driver name (`i915` or `xe`). Empty when the driver symlink could
+    /// not be resolved — in that case the reader still emits the GPU but
+    /// skips xe-only or i915-only paths.
+    driver: String,
+    /// PCI device identifier (numeric `device` value, e.g. `0xE20B`).
+    device_id: u32,
+    /// Classification populated at construction time.
+    variant: MemoryVariant,
+    /// Cached static info (name + base `detail` map). Filled on first
+    /// `get_gpu_info` call so that `IntelGpuReader::new` stays cheap.
+    static_info: OnceLock<DeviceStaticInfo>,
+}
+
+/// Render the discrete/integrated classification as the string we put in
+/// `detail["Variant"]`.
+fn variant_label(variant: MemoryVariant) -> &'static str {
+    match variant {
+        MemoryVariant::Discrete => "Discrete",
+        MemoryVariant::Integrated => "Integrated",
+    }
+}
+
+/// The reader itself. Holds a snapshot of cards discovered at
+/// construction time. Hot-plug is not supported in v1 — matching the AMD
+/// reader pattern, which also samples device list at `new()`.
+pub struct IntelGpuReader {
+    cards: Vec<IntelGpuCard>,
+}
+
+impl Default for IntelGpuReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntelGpuReader {
+    pub fn new() -> Self {
+        Self::new_from_root(Path::new("/sys/class/drm"))
+    }
+
+    /// Constructor used by tests: walk an arbitrary `cardN` root rather
+    /// than the real `/sys/class/drm`. Production code uses
+    /// [`IntelGpuReader::new`].
+    fn new_from_root(drm_root: &Path) -> Self {
+        let cards = discover_cards(drm_root);
+        Self { cards }
+    }
+
+    /// Compute the per-card static identity once and cache it.
+    fn ensure_static_info<'a>(&self, card: &'a IntelGpuCard) -> &'a DeviceStaticInfo {
+        card.static_info.get_or_init(|| {
+            let device_dir = card.card_path.join("device");
+            let name = resolve_device_name(&device_dir, card.device_id);
+
+            let mut detail = HashMap::new();
+            detail.insert("Device ID".to_string(), format!("{:#06x}", card.device_id));
+            detail.insert(
+                "Variant".to_string(),
+                variant_label(card.variant).to_string(),
+            );
+            if !card.driver.is_empty() {
+                detail.insert("Driver".to_string(), card.driver.clone());
+            }
+            if let Some(bus) = read_pci_bus_id(&device_dir) {
+                detail.insert("PCI Bus".to_string(), bus);
+            }
+            // Document the v1 scope limitation in-band so library
+            // consumers see *why* utilization is always reported as
+            // zero rather than thinking the GPU is idle.
+            detail.insert(
+                "Utilization".to_string(),
+                "Requires intel_gpu_top (perf engine counters)".to_string(),
+            );
+            if card.variant == MemoryVariant::Integrated {
+                detail.insert(
+                    "Memory".to_string(),
+                    "Shared system memory (no dedicated VRAM)".to_string(),
+                );
+            }
+
+            DeviceStaticInfo::with_details(name, None, detail)
+        })
+    }
+}
+
+impl GpuReader for IntelGpuReader {
+    fn get_gpu_info(&self) -> Vec<GpuInfo> {
+        let hostname = get_hostname();
+        let time = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        let mut out = Vec::with_capacity(self.cards.len());
+
+        for card in &self.cards {
+            let static_info = self.ensure_static_info(card);
+            let mut detail = static_info.detail.clone();
+
+            let device_dir = card.card_path.join("device");
+            let (used_memory, total_memory) = read_memory_bytes(&device_dir, card.variant);
+            let frequency = read_frequency_mhz(&device_dir);
+            let temperature = read_temperature_celsius(&device_dir);
+            let power_consumption = read_power_watts(&device_dir);
+
+            // Round-trip values through the validation caps so that a
+            // garbled sysfs file can never propagate u32::MAX into the
+            // exporter. See the AMD reader for the same defence-in-depth
+            // pattern.
+            let temperature = temperature.min(MAX_GPU_TEMP_CELSIUS);
+            let frequency = frequency.min(MAX_GPU_FREQ_MHZ);
+            let power_consumption = power_consumption.clamp(0.0, MAX_GPU_POWER_WATTS);
+            let total_memory = total_memory.min(MAX_GPU_MEMORY_BYTES);
+            let used_memory = used_memory.min(total_memory);
+
+            // Surface the raw memory budget as a detail entry too so a
+            // remote operator inspecting the `detail` map can see what
+            // the driver reported even when `total_memory` was clamped
+            // (this is purely defensive — no current Intel client GPU
+            // is anywhere near the 96GB cap).
+            if total_memory > 0 {
+                detail.insert("VRAM Total".to_string(), format!("{total_memory} bytes"));
+            }
+
+            let uuid = build_uuid(card, &device_dir);
+
+            out.push(GpuInfo {
+                uuid,
+                time: time.clone(),
+                name: static_info.name.clone(),
+                device_type: "GPU".to_string(),
+                host_id: hostname.clone(),
+                hostname: hostname.clone(),
+                instance: hostname.clone(),
+                utilization: 0.0,
+                ane_utilization: 0.0,
+                dla_utilization: None,
+                tensorcore_utilization: None,
+                temperature,
+                used_memory,
+                total_memory,
+                frequency,
+                power_consumption,
+                gpu_core_count: None,
+                // Intel client GPUs do not expose NVML-style thermal
+                // thresholds or P-states; leave those `None` so the UI
+                // renders them as unavailable rather than as zero.
+                temperature_threshold_slowdown: None,
+                temperature_threshold_shutdown: None,
+                temperature_threshold_max_operating: None,
+                temperature_threshold_acoustic: None,
+                performance_state: None,
+                // NVIDIA-only hardware details.
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
+                detail,
+            });
+        }
+
+        out
+    }
+
+    fn get_process_info(&self) -> Vec<ProcessInfo> {
+        // Per-process GPU memory accounting on Intel requires walking
+        // `/proc/<pid>/fdinfo/*` for DRM clients and parsing the
+        // driver-specific `drm-engine-*` / `drm-memory-local` keys. The
+        // engine counter format differs between `i915` and `xe`, and
+        // the implementation needs a delta-tracker to be useful — we
+        // defer that to a follow-up just like utilization.
+        Vec::new()
+    }
+}
+
+// ---------- Discovery ----------
+
+fn discover_cards(drm_root: &Path) -> Vec<IntelGpuCard> {
+    let entries = match std::fs::read_dir(drm_root) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut cards = Vec::new();
+    for entry in entries.flatten() {
+        if cards.len() >= MAX_DEVICES {
+            break;
+        }
+        let path = entry.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        // Match `cardN` exactly (not `card0-eDP-1` connector nodes).
+        if !is_card_node(&name) {
+            continue;
+        }
+
+        let device_dir = path.join("device");
+        if !is_intel_vendor(&device_dir) {
+            continue;
+        }
+
+        // Resolve the driver to confirm this is `i915` or `xe`. A bare
+        // Intel vendor ID without a graphics driver attached (e.g. a
+        // future Intel-vendor accelerator) MUST NOT be claimed by this
+        // reader; that's what the Habana-vendor `0x1da3` separation in
+        // `has_gaudi()` exists to prevent for the inverse case.
+        let driver = resolve_driver(&device_dir);
+        if driver != "i915" && driver != "xe" {
+            continue;
+        }
+
+        let device_id = read_device_id(&device_dir).unwrap_or(0);
+        let variant = classify_variant(&device_dir);
+
+        let index = parse_card_index(&name);
+
+        cards.push(IntelGpuCard {
+            index,
+            card_path: path,
+            driver,
+            device_id,
+            variant,
+            static_info: OnceLock::new(),
+        });
+    }
+
+    // Stable ordering by card index so UUID assignment and the reader
+    // output stay deterministic across runs on the same machine.
+    cards.sort_by_key(|c| c.index);
+    cards
+}
+
+fn is_card_node(name: &str) -> bool {
+    if let Some(rest) = name.strip_prefix("card") {
+        !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
+    } else {
+        false
+    }
+}
+
+fn parse_card_index(name: &str) -> u32 {
+    name.strip_prefix("card")
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(0)
+}
+
+fn is_intel_vendor(device_dir: &Path) -> bool {
+    match std::fs::read_to_string(device_dir.join("vendor")) {
+        Ok(s) => s.trim().eq_ignore_ascii_case("0x8086"),
+        Err(_) => false,
+    }
+}
+
+fn resolve_driver(device_dir: &Path) -> String {
+    // `/sys/class/drm/cardN/device/driver` is a symlink to
+    // `/sys/bus/pci/drivers/<driver>`; the file name is the driver name.
+    match std::fs::read_link(device_dir.join("driver")) {
+        Ok(target) => target
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+fn read_device_id(device_dir: &Path) -> Option<u32> {
+    let s = std::fs::read_to_string(device_dir.join("device")).ok()?;
+    parse_hex_u32(s.trim())
+}
+
+fn parse_hex_u32(s: &str) -> Option<u32> {
+    let stripped = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s);
+    u32::from_str_radix(stripped, 16).ok()
+}
+
+fn read_pci_bus_id(device_dir: &Path) -> Option<String> {
+    // The PCI bus id is the last path segment of the `device` symlink
+    // target, e.g. `…/0000:03:00.0`. Falls back to None when the link is
+    // missing (synthetic fixtures don't bother to create it).
+    let link = std::fs::read_link(device_dir).ok()?;
+    link.file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+}
+
+fn build_uuid(card: &IntelGpuCard, device_dir: &Path) -> String {
+    // Prefer the PCI bus id when present, fall back to card index. The
+    // resulting UUID is stable across the lifetime of the kernel.
+    if let Some(bus) = read_pci_bus_id(device_dir) {
+        format!("Intel-GPU-{bus}")
+    } else {
+        format!("Intel-GPU-card{}", card.index)
+    }
+}
+
+fn classify_variant(device_dir: &Path) -> MemoryVariant {
+    if has_nonzero_u64(&device_dir.join("mem_info_vram_total"))
+        || has_nonzero_u64(&device_dir.join("tile0").join("vram0").join("total_bytes"))
+    {
+        MemoryVariant::Discrete
+    } else {
+        MemoryVariant::Integrated
+    }
+}
+
+// ---------- Static identity ----------
+
+fn resolve_device_name(device_dir: &Path, device_id: u32) -> String {
+    // `device/label` exists on a handful of integrated SKUs that carry a
+    // pre-cooked marketing string; it's rare but free to check.
+    if let Ok(label) = std::fs::read_to_string(device_dir.join("label")) {
+        let trimmed = label.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    resolve_intel_gpu_name(device_id)
+}
+
+// ---------- Detection helper ----------
+
+/// Check whether at least one Intel client GPU is present on this Linux
+/// host. Walks `/sys/class/drm/card*` first (cheap), then falls back to
+/// `lspci -n` so containers without `/sys` access still work.
+///
+/// Distinguishes Intel **GPUs** from Habana / Gaudi (vendor `0x1da3`,
+/// not Intel) and from Intel network/storage devices by requiring the
+/// PCI driver to be `i915` or `xe`. Defends against false positives on
+/// hosts that have an Intel-vendor PCI device which is not a GPU at all.
+#[cfg(target_os = "linux")]
+pub fn has_intel_client_gpu() -> bool {
+    has_intel_client_gpu_from_root(Path::new("/sys/class/drm"))
+}
+
+#[cfg(target_os = "linux")]
+fn has_intel_client_gpu_from_root(drm_root: &Path) -> bool {
+    if let Ok(entries) = std::fs::read_dir(drm_root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            if !is_card_node(&name) {
+                continue;
+            }
+            let device_dir = path.join("device");
+            if !is_intel_vendor(&device_dir) {
+                continue;
+            }
+            let driver = resolve_driver(&device_dir);
+            if driver == "i915" || driver == "xe" {
+                return true;
+            }
+        }
+    }
+
+    // Fallback: `lspci -n` parsing for hosts without `/sys` access (some
+    // unprivileged containers). Class codes 0300/0301/0302/0380 cover
+    // VGA / XGA / 3D / Display controllers respectively. We need to
+    // confirm vendor `8086` AND a graphics class — a NIC at vendor 8086
+    // would fail the class check.
+    if let Ok(output) = execute_command_default("lspci", &["-n"])
+        && output.status == 0
+    {
+        for line in output.stdout.lines() {
+            if line_matches_intel_gpu(line) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn line_matches_intel_gpu(line: &str) -> bool {
+    // `lspci -n` lines look like:
+    //   `03:00.0 0300: 8086:56a0 (rev 08)`
+    // Pull out the class (`0300`) and the vendor (`8086`) tokens.
+    let mut tokens = line.split_whitespace();
+    let _bdf = tokens.next();
+    let class = tokens.next().unwrap_or("").trim_end_matches(':');
+    let vendor_device = tokens.next().unwrap_or("");
+
+    let class_match = matches!(class, "0300" | "0301" | "0302" | "0380");
+    if !class_match {
+        return false;
+    }
+    vendor_device.split(':').next() == Some("8086")
+}
+
+#[cfg(test)]
+#[path = "intel_gpu_linux/tests.rs"]
+mod tests;

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -44,7 +44,7 @@
 use crate::device::GpuReader;
 use crate::device::common::execute_command_default;
 use crate::device::readers::common_cache::{DeviceStaticInfo, MAX_DEVICES};
-use crate::device::readers::intel_gpu_names::resolve_intel_gpu_name;
+use crate::device::readers::intel_gpu_names::{classify_intel_architecture, resolve_intel_gpu_name};
 use crate::device::readers::intel_gpu_sysfs::{
     MemoryVariant, has_nonzero_u64, read_frequency_mhz, read_memory_bytes, read_power_watts,
     read_temperature_celsius,
@@ -140,6 +140,20 @@ impl IntelGpuReader {
             if let Some(bus) = read_pci_bus_id(&device_dir) {
                 detail.insert("PCI Bus".to_string(), bus);
             }
+            // Architecture / SYCL classification — derived from the
+            // marketing name so downstream consumers (Backend.AI's
+            // accelerator-selection layer, the llama.cpp SYCL backend
+            // picker, etc.) can rely on all-smi as a single source of
+            // truth instead of reimplementing the same name-pattern
+            // table. The classifier is intentionally pure-string so it
+            // stays platform-agnostic and shareable with the Windows
+            // reader.
+            let arch = classify_intel_architecture(&name);
+            detail.insert("Architecture".to_string(), arch.label().to_string());
+            detail.insert(
+                "SYCL Capable".to_string(),
+                arch.sycl_capable_label().to_string(),
+            );
             // Document the v1 scope limitation in-band so library
             // consumers see *why* utilization is always reported as
             // zero rather than thinking the GPU is idle.

--- a/src/device/readers/intel_gpu_linux/tests.rs
+++ b/src/device/readers/intel_gpu_linux/tests.rs
@@ -155,7 +155,10 @@ fn get_gpu_info_populates_basic_fields() {
         g.detail.get("Architecture").map(String::as_str),
         Some("Alchemist (Xe-HPG, A-series)")
     );
-    assert_eq!(g.detail.get("SYCL Capable").map(String::as_str), Some("Yes"));
+    assert_eq!(
+        g.detail.get("SYCL Capable").map(String::as_str),
+        Some("Yes")
+    );
     // The Intel reader populates NVIDIA-only fields with None / empty
     // defaults — verify the contract so consumers can render them as
     // "unavailable" rather than misinterpreting zeros.

--- a/src/device/readers/intel_gpu_linux/tests.rs
+++ b/src/device/readers/intel_gpu_linux/tests.rs
@@ -149,6 +149,13 @@ fn get_gpu_info_populates_basic_fields() {
     );
     assert_eq!(g.detail.get("Driver").map(String::as_str), Some("i915"));
     assert!(g.detail.contains_key("Utilization"));
+    // Architecture / SYCL classification — derived from the resolved
+    // marketing name. Arc A770 is Alchemist (SYCL-capable).
+    assert_eq!(
+        g.detail.get("Architecture").map(String::as_str),
+        Some("Alchemist (Xe-HPG, A-series)")
+    );
+    assert_eq!(g.detail.get("SYCL Capable").map(String::as_str), Some("Yes"));
     // The Intel reader populates NVIDIA-only fields with None / empty
     // defaults — verify the contract so consumers can render them as
     // "unavailable" rather than misinterpreting zeros.
@@ -176,6 +183,15 @@ fn get_gpu_info_integrated_reports_zero_memory() {
     assert!(
         info[0].detail.contains_key("Memory"),
         "integrated GPUs should explain the shared-memory situation"
+    );
+    // Meteor Lake / Core Ultra iGPU is Xe-LPG and SYCL-capable.
+    assert_eq!(
+        info[0].detail.get("Architecture").map(String::as_str),
+        Some("Xe-LPG (Meteor Lake)")
+    );
+    assert_eq!(
+        info[0].detail.get("SYCL Capable").map(String::as_str),
+        Some("Yes")
     );
 }
 

--- a/src/device/readers/intel_gpu_linux/tests.rs
+++ b/src/device/readers/intel_gpu_linux/tests.rs
@@ -1,0 +1,222 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the Intel client GPU reader. Pulled out of
+//! `intel_gpu_linux.rs` to keep that file under the 500-line budget.
+
+use super::*;
+use crate::device::readers::intel_gpu_sysfs::MemoryVariant;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
+/// Build a synthetic `cardN` sysfs node beneath `root`.
+///
+/// The driver symlink target's *file name* is what
+/// [`super::resolve_driver`] returns, so we create a directory named
+/// exactly `driver` and point the `device/driver` symlink at it. The
+/// real kernel link target looks like
+/// `/sys/bus/pci/drivers/i915` — only the basename matters.
+fn make_card(root: &Path, idx: u32, vendor: &str, driver: &str, device_id: &str) -> PathBuf {
+    let card = root.join(format!("card{idx}"));
+    let device = card.join("device");
+    fs::create_dir_all(&device).unwrap();
+    fs::write(device.join("vendor"), format!("{vendor}\n")).unwrap();
+    fs::write(device.join("device"), format!("{device_id}\n")).unwrap();
+    let drivers_dir = root.join("_drivers");
+    fs::create_dir_all(&drivers_dir).unwrap();
+    let driver_target = drivers_dir.join(driver);
+    fs::create_dir_all(&driver_target).unwrap();
+    std::os::unix::fs::symlink(&driver_target, device.join("driver")).unwrap();
+    card
+}
+
+#[test]
+fn discover_skips_non_card_entries() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    make_card(root, 0, "0x8086", "i915", "0x56A0");
+    // A non-card directory that mustn't be picked up.
+    fs::create_dir_all(root.join("renderD128").join("device")).unwrap();
+    fs::write(
+        root.join("renderD128").join("device").join("vendor"),
+        "0x8086\n",
+    )
+    .unwrap();
+
+    let cards = discover_cards(root);
+    assert_eq!(cards.len(), 1);
+    assert_eq!(cards[0].driver, "i915");
+    assert_eq!(cards[0].device_id, 0x56A0);
+}
+
+#[test]
+fn discover_excludes_habana_vendor() {
+    // Habana / Gaudi devices have vendor `0x1da3`, not `0x8086`, and
+    // are not driven by i915/xe. They MUST NOT appear in the Intel
+    // GPU reader output even though Habana is owned by Intel.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    make_card(root, 0, "0x1da3", "habanalabs", "0x1020");
+
+    let cards = discover_cards(root);
+    assert!(cards.is_empty());
+}
+
+#[test]
+fn discover_requires_i915_or_xe_driver() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    // Intel-vendor PCI device without a graphics driver (e.g. a
+    // hypothetical Intel-vendor accelerator). Must be rejected.
+    make_card(root, 0, "0x8086", "some_other_driver", "0x1234");
+
+    let cards = discover_cards(root);
+    assert!(cards.is_empty());
+}
+
+#[test]
+fn classify_variant_discrete_via_i915() {
+    let dir = tempdir().unwrap();
+    let card = make_card(dir.path(), 0, "0x8086", "i915", "0x56A0");
+    let device = card.join("device");
+    fs::write(device.join("mem_info_vram_total"), "17179869184\n").unwrap();
+
+    assert_eq!(classify_variant(&device), MemoryVariant::Discrete);
+}
+
+#[test]
+fn classify_variant_discrete_via_xe() {
+    let dir = tempdir().unwrap();
+    let card = make_card(dir.path(), 0, "0x8086", "xe", "0xE20B");
+    let device = card.join("device");
+    let xe_dir = device.join("tile0").join("vram0");
+    fs::create_dir_all(&xe_dir).unwrap();
+    fs::write(xe_dir.join("total_bytes"), "12884901888\n").unwrap();
+
+    assert_eq!(classify_variant(&device), MemoryVariant::Discrete);
+}
+
+#[test]
+fn classify_variant_integrated_when_no_vram() {
+    let dir = tempdir().unwrap();
+    let card = make_card(dir.path(), 0, "0x8086", "i915", "0x7D40");
+    let device = card.join("device");
+
+    assert_eq!(classify_variant(&device), MemoryVariant::Integrated);
+}
+
+#[test]
+fn get_gpu_info_populates_basic_fields() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let card = make_card(root, 0, "0x8086", "i915", "0x56A0");
+    let device = card.join("device");
+    fs::write(device.join("mem_info_vram_total"), "17179869184\n").unwrap();
+    fs::write(device.join("mem_info_vram_used"), "4294967296\n").unwrap();
+    fs::write(device.join("gt_cur_freq_mhz"), "1950\n").unwrap();
+    let hwmon = device.join("hwmon").join("hwmon0");
+    fs::create_dir_all(&hwmon).unwrap();
+    fs::write(hwmon.join("temp1_input"), "68000\n").unwrap();
+    fs::write(hwmon.join("power1_average"), "150000000\n").unwrap();
+
+    let reader = IntelGpuReader::new_from_root(root);
+    let info = reader.get_gpu_info();
+    assert_eq!(info.len(), 1);
+    let g = &info[0];
+    assert_eq!(g.device_type, "GPU");
+    assert!(g.name.contains("Arc A770"));
+    assert_eq!(g.total_memory, 17_179_869_184);
+    assert_eq!(g.used_memory, 4_294_967_296);
+    assert_eq!(g.frequency, 1950);
+    assert_eq!(g.temperature, 68);
+    assert!((g.power_consumption - 150.0).abs() < 0.01);
+    assert_eq!(g.utilization, 0.0);
+    assert_eq!(
+        g.detail.get("Variant").map(String::as_str),
+        Some("Discrete")
+    );
+    assert_eq!(g.detail.get("Driver").map(String::as_str), Some("i915"));
+    assert!(g.detail.contains_key("Utilization"));
+    // The Intel reader populates NVIDIA-only fields with None / empty
+    // defaults — verify the contract so consumers can render them as
+    // "unavailable" rather than misinterpreting zeros.
+    assert!(g.temperature_threshold_slowdown.is_none());
+    assert!(g.performance_state.is_none());
+    assert!(g.nvlink_remote_devices.is_empty());
+    assert!(g.gpm_metrics.is_none());
+}
+
+#[test]
+fn get_gpu_info_integrated_reports_zero_memory() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    make_card(root, 0, "0x8086", "i915", "0x7D40");
+
+    let reader = IntelGpuReader::new_from_root(root);
+    let info = reader.get_gpu_info();
+    assert_eq!(info.len(), 1);
+    assert_eq!(info[0].total_memory, 0);
+    assert_eq!(info[0].used_memory, 0);
+    assert_eq!(
+        info[0].detail.get("Variant").map(String::as_str),
+        Some("Integrated")
+    );
+    assert!(
+        info[0].detail.contains_key("Memory"),
+        "integrated GPUs should explain the shared-memory situation"
+    );
+}
+
+#[test]
+fn has_intel_client_gpu_positive() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    make_card(root, 0, "0x8086", "i915", "0x56A0");
+    assert!(has_intel_client_gpu_from_root(root));
+}
+
+#[test]
+fn has_intel_client_gpu_rejects_amd() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    make_card(root, 0, "0x1002", "amdgpu", "0x73BF");
+    assert!(!has_intel_client_gpu_from_root(root));
+}
+
+#[test]
+fn line_matches_intel_gpu_positive_3d() {
+    // Class 0302 (3D controller), Intel vendor.
+    let line = "03:00.0 0302: 8086:56a0 (rev 08)";
+    assert!(line_matches_intel_gpu(line));
+}
+
+#[test]
+fn line_matches_intel_gpu_positive_vga() {
+    let line = "00:02.0 0300: 8086:7d40";
+    assert!(line_matches_intel_gpu(line));
+}
+
+#[test]
+fn line_matches_intel_gpu_rejects_intel_nic() {
+    // Intel NIC, vendor 8086 but class 0200 (Ethernet).
+    let line = "02:00.0 0200: 8086:15bb";
+    assert!(!line_matches_intel_gpu(line));
+}
+
+#[test]
+fn line_matches_intel_gpu_rejects_other_vendor_vga() {
+    let line = "01:00.0 0300: 10de:2204";
+    assert!(!line_matches_intel_gpu(line));
+}

--- a/src/device/readers/intel_gpu_names.rs
+++ b/src/device/readers/intel_gpu_names.rs
@@ -101,6 +101,165 @@ pub fn resolve_intel_gpu_name(device_id: u32) -> String {
     }
 }
 
+// ---------------------------------------------------------------------
+// Architecture classification (consumed by both intel_gpu_linux and
+// intel_gpu_windows readers, and re-exported for downstream consumers).
+// ---------------------------------------------------------------------
+
+/// Intel client GPU architecture family, derived from the marketing name.
+///
+/// Used by downstream consumers (e.g. an accelerator-selection layer that
+/// chooses between SYCL/oneAPI and CPU inference backends) to avoid
+/// re-implementing the same name-pattern table. The classification
+/// mirrors the `INTEL_GPU_PATTERNS` table in lablup/backend.ai-go's
+/// `src-tauri/src/engine/gpu.rs` so the two projects stay in agreement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntelArchitecture {
+    /// Arc A-series discrete (A310/A380/A580/A750/A770) — Alchemist (Xe-HPG).
+    Alchemist,
+    /// Arc B-series discrete (e.g. B580) — Battlemage (Xe2).
+    Battlemage,
+    /// Xe-LPG integrated (Meteor Lake / Core Ultra Series 1).
+    XeLpg,
+    /// Xe-LPG+ integrated (Lunar Lake / Core Ultra Series 2 / Arc 140V/130V).
+    XeLpgPlus,
+    /// Xe (Iris Xe on Tiger / Alder / Raptor Lake integrated graphics).
+    IrisXe,
+    /// Older integrated graphics — HD Graphics / UHD Graphics on pre-Xe
+    /// parts. Not SYCL-capable.
+    OlderIntegrated,
+    /// Could not be classified from the name.
+    Unknown,
+}
+
+impl IntelArchitecture {
+    /// Returns `true` when this architecture is expected to support SYCL /
+    /// oneAPI compute. Mirrors lablup/backend.ai-go's
+    /// `check_intel_sycl_support`.
+    pub fn is_sycl_capable(self) -> bool {
+        matches!(
+            self,
+            Self::Alchemist
+                | Self::Battlemage
+                | Self::XeLpg
+                | Self::XeLpgPlus
+                | Self::IrisXe,
+        )
+    }
+
+    /// Short human-readable label suitable for a `detail` map entry.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Alchemist => "Alchemist (Xe-HPG, A-series)",
+            Self::Battlemage => "Battlemage (Xe2, B-series)",
+            Self::XeLpg => "Xe-LPG (Meteor Lake)",
+            Self::XeLpgPlus => "Xe-LPG+ (Lunar Lake)",
+            Self::IrisXe => "Iris Xe (Tiger/Alder/Raptor Lake)",
+            Self::OlderIntegrated => "Pre-Xe (HD/UHD Graphics)",
+            Self::Unknown => "Unknown",
+        }
+    }
+
+    /// Render the SYCL-capability decision for the `detail["SYCL Capable"]`
+    /// map entry. Unlike a bare `is_sycl_capable()` boolean, this returns
+    /// `"Unknown"` for the [`Unknown`](Self::Unknown) variant so consumers
+    /// can distinguish "we know this GPU is not SYCL-capable" from "we
+    /// couldn't classify this GPU at all".
+    pub fn sycl_capable_label(self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            _ if self.is_sycl_capable() => "Yes",
+            _ => "No",
+        }
+    }
+}
+
+/// Classify the architecture of an Intel client GPU from its marketing
+/// name.
+///
+/// The matcher is pure-Rust string analysis — no regex, no allocations
+/// beyond the single lowercase copy of the input. Pattern order is
+/// load-bearing:
+///
+/// 1. **Older integrated first** so a `HD Graphics 520` style name never
+///    accidentally matches a later Xe-LPG / Iris Xe rule.
+/// 2. **Battlemage before Alchemist** because `Intel Arc B580` contains
+///    the substring `arc` but is not Alchemist.
+/// 3. **Alchemist before Lunar Lake** for the same reason — Alchemist
+///    names contain a specific `a3`/`a5`/`a7` token, Lunar Lake's Arc
+///    140V/130V names do not.
+/// 4. **Lunar Lake before generic Xe-LPG** because Lunar Lake is a
+///    distinct architecture and we want it labelled `XeLpgPlus`, not the
+///    Meteor Lake `XeLpg`.
+/// 5. **Generic Xe-LPG before Iris Xe** so Core Ultra (Meteor Lake) iGPU
+///    names — sold as `Intel Arc Graphics` with no model number — land in
+///    `XeLpg`, not in `IrisXe` or `Unknown`.
+///
+/// The trickiest disambiguation is the trio
+/// `Intel Arc Graphics` (Meteor Lake iGPU, → `XeLpg`),
+/// `Intel Arc A770 Graphics` (discrete Alchemist, → `Alchemist`), and
+/// `Intel Arc 140V Graphics` (Lunar Lake iGPU, → `XeLpgPlus`). The
+/// substring `a3`/`a5`/`a7` is the single token that distinguishes
+/// Alchemist from the two integrated iGPU variants — `140v` contains an
+/// `a` but no `a3`/`a5`/`a7`, so it falls through to the Lunar Lake rule.
+pub fn classify_intel_architecture(name: &str) -> IntelArchitecture {
+    let n = name.to_lowercase();
+
+    // 1. Older integrated FIRST. These names contain `hd graphics` or
+    //    `uhd graphics` and NO modern architecture token. The guards
+    //    against `arc`/`iris`/`xe` are belt-and-braces — current Intel
+    //    naming conventions never mix the two, but if a future SKU were
+    //    named "HD Graphics Xe Edition" we want the modern token to win.
+    if (n.contains("hd graphics") || n.contains("uhd graphics"))
+        && !n.contains("iris")
+        && !n.contains("arc")
+        && !n.contains("xe")
+    {
+        return IntelArchitecture::OlderIntegrated;
+    }
+
+    // 2. Battlemage — explicit family name, or Arc + a known B-series SKU.
+    if n.contains("battlemage")
+        || (n.contains("arc")
+            && (n.contains("b580") || n.contains("b570") || n.contains("b380")))
+    {
+        return IntelArchitecture::Battlemage;
+    }
+
+    // 3. Alchemist (Arc A-series discrete). Arc + one of the A-series
+    //    family tokens. A3/A5/A7 are the three product tiers (Pro / Mid /
+    //    High); A1/A2/A4/A6 are not real SKUs.
+    if n.contains("arc") && (n.contains("a3") || n.contains("a5") || n.contains("a7")) {
+        return IntelArchitecture::Alchemist;
+    }
+
+    // 4. Lunar Lake (Xe-LPG+). Either the explicit family name, or the
+    //    Arc 140V / 130V iGPU on Core Ultra Series 2.
+    if n.contains("lunarlake")
+        || n.contains("lunar lake")
+        || (n.contains("arc") && (n.contains("140v") || n.contains("130v")))
+    {
+        return IntelArchitecture::XeLpgPlus;
+    }
+
+    // 5. Xe-LPG (Meteor Lake). Either the explicit `xe-lpg`/`xe lpg`
+    //    family name, or any other Arc iGPU — by this point Alchemist and
+    //    Lunar Lake have been ruled out, so a residual `arc` + `graphics`
+    //    name (notably `Intel Arc Graphics`) is the Meteor Lake iGPU.
+    if (n.contains("xe") && n.contains("lpg"))
+        || (n.contains("arc") && n.contains("graphics"))
+    {
+        return IntelArchitecture::XeLpg;
+    }
+
+    // 6. Iris Xe (Tiger / Alder / Raptor Lake integrated).
+    if n.contains("iris") && n.contains("xe") {
+        return IntelArchitecture::IrisXe;
+    }
+
+    IntelArchitecture::Unknown
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,5 +290,204 @@ mod tests {
         // we mask to the device portion before matching.
         assert!(resolve_intel_gpu_name(0x0000_56A0).contains("Arc A770"));
         assert!(resolve_intel_gpu_name(0xFFFF_56A0).contains("Arc A770"));
+    }
+
+    // ---------- Architecture classification tests ----------
+    //
+    // The fixtures below mirror lablup/backend.ai-go's `INTEL_GPU_PATTERNS`
+    // and `check_intel_sycl_support` tests so the two projects stay in
+    // agreement about what each marketing name means.
+
+    #[test]
+    fn classifies_arc_a_series_as_alchemist() {
+        for name in &[
+            "Intel Arc A770 Graphics",
+            "Intel Arc A750",
+            "Intel Arc A580",
+            "Intel Arc A380",
+            "Intel Arc A310",
+            "Intel(R) Arc(TM) A770 Graphics",
+        ] {
+            assert_eq!(
+                classify_intel_architecture(name),
+                IntelArchitecture::Alchemist,
+                "mis-classified: {name}"
+            );
+            assert!(IntelArchitecture::Alchemist.is_sycl_capable());
+        }
+    }
+
+    #[test]
+    fn classifies_battlemage_b_series() {
+        for name in &[
+            "Intel Battlemage Graphics",
+            "Intel(R) Battlemage(TM) Graphics",
+            "Intel Arc B580",
+            "Intel(R) Arc(TM) B580 Graphics",
+        ] {
+            assert_eq!(
+                classify_intel_architecture(name),
+                IntelArchitecture::Battlemage,
+                "mis-classified: {name}"
+            );
+            assert!(IntelArchitecture::Battlemage.is_sycl_capable());
+        }
+    }
+
+    #[test]
+    fn classifies_core_ultra_integrated_arc_as_xe_lpg() {
+        // Arc integrated graphics on Core Ultra (Meteor Lake, no A-series
+        // model number) is Xe-LPG, not Alchemist.
+        assert_eq!(
+            classify_intel_architecture("Intel Arc Graphics"),
+            IntelArchitecture::XeLpg,
+        );
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) Graphics"),
+            IntelArchitecture::XeLpg,
+        );
+        assert!(IntelArchitecture::XeLpg.is_sycl_capable());
+    }
+
+    #[test]
+    fn classifies_lunar_lake_arc_140v() {
+        // Arc 140V / 130V on Lunar Lake — should map to XeLpgPlus, not
+        // Alchemist. "140V" contains "a" in "140V Graphics" but no A3/A5/A7
+        // token, so the Alchemist matcher must not fire.
+        let result = classify_intel_architecture("Intel Arc 140V Graphics");
+        assert!(
+            matches!(result, IntelArchitecture::XeLpgPlus | IntelArchitecture::XeLpg),
+            "Arc 140V should classify as a Lunar Lake / Xe-LPG-family part, got {result:?}",
+        );
+        assert!(result.is_sycl_capable());
+
+        // Lunar Lake's other iGPU SKU.
+        let result_130v = classify_intel_architecture("Intel Arc 130V Graphics");
+        assert!(
+            matches!(
+                result_130v,
+                IntelArchitecture::XeLpgPlus | IntelArchitecture::XeLpg
+            ),
+            "Arc 130V should classify as a Lunar Lake / Xe-LPG-family part, got {result_130v:?}",
+        );
+    }
+
+    #[test]
+    fn classifies_iris_xe_as_iris_xe() {
+        for name in &["Intel Iris Xe Graphics", "Intel(R) Iris(R) Xe Graphics"] {
+            assert_eq!(
+                classify_intel_architecture(name),
+                IntelArchitecture::IrisXe,
+                "mis-classified: {name}"
+            );
+            assert!(IntelArchitecture::IrisXe.is_sycl_capable());
+        }
+    }
+
+    #[test]
+    fn classifies_xe_lpg_meteor_lake() {
+        assert_eq!(
+            classify_intel_architecture("Intel Xe-LPG Graphics"),
+            IntelArchitecture::XeLpg,
+        );
+    }
+
+    #[test]
+    fn classifies_lunar_lake_explicit() {
+        for name in &[
+            "Intel LunarLake Graphics",
+            "Intel(R) LunarLake(TM) Graphics",
+            "Intel Lunar Lake Graphics",
+        ] {
+            assert_eq!(
+                classify_intel_architecture(name),
+                IntelArchitecture::XeLpgPlus,
+                "mis-classified: {name}"
+            );
+            assert!(IntelArchitecture::XeLpgPlus.is_sycl_capable());
+        }
+    }
+
+    #[test]
+    fn older_integrated_is_not_sycl_capable() {
+        for name in &[
+            "Intel HD Graphics 630",
+            "Intel UHD Graphics 770",
+            "Intel HD Graphics 520",
+            "Intel UHD Graphics 620",
+        ] {
+            let arch = classify_intel_architecture(name);
+            assert_eq!(
+                arch,
+                IntelArchitecture::OlderIntegrated,
+                "mis-classified: {name}"
+            );
+            assert!(!arch.is_sycl_capable(), "{name} should not be SYCL capable");
+        }
+    }
+
+    #[test]
+    fn unknown_names_classified_as_unknown() {
+        let arch = classify_intel_architecture("Definitely Not An Intel GPU");
+        assert_eq!(arch, IntelArchitecture::Unknown);
+        assert!(!arch.is_sycl_capable());
+
+        // An empty name is also unknown.
+        assert_eq!(
+            classify_intel_architecture(""),
+            IntelArchitecture::Unknown
+        );
+    }
+
+    #[test]
+    fn architecture_labels_are_stable() {
+        // Lock in the label strings so downstream consumers (which embed
+        // them in `detail["Architecture"]`) can rely on them.
+        assert_eq!(
+            IntelArchitecture::Alchemist.label(),
+            "Alchemist (Xe-HPG, A-series)"
+        );
+        assert_eq!(
+            IntelArchitecture::Battlemage.label(),
+            "Battlemage (Xe2, B-series)"
+        );
+        assert_eq!(IntelArchitecture::XeLpg.label(), "Xe-LPG (Meteor Lake)");
+        assert_eq!(IntelArchitecture::XeLpgPlus.label(), "Xe-LPG+ (Lunar Lake)");
+        assert_eq!(
+            IntelArchitecture::IrisXe.label(),
+            "Iris Xe (Tiger/Alder/Raptor Lake)"
+        );
+        assert_eq!(
+            IntelArchitecture::OlderIntegrated.label(),
+            "Pre-Xe (HD/UHD Graphics)"
+        );
+        assert_eq!(IntelArchitecture::Unknown.label(), "Unknown");
+    }
+
+    #[test]
+    fn sycl_capability_matches_backend_ai_go() {
+        // The five SYCL-capable architectures, mirrored from
+        // lablup/backend.ai-go's check_intel_sycl_support.
+        assert!(IntelArchitecture::Alchemist.is_sycl_capable());
+        assert!(IntelArchitecture::Battlemage.is_sycl_capable());
+        assert!(IntelArchitecture::XeLpg.is_sycl_capable());
+        assert!(IntelArchitecture::XeLpgPlus.is_sycl_capable());
+        assert!(IntelArchitecture::IrisXe.is_sycl_capable());
+        assert!(!IntelArchitecture::OlderIntegrated.is_sycl_capable());
+        assert!(!IntelArchitecture::Unknown.is_sycl_capable());
+    }
+
+    #[test]
+    fn sycl_capable_label_distinguishes_unknown_from_no() {
+        // The map-entry label must not collapse Unknown into "No" —
+        // downstream consumers need to know whether the GPU is *known*
+        // not to be SYCL-capable vs. unrecognised.
+        assert_eq!(IntelArchitecture::Alchemist.sycl_capable_label(), "Yes");
+        assert_eq!(IntelArchitecture::Battlemage.sycl_capable_label(), "Yes");
+        assert_eq!(IntelArchitecture::XeLpg.sycl_capable_label(), "Yes");
+        assert_eq!(IntelArchitecture::XeLpgPlus.sycl_capable_label(), "Yes");
+        assert_eq!(IntelArchitecture::IrisXe.sycl_capable_label(), "Yes");
+        assert_eq!(IntelArchitecture::OlderIntegrated.sycl_capable_label(), "No");
+        assert_eq!(IntelArchitecture::Unknown.sycl_capable_label(), "Unknown");
     }
 }

--- a/src/device/readers/intel_gpu_names.rs
+++ b/src/device/readers/intel_gpu_names.rs
@@ -1,0 +1,135 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Friendly-name lookup for Intel client GPU PCI device IDs.
+//!
+//! Kept in its own module so [`super::intel_gpu_linux`] stays under the
+//! 500-line budget. The table intentionally covers the families called
+//! out in issue #244 — Arc A-series (Alchemist), Arc B-series
+//! (Battlemage), Iris Xe on Tiger / Alder / Raptor Lake, and the Arc
+//! iGPU on Core Ultra / Meteor Lake — plus a generic fallback for IDs we
+//! have not catalogued. We deliberately do **not** vendor the full Intel
+//! PCI ID database; for the curious, the canonical source is
+//! <https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/include/pci_ids/i915_pci_ids.h>
+//! and the Linux kernel's `i915_pci.c` / `xe_pci.c`. Unknown IDs render
+//! as `Intel Graphics (device 0xXXXX)` so the GPU is still detected and
+//! the operator can identify it from the device ID.
+
+/// Map a PCI device ID (low 16 bits) to a friendly marketing string.
+///
+/// Returns an empty `String` when the ID is not in the curated table —
+/// the caller substitutes the generic `Intel Graphics (device 0xXXXX)`
+/// fallback. Keeping the "unknown" sentinel out of this function lets
+/// the table stay pure-data and easy to extend.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn intel_gpu_marketing_name(device_id: u32) -> String {
+    let id = device_id & 0xFFFF;
+    match id {
+        // ---- Arc A-series "Alchemist" (DG2). Range 0x5690-0x56BF.
+        0x5690..=0x5692 => "Intel Arc A770M / A730M / A550M".to_string(),
+        0x5693..=0x5695 => "Intel Arc A370M / A350M".to_string(),
+        0x56A0 | 0x56A1 => "Intel Arc A770".to_string(),
+        0x56A2 => "Intel Arc A750".to_string(),
+        0x56A3 | 0x56A4 => "Intel Arc A580".to_string(),
+        0x56A5 | 0x56A6 => "Intel Arc A380 / A310".to_string(),
+        0x56B0..=0x56B3 => "Intel Arc Pro A-series".to_string(),
+        0x56BA..=0x56BD => "Intel Arc A-series (mobile)".to_string(),
+
+        // ---- Arc B-series "Battlemage" (BMG-G21).
+        // Public IDs for B570/B580 cluster around 0xE20B-0xE20D.
+        0xE202 | 0xE20B | 0xE20C | 0xE20D | 0xE210 | 0xE211 | 0xE212 | 0xE215 | 0xE216 => {
+            "Intel Arc B-series (Battlemage)".to_string()
+        }
+
+        // ---- Xe-LPG / Arc iGPU on Core Ultra (Meteor Lake). 0x7D40-0x7DFF.
+        0x7D40 | 0x7D41 | 0x7D45 | 0x7D55 | 0x7DD5 => {
+            "Intel Arc Graphics (Core Ultra / Meteor Lake)".to_string()
+        }
+        0x7D50 | 0x7D51 | 0x7D60 => "Intel Graphics (Core Ultra / Meteor Lake)".to_string(),
+
+        // ---- Iris Xe / UHD on Tiger Lake (Gen12 LP). 0x9A40-0x9AFF.
+        0x9A40 | 0x9A49 | 0x9A60 | 0x9A68 | 0x9A70 | 0x9A78 | 0x9AC0 | 0x9AC9 | 0x9AD9 | 0x9AF8 => {
+            "Intel Iris Xe Graphics (Tiger Lake)".to_string()
+        }
+
+        // ---- Iris Xe on Alder Lake / Raptor Lake. 0x4680-0x46FF cluster.
+        0x4680 | 0x4682 | 0x4688 | 0x468A | 0x468B | 0x4690 | 0x4692 | 0x4693 | 0x46A0 | 0x46A3
+        | 0x46A6 | 0x46A8 | 0x46AA | 0x46B0 | 0x46B3 | 0x46C0 | 0x46C3 | 0x46D0 | 0x46D1
+        | 0x46D2 | 0x46D3 | 0x46D4 => {
+            "Intel UHD / Iris Xe Graphics (Alder/Raptor Lake)".to_string()
+        }
+
+        // ---- UHD Graphics on Rocket Lake. 0x4C8x range.
+        0x4C8A | 0x4C8B | 0x4C8C | 0x4C90 | 0x4C9A => {
+            "Intel UHD Graphics (Rocket Lake)".to_string()
+        }
+
+        // ---- Iris Plus / UHD on Ice Lake. 0x8A50 family.
+        0x8A50 | 0x8A51 | 0x8A52 | 0x8A53 | 0x8A56 | 0x8A57 | 0x8A58 | 0x8A59 | 0x8A5A | 0x8A5B
+        | 0x8A5C | 0x8A5D | 0x8A71 => "Intel Iris Plus / UHD Graphics (Ice Lake)".to_string(),
+
+        // ---- Xe2 / Lunar Lake / Arrow Lake (Gen13/14 IDs in 0xA7* range).
+        0xA780 | 0xA781 | 0xA782 | 0xA783 | 0xA788 | 0xA789 | 0xA78A | 0xA78B | 0xA7A0 | 0xA7A1
+        | 0xA7A8 | 0xA7A9 | 0xA7AA | 0xA7AB | 0xA7AC | 0xA7AD => {
+            "Intel Graphics (Arrow/Lunar Lake)".to_string()
+        }
+
+        _ => String::new(),
+    }
+}
+
+/// Compose a final marketing string, falling back to the generic
+/// "Intel Graphics (device 0xXXXX)" form when the table has no entry.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn resolve_intel_gpu_name(device_id: u32) -> String {
+    let curated = intel_gpu_marketing_name(device_id);
+    if curated.is_empty() {
+        format!("Intel Graphics (device {:#06x})", device_id & 0xFFFF)
+    } else {
+        curated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_families_resolve() {
+        assert!(intel_gpu_marketing_name(0x56A0).contains("Arc A770"));
+        assert!(intel_gpu_marketing_name(0x56A2).contains("Arc A750"));
+        assert!(intel_gpu_marketing_name(0xE20B).contains("Battlemage"));
+        assert!(intel_gpu_marketing_name(0x7D40).contains("Meteor Lake"));
+        assert!(intel_gpu_marketing_name(0x9A49).contains("Tiger Lake"));
+        assert!(intel_gpu_marketing_name(0x46A6).contains("Alder/Raptor Lake"));
+        assert!(intel_gpu_marketing_name(0x4C8A).contains("Rocket Lake"));
+        assert!(intel_gpu_marketing_name(0x8A50).contains("Ice Lake"));
+        assert!(intel_gpu_marketing_name(0xA780).contains("Arrow/Lunar Lake"));
+    }
+
+    #[test]
+    fn unknown_falls_back_to_generic() {
+        let n = resolve_intel_gpu_name(0x1234);
+        assert!(n.starts_with("Intel Graphics (device"));
+        assert!(n.contains("0x1234"));
+    }
+
+    #[test]
+    fn high_bits_ignored() {
+        // Some lspci output reports IDs with the upper 16 bits set;
+        // we mask to the device portion before matching.
+        assert!(resolve_intel_gpu_name(0x0000_56A0).contains("Arc A770"));
+        assert!(resolve_intel_gpu_name(0xFFFF_56A0).contains("Arc A770"));
+    }
+}

--- a/src/device/readers/intel_gpu_names.rs
+++ b/src/device/readers/intel_gpu_names.rs
@@ -139,11 +139,7 @@ impl IntelArchitecture {
     pub fn is_sycl_capable(self) -> bool {
         matches!(
             self,
-            Self::Alchemist
-                | Self::Battlemage
-                | Self::XeLpg
-                | Self::XeLpgPlus
-                | Self::IrisXe,
+            Self::Alchemist | Self::Battlemage | Self::XeLpg | Self::XeLpgPlus | Self::IrisXe,
         )
     }
 
@@ -220,8 +216,7 @@ pub fn classify_intel_architecture(name: &str) -> IntelArchitecture {
 
     // 2. Battlemage — explicit family name, or Arc + a known B-series SKU.
     if n.contains("battlemage")
-        || (n.contains("arc")
-            && (n.contains("b580") || n.contains("b570") || n.contains("b380")))
+        || (n.contains("arc") && (n.contains("b580") || n.contains("b570") || n.contains("b380")))
     {
         return IntelArchitecture::Battlemage;
     }
@@ -246,9 +241,7 @@ pub fn classify_intel_architecture(name: &str) -> IntelArchitecture {
     //    family name, or any other Arc iGPU — by this point Alchemist and
     //    Lunar Lake have been ruled out, so a residual `arc` + `graphics`
     //    name (notably `Intel Arc Graphics`) is the Meteor Lake iGPU.
-    if (n.contains("xe") && n.contains("lpg"))
-        || (n.contains("arc") && n.contains("graphics"))
-    {
+    if (n.contains("xe") && n.contains("lpg")) || (n.contains("arc") && n.contains("graphics")) {
         return IntelArchitecture::XeLpg;
     }
 
@@ -356,7 +349,10 @@ mod tests {
         // token, so the Alchemist matcher must not fire.
         let result = classify_intel_architecture("Intel Arc 140V Graphics");
         assert!(
-            matches!(result, IntelArchitecture::XeLpgPlus | IntelArchitecture::XeLpg),
+            matches!(
+                result,
+                IntelArchitecture::XeLpgPlus | IntelArchitecture::XeLpg
+            ),
             "Arc 140V should classify as a Lunar Lake / Xe-LPG-family part, got {result:?}",
         );
         assert!(result.is_sycl_capable());
@@ -433,10 +429,7 @@ mod tests {
         assert!(!arch.is_sycl_capable());
 
         // An empty name is also unknown.
-        assert_eq!(
-            classify_intel_architecture(""),
-            IntelArchitecture::Unknown
-        );
+        assert_eq!(classify_intel_architecture(""), IntelArchitecture::Unknown);
     }
 
     #[test]
@@ -487,7 +480,10 @@ mod tests {
         assert_eq!(IntelArchitecture::XeLpg.sycl_capable_label(), "Yes");
         assert_eq!(IntelArchitecture::XeLpgPlus.sycl_capable_label(), "Yes");
         assert_eq!(IntelArchitecture::IrisXe.sycl_capable_label(), "Yes");
-        assert_eq!(IntelArchitecture::OlderIntegrated.sycl_capable_label(), "No");
+        assert_eq!(
+            IntelArchitecture::OlderIntegrated.sycl_capable_label(),
+            "No"
+        );
         assert_eq!(IntelArchitecture::Unknown.sycl_capable_label(), "Unknown");
     }
 }

--- a/src/device/readers/intel_gpu_sysfs.rs
+++ b/src/device/readers/intel_gpu_sysfs.rs
@@ -1,0 +1,258 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Lower-level sysfs helpers used by the Intel client GPU reader.
+//!
+//! Split out of [`super::intel_gpu_linux`] so each file stays small and
+//! the dynamic counter readers can be unit-tested without pulling the
+//! main reader struct into the test harness.
+
+use std::path::Path;
+
+/// Memory variant of the GPU. Mirrors
+/// `super::intel_gpu_linux::IntelGpuVariant` but kept private to this
+/// module so the public API surface stays in the main reader file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub enum MemoryVariant {
+    /// Has dedicated VRAM advertised via `mem_info_vram_total` (i915) or
+    /// `tile0/vram0/total_bytes` (xe).
+    Discrete,
+    /// No dedicated VRAM — Iris Xe / Xe-LPG / Arc iGPU.
+    Integrated,
+}
+
+/// Read used/total VRAM bytes for the device. Integrated GPUs always
+/// return `(0, 0)` because the kernel does not pre-reserve a budget
+/// (GTT pages are allocated on demand). Returning a fabricated value
+/// derived from system RAM would mis-represent the actual GPU memory
+/// situation, so we intentionally surface zero and let the reader add a
+/// `detail["Memory"]` note explaining the value.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_memory_bytes(device_dir: &Path, variant: MemoryVariant) -> (u64, u64) {
+    if variant == MemoryVariant::Integrated {
+        return (0, 0);
+    }
+
+    // i915 path first (older driver, more common on Arc A-series).
+    let mut total = read_u64(&device_dir.join("mem_info_vram_total")).unwrap_or(0);
+    let mut used = read_u64(&device_dir.join("mem_info_vram_used")).unwrap_or(0);
+
+    // xe path: `tile0/vram0/total_bytes` and `used_bytes`. We only look
+    // at tile0 because consumer Intel discrete GPUs are single-tile;
+    // datacenter Flex/Max parts (xe with multiple tiles) are out of
+    // scope for the *client* GPU reader.
+    if total == 0 {
+        total = read_u64(&device_dir.join("tile0").join("vram0").join("total_bytes")).unwrap_or(0);
+    }
+    if used == 0 {
+        used = read_u64(&device_dir.join("tile0").join("vram0").join("used_bytes")).unwrap_or(0);
+    }
+
+    (used, total)
+}
+
+/// Read the current GT0 frequency in MHz.
+///
+/// i915 exposes the value directly in MHz under `gt_cur_freq_mhz`.
+/// The newer `xe` driver exposes it under `tile0/gt0/freq0/cur_freq`
+/// — older xe builds report Hz, newer ones report MHz. Heuristic: any
+/// value above 100_000 is interpreted as Hz (the highest Intel client
+/// GPU clocks are under 3 GHz, so a true MHz reading can never exceed
+/// 100_000).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_frequency_mhz(device_dir: &Path) -> u32 {
+    if let Some(mhz) = read_u32(&device_dir.join("gt_cur_freq_mhz")) {
+        return mhz;
+    }
+    if let Some(raw) = read_u64(
+        &device_dir
+            .join("tile0")
+            .join("gt0")
+            .join("freq0")
+            .join("cur_freq"),
+    ) {
+        let mhz = if raw > 100_000 { raw / 1_000_000 } else { raw };
+        if mhz <= u64::from(u32::MAX) {
+            return mhz as u32;
+        }
+    }
+    0
+}
+
+/// Walk `device/hwmon/hwmon*/temp1_input` (milli-Celsius). Returns the
+/// first parseable value divided by 1000. On failure or absence the
+/// reader returns `0`; the caller documents that "no thermal data" in
+/// `detail` so consumers don't confuse zero with "literally 0 degrees".
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_temperature_celsius(device_dir: &Path) -> u32 {
+    let hwmon_root = device_dir.join("hwmon");
+    let iter = match std::fs::read_dir(&hwmon_root) {
+        Ok(i) => i,
+        Err(_) => return 0,
+    };
+    for entry in iter.flatten() {
+        if let Some(milli) = read_u64(&entry.path().join("temp1_input")) {
+            return (milli / 1000) as u32;
+        }
+    }
+    0
+}
+
+/// Walk `device/hwmon/hwmon*/power1_average` (microwatts). Returns the
+/// first parseable value divided by 1_000_000 (W). On absence returns
+/// `0.0`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_power_watts(device_dir: &Path) -> f64 {
+    let hwmon_root = device_dir.join("hwmon");
+    let iter = match std::fs::read_dir(&hwmon_root) {
+        Ok(i) => i,
+        Err(_) => return 0.0,
+    };
+    for entry in iter.flatten() {
+        if let Some(uw) = read_u64(&entry.path().join("power1_average")) {
+            return uw as f64 / 1_000_000.0;
+        }
+    }
+    0.0
+}
+
+/// Read `path` as a decimal u64. Whitespace-trimmed; returns `None` on
+/// any I/O or parse failure.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_u64(path: &Path) -> Option<u64> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+}
+
+/// Read `path` as a decimal u32. Whitespace-trimmed; returns `None` on
+/// any I/O or parse failure.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_u32(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<u32>()
+        .ok()
+}
+
+/// Returns `true` when `path` contains a strictly positive u64. Used by
+/// the variant classifier — a missing or zero file is not a discrete
+/// GPU.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn has_nonzero_u64(path: &Path) -> bool {
+    read_u64(path).map(|v| v > 0).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn read_memory_integrated_returns_zero() {
+        let dir = tempdir().unwrap();
+        let (used, total) = read_memory_bytes(dir.path(), MemoryVariant::Integrated);
+        assert_eq!(used, 0);
+        assert_eq!(total, 0);
+    }
+
+    #[test]
+    fn read_memory_discrete_via_i915() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("mem_info_vram_total"), "17179869184\n").unwrap();
+        fs::write(dir.path().join("mem_info_vram_used"), "1073741824\n").unwrap();
+        let (used, total) = read_memory_bytes(dir.path(), MemoryVariant::Discrete);
+        assert_eq!(total, 17_179_869_184);
+        assert_eq!(used, 1_073_741_824);
+    }
+
+    #[test]
+    fn read_memory_discrete_via_xe() {
+        let dir = tempdir().unwrap();
+        let xe = dir.path().join("tile0").join("vram0");
+        fs::create_dir_all(&xe).unwrap();
+        fs::write(xe.join("total_bytes"), "12884901888\n").unwrap();
+        fs::write(xe.join("used_bytes"), "536870912\n").unwrap();
+        let (used, total) = read_memory_bytes(dir.path(), MemoryVariant::Discrete);
+        assert_eq!(total, 12_884_901_888);
+        assert_eq!(used, 536_870_912);
+    }
+
+    #[test]
+    fn frequency_prefers_i915_path() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("gt_cur_freq_mhz"), "2100\n").unwrap();
+        assert_eq!(read_frequency_mhz(dir.path()), 2100);
+    }
+
+    #[test]
+    fn frequency_xe_hz_path() {
+        let dir = tempdir().unwrap();
+        let freq = dir.path().join("tile0").join("gt0").join("freq0");
+        fs::create_dir_all(&freq).unwrap();
+        fs::write(freq.join("cur_freq"), "2500000000\n").unwrap();
+        assert_eq!(read_frequency_mhz(dir.path()), 2500);
+    }
+
+    #[test]
+    fn frequency_xe_mhz_path() {
+        let dir = tempdir().unwrap();
+        let freq = dir.path().join("tile0").join("gt0").join("freq0");
+        fs::create_dir_all(&freq).unwrap();
+        fs::write(freq.join("cur_freq"), "2300\n").unwrap();
+        assert_eq!(read_frequency_mhz(dir.path()), 2300);
+    }
+
+    #[test]
+    fn temperature_handles_milli_celsius() {
+        let dir = tempdir().unwrap();
+        let hwmon = dir.path().join("hwmon").join("hwmon3");
+        fs::create_dir_all(&hwmon).unwrap();
+        fs::write(hwmon.join("temp1_input"), "72500\n").unwrap();
+        assert_eq!(read_temperature_celsius(dir.path()), 72);
+    }
+
+    #[test]
+    fn temperature_missing_returns_zero() {
+        let dir = tempdir().unwrap();
+        assert_eq!(read_temperature_celsius(dir.path()), 0);
+    }
+
+    #[test]
+    fn power_handles_microwatts() {
+        let dir = tempdir().unwrap();
+        let hwmon = dir.path().join("hwmon").join("hwmon2");
+        fs::create_dir_all(&hwmon).unwrap();
+        fs::write(hwmon.join("power1_average"), "185500000\n").unwrap();
+        let w = read_power_watts(dir.path());
+        assert!((w - 185.5).abs() < 0.01, "got {w}");
+    }
+
+    #[test]
+    fn has_nonzero_u64_works() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("x");
+        fs::write(&f, "0\n").unwrap();
+        assert!(!has_nonzero_u64(&f));
+        fs::write(&f, "42\n").unwrap();
+        assert!(has_nonzero_u64(&f));
+        // Missing file.
+        assert!(!has_nonzero_u64(&dir.path().join("missing")));
+    }
+}

--- a/src/device/readers/intel_gpu_windows.rs
+++ b/src/device/readers/intel_gpu_windows.rs
@@ -31,6 +31,7 @@
 //! the missing values aren't a regression.
 
 use crate::device::GpuReader;
+use crate::device::readers::intel_gpu_names::classify_intel_architecture;
 use crate::device::types::{GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
 use chrono::Local;
@@ -151,6 +152,18 @@ impl IntelWindowsGpuReader {
                         "Variant".to_string(),
                         classify_intel_variant(&name).to_string(),
                     );
+                    // Architecture / SYCL classification — shared with
+                    // the Linux reader via `intel_gpu_names::classify_*`
+                    // so a single source of truth drives downstream
+                    // accelerator-selection logic (Backend.AI's
+                    // accelerator picker, llama.cpp SYCL backend, etc.)
+                    // on both Linux and Windows.
+                    let arch = classify_intel_architecture(&name);
+                    detail.insert("Architecture".to_string(), arch.label().to_string());
+                    detail.insert(
+                        "SYCL Capable".to_string(),
+                        arch.sycl_capable_label().to_string(),
+                    );
                     detail.insert(
                         "Note".to_string(),
                         "Detailed metrics require Level Zero / xpu-smi".to_string(),
@@ -257,9 +270,11 @@ pub fn has_intel_gpu_windows() -> bool {
 /// Intel client GPU. Requires both:
 ///
 /// 1. The name contains "intel" (case-insensitive).
-/// 2. The name contains at least one of the graphics-family tokens —
-///    `arc`, `iris`, `uhd graphics`, `hd graphics`, `xe graphics`, or
-///    matches the iGPU pattern `intel graphics`.
+/// 2. The name contains at least one of the graphics-family tokens
+///    listed in `FAMILY_TOKENS` — covering both legacy (`hd graphics`,
+///    `uhd graphics`, `iris`) and modern (`arc`, `xe graphics`,
+///    `xe-lpg`, `battlemage`, `lunarlake`, `lunar lake`) marketing
+///    names.
 ///
 /// Step 2 deliberately excludes names like "Intel Display Audio",
 /// "Intel(R) Management Engine Interface", and "Intel Smart Sound" —
@@ -270,7 +285,11 @@ pub fn is_intel_gpu_name(name: &str) -> bool {
         return false;
     }
     // Common Intel GPU family tokens. Order doesn't matter — we just
-    // need ANY match.
+    // need ANY match. The list mirrors the architecture matchers in
+    // `intel_gpu_names::classify_intel_architecture` so any name the
+    // classifier would label as a real Intel GPU also passes this
+    // filter. New family names (e.g. future "Celestial" / "Druid" Arc
+    // generations) need to be added here AND to the classifier.
     const FAMILY_TOKENS: &[&str] = &[
         "arc",
         "iris",
@@ -278,6 +297,10 @@ pub fn is_intel_gpu_name(name: &str) -> bool {
         "hd graphics",
         "xe graphics",
         "intel graphics",
+        "xe-lpg",
+        "battlemage",
+        "lunarlake",
+        "lunar lake",
     ];
     FAMILY_TOKENS.iter().any(|t| lower.contains(t))
 }
@@ -325,122 +348,5 @@ fn is_arc_model_token(token: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn intel_arc_a770_recognised() {
-        assert!(is_intel_gpu_name("Intel(R) Arc(TM) A770 Graphics"));
-    }
-
-    #[test]
-    fn intel_arc_b580_recognised() {
-        assert!(is_intel_gpu_name("Intel(R) Arc(TM) B580 Graphics"));
-    }
-
-    #[test]
-    fn intel_iris_xe_recognised() {
-        assert!(is_intel_gpu_name("Intel(R) Iris(R) Xe Graphics"));
-    }
-
-    #[test]
-    fn intel_uhd_770_recognised() {
-        assert!(is_intel_gpu_name("Intel(R) UHD Graphics 770"));
-    }
-
-    #[test]
-    fn intel_hd_graphics_recognised() {
-        assert!(is_intel_gpu_name("Intel(R) HD Graphics 530"));
-    }
-
-    #[test]
-    fn meteor_lake_arc_igpu_recognised() {
-        // Meteor Lake / Core Ultra iGPU ships as "Intel(R) Arc(TM)
-        // Graphics" with no number.
-        assert!(is_intel_gpu_name("Intel(R) Arc(TM) Graphics"));
-    }
-
-    #[test]
-    fn intel_display_audio_excluded() {
-        // Audio device — must NOT match even though "Intel" is in the name.
-        assert!(!is_intel_gpu_name("Intel(R) Display Audio"));
-    }
-
-    #[test]
-    fn intel_management_engine_excluded() {
-        assert!(!is_intel_gpu_name(
-            "Intel(R) Management Engine Interface #1"
-        ));
-    }
-
-    #[test]
-    fn intel_smart_sound_excluded() {
-        assert!(!is_intel_gpu_name(
-            "Intel(R) Smart Sound Technology (Intel(R) SST)"
-        ));
-    }
-
-    #[test]
-    fn non_intel_excluded() {
-        assert!(!is_intel_gpu_name("NVIDIA GeForce RTX 4090"));
-        assert!(!is_intel_gpu_name("AMD Radeon RX 7900 XTX"));
-    }
-
-    #[test]
-    fn classify_arc_discrete() {
-        assert_eq!(
-            classify_intel_variant("Intel(R) Arc(TM) A770 Graphics"),
-            "Discrete"
-        );
-        assert_eq!(
-            classify_intel_variant("Intel(R) Arc(TM) B580 Graphics"),
-            "Discrete"
-        );
-    }
-
-    #[test]
-    fn classify_iris_integrated() {
-        assert_eq!(
-            classify_intel_variant("Intel(R) Iris(R) Xe Graphics"),
-            "Integrated"
-        );
-    }
-
-    #[test]
-    fn classify_uhd_integrated() {
-        assert_eq!(
-            classify_intel_variant("Intel(R) UHD Graphics 770"),
-            "Integrated"
-        );
-    }
-
-    #[test]
-    fn classify_meteor_lake_arc_igpu_as_integrated() {
-        // "Intel Arc Graphics" without a model number on Core Ultra is
-        // the iGPU and must NOT be classified as Discrete.
-        assert_eq!(
-            classify_intel_variant("Intel(R) Arc(TM) Graphics"),
-            "Integrated"
-        );
-    }
-
-    #[test]
-    fn arc_model_token_recognises_known_skus() {
-        assert!(is_arc_model_token("a770"));
-        assert!(is_arc_model_token("a750"));
-        assert!(is_arc_model_token("a580"));
-        assert!(is_arc_model_token("a380"));
-        assert!(is_arc_model_token("b580"));
-        assert!(is_arc_model_token("b570"));
-    }
-
-    #[test]
-    fn arc_model_token_rejects_non_models() {
-        assert!(!is_arc_model_token("arc"));
-        assert!(!is_arc_model_token("tm"));
-        assert!(!is_arc_model_token("graphics"));
-        assert!(!is_arc_model_token("a"));
-        // Single letter followed by <3 digits doesn't count as a model.
-        assert!(!is_arc_model_token("a77"));
-    }
-}
+#[path = "intel_gpu_windows/tests.rs"]
+mod tests;

--- a/src/device/readers/intel_gpu_windows.rs
+++ b/src/device/readers/intel_gpu_windows.rs
@@ -1,0 +1,446 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Intel client GPU reader for Windows using WMI.
+//!
+//! Mirrors [`super::amd_windows`] closely — both readers query
+//! `Win32_VideoController` and fill the same defensive `GpuInfo`
+//! template. The only differences are the vendor / family filter and a
+//! discrete-vs-integrated heuristic surfaced in `detail["Variant"]`.
+//!
+//! ## Limitations (v1 scope)
+//!
+//! Detailed metrics (utilization, temperature, fine-grained power) are
+//! **not** available through WMI on Windows for Intel client GPUs.
+//! Surfacing them requires Level Zero (`ze_*` API via the
+//! `libze_intel_gpu` shared library) or `xpu-smi` for datacenter Flex /
+//! Max. That follow-up is documented in the issue and intentionally
+//! deferred — this reader returns `0` for those fields and adds a
+//! `detail["Note"]` entry pointing at the future work, so consumers know
+//! the missing values aren't a regression.
+
+use crate::device::GpuReader;
+use crate::device::types::{GpuInfo, ProcessInfo};
+use crate::utils::get_hostname;
+use chrono::Local;
+use serde::Deserialize;
+use std::collections::HashMap;
+use wmi::WMIConnection;
+
+// Thread-local WMI connection for reuse within the same thread —
+// identical pattern to amd_windows.rs so we don't pay the COM init cost
+// per request.
+thread_local! {
+    static WMI_CONNECTION: std::cell::RefCell<Option<WMIConnection>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+fn with_wmi_connection<T, F: FnOnce(&WMIConnection) -> T>(f: F) -> Option<T> {
+    WMI_CONNECTION.with(|cell| {
+        let mut conn_ref = cell.borrow_mut();
+        if conn_ref.is_none() {
+            match WMIConnection::new() {
+                Ok(wmi_con) => {
+                    *conn_ref = Some(wmi_con);
+                }
+                Err(e) => {
+                    eprintln!("Intel GPU: Failed to create WMI connection: {e}");
+                }
+            }
+        }
+        conn_ref.as_ref().map(f)
+    })
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "PascalCase")]
+struct Win32VideoController {
+    name: Option<String>,
+    adapter_r_a_m: Option<u64>,
+    driver_version: Option<String>,
+    video_processor: Option<String>,
+    pnp_device_i_d: Option<String>,
+    status: Option<String>,
+    adapter_d_a_c_type: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct VideoControllerName {
+    name: Option<String>,
+}
+
+pub struct IntelWindowsGpuReader {}
+
+impl Default for IntelWindowsGpuReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntelWindowsGpuReader {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn query_intel_gpus(&self) -> Vec<GpuInfo> {
+        with_wmi_connection(|wmi_con| {
+            let mut gpu_list = Vec::new();
+
+            let result: Result<Vec<Win32VideoController>, _> = wmi_con.raw_query(
+                "SELECT Name, AdapterRAM, DriverVersion, VideoProcessor, PNPDeviceID, Status, AdapterDACType FROM Win32_VideoController",
+            );
+
+            if let Ok(controllers) = result {
+                let hostname = get_hostname();
+                let time = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+
+                for (idx, controller) in controllers.iter().enumerate() {
+                    let name = controller.name.clone().unwrap_or_default();
+                    if !is_intel_gpu_name(&name) {
+                        continue;
+                    }
+
+                    let uuid = controller
+                        .pnp_device_i_d
+                        .clone()
+                        .unwrap_or_else(|| format!("Intel-GPU-{idx}"));
+
+                    // LIMITATION: Win32_VideoController.AdapterRAM is a
+                    // 32-bit uint32 in WMI, capped at 4GB. For an
+                    // Intel Arc A770 16GB or B580 12GB the value will
+                    // be clipped or wrapped — the same gotcha applies
+                    // here as in amd_windows.rs. We warn on the same
+                    // thresholds so downstream operators can identify
+                    // it from logs.
+                    let total_memory = controller.adapter_r_a_m.unwrap_or(0);
+                    const FOUR_GB: u64 = 4 * 1024 * 1024 * 1024;
+                    if total_memory == 0 {
+                        eprintln!("Intel GPU '{name}': VRAM size unavailable (reported as 0)");
+                    } else if total_memory >= FOUR_GB - (512 * 1024 * 1024) {
+                        eprintln!(
+                            "Intel GPU '{name}': VRAM reported as {total_memory} bytes, may be inaccurate for >4GB GPUs due to WMI 32-bit limitation"
+                        );
+                    }
+
+                    let mut detail = HashMap::new();
+                    if let Some(ref driver) = controller.driver_version {
+                        detail.insert("Driver Version".to_string(), driver.clone());
+                    }
+                    if let Some(ref processor) = controller.video_processor {
+                        detail.insert("Video Processor".to_string(), processor.clone());
+                    }
+                    if let Some(ref status) = controller.status {
+                        detail.insert("Status".to_string(), status.clone());
+                    }
+                    if let Some(ref dac_type) = controller.adapter_d_a_c_type {
+                        detail.insert("DAC Type".to_string(), dac_type.clone());
+                    }
+                    detail.insert(
+                        "Variant".to_string(),
+                        classify_intel_variant(&name).to_string(),
+                    );
+                    detail.insert(
+                        "Note".to_string(),
+                        "Detailed metrics require Level Zero / xpu-smi".to_string(),
+                    );
+
+                    gpu_list.push(GpuInfo {
+                        uuid,
+                        time: time.clone(),
+                        name,
+                        device_type: "GPU".to_string(),
+                        host_id: hostname.clone(),
+                        hostname: hostname.clone(),
+                        instance: hostname.clone(),
+                        utilization: 0.0,
+                        ane_utilization: 0.0,
+                        dla_utilization: None,
+                        tensorcore_utilization: None,
+                        temperature: 0,
+                        used_memory: 0,
+                        total_memory,
+                        frequency: 0,
+                        power_consumption: 0.0,
+                        gpu_core_count: None,
+                        // Intel-on-Windows surfaces nothing beyond the
+                        // basic WMI query — NVML thermal thresholds /
+                        // P-states and NVIDIA hardware details (NUMA,
+                        // GSP firmware, NvLink, GPM) do not apply.
+                        temperature_threshold_slowdown: None,
+                        temperature_threshold_shutdown: None,
+                        temperature_threshold_max_operating: None,
+                        temperature_threshold_acoustic: None,
+                        performance_state: None,
+                        numa_node_id: None,
+                        gsp_firmware_mode: None,
+                        gsp_firmware_version: None,
+                        nvlink_remote_devices: Vec::new(),
+                        gpm_metrics: None,
+                        detail,
+                    });
+                }
+            }
+
+            gpu_list
+        })
+        .unwrap_or_default()
+    }
+}
+
+impl GpuReader for IntelWindowsGpuReader {
+    fn get_gpu_info(&self) -> Vec<GpuInfo> {
+        self.query_intel_gpus()
+    }
+
+    fn get_process_info(&self) -> Vec<ProcessInfo> {
+        // Per-process GPU memory on Windows requires PDH / D3DKMT or
+        // Level Zero. Not available via Win32_VideoController. Mirrors
+        // the AMD-on-Windows reader.
+        Vec::new()
+    }
+}
+
+/// Detect Intel client GPU presence on Windows via WMI.
+///
+/// Filter logic is intentionally conservative — we keep only controllers
+/// that contain `intel` **and** a graphics family token (`arc`, `iris`,
+/// `xe graphics`, or any `uhd`/`hd graphics` form). That way controllers
+/// like "Intel Display Audio" or "Intel(R) Management Engine Interface"
+/// are excluded even though they share the "Intel" name.
+pub fn has_intel_gpu_windows() -> bool {
+    let wmi_con = match WMIConnection::new() {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("Intel GPU detection: Failed to create WMI connection: {e}");
+            return false;
+        }
+    };
+
+    let query_result: Result<Vec<VideoControllerName>, _> =
+        wmi_con.raw_query("SELECT Name FROM Win32_VideoController");
+
+    match query_result {
+        Ok(controllers) => {
+            for controller in controllers {
+                if let Some(name) = &controller.name
+                    && is_intel_gpu_name(name)
+                {
+                    return true;
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Intel GPU detection: WMI query failed: {e}");
+            return false;
+        }
+    }
+
+    false
+}
+
+/// Free function — factored out of the reader so unit tests can exercise
+/// the filter logic without touching WMI.
+///
+/// Returns `true` when the controller name plausibly identifies an
+/// Intel client GPU. Requires both:
+///
+/// 1. The name contains "intel" (case-insensitive).
+/// 2. The name contains at least one of the graphics-family tokens —
+///    `arc`, `iris`, `uhd graphics`, `hd graphics`, `xe graphics`, or
+///    matches the iGPU pattern `intel graphics`.
+///
+/// Step 2 deliberately excludes names like "Intel Display Audio",
+/// "Intel(R) Management Engine Interface", and "Intel Smart Sound" —
+/// those share the "Intel" name but are not GPUs.
+pub fn is_intel_gpu_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    if !lower.contains("intel") {
+        return false;
+    }
+    // Common Intel GPU family tokens. Order doesn't matter — we just
+    // need ANY match.
+    const FAMILY_TOKENS: &[&str] = &[
+        "arc",
+        "iris",
+        "uhd graphics",
+        "hd graphics",
+        "xe graphics",
+        "intel graphics",
+    ];
+    FAMILY_TOKENS.iter().any(|t| lower.contains(t))
+}
+
+/// Heuristic discrete-vs-integrated discriminator for Intel client
+/// GPUs on Windows. We can't introspect VRAM reliably via WMI (the 32-bit
+/// `AdapterRAM` field is unreliable, see above) so we fall back to a
+/// name-pattern check that the test suite locks in.
+///
+/// The discriminator looks for an Arc model number — discrete Arc cards
+/// always carry one (e.g. `A770`, `A750`, `B580`, `B570`), while the
+/// Meteor Lake / Core Ultra iGPU is sold as "Intel(R) Arc(TM) Graphics"
+/// with no number. Iris / UHD / HD Graphics / Xe Graphics are always
+/// integrated.
+fn classify_intel_variant(name: &str) -> &'static str {
+    let lower = name.to_lowercase();
+    if !lower.contains("arc") {
+        return "Integrated";
+    }
+    // Heuristic: discrete Arc names contain a token like "a770", "b580"
+    // etc. — a letter A/B/C followed by 3+ digits. Scan word boundaries.
+    let has_model_number = lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(is_arc_model_token);
+    if has_model_number {
+        "Discrete"
+    } else {
+        "Integrated"
+    }
+}
+
+/// `true` for tokens like `a770`, `a750`, `b580`, `c770` — a single
+/// letter (current Arc generations are A/B; reserve C/D for forward
+/// compatibility) followed by 3+ digits.
+fn is_arc_model_token(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    if bytes.len() < 4 {
+        return false;
+    }
+    let first = bytes[0] as char;
+    if !matches!(first, 'a' | 'b' | 'c' | 'd') {
+        return false;
+    }
+    bytes[1..].iter().all(|b| b.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intel_arc_a770_recognised() {
+        assert!(is_intel_gpu_name("Intel(R) Arc(TM) A770 Graphics"));
+    }
+
+    #[test]
+    fn intel_arc_b580_recognised() {
+        assert!(is_intel_gpu_name("Intel(R) Arc(TM) B580 Graphics"));
+    }
+
+    #[test]
+    fn intel_iris_xe_recognised() {
+        assert!(is_intel_gpu_name("Intel(R) Iris(R) Xe Graphics"));
+    }
+
+    #[test]
+    fn intel_uhd_770_recognised() {
+        assert!(is_intel_gpu_name("Intel(R) UHD Graphics 770"));
+    }
+
+    #[test]
+    fn intel_hd_graphics_recognised() {
+        assert!(is_intel_gpu_name("Intel(R) HD Graphics 530"));
+    }
+
+    #[test]
+    fn meteor_lake_arc_igpu_recognised() {
+        // Meteor Lake / Core Ultra iGPU ships as "Intel(R) Arc(TM)
+        // Graphics" with no number.
+        assert!(is_intel_gpu_name("Intel(R) Arc(TM) Graphics"));
+    }
+
+    #[test]
+    fn intel_display_audio_excluded() {
+        // Audio device — must NOT match even though "Intel" is in the name.
+        assert!(!is_intel_gpu_name("Intel(R) Display Audio"));
+    }
+
+    #[test]
+    fn intel_management_engine_excluded() {
+        assert!(!is_intel_gpu_name(
+            "Intel(R) Management Engine Interface #1"
+        ));
+    }
+
+    #[test]
+    fn intel_smart_sound_excluded() {
+        assert!(!is_intel_gpu_name(
+            "Intel(R) Smart Sound Technology (Intel(R) SST)"
+        ));
+    }
+
+    #[test]
+    fn non_intel_excluded() {
+        assert!(!is_intel_gpu_name("NVIDIA GeForce RTX 4090"));
+        assert!(!is_intel_gpu_name("AMD Radeon RX 7900 XTX"));
+    }
+
+    #[test]
+    fn classify_arc_discrete() {
+        assert_eq!(
+            classify_intel_variant("Intel(R) Arc(TM) A770 Graphics"),
+            "Discrete"
+        );
+        assert_eq!(
+            classify_intel_variant("Intel(R) Arc(TM) B580 Graphics"),
+            "Discrete"
+        );
+    }
+
+    #[test]
+    fn classify_iris_integrated() {
+        assert_eq!(
+            classify_intel_variant("Intel(R) Iris(R) Xe Graphics"),
+            "Integrated"
+        );
+    }
+
+    #[test]
+    fn classify_uhd_integrated() {
+        assert_eq!(
+            classify_intel_variant("Intel(R) UHD Graphics 770"),
+            "Integrated"
+        );
+    }
+
+    #[test]
+    fn classify_meteor_lake_arc_igpu_as_integrated() {
+        // "Intel Arc Graphics" without a model number on Core Ultra is
+        // the iGPU and must NOT be classified as Discrete.
+        assert_eq!(
+            classify_intel_variant("Intel(R) Arc(TM) Graphics"),
+            "Integrated"
+        );
+    }
+
+    #[test]
+    fn arc_model_token_recognises_known_skus() {
+        assert!(is_arc_model_token("a770"));
+        assert!(is_arc_model_token("a750"));
+        assert!(is_arc_model_token("a580"));
+        assert!(is_arc_model_token("a380"));
+        assert!(is_arc_model_token("b580"));
+        assert!(is_arc_model_token("b570"));
+    }
+
+    #[test]
+    fn arc_model_token_rejects_non_models() {
+        assert!(!is_arc_model_token("arc"));
+        assert!(!is_arc_model_token("tm"));
+        assert!(!is_arc_model_token("graphics"));
+        assert!(!is_arc_model_token("a"));
+        // Single letter followed by <3 digits doesn't count as a model.
+        assert!(!is_arc_model_token("a77"));
+    }
+}

--- a/src/device/readers/intel_gpu_windows/tests.rs
+++ b/src/device/readers/intel_gpu_windows/tests.rs
@@ -1,0 +1,255 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the Intel client GPU reader on Windows. Pulled out of
+//! `intel_gpu_windows.rs` to keep that file under the 500-line budget,
+//! mirroring the `intel_gpu_linux/tests.rs` split.
+
+use super::*;
+
+#[test]
+fn intel_arc_a770_recognised() {
+    assert!(is_intel_gpu_name("Intel(R) Arc(TM) A770 Graphics"));
+}
+
+#[test]
+fn intel_arc_b580_recognised() {
+    assert!(is_intel_gpu_name("Intel(R) Arc(TM) B580 Graphics"));
+}
+
+#[test]
+fn intel_iris_xe_recognised() {
+    assert!(is_intel_gpu_name("Intel(R) Iris(R) Xe Graphics"));
+}
+
+#[test]
+fn intel_uhd_770_recognised() {
+    assert!(is_intel_gpu_name("Intel(R) UHD Graphics 770"));
+}
+
+#[test]
+fn intel_hd_graphics_recognised() {
+    assert!(is_intel_gpu_name("Intel(R) HD Graphics 530"));
+}
+
+#[test]
+fn meteor_lake_arc_igpu_recognised() {
+    // Meteor Lake / Core Ultra iGPU ships as "Intel(R) Arc(TM)
+    // Graphics" with no number.
+    assert!(is_intel_gpu_name("Intel(R) Arc(TM) Graphics"));
+}
+
+#[test]
+fn intel_display_audio_excluded() {
+    // Audio device — must NOT match even though "Intel" is in the name.
+    assert!(!is_intel_gpu_name("Intel(R) Display Audio"));
+}
+
+#[test]
+fn intel_management_engine_excluded() {
+    assert!(!is_intel_gpu_name(
+        "Intel(R) Management Engine Interface #1"
+    ));
+}
+
+#[test]
+fn intel_smart_sound_excluded() {
+    assert!(!is_intel_gpu_name(
+        "Intel(R) Smart Sound Technology (Intel(R) SST)"
+    ));
+}
+
+#[test]
+fn non_intel_excluded() {
+    assert!(!is_intel_gpu_name("NVIDIA GeForce RTX 4090"));
+    assert!(!is_intel_gpu_name("AMD Radeon RX 7900 XTX"));
+}
+
+#[test]
+fn classify_arc_discrete() {
+    assert_eq!(
+        classify_intel_variant("Intel(R) Arc(TM) A770 Graphics"),
+        "Discrete"
+    );
+    assert_eq!(
+        classify_intel_variant("Intel(R) Arc(TM) B580 Graphics"),
+        "Discrete"
+    );
+}
+
+#[test]
+fn classify_iris_integrated() {
+    assert_eq!(
+        classify_intel_variant("Intel(R) Iris(R) Xe Graphics"),
+        "Integrated"
+    );
+}
+
+#[test]
+fn classify_uhd_integrated() {
+    assert_eq!(
+        classify_intel_variant("Intel(R) UHD Graphics 770"),
+        "Integrated"
+    );
+}
+
+#[test]
+fn classify_meteor_lake_arc_igpu_as_integrated() {
+    // "Intel Arc Graphics" without a model number on Core Ultra is
+    // the iGPU and must NOT be classified as Discrete.
+    assert_eq!(
+        classify_intel_variant("Intel(R) Arc(TM) Graphics"),
+        "Integrated"
+    );
+}
+
+#[test]
+fn arc_model_token_recognises_known_skus() {
+    assert!(is_arc_model_token("a770"));
+    assert!(is_arc_model_token("a750"));
+    assert!(is_arc_model_token("a580"));
+    assert!(is_arc_model_token("a380"));
+    assert!(is_arc_model_token("b580"));
+    assert!(is_arc_model_token("b570"));
+}
+
+#[test]
+fn arc_model_token_rejects_non_models() {
+    assert!(!is_arc_model_token("arc"));
+    assert!(!is_arc_model_token("tm"));
+    assert!(!is_arc_model_token("graphics"));
+    assert!(!is_arc_model_token("a"));
+    // Single letter followed by <3 digits doesn't count as a model.
+    assert!(!is_arc_model_token("a77"));
+}
+
+// ---------- Marketing-name fixture parity with backend.ai-go ----------
+//
+// Every name the architecture classifier handles must also pass the
+// WMI name filter, otherwise the reader would drop the GPU before it
+// ever gets classified. These tests pin that contract.
+
+#[test]
+fn arc_a_series_fixtures_all_pass_filter() {
+    for name in &[
+        "Intel Arc A770 Graphics",
+        "Intel Arc A750",
+        "Intel Arc A580",
+        "Intel Arc A380",
+        "Intel Arc A310",
+        "Intel(R) Arc(TM) A770 Graphics",
+    ] {
+        assert!(is_intel_gpu_name(name), "filter dropped: {name}");
+    }
+}
+
+#[test]
+fn arc_b_series_fixtures_all_pass_filter() {
+    for name in &[
+        "Intel Arc B580",
+        "Intel(R) Arc(TM) B580 Graphics",
+        "Intel Arc B570",
+    ] {
+        assert!(is_intel_gpu_name(name), "filter dropped: {name}");
+    }
+}
+
+#[test]
+fn arc_lunar_lake_fixtures_pass_filter() {
+    for name in &[
+        "Intel Arc 140V Graphics",
+        "Intel Arc 130V Graphics",
+        "Intel LunarLake Graphics",
+        "Intel(R) LunarLake(TM) Graphics",
+        "Intel Lunar Lake Graphics",
+    ] {
+        assert!(is_intel_gpu_name(name), "filter dropped: {name}");
+    }
+}
+
+#[test]
+fn battlemage_explicit_fixtures_pass_filter() {
+    for name in &[
+        "Intel Battlemage Graphics",
+        "Intel(R) Battlemage(TM) Graphics",
+    ] {
+        assert!(is_intel_gpu_name(name), "filter dropped: {name}");
+    }
+}
+
+#[test]
+fn xe_lpg_explicit_fixtures_pass_filter() {
+    assert!(is_intel_gpu_name("Intel Xe-LPG Graphics"));
+}
+
+#[test]
+fn iris_xe_fixtures_pass_filter() {
+    assert!(is_intel_gpu_name("Intel Iris Xe Graphics"));
+    assert!(is_intel_gpu_name("Intel(R) Iris(R) Xe Graphics"));
+}
+
+#[test]
+fn older_integrated_fixtures_pass_filter() {
+    // These are still legitimate GPUs (just not SYCL-capable) so the
+    // filter MUST keep them — the classifier downstream labels them
+    // OlderIntegrated and marks SYCL Capable = "No".
+    for name in &[
+        "Intel HD Graphics 630",
+        "Intel UHD Graphics 770",
+        "Intel HD Graphics 520",
+        "Intel UHD Graphics 620",
+    ] {
+        assert!(is_intel_gpu_name(name), "filter dropped: {name}");
+    }
+}
+
+// Regression cases — these "Intel"-named devices that can appear in
+// `Win32_VideoController` enumeration on some systems MUST NOT be
+// matched as GPUs. Includes both the `(R)`/`(TM)`-decorated and
+// plain-prose variants since both forms appear in WMI output.
+
+#[test]
+fn intel_display_audio_excluded_plain() {
+    assert!(!is_intel_gpu_name("Intel Display Audio"));
+}
+
+#[test]
+fn intel_smart_sound_excluded_plain() {
+    assert!(!is_intel_gpu_name("Intel Smart Sound Technology"));
+}
+
+#[test]
+fn intel_thunderbolt_excluded() {
+    assert!(!is_intel_gpu_name("Intel(R) Thunderbolt(TM) Controller"));
+}
+
+#[test]
+fn intel_wifi_excluded() {
+    assert!(!is_intel_gpu_name("Intel(R) Wi-Fi 6E AX211 160MHz"));
+}
+
+// ---------- Architecture classifier wiring ----------
+
+#[test]
+fn sycl_capable_label_renders_known_yes_no_unknown() {
+    use crate::device::readers::intel_gpu_names::IntelArchitecture;
+
+    assert_eq!(IntelArchitecture::Alchemist.sycl_capable_label(), "Yes");
+    assert_eq!(IntelArchitecture::Battlemage.sycl_capable_label(), "Yes");
+    assert_eq!(IntelArchitecture::XeLpg.sycl_capable_label(), "Yes");
+    assert_eq!(IntelArchitecture::XeLpgPlus.sycl_capable_label(), "Yes");
+    assert_eq!(IntelArchitecture::IrisXe.sycl_capable_label(), "Yes");
+    assert_eq!(IntelArchitecture::OlderIntegrated.sycl_capable_label(), "No");
+    assert_eq!(IntelArchitecture::Unknown.sycl_capable_label(), "Unknown");
+}

--- a/src/device/readers/intel_gpu_windows/tests.rs
+++ b/src/device/readers/intel_gpu_windows/tests.rs
@@ -250,6 +250,9 @@ fn sycl_capable_label_renders_known_yes_no_unknown() {
     assert_eq!(IntelArchitecture::XeLpg.sycl_capable_label(), "Yes");
     assert_eq!(IntelArchitecture::XeLpgPlus.sycl_capable_label(), "Yes");
     assert_eq!(IntelArchitecture::IrisXe.sycl_capable_label(), "Yes");
-    assert_eq!(IntelArchitecture::OlderIntegrated.sycl_capable_label(), "No");
+    assert_eq!(
+        IntelArchitecture::OlderIntegrated.sycl_capable_label(),
+        "No"
+    );
     assert_eq!(IntelArchitecture::Unknown.sycl_capable_label(), "Unknown");
 }

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -51,3 +51,13 @@ pub mod amd;
 
 #[cfg(target_os = "windows")]
 pub mod amd_windows;
+
+// Intel client GPU (Arc / Iris / Xe) — see issue #244. Sysfs on Linux.
+// The PCI-ID name lookup and low-level sysfs helpers live in sibling
+// modules so the per-OS reader file stays small.
+#[cfg(target_os = "linux")]
+pub mod intel_gpu_linux;
+#[cfg(target_os = "linux")]
+pub mod intel_gpu_names;
+#[cfg(target_os = "linux")]
+pub mod intel_gpu_sysfs;

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -52,12 +52,15 @@ pub mod amd;
 #[cfg(target_os = "windows")]
 pub mod amd_windows;
 
-// Intel client GPU (Arc / Iris / Xe) — see issue #244. Sysfs on Linux.
-// The PCI-ID name lookup and low-level sysfs helpers live in sibling
-// modules so the per-OS reader file stays small.
+// Intel client GPU (Arc / Iris / Xe) — see issue #244. Sysfs on Linux,
+// WMI on Windows. The PCI-ID name lookup and low-level sysfs helpers
+// live in sibling modules so the per-OS reader files stay small.
 #[cfg(target_os = "linux")]
 pub mod intel_gpu_linux;
 #[cfg(target_os = "linux")]
 pub mod intel_gpu_names;
 #[cfg(target_os = "linux")]
 pub mod intel_gpu_sysfs;
+
+#[cfg(target_os = "windows")]
+pub mod intel_gpu_windows;

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -55,9 +55,13 @@ pub mod amd_windows;
 // Intel client GPU (Arc / Iris / Xe) — see issue #244. Sysfs on Linux,
 // WMI on Windows. The PCI-ID name lookup and low-level sysfs helpers
 // live in sibling modules so the per-OS reader files stay small.
+// `intel_gpu_names` is platform-agnostic (pure string matching) and is
+// available on both Linux and Windows so the architecture / SYCL
+// classification can be reused by both per-OS readers and by external
+// consumers of the library.
 #[cfg(target_os = "linux")]
 pub mod intel_gpu_linux;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub mod intel_gpu_names;
 #[cfg(target_os = "linux")]
 pub mod intel_gpu_sysfs;

--- a/src/doctor/checks/platform.rs
+++ b/src/doctor/checks/platform.rs
@@ -190,6 +190,11 @@ fn check_hardware(_ctx: &CheckCtx) -> CheckResult {
     if snap.gaudi {
         kinds.push("Intel Gaudi");
     }
+    if snap.intel_gpu {
+        // Distinct from `gaudi`: this is the Intel **client** GPU
+        // family (Arc / Iris / Xe / integrated graphics, issue #244).
+        kinds.push("Intel GPU");
+    }
     if snap.google_tpu {
         kinds.push("Google TPU");
     }

--- a/src/mock/constants.rs
+++ b/src/mock/constants.rs
@@ -25,6 +25,15 @@ pub const DEFAULT_AMD_DRIVER_VERSION: &str = "30.10.1";
 pub const DEFAULT_AMD_ROCM_VERSION: &str = "7.0.2";
 pub const DEFAULT_TENSTORRENT_NAME: &str = "Tenstorrent Grayskull e75 120W";
 pub const DEFAULT_FURIOSA_NAME: &str = "Furiosa RNGD";
+/// Default device name for the Intel client GPU mock (issue #244).
+/// We anchor on the Arc B580 (Battlemage, 12GB) — current-generation
+/// discrete Arc, around 190W TDP. Override via `--gpu-name`.
+pub const DEFAULT_INTEL_GPU_NAME: &str = "Intel Arc B580 12GB";
+/// Representative Intel Graphics Driver version string. The "real"
+/// equivalent on Linux is the kernel/mesa stack, which doesn't
+/// translate to a single version number; the Windows-style version is
+/// what consumers see in the WMI reader's `detail["Driver Version"]`.
+pub const DEFAULT_INTEL_DRIVER_VERSION: &str = "32.0.101.6299";
 pub const NUM_GPUS: usize = 8;
 pub const UPDATE_INTERVAL_SECS: u64 = 3;
 pub const MAX_CONNECTIONS_PER_SERVER: usize = 10;

--- a/src/mock/generator.rs
+++ b/src/mock/generator.rs
@@ -87,6 +87,12 @@ pub fn generate_gpus(gpu_name: &str, platform: &PlatformType) -> Vec<GpuMetrics>
             let gpu_bias = rng.random_range(-30.0..30.0);
             let max_power = match platform {
                 PlatformType::Furiosa => 180.0, // Furiosa RNGD TDP is 180W
+                // Intel client GPU max power cap. Current-generation
+                // Arc tops out at ~225W (A770 16GB); Battlemage B580
+                // is ~190W. We size the cap with headroom for future
+                // SKUs and prevent the random draw from generating
+                // datacenter-scale wattage on a consumer card.
+                PlatformType::Intel => 250.0,
                 _ => 700.0,
             };
             let power_consumption_watts = match platform {

--- a/src/mock/server.rs
+++ b/src/mock/server.rs
@@ -212,6 +212,7 @@ pub async fn start_servers(args: Args) -> Result<()> {
             }
             PlatformType::Furiosa => crate::mock::constants::DEFAULT_FURIOSA_NAME.to_string(),
             PlatformType::AmdGpu => crate::mock::constants::DEFAULT_AMD_GPU_NAME.to_string(),
+            PlatformType::Intel => crate::mock::constants::DEFAULT_INTEL_GPU_NAME.to_string(),
             _ => args.gpu_name.clone(),
         }
     } else {

--- a/src/mock/template_engine.rs
+++ b/src/mock/template_engine.rs
@@ -18,8 +18,8 @@ use crate::mock::constants::{PLACEHOLDER_DISK_AVAIL, PLACEHOLDER_DISK_TOTAL};
 use crate::mock::metrics::{CpuMetrics, GpuMetrics, MemoryMetrics, PlatformType};
 use crate::mock::templates::{
     amd_gpu::AmdGpuMockGenerator, apple_silicon::AppleSiliconMockGenerator,
-    furiosa::FuriosaMockGenerator, gaudi::GaudiMockGenerator, jetson::JetsonMockGenerator,
-    nvidia::NvidiaMockGenerator, rebellions::RebellionsMockGenerator,
+    furiosa::FuriosaMockGenerator, gaudi::GaudiMockGenerator, intel_gpu::IntelGpuMockGenerator,
+    jetson::JetsonMockGenerator, nvidia::NvidiaMockGenerator, rebellions::RebellionsMockGenerator,
     tenstorrent::TenstorrentMockGenerator,
 };
 use all_smi::traits::mock_generator::{MockConfig, MockGenerator, MockPlatform};
@@ -123,6 +123,15 @@ pub fn build_response_template(
             crate::mock::templates::disk::add_disk_metrics(&mut template, instance_name);
             template
         }
+        PlatformType::Intel => {
+            let generator =
+                IntelGpuMockGenerator::new(Some(gpu_name.to_string()), instance_name.to_string());
+            let mut template = generator.build_intel_template(gpus, cpu, memory);
+
+            // Add disk metrics
+            crate::mock::templates::disk::add_disk_metrics(&mut template, instance_name);
+            template
+        }
         _ => {
             // Default to NVIDIA for unsupported platforms
             let generator =
@@ -178,6 +187,10 @@ pub fn render_response(
         PlatformType::AmdGpu => {
             let generator = AmdGpuMockGenerator::new(None, "".to_string());
             generator.render_amd_response(template, gpus, cpu, memory)
+        }
+        PlatformType::Intel => {
+            let generator = IntelGpuMockGenerator::new(None, "".to_string());
+            generator.render_intel_response(template, gpus, cpu, memory)
         }
         _ => template.to_string(),
     };
@@ -245,6 +258,7 @@ fn create_generator(
         PlatformType::Furiosa => Box::new(FuriosaMockGenerator::new(Some(gpu_name), instance_name)),
         PlatformType::Gaudi => Box::new(GaudiMockGenerator::new(Some(gpu_name), instance_name)),
         PlatformType::AmdGpu => Box::new(AmdGpuMockGenerator::new(Some(gpu_name), instance_name)),
+        PlatformType::Intel => Box::new(IntelGpuMockGenerator::new(Some(gpu_name), instance_name)),
         _ => Box::new(NvidiaMockGenerator::new(Some(gpu_name), instance_name)),
     }
 }
@@ -260,6 +274,7 @@ fn platform_type_to_mock_platform(platform: &PlatformType) -> MockPlatform {
         PlatformType::Furiosa => MockPlatform::Custom("Furiosa".to_string()),
         PlatformType::Gaudi => MockPlatform::Custom("Intel Gaudi".to_string()),
         PlatformType::AmdGpu => MockPlatform::AmdGpu,
+        PlatformType::Intel => MockPlatform::IntelGpu,
         _ => MockPlatform::Nvidia,
     }
 }

--- a/src/mock/templates/intel_gpu.rs
+++ b/src/mock/templates/intel_gpu.rs
@@ -1,0 +1,533 @@
+//! Intel client GPU mock template generator (issue #244).
+
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::mock::metrics::{CpuMetrics, GpuMetrics, MemoryMetrics};
+use all_smi::traits::mock_generator::{
+    MockConfig, MockData, MockGenerator, MockPlatform, MockResult,
+};
+use rand::{RngExt, rng};
+
+/// Intel client GPU mock generator. Modelled on
+/// [`super::amd_gpu::AmdGpuMockGenerator`] — same metric set, same
+/// template shape — with an `all_smi_intel_driver_version` info metric
+/// replacing the AMD `all_smi_amd_rocm_version` analogue, and a memory
+/// table sized for client SKUs (4–16 GB) instead of HBM stacks.
+pub struct IntelGpuMockGenerator {
+    gpu_name: String,
+    instance_name: String,
+}
+
+impl IntelGpuMockGenerator {
+    /// Create a new Intel client GPU mock generator. Supported `--gpu-name`
+    /// values include discrete Arc (e.g. `Intel Arc B580 12GB`,
+    /// `Intel Arc A770 16GB`, `Intel Arc A750 8GB`) and integrated
+    /// families (`Intel Arc Graphics` on Core Ultra, `Intel Iris Xe
+    /// Graphics`, `Intel UHD Graphics 770`). Integrated names yield
+    /// `0` total memory to mirror the production reader semantics.
+    pub fn new(gpu_name: Option<String>, instance_name: String) -> Self {
+        Self {
+            gpu_name: gpu_name
+                .unwrap_or_else(|| crate::mock::constants::DEFAULT_INTEL_GPU_NAME.to_string()),
+            instance_name,
+        }
+    }
+
+    /// Parse memory size from GPU name. Returns 0 for integrated GPUs
+    /// — they have no dedicated VRAM and the reader on a real Intel
+    /// host reports `0` total with a `detail["Memory"]` note. We mirror
+    /// that semantics here so library consumers see the same shape from
+    /// the mock as they would from a live integrated Intel host.
+    fn get_gpu_memory_bytes(&self) -> u64 {
+        // Match the actual production reader: integrated GPUs report 0.
+        if is_integrated_name(&self.gpu_name) {
+            return 0;
+        }
+        // Discrete Arc: scan for the `NNGB` token.
+        const GB: u64 = 1024 * 1024 * 1024;
+        if self.gpu_name.contains("16GB") {
+            16 * GB
+        } else if self.gpu_name.contains("12GB") {
+            12 * GB
+        } else if self.gpu_name.contains("10GB") {
+            10 * GB
+        } else if self.gpu_name.contains("8GB") {
+            8 * GB
+        } else if self.gpu_name.contains("6GB") {
+            6 * GB
+        } else if self.gpu_name.contains("4GB") {
+            4 * GB
+        } else if self.gpu_name.to_lowercase().contains("a770") {
+            16 * GB
+        } else if self.gpu_name.to_lowercase().contains("a750") {
+            8 * GB
+        } else if self.gpu_name.to_lowercase().contains("b580") {
+            12 * GB
+        } else if self.gpu_name.to_lowercase().contains("b570") {
+            10 * GB
+        } else {
+            // Default to 12 GB (Arc B580) when no size hint is present.
+            12 * GB
+        }
+    }
+
+    /// Build the Intel-specific template (metric names + placeholders).
+    pub fn build_intel_template(
+        &self,
+        gpus: &[GpuMetrics],
+        cpu: &CpuMetrics,
+        memory: &MemoryMetrics,
+    ) -> String {
+        let mut template = String::with_capacity(4096);
+        self.add_gpu_metrics(&mut template, gpus);
+        self.add_intel_driver_info(&mut template);
+        self.add_system_metrics(&mut template, cpu, memory);
+        template
+    }
+
+    fn add_gpu_metrics(&self, template: &mut String, gpus: &[GpuMetrics]) {
+        let gpu_metrics = [
+            ("all_smi_gpu_utilization", "GPU utilization percentage"),
+            ("all_smi_gpu_memory_used_bytes", "GPU memory used in bytes"),
+            (
+                "all_smi_gpu_memory_total_bytes",
+                "GPU memory total in bytes",
+            ),
+            (
+                "all_smi_gpu_temperature_celsius",
+                "GPU temperature in celsius",
+            ),
+            (
+                "all_smi_gpu_power_consumption_watts",
+                "GPU power consumption in watts",
+            ),
+            ("all_smi_gpu_frequency_mhz", "GPU frequency in MHz"),
+        ];
+
+        for (metric_name, help_text) in gpu_metrics {
+            template.push_str(&format!("# HELP {metric_name} {help_text}\n"));
+            template.push_str(&format!("# TYPE {metric_name} gauge\n"));
+
+            for (i, gpu) in gpus.iter().enumerate() {
+                let labels = format!(
+                    "gpu=\"{}\", instance=\"{}\", gpu_uuid=\"{}\", gpu_index=\"{i}\"",
+                    self.gpu_name, self.instance_name, gpu.uuid
+                );
+                let placeholder = match metric_name {
+                    "all_smi_gpu_utilization" => format!("{{{{UTIL_{i}}}}}"),
+                    "all_smi_gpu_memory_used_bytes" => format!("{{{{MEM_USED_{i}}}}}"),
+                    "all_smi_gpu_memory_total_bytes" => format!("{{{{MEM_TOTAL_{i}}}}}"),
+                    "all_smi_gpu_temperature_celsius" => format!("{{{{TEMP_{i}}}}}"),
+                    "all_smi_gpu_power_consumption_watts" => format!("{{{{POWER_{i}}}}}"),
+                    "all_smi_gpu_frequency_mhz" => format!("{{{{FREQ_{i}}}}}"),
+                    _ => "0".to_string(),
+                };
+                template.push_str(&format!("{metric_name}{{{labels}}} {placeholder}\n"));
+            }
+        }
+
+        self.add_gpu_info_metric(template, gpus);
+    }
+
+    fn add_gpu_info_metric(&self, template: &mut String, gpus: &[GpuMetrics]) {
+        use crate::mock::constants::DEFAULT_INTEL_DRIVER_VERSION;
+
+        template.push_str("# HELP all_smi_gpu_info GPU device information\n");
+        template.push_str("# TYPE all_smi_gpu_info gauge\n");
+
+        let variant = if is_integrated_name(&self.gpu_name) {
+            "Integrated"
+        } else {
+            "Discrete"
+        };
+
+        for (i, gpu) in gpus.iter().enumerate() {
+            let labels = format!(
+                "gpu=\"{}\", instance=\"{}\", gpu_uuid=\"{}\", gpu_index=\"{i}\", type=\"GPU\", \
+                 driver_version=\"{DEFAULT_INTEL_DRIVER_VERSION}\", variant=\"{variant}\", \
+                 lib_name=\"Intel Graphics Driver\", lib_version=\"{DEFAULT_INTEL_DRIVER_VERSION}\"",
+                self.gpu_name, self.instance_name, gpu.uuid
+            );
+            template.push_str(&format!("all_smi_gpu_info{{{labels}}} 1\n"));
+        }
+    }
+
+    fn add_intel_driver_info(&self, template: &mut String) {
+        use crate::mock::constants::DEFAULT_INTEL_DRIVER_VERSION;
+
+        template.push_str("# HELP all_smi_intel_driver_version Intel Graphics Driver version\n");
+        template.push_str("# TYPE all_smi_intel_driver_version gauge\n");
+        template.push_str(&format!(
+            "all_smi_intel_driver_version{{instance=\"{}\", version=\"{DEFAULT_INTEL_DRIVER_VERSION}\"}} 1\n",
+            self.instance_name
+        ));
+    }
+
+    fn add_system_metrics(&self, template: &mut String, cpu: &CpuMetrics, memory: &MemoryMetrics) {
+        template.push_str("# HELP all_smi_cpu_utilization CPU utilization percentage\n");
+        template.push_str("# TYPE all_smi_cpu_utilization gauge\n");
+        template.push_str(&format!(
+            "all_smi_cpu_utilization{{instance=\"{}\"}} {{{{CPU_UTIL}}}}\n",
+            self.instance_name
+        ));
+
+        template.push_str("# HELP all_smi_cpu_core_count Total number of CPU cores\n");
+        template.push_str("# TYPE all_smi_cpu_core_count gauge\n");
+        template.push_str(&format!(
+            "all_smi_cpu_core_count{{instance=\"{}\"}} {}\n",
+            self.instance_name, cpu.core_count
+        ));
+
+        template.push_str("# HELP all_smi_cpu_model CPU model name\n");
+        template.push_str("# TYPE all_smi_cpu_model info\n");
+        template.push_str(&format!(
+            "all_smi_cpu_model{{instance=\"{}\", model=\"{}\"}} 1\n",
+            self.instance_name, cpu.model
+        ));
+
+        template.push_str("# HELP all_smi_cpu_frequency_mhz CPU frequency in MHz\n");
+        template.push_str("# TYPE all_smi_cpu_frequency_mhz gauge\n");
+        template.push_str(&format!(
+            "all_smi_cpu_frequency_mhz{{instance=\"{}\"}} {}\n",
+            self.instance_name, cpu.frequency_mhz
+        ));
+
+        template.push_str("# HELP all_smi_cpu_temperature_celsius CPU temperature in celsius\n");
+        template.push_str("# TYPE all_smi_cpu_temperature_celsius gauge\n");
+        if let Some(temp) = cpu.temperature_celsius {
+            template.push_str(&format!(
+                "all_smi_cpu_temperature_celsius{{instance=\"{}\"}} {temp}\n",
+                self.instance_name
+            ));
+        }
+
+        template.push_str("# HELP all_smi_memory_used_bytes System memory used in bytes\n");
+        template.push_str("# TYPE all_smi_memory_used_bytes gauge\n");
+        template.push_str(&format!(
+            "all_smi_memory_used_bytes{{instance=\"{}\"}} {{{{MEM_USED}}}}\n",
+            self.instance_name
+        ));
+
+        template.push_str("# HELP all_smi_memory_total_bytes System memory total in bytes\n");
+        template.push_str("# TYPE all_smi_memory_total_bytes gauge\n");
+        template.push_str(&format!(
+            "all_smi_memory_total_bytes{{instance=\"{}\"}} {}\n",
+            self.instance_name, memory.total_bytes
+        ));
+    }
+
+    /// Render dynamic values for Intel GPUs into a previously built template.
+    pub fn render_intel_response(
+        &self,
+        template: &str,
+        gpus: &[GpuMetrics],
+        cpu: &CpuMetrics,
+        memory: &MemoryMetrics,
+    ) -> String {
+        let mut response = template.to_string();
+
+        for (i, gpu) in gpus.iter().enumerate() {
+            response = response
+                .replace(
+                    &format!("{{{{UTIL_{i}}}}}"),
+                    &format!("{:.2}", gpu.utilization),
+                )
+                .replace(
+                    &format!("{{{{MEM_USED_{i}}}}}"),
+                    &gpu.memory_used_bytes.to_string(),
+                )
+                .replace(
+                    &format!("{{{{MEM_TOTAL_{i}}}}}"),
+                    &gpu.memory_total_bytes.to_string(),
+                )
+                .replace(
+                    &format!("{{{{TEMP_{i}}}}}"),
+                    &gpu.temperature_celsius.to_string(),
+                )
+                .replace(
+                    &format!("{{{{POWER_{i}}}}}"),
+                    &format!("{:.3}", gpu.power_consumption_watts),
+                )
+                .replace(&format!("{{{{FREQ_{i}}}}}"), &gpu.frequency_mhz.to_string());
+        }
+
+        response = response
+            .replace("{{CPU_UTIL}}", &format!("{:.2}", cpu.utilization))
+            .replace("{{MEM_USED}}", &memory.used_bytes.to_string());
+
+        response
+    }
+}
+
+/// Heuristic: a GPU name represents an integrated Intel GPU when it
+/// lacks an Arc model number (A770 / B580 / etc.) AND contains one of
+/// the integrated-family tokens. Matches the production reader's
+/// classification so the mock and the real reader agree on `Variant`.
+fn is_integrated_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    let has_arc_model = lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|token| {
+            let bytes = token.as_bytes();
+            if bytes.len() < 4 {
+                return false;
+            }
+            let first = bytes[0] as char;
+            matches!(first, 'a' | 'b' | 'c' | 'd') && bytes[1..].iter().all(|b| b.is_ascii_digit())
+        });
+    if has_arc_model {
+        return false;
+    }
+    lower.contains("iris")
+        || lower.contains("uhd")
+        || lower.contains("hd graphics")
+        || lower.contains("xe graphics")
+        || (lower.contains("arc") && lower.contains("graphics"))
+        || lower.contains("intel graphics")
+}
+
+impl MockGenerator for IntelGpuMockGenerator {
+    fn generate(&self, config: &MockConfig) -> MockResult<MockData> {
+        self.validate_config(config)?;
+
+        let mut rng = rng();
+        let memory_total_bytes = self.get_gpu_memory_bytes();
+        // Cap the random memory-used draw at 80% of total. Integrated
+        // GPUs (memory_total_bytes == 0) get a flat zero, mirroring the
+        // real reader.
+        let memory_used_max = (memory_total_bytes / 10).saturating_mul(8);
+
+        let gpus: Vec<GpuMetrics> = (0..config.device_count)
+            .map(|_| {
+                let memory_used_bytes = if memory_total_bytes == 0 {
+                    0
+                } else {
+                    rng.random_range(memory_total_bytes / 10..memory_used_max.max(2_000_000_000))
+                };
+                GpuMetrics {
+                    uuid: crate::mock::metrics::gpu::generate_uuid_with_rng(&mut rng),
+                    utilization: rng.random_range(0.0..100.0),
+                    memory_used_bytes,
+                    memory_total_bytes,
+                    temperature_celsius: rng.random_range(40..78),
+                    // Discrete Arc client cards sit in 110–225W
+                    // depending on SKU; integrated Intel GPUs are
+                    // package-shared and report low single-digit
+                    // watts. Pick a representative draw.
+                    power_consumption_watts: if memory_total_bytes == 0 {
+                        rng.random_range(2.0..15.0)
+                    } else {
+                        rng.random_range(80.0..225.0)
+                    },
+                    frequency_mhz: rng.random_range(1100..2400),
+                    ane_utilization_watts: 0.0,
+                    thermal_pressure_level: None,
+                }
+            })
+            .collect();
+
+        let cpu = CpuMetrics {
+            // Intel client GPUs (Arc + iGPU) typically live in Intel
+            // Core / Core Ultra hosts. Pick a representative model.
+            model: "Intel Core Ultra 7 165H".to_string(),
+            utilization: rng.random_range(10.0..90.0),
+            socket_count: 1,
+            core_count: 16,
+            thread_count: 22,
+            frequency_mhz: 3800,
+            temperature_celsius: Some(60),
+            power_consumption_watts: Some(45.0),
+            socket_utilizations: vec![rng.random_range(10.0..90.0)],
+            p_core_count: None,
+            e_core_count: None,
+            gpu_core_count: None,
+            p_core_utilization: None,
+            e_core_utilization: None,
+            p_cluster_frequency_mhz: None,
+            e_cluster_frequency_mhz: None,
+            per_core_utilization: vec![],
+        };
+
+        let memory = MemoryMetrics {
+            total_bytes: 64 * 1024 * 1024 * 1024, // 64 GiB
+            used_bytes: rng.random_range(8_000_000_000..40_000_000_000),
+            available_bytes: rng.random_range(20_000_000_000..50_000_000_000),
+            free_bytes: rng.random_range(10_000_000_000..30_000_000_000),
+            cached_bytes: rng.random_range(2_000_000_000..10_000_000_000),
+            buffers_bytes: rng.random_range(100_000_000..1_000_000_000),
+            swap_total_bytes: 0,
+            swap_used_bytes: 0,
+            swap_free_bytes: 0,
+            utilization: rng.random_range(10.0..80.0),
+        };
+
+        let template = self.build_intel_template(&gpus, &cpu, &memory);
+        let response = self.render_intel_response(&template, &gpus, &cpu, &memory);
+
+        Ok(MockData {
+            response,
+            content_type: "text/plain; version=0.0.4".to_string(),
+            timestamp: chrono::Utc::now(),
+            platform: MockPlatform::IntelGpu,
+        })
+    }
+
+    fn generate_template(&self, config: &MockConfig) -> MockResult<String> {
+        self.validate_config(config)?;
+
+        let memory_total_bytes = self.get_gpu_memory_bytes();
+        let gpus: Vec<GpuMetrics> = (0..config.device_count)
+            .map(|i| GpuMetrics {
+                uuid: format!("GPU-{:08x}", i as u32),
+                utilization: 0.0,
+                memory_used_bytes: 0,
+                memory_total_bytes,
+                temperature_celsius: 0,
+                power_consumption_watts: 0.0,
+                frequency_mhz: 0,
+                ane_utilization_watts: 0.0,
+                thermal_pressure_level: None,
+            })
+            .collect();
+
+        let cpu = CpuMetrics {
+            model: "Intel Core Ultra 7 165H".to_string(),
+            utilization: 0.0,
+            socket_count: 1,
+            core_count: 16,
+            thread_count: 22,
+            frequency_mhz: 3800,
+            temperature_celsius: Some(60),
+            power_consumption_watts: Some(45.0),
+            socket_utilizations: vec![0.0],
+            p_core_count: None,
+            e_core_count: None,
+            gpu_core_count: None,
+            p_core_utilization: None,
+            e_core_utilization: None,
+            p_cluster_frequency_mhz: None,
+            e_cluster_frequency_mhz: None,
+            per_core_utilization: vec![],
+        };
+
+        let memory = MemoryMetrics {
+            total_bytes: 64 * 1024 * 1024 * 1024,
+            used_bytes: 0,
+            available_bytes: 64 * 1024 * 1024 * 1024,
+            free_bytes: 64 * 1024 * 1024 * 1024,
+            cached_bytes: 0,
+            buffers_bytes: 0,
+            swap_total_bytes: 0,
+            swap_used_bytes: 0,
+            swap_free_bytes: 0,
+            utilization: 0.0,
+        };
+
+        Ok(self.build_intel_template(&gpus, &cpu, &memory))
+    }
+
+    fn render(&self, template: &str, config: &MockConfig) -> MockResult<String> {
+        self.validate_config(config)?;
+        Ok(template.to_string())
+    }
+
+    fn platform(&self) -> MockPlatform {
+        MockPlatform::IntelGpu
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_contains_canonical_metric_names() {
+        let g = IntelGpuMockGenerator::new(
+            Some("Intel Arc B580 12GB".to_string()),
+            "intel-test".to_string(),
+        );
+        let cfg = MockConfig {
+            platform: MockPlatform::IntelGpu,
+            device_count: 2,
+            ..MockConfig::default()
+        };
+        let template = g.generate_template(&cfg).expect("template builds");
+        // Core metric families.
+        assert!(template.contains("all_smi_gpu_utilization"));
+        assert!(template.contains("all_smi_gpu_memory_used_bytes"));
+        assert!(template.contains("all_smi_gpu_memory_total_bytes"));
+        assert!(template.contains("all_smi_gpu_temperature_celsius"));
+        assert!(template.contains("all_smi_gpu_power_consumption_watts"));
+        assert!(template.contains("all_smi_gpu_frequency_mhz"));
+        // Intel-specific info metric — analogue of AMD's
+        // `all_smi_amd_rocm_version`.
+        assert!(template.contains("all_smi_intel_driver_version"));
+        // GPU info metric carries variant/driver labels.
+        assert!(template.contains("all_smi_gpu_info"));
+        assert!(template.contains("variant=\"Discrete\""));
+        // CPU + memory.
+        assert!(template.contains("all_smi_cpu_utilization"));
+        assert!(template.contains("all_smi_memory_total_bytes"));
+    }
+
+    #[test]
+    fn discrete_arc_b580_reports_12gb() {
+        let g =
+            IntelGpuMockGenerator::new(Some("Intel Arc B580 12GB".to_string()), "i".to_string());
+        assert_eq!(g.get_gpu_memory_bytes(), 12 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn discrete_arc_a770_reports_16gb() {
+        let g =
+            IntelGpuMockGenerator::new(Some("Intel Arc A770 16GB".to_string()), "i".to_string());
+        assert_eq!(g.get_gpu_memory_bytes(), 16 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn arc_a750_defaults_to_8gb() {
+        let g = IntelGpuMockGenerator::new(Some("Intel Arc A750".to_string()), "i".to_string());
+        assert_eq!(g.get_gpu_memory_bytes(), 8 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn integrated_reports_zero_memory() {
+        let g =
+            IntelGpuMockGenerator::new(Some("Intel Iris Xe Graphics".to_string()), "i".to_string());
+        assert_eq!(g.get_gpu_memory_bytes(), 0);
+
+        let g2 =
+            IntelGpuMockGenerator::new(Some("Intel UHD Graphics 770".to_string()), "i".to_string());
+        assert_eq!(g2.get_gpu_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn meteor_lake_arc_igpu_classified_as_integrated() {
+        // The Meteor Lake iGPU ships as "Intel Arc Graphics" with no
+        // model number — must be classified as integrated.
+        assert!(is_integrated_name("Intel(R) Arc(TM) Graphics"));
+        let g = IntelGpuMockGenerator::new(
+            Some("Intel(R) Arc(TM) Graphics".to_string()),
+            "i".to_string(),
+        );
+        assert_eq!(g.get_gpu_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn discrete_arc_not_classified_as_integrated() {
+        assert!(!is_integrated_name("Intel Arc A770 16GB"));
+        assert!(!is_integrated_name("Intel Arc B580 12GB"));
+    }
+}

--- a/src/mock/templates/intel_gpu.rs
+++ b/src/mock/templates/intel_gpu.rs
@@ -530,4 +530,36 @@ mod tests {
         assert!(!is_integrated_name("Intel Arc A770 16GB"));
         assert!(!is_integrated_name("Intel Arc B580 12GB"));
     }
+
+    #[test]
+    fn generate_leaves_no_unreplaced_placeholders() {
+        // `generate_template` intentionally contains `{{UTIL_N}}` etc.;
+        // `generate` must replace every placeholder before returning the
+        // response. Any leftover `{{` would be emitted verbatim to the
+        // Prometheus scraper, breaking numeric-value parsing.
+        let g = IntelGpuMockGenerator::new(
+            Some("Intel Arc B580 12GB".to_string()),
+            "intel-test".to_string(),
+        );
+        let cfg = MockConfig {
+            platform: MockPlatform::IntelGpu,
+            device_count: 2,
+            ..MockConfig::default()
+        };
+        let data = g.generate(&cfg).expect("generate succeeds");
+        assert!(
+            !data.response.contains("{{"),
+            "unreplaced placeholder in output: {}",
+            // Show the first occurrence for easier diagnosis.
+            data.response
+                .lines()
+                .find(|l| l.contains("{{"))
+                .unwrap_or("<not found>")
+        );
+        // Verify the output is Prometheus text format: every metric line
+        // must be preceded by # HELP and # TYPE comment blocks.
+        assert!(data.response.contains("# HELP "), "missing # HELP block");
+        assert!(data.response.contains("# TYPE "), "missing # TYPE block");
+        assert_eq!(data.content_type, "text/plain; version=0.0.4");
+    }
 }

--- a/src/mock/templates/mod.rs
+++ b/src/mock/templates/mod.rs
@@ -20,6 +20,7 @@ pub mod common;
 pub mod disk;
 pub mod furiosa;
 pub mod gaudi;
+pub mod intel_gpu;
 pub mod jetson;
 pub mod mig;
 pub mod nvidia;

--- a/src/traits/mock_generator.rs
+++ b/src/traits/mock_generator.rs
@@ -56,6 +56,10 @@ pub enum MockPlatform {
     AppleSilicon,
     Jetson,
     AmdGpu,
+    /// Intel **client** GPU family (Arc / Iris / Xe / integrated
+    /// graphics, issue #244). Distinct from any Intel datacenter HPU
+    /// path which is covered by other readers.
+    IntelGpu,
     Tenstorrent,
     Rebellions,
     Furiosa,


### PR DESCRIPTION
## Summary

Adds the missing Intel client GPU reader (issue #244) — both discrete Intel Arc (A-series / B-series "Battlemage") and integrated graphics (Iris Xe, Xe-LPG, Arc iGPU on Core Ultra / Meteor Lake) — on Linux (sysfs / i915 / xe) and Windows (WMI). On Intel client hosts, `get_gpu_info()` now returns a populated `GpuInfo` with name, memory, frequency, temperature, and power instead of an empty vector, fixing SYCL / oneAPI accelerator selection downstream.

## What changed

**New device readers**

- `src/device/readers/intel_gpu_linux.rs` (+ `intel_gpu_linux/tests.rs`) — sysfs walker over `/sys/class/drm/card*` for vendor `0x8086` cards driven by `i915` or `xe`. Distinguishes discrete vs integrated via the presence of `mem_info_vram_total` / `tile0/vram0/total_bytes` and rejects Habana / Gaudi (vendor `0x1da3`) plus Intel-vendor non-GPU devices.
- `src/device/readers/intel_gpu_sysfs.rs` — low-level sysfs I/O helpers split out so the main reader stays under the 500-line budget. Hosts memory / frequency / temperature / power readers with their own unit tests.
- `src/device/readers/intel_gpu_names.rs` — PCI device-ID → marketing-name table covering Arc A-series, Battlemage, Tiger / Alder / Raptor / Meteor / Ice / Rocket / Arrow / Lunar Lake, with a generic `Intel Graphics (device 0xXXXX)` fallback.
- `src/device/readers/intel_gpu_windows.rs` (+ `intel_gpu_windows/tests.rs`) — WMI reader mirroring `amd_windows.rs`. The `is_intel_gpu_name()` filter and `classify_intel_variant()` discriminator are free functions so they can be unit-tested without WMI; "Intel Display Audio" / "Intel(R) Management Engine Interface" / "Intel(R) Smart Sound" are correctly excluded.

**Wiring**

- `src/device/platform_detection.rs` — `has_intel_gpu()` detector + `PlatformSnapshot.intel_gpu` field. Linux uses `/sys/class/drm` with an `lspci -n` fallback; Windows uses WMI.
- `src/device/reader_factory.rs` — registers `IntelGpuReader` on Linux and `IntelWindowsGpuReader` on Windows, gated on the detector.
- `src/device/readers/mod.rs` — module declarations.
- `src/doctor/checks/platform.rs::check_hardware` — surfaces "Intel GPU" in `all-smi doctor` alongside "Intel Gaudi".

**Mock**

- `src/mock/templates/intel_gpu.rs` — Intel mock generator modelled on `amd_gpu.rs`. Default device is **Intel Arc B580 12GB** (Battlemage) so the mock reflects the current Intel client generation; A770 16GB and other SKUs work via `--gpu-name`. Adds `all_smi_intel_driver_version` as the Intel analogue of `all_smi_amd_rocm_version`.
- `src/mock/template_engine.rs`, `src/mock/server.rs`, `src/mock/templates/mod.rs`, `src/mock/constants.rs`, `src/mock/generator.rs`, `src/traits/mock_generator.rs` — `PlatformType::Intel` (already existed) is now routed end-to-end; `MockPlatform::IntelGpu` added to the trait-level enum; power cap for Intel platform is 250 W (vs the AMD-style generator's 700 W default).

## Architecture & SYCL classification

Per maintainer guidance, the Intel reader now classifies the detected GPU's architecture (Alchemist / Battlemage / Xe-LPG / Xe-LPG+ / Iris Xe / older integrated) and surfaces it in `GpuInfo.detail` as:

- `detail["Architecture"]` — e.g. `"Alchemist (Xe-HPG, A-series)"`
- `detail["SYCL Capable"]` — `"Yes"` / `"No"` / `"Unknown"`

This mirrors the `INTEL_GPU_PATTERNS` table in [lablup/backend.ai-go](https://github.com/lablup/backend.ai-go)'s `src-tauri/src/engine/gpu.rs` so downstream consumers (Backend.AI's accelerator-selection layer, llama.cpp SYCL backend picker, etc.) can rely on all-smi as their single source of truth without re-implementing the same name-pattern table.

The classifier is exposed publicly via `all_smi::device::readers::intel_gpu_names::{IntelArchitecture, classify_intel_architecture}` on both Linux and Windows. The `IntelArchitecture` enum carries three helpers: `is_sycl_capable()` (bool, matches backend.ai-go's `check_intel_sycl_support`), `label()` (`"Alchemist (Xe-HPG, A-series)"` etc., used in the detail map), and `sycl_capable_label()` which distinguishes `"Unknown"` from `"No"` so consumers can tell "we know this GPU is not SYCL-capable" from "we couldn't classify this GPU at all".

The matcher uses pure-Rust string analysis with a load-bearing pattern order: older HD/UHD integrated first (so they don't accidentally match later Xe rules), then Battlemage (since `Intel Arc B580` contains `arc`), then Alchemist (`arc` + `a3`/`a5`/`a7`), then Lunar Lake (handles both explicit `lunarlake` / `lunar lake` names and the Arc 140V/130V iGPU), then generic Xe-LPG (Meteor Lake's `Intel Arc Graphics` iGPU with no model number), then Iris Xe. The trickiest disambiguation — `Intel Arc Graphics` (Meteor Lake iGPU → `XeLpg`) vs `Intel Arc A770 Graphics` (discrete Alchemist → `Alchemist`) vs `Intel Arc 140V Graphics` (Lunar Lake iGPU → `XeLpgPlus`) — is covered by dedicated tests.

## v1 scope limitations (documented in code + below)

- **Utilization is always reported as `0.0`** with `detail["Utilization"] = "Requires intel_gpu_top (perf engine counters)"`. Real engine-busy% requires reading `engine/*/busy` perf counters and tracking deltas across polling intervals — that's a follow-up so we don't fabricate a value.
- **Per-process GPU memory accounting** is empty. `/proc/<pid>/fdinfo/*` DRM client parsing differs between `i915` and `xe` and also needs delta tracking; deferred.
- **Level Zero integration is deferred.** The Linux reader is sysfs-only and the Windows reader is WMI-only — no new external library dependencies. Adding Level Zero (`libze_intel_gpu`) for compute-capable metrics is the documented next step.
- **Windows metrics are limited to what WMI surfaces**, matching the AMD-on-Windows reader: only `AdapterRAM` (with the same 4 GB / 32-bit caveat warning), driver version, video processor, status, DAC type. Utilization / temperature / fine-grained power need Level Zero or `xpu-smi` on Windows too.
- **No new external library dependencies** were added to `Cargo.toml`.

## Test plan

- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo test --lib device::readers::intel_gpu_linux` (14 passed, includes the Architecture / SYCL assertions for both discrete A770 and Meteor Lake iGPU)
- [x] `cargo test --lib device::readers::intel_gpu_sysfs` (10 passed)
- [x] `cargo test --lib device::readers::intel_gpu_names` (15 passed — every backend.ai-go fixture exercised: A-series → Alchemist, B-series + explicit Battlemage → Battlemage, Arc 140V/130V + LunarLake → XeLpgPlus, Intel Arc Graphics → XeLpg, Iris Xe → IrisXe, HD/UHD → OlderIntegrated/not-SYCL, unknown → Unknown)
- [x] `cargo test --bin all-smi-mock-server --features mock intel_gpu` (7 passed)
- [x] `cargo test --lib device::platform_detection::introspection` (2 passed, including the updated `snapshot_is_default_friendly` covering the new `intel_gpu` field)
- [x] Regression: `cargo test --lib device::readers` (114 passed) and `cargo test --bin all-smi-mock-server --features mock` (62 passed)

Closes #244
