### PR TITLE
fix: harden Intel Level Zero and fdinfo paths

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -597,17 +597,9 @@ mod tests {
         assert!(!cfg.cost_visible(), "show_cost=false must hide cost");
     }
 
-    /// Shared mutex used by the env-var tests to serialize
-    /// mutations of `ALL_SMI_ENERGY_*`. Cargo runs test fns on
-    /// multiple threads by default; without this lock, the `set_var`
-    /// / `remove_var` calls from two tests would race and either
-    /// observe each other's partial state or observe the value the
-    /// OTHER test was mid-clearing.
-    static ENERGY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     #[test]
     fn energy_config_env_overrides_apply() {
-        let _guard = ENERGY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::common::test_env::lock_env();
         let keys = [
             "ALL_SMI_ENERGY_PRICE",
             "ALL_SMI_ENERGY_CURRENCY",
@@ -643,7 +635,7 @@ mod tests {
 
     #[test]
     fn energy_config_gap_seconds_env_clamped_to_range() {
-        let _guard = ENERGY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::common::test_env::lock_env();
         // A value beyond the 1-hour cap must be ignored so the default
         // survives instead of allowing an hours-long hold-last window.
         unsafe {
@@ -671,7 +663,7 @@ mod tests {
 
     #[test]
     fn energy_config_invalid_price_env_ignored() {
-        let _guard = ENERGY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::common::test_env::lock_env();
         unsafe {
             std::env::remove_var("ALL_SMI_ENERGY_PRICE");
             std::env::set_var("ALL_SMI_ENERGY_PRICE", "not-a-number");

--- a/src/common/config_file_tests.rs
+++ b/src/common/config_file_tests.rs
@@ -17,11 +17,6 @@
 
 use super::*;
 
-/// Shared mutex used by env-var tests. Cargo runs tests on multiple
-/// threads by default; without this lock the `set_var`/`remove_var`
-/// calls from concurrent tests race each other.
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 fn clear_env() {
     let keys = [
         "ALL_SMI_GENERAL_DEFAULT_MODE",
@@ -146,7 +141,7 @@ fn parse_toml_fails_on_invalid_syntax() {
 
 #[test]
 fn load_with_missing_path_returns_error() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let path = std::path::Path::new("/nonexistent/all-smi/fake-test-config.toml");
     let result = load(Some(path));
@@ -158,7 +153,7 @@ fn load_with_missing_path_returns_error() {
 
 #[test]
 fn load_without_path_uses_defaults_when_no_file() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     // We pass `None` to `load`. If no candidate file exists we get
     // compiled defaults; if one happens to exist on the test host we
@@ -172,7 +167,7 @@ fn load_without_path_uses_defaults_when_no_file() {
 
 #[test]
 fn load_with_explicit_file_applies_values() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -213,7 +208,7 @@ currency = "EUR"
 
 #[test]
 fn schema_version_mismatch_rejected() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -233,7 +228,7 @@ fn schema_version_mismatch_rejected() {
 
 #[test]
 fn semantic_error_on_invalid_theme() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -247,7 +242,7 @@ fn semantic_error_on_invalid_theme() {
 
 #[test]
 fn semantic_error_on_negative_price() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -258,7 +253,7 @@ fn semantic_error_on_negative_price() {
 
 #[test]
 fn validate_file_strict_rejects_unknown() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -271,7 +266,7 @@ fn validate_file_strict_rejects_unknown() {
 
 #[test]
 fn env_override_wins_over_file() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -291,7 +286,7 @@ fn env_override_wins_over_file() {
 
 #[test]
 fn legacy_alert_env_alias_still_works() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     unsafe {
         std::env::set_var("ALL_SMI_ALERT_TEMP", "77");
@@ -310,7 +305,7 @@ fn legacy_alert_env_alias_still_works() {
 
 #[test]
 fn legacy_energy_env_alias_still_works() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     unsafe {
         std::env::set_var("ALL_SMI_ENERGY_PRICE", "0.25");
@@ -327,7 +322,7 @@ fn legacy_energy_env_alias_still_works() {
 
 #[test]
 fn canonical_energy_env_wins_over_legacy() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     unsafe {
         std::env::set_var("ALL_SMI_ENERGY_PRICE", "0.10"); // legacy
@@ -343,7 +338,7 @@ fn canonical_energy_env_wins_over_legacy() {
 
 #[test]
 fn unknown_keys_captured_in_settings() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -371,7 +366,7 @@ fn unknown_keys_captured_in_settings() {
 
 #[test]
 fn api_socket_as_bool_and_path() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
@@ -392,7 +387,7 @@ fn api_socket_as_bool_and_path() {
 
 #[test]
 fn malformed_toml_returns_parse_error() {
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::common::test_env::lock_env();
     clear_env();
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");

--- a/src/common/test_env.rs
+++ b/src/common/test_env.rs
@@ -12,23 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "cli")]
-pub mod cache_migration;
-pub mod config;
-#[cfg(feature = "cli")]
-pub mod config_apply;
-#[cfg(feature = "cli")]
-pub mod config_env;
-#[cfg(feature = "cli")]
-pub mod config_file;
-#[cfg(feature = "cli")]
-pub mod config_schema;
-pub mod error_handling;
-#[cfg(feature = "cli")]
-pub mod paths;
-#[cfg(feature = "cli")]
-pub mod progress_bar;
-#[cfg(feature = "cli")]
-pub mod secure_write;
-#[cfg(test)]
-pub(crate) mod test_env;
+//! Shared test-only process environment lock.
+
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}

--- a/src/device/readers/intel_gpu_fdinfo.rs
+++ b/src/device/readers/intel_gpu_fdinfo.rs
@@ -61,6 +61,10 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+#[path = "intel_gpu_fdinfo/io.rs"]
+mod io;
+use io::read_fdinfo_to_string;
+
 /// Hard cap on process enumeration. Matches the spirit of
 /// `MAX_DEVICES = 256` in [`crate::device::readers::common_cache`] —
 /// defends against a runaway `/proc` walk on degenerate hosts. A real
@@ -407,9 +411,8 @@ pub fn collect_intel_gpu_processes(
         process_count += 1;
 
         for fd in fds {
-            let content = match std::fs::read_to_string(&fd.fdinfo_path) {
-                Ok(c) => c,
-                Err(_) => continue, // permission / TOCTOU process exit
+            let Some(content) = read_fdinfo_to_string(&fd.fdinfo_path) else {
+                continue; // permission / TOCTOU process exit / oversized fdinfo
             };
             let Some(info) = parse_fdinfo(&content) else {
                 continue;

--- a/src/device/readers/intel_gpu_fdinfo/io.rs
+++ b/src/device/readers/intel_gpu_fdinfo/io.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded fdinfo file reads for the Intel DRM client walker.
+
+use std::io::Read;
+use std::path::Path;
+
+/// Real DRM fdinfo files are a few kilobytes at most. Keep a generous
+/// cap so a future kernel change or synthetic procfs cannot make one
+/// file read allocate without bound during a process scan.
+const MAX_FDINFO_BYTES: u64 = 64 * 1024;
+
+pub(super) fn read_fdinfo_to_string(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut limited = file.take(MAX_FDINFO_BYTES + 1);
+    let mut content = String::new();
+    limited.read_to_string(&mut content).ok()?;
+    if content.len() as u64 > MAX_FDINFO_BYTES {
+        return None;
+    }
+    Some(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_fdinfo_to_string_reads_normal_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fdinfo");
+        std::fs::write(&path, "drm-driver: i915\n").unwrap();
+
+        assert_eq!(
+            read_fdinfo_to_string(&path).as_deref(),
+            Some("drm-driver: i915\n")
+        );
+    }
+
+    #[test]
+    fn read_fdinfo_to_string_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fdinfo");
+        let oversized = vec![b'x'; (MAX_FDINFO_BYTES + 1) as usize];
+        std::fs::write(&path, oversized).unwrap();
+
+        assert!(read_fdinfo_to_string(&path).is_none());
+    }
+}

--- a/src/device/readers/intel_gpu_level_zero.rs
+++ b/src/device/readers/intel_gpu_level_zero.rs
@@ -76,6 +76,7 @@ mod tests;
 #[allow(unused_imports)]
 // `normalise_pci_bdf` is consumed by the per-OS readers wired in commits 3-4.
 pub use loader::normalise_pci_bdf;
+pub use loader::prepare_sysman_env_for_legacy_runtime;
 pub(crate) use loader::with_runtime;
 pub(crate) use refresh::{
     EngineSample, PowerSample, populate_engine_samples, populate_power_samples, refresh_engines,

--- a/src/device/readers/intel_gpu_level_zero/ffi.rs
+++ b/src/device/readers/intel_gpu_level_zero/ffi.rs
@@ -222,6 +222,12 @@ pub struct zes_power_energy_counter_t {
 
 pub type ZeInit = unsafe extern "C" fn(flags: u32) -> i32;
 
+/// Optional modern Sysman initialiser. Newer Level Zero loaders expose
+/// this so callers do not need to mutate `ZES_ENABLE_SYSMAN` before
+/// `zeInit`; older loaders may not export it, so the dynamic resolver
+/// treats this symbol as optional.
+pub type ZesInit = unsafe extern "C" fn(flags: u32) -> i32;
+
 pub type ZeDriverGet =
     unsafe extern "C" fn(p_count: *mut u32, p_drivers: *mut ze_driver_handle_t) -> i32;
 

--- a/src/device/readers/intel_gpu_level_zero/loader.rs
+++ b/src/device/readers/intel_gpu_level_zero/loader.rs
@@ -87,20 +87,45 @@ pub(crate) const LIBZE_PATHS: &[&str] = &[
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
 pub(crate) const LIBZE_PATHS: &[&str] = &[];
 
-/// Sysman is initialised by setting `ZES_ENABLE_SYSMAN=1` **before**
-/// the first `zeInit` call. See
+/// Legacy Sysman initialisation environment key. Newer loaders expose
+/// `zesInit`; older ones require `ZES_ENABLE_SYSMAN=1` **before** the
+/// first `zeInit` call. See
 /// <https://oneapi-src.github.io/level-zero-spec/level-zero/latest/sysman/PROG.html#using-sysman>.
 ///
-/// Issue #248 design notes picked the env-var route (Option A) over
-/// `zesInit` for broader compatibility — older Intel driver stacks ship
-/// a loader that exports `zeInit` but not `zesInit`.
+/// The CLI binary sets this at process start for legacy runtime
+/// compatibility. Library callers can either call `zesInit` through a
+/// modern loader (handled automatically here) or set this environment
+/// variable before starting threads / invoking all-smi.
 pub(crate) const SYSMAN_ENV_KEY: &str = "ZES_ENABLE_SYSMAN";
 
-/// One-shot env-var injector. Setting an env var inside a process is
-/// `unsafe` under the 2024 edition because other threads could read
-/// the environment concurrently; we therefore gate the call behind
-/// [`Once`] and ensure it runs strictly before the first `zeInit`.
+/// One-shot env-var injector used only by callers that can prove they
+/// are still in process startup.
 static SYSMAN_ENV_INIT: Once = Once::new();
+
+/// Enable Sysman for legacy Level Zero loaders that do not export
+/// `zesInit`.
+///
+/// Modern loaders are initialised through `zesInit` in
+/// [`initialize_runtime`], so this function exists only to preserve
+/// compatibility with older Intel runtimes that still require the
+/// environment-variable path.
+///
+/// # Safety
+///
+/// Must be called during single-threaded process startup, before any
+/// other thread can concurrently read or mutate the process
+/// environment. This is why the CLI calls it from `main()` before
+/// constructing a Tokio runtime or spawning signal-handler tasks.
+pub unsafe fn prepare_sysman_env_for_legacy_runtime() {
+    SYSMAN_ENV_INIT.call_once(|| {
+        // SAFETY: upheld by this function's contract.
+        unsafe {
+            if std::env::var_os(SYSMAN_ENV_KEY).is_none() {
+                std::env::set_var(SYSMAN_ENV_KEY, "1");
+            }
+        }
+    });
+}
 
 /// Process-wide initialisation latch. First caller pays the dlopen +
 /// `zeInit` + driver/device enumeration cost; later callers reuse the
@@ -129,6 +154,7 @@ unsafe impl Sync for LzRuntime {}
 #[derive(Clone, Copy)]
 pub(crate) struct LzApi {
     pub(crate) ze_init: ffi::ZeInit,
+    pub(crate) zes_init: Option<ffi::ZesInit>,
     pub(crate) ze_driver_get: ffi::ZeDriverGet,
     pub(crate) ze_device_get: ffi::ZeDeviceGet,
     pub(crate) zes_device_pci_get_properties: ffi::ZesDevicePciGetProperties,
@@ -191,6 +217,8 @@ pub unsafe fn try_load_library(path: &str) -> Option<LoadedLibrary> {
         // means the runtime does not match our expected API surface;
         // we conservatively refuse to bind.
         let ze_init: Symbol<ffi::ZeInit> = lib.get(b"zeInit\0").ok()?;
+        let zes_init: Option<ffi::ZesInit> =
+            lib.get::<ffi::ZesInit>(b"zesInit\0").ok().map(|sym| *sym);
         let ze_driver_get: Symbol<ffi::ZeDriverGet> = lib.get(b"zeDriverGet\0").ok()?;
         let ze_device_get: Symbol<ffi::ZeDeviceGet> = lib.get(b"zeDeviceGet\0").ok()?;
         let zes_device_pci_get_properties: Symbol<ffi::ZesDevicePciGetProperties> =
@@ -208,6 +236,7 @@ pub unsafe fn try_load_library(path: &str) -> Option<LoadedLibrary> {
 
         let api = LzApi {
             ze_init: *ze_init,
+            zes_init,
             ze_driver_get: *ze_driver_get,
             ze_device_get: *ze_device_get,
             zes_device_pci_get_properties: *zes_device_pci_get_properties,
@@ -240,20 +269,6 @@ pub(crate) fn with_runtime<R>(f: impl FnOnce(&LzRuntime) -> R) -> Option<R> {
 }
 
 fn initialize_runtime() -> Option<LzRuntime> {
-    // Set ZES_ENABLE_SYSMAN before any L0 call, exactly once.
-    SYSMAN_ENV_INIT.call_once(|| {
-        // SAFETY: Inside `Once::call_once`, so no L0 thread has begun
-        // yet (every L0 caller goes through `ensure_runtime`, which is
-        // what we are inside of). We only set the variable when it is
-        // currently unset so we never clobber an operator's
-        // intentional override.
-        unsafe {
-            if std::env::var_os(SYSMAN_ENV_KEY).is_none() {
-                std::env::set_var(SYSMAN_ENV_KEY, "1");
-            }
-        }
-    });
-
     // Try every candidate path until one loads and resolves all
     // symbols. A failure here is the normal case on a host without the
     // L0 runtime — we log at debug, never warn or error.
@@ -270,6 +285,15 @@ fn initialize_runtime() -> Option<LzRuntime> {
     let loaded = loaded?;
 
     let api = loaded.api;
+    let sysman_env_enabled = std::env::var(SYSMAN_ENV_KEY)
+        .map(|v| v == "1")
+        .unwrap_or(false);
+    if api.zes_init.is_none() && !sysman_env_enabled {
+        debug!(
+            "Level Zero: loader does not expose zesInit and {SYSMAN_ENV_KEY}=1 was not set before zeInit; degrading"
+        );
+        return None;
+    }
 
     // SAFETY: api function pointers were resolved from the library
     // above and `lib` is still alive (we own it). Their C signatures
@@ -278,6 +302,18 @@ fn initialize_runtime() -> Option<LzRuntime> {
     if init_res != ffi::ZE_RESULT_SUCCESS {
         debug!("Level Zero: zeInit returned {init_res}; degrading");
         return None;
+    }
+
+    if let Some(zes_init) = api.zes_init {
+        // SAFETY: optional symbol was resolved from the same live
+        // Level Zero loader as the other function pointers. The spec
+        // allows calling `zesInit` before or after `zeInit`, but it
+        // must happen before any other Sysman function.
+        let sysman_res = unsafe { (zes_init)(ffi::ZE_INIT_FLAG_DEFAULT) };
+        if sysman_res != ffi::ZE_RESULT_SUCCESS {
+            debug!("Level Zero: zesInit returned {sysman_res}; degrading");
+            return None;
+        }
     }
 
     let devices_by_pci = enumerate_devices(&api);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,4 +205,6 @@ pub mod common {
     /// Shared secure file-write helper (O_NOFOLLOW + 0o600).
     #[cfg(feature = "cli")]
     pub mod secure_write;
+    #[cfg(test)]
+    pub(crate) mod test_env;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,22 @@ fn main() {
     // Set up panic handler for cleanup (cross-platform)
     setup_panic_handlers();
 
+    // Level Zero Sysman can be initialised with `zesInit` on modern
+    // runtimes, but older Intel loaders still require
+    // ZES_ENABLE_SYSMAN=1 before the first `zeInit`. Do that while the
+    // process is still single-threaded so Rust 2024's environment
+    // mutation safety contract is upheld.
+    #[cfg(all(
+        any(target_os = "linux", target_os = "windows"),
+        feature = "level_zero"
+    ))]
+    unsafe {
+        // SAFETY: `main` has not created the Tokio runtime or spawned
+        // signal-handler/background threads yet, and this runs before
+        // any Level Zero loader call.
+        device::readers::intel_gpu_level_zero::prepare_sysman_env_for_legacy_runtime();
+    }
+
     // Best-effort one-time migration of legacy `~/.cache/all-smi/...`
     // data to the platform-correct cache dir (issue #229). Runs before
     // any subcommand touches the cache so the new root is the one each


### PR DESCRIPTION
## Summary

This is the follow-up hardening PR after reviewing the merged Intel client GPU work from issues #244, #246, #247, and #248, implemented through PRs #245, #249, #250, and #251.

The merged implementation is broadly aligned with the intended direction:

- Intel Linux/Windows baseline readers are present in the default build.
- Linux Intel utilization and process memory use sysfs / DRM fdinfo fallbacks without requiring Level Zero.
- Level Zero remains opt-in behind the `level_zero` feature and dynamically loads the Intel loader at runtime.
- The merged Level Zero code already fixed the earlier high-risk FFI issues around driver-reported count caps and Sysman struct layout/constants.

This PR fixes the remaining hardening gaps found during the post-merge audit.

## Changes

### Intel fdinfo process scan hardening

- Replaces unbounded `std::fs::read_to_string()` on `/proc/<pid>/fdinfo/*` with a bounded helper.
- Caps each fdinfo read at 64 KiB, which is far above real DRM fdinfo sizes but prevents pathological procfs or synthetic test inputs from forcing unbounded allocation during process scans.
- Adds unit coverage for normal and oversized fdinfo reads.

### Level Zero Sysman initialization hardening

- Resolves optional `zesInit` from the dynamically loaded Level Zero loader.
- Uses `zesInit` for modern runtimes instead of relying only on `ZES_ENABLE_SYSMAN`.
- Moves the legacy `ZES_ENABLE_SYSMAN=1` mutation out of lazy runtime initialization and into CLI startup, before Tokio runtime creation or signal/background task spawning.
- Keeps the `unsafe` environment mutation behind an explicit startup-only function with a documented safety contract.
- If a library caller does not use the CLI startup path and the loader lacks `zesInit`, the Level Zero backend now degrades cleanly instead of mutating the process environment after threads may exist.

### Test stability hardening

- Shares one test-only environment lock between `common::config` and `common::config_file` tests.
- This fixes a real `cargo test` race where parallel tests mutated overlapping `ALL_SMI_ENERGY_*` variables with separate mutexes.

## Build/default-feature behavior verified

The default build still does **not** include the Level Zero backend. I rebuilt `all-smi` without `--features level_zero` and verified the binary contains no strings matching:

- `libze_loader`
- `ze_loader`
- `ZES_ENABLE_SYSMAN`
- `zesInit`
- `zesDevice`
- `Level Zero`

So the current behavior remains:

- AMD Linux glibc support is included by default through the target-specific `libamdgpu_top` dependency.
- Intel baseline Linux/Windows readers are included by default.
- Intel Level Zero Sysman advanced metrics remain opt-in via `--features level_zero`.

## Follow-up design issue

A larger Sysman-first metric-source redesign is intentionally not implemented here because it changes metric precedence and expands the Level Zero FFI surface. I filed that as #252 with detailed implementation guidance.

The intended long-term policy is:

- temperature: Sysman -> hwmon -> unavailable
- power: Sysman energy counter delta -> hwmon power -> unavailable
- memory: Sysman memory state -> DRM/sysfs -> unavailable
- engine util: Sysman engine activity delta -> DRM/sysfs/perf fallback -> unavailable
- fan: hwmon -> Sysman fan if available -> unavailable

## Validation

Passed locally:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --lib --tests`
- `cargo check --lib --tests --features level_zero`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo clippy --lib --tests --features level_zero -- -D warnings`
- `cargo clippy -- -D warnings`
- `cargo clippy --features level_zero -- -D warnings`
- `cargo test --lib common::config -- --nocapture`
- `cargo test --lib common::config_file -- --nocapture`
- `cargo test --lib device::readers::intel_gpu_fdinfo`
- `cargo test --lib device::readers::intel_gpu_level_zero --features level_zero`
- `cargo build --bin all-smi`
- default binary Level Zero string audit with `strings target/debug/all-smi | rg -i "libze_loader|ze_loader|ZES_ENABLE_SYSMAN|zesInit|zesDevice|Level Zero"` returned no matches
- `cargo test --verbose`

Note: the local commit hook attempted an additional `furiosa` feature build and failed before commit completion logs with a host toolchain/sysroot issue from `furiosa-smi-rs` bindgen (`stdarg.h` not found). That path is unrelated to this Intel hardening PR; the commit was still created, and the default plus Level Zero validation above passed.

Refs #244.
Refs #246.
Refs #247.
Refs #248.
Refs #251.
Refs #252.
