### PR TITLE
chore: bump sysinfo to 0.39 and raise MSRV to Rust 1.95

### DIFF
--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -25,14 +25,14 @@ jobs:
       matrix:
         include:
           - distro: jammy
-            vendor_rust: "1.93.0"
-            toolchain_source: "Requires Rust 1.93+ from ~lablup/+archive/ubuntu/rustc-release"
+            vendor_rust: "1.95.0"
+            toolchain_source: "Requires Rust 1.95+ from ~lablup/+archive/ubuntu/rustc-release"
           - distro: noble
-            vendor_rust: "1.93.0"
-            toolchain_source: "Requires Rust 1.93+ from ~lablup/+archive/ubuntu/rustc-release"
+            vendor_rust: "1.95.0"
+            toolchain_source: "Requires Rust 1.95+ from ~lablup/+archive/ubuntu/rustc-release"
           - distro: resolute
-            vendor_rust: "1.93.0"
-            toolchain_source: "Requires a Rust 1.93+ toolchain"
+            vendor_rust: "1.95.0"
+            toolchain_source: "Requires a Rust 1.95+ toolchain"
 
     steps:
     - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,12 +2711,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2717,6 +2754,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4305,15 +4353,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["cli", "rust"]
 categories = ["command-line-utilities"]
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.95"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -28,7 +28,7 @@ reqwest = { version = "0.13", features = ["json"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 regex = "1.12.2"
-sysinfo = "0.38"
+sysinfo = "0.39"
 anyhow = { version = "1.0.100", optional = true }
 hyper = { version = "1.9.0", features = ["full"], optional = true }
 hyper-util = { version = "0.1.18", features = ["full"], optional = true }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for optimal image size
-FROM rust:1.93-slim AS builder
+FROM rust:1.95-slim AS builder
 
 # Install system dependencies for cross-compilation
 RUN apt-get update && apt-get install -y \

--- a/debian/README.packaging
+++ b/debian/README.packaging
@@ -10,8 +10,8 @@ Launchpad build environments do NOT have internet access. This means:
 
 ### Build Dependencies
 The following packages are required and must be available in the Ubuntu repository:
-- `rustc-1.93 | rustc-1.94 | rustc-1.95 | rustc (>= 1.93)` - Rust compiler for the current dependency set
-- `cargo-1.93 | cargo-1.94 | cargo-1.95 | cargo (>= 1.93)` - Cargo for the current lockfile/dependency set
+- `rustc-1.95 | rustc (>= 1.95)` - Rust compiler for the current dependency set
+- `cargo-1.95 | cargo (>= 1.95)` - Cargo for the current lockfile/dependency set
 - `pkg-config` - For finding system libraries
 - `libssl-dev` - OpenSSL development files
 - `protobuf-compiler` - Protocol buffer compiler
@@ -19,15 +19,15 @@ The following packages are required and must be available in the Ubuntu reposito
 - `cmake` - Build system
 
 ### Rust Version Requirements
-This project currently requires Rust 1.93 or newer. This means:
-- Ubuntu 22.04 (Jammy): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA (provides `rustc-1.93`)
-- Ubuntu 24.04 (Noble): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA (provides `rustc-1.93`)
-- Ubuntu 26.04 (Resolute): ships `rustc`/`cargo` 1.93 in the archive — no extra PPA required
+This project currently requires Rust 1.95 or newer. This means:
+- Ubuntu 22.04 (Jammy): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA (provides `rustc-1.95`)
+- Ubuntu 24.04 (Noble): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA (provides `rustc-1.95`)
+- Ubuntu 26.04 (Resolute): its archived `rustc`/`cargo` (1.93) is below the new 1.95 floor, so it also needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA (provides `rustc-1.95`)
 
 ### Build Process
 1. The GitHub Actions workflow vendors dependencies into `vendor/`
 2. `debian/sanitize-vendor.py` removes hidden/orig checksum entries that break Launchpad source tarballs
-3. The debian/rules file auto-detects the newest available toolchain among `rustc-1.95` / `rustc-1.94` / `rustc-1.93`, falling back to the unversioned `rustc` (a `>= 1.93` guard validates whichever is selected)
+3. The debian/rules file auto-detects an available toolchain, preferring `rustc-1.95` and falling back to the unversioned `rustc` (a `>= 1.95` guard validates whichever is selected)
 4. The project is built with `cargo build --release --frozen`
 5. The binary is installed to `/usr/bin/all-smi`
 
@@ -36,7 +36,7 @@ If the build fails on Launchpad:
 1. Check the build log for the exact error
 2. Common issues:
    - Missing build dependencies: Add them to debian/control
-   - Rust version incompatibility: Ensure Rust 1.93+ is available
+   - Rust version incompatibility: Ensure Rust 1.95+ is available
    - Network access attempts: Remove any code that downloads dependencies
    - Vendored checksum mismatch: Re-run the vendor sanitization step
    - Permission issues: Ensure proper file permissions in debian/rules

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.93 | rustc-1.94 | rustc-1.95 | rustc (>= 1.93),
-               cargo-1.93 | cargo-1.94 | cargo-1.95 | cargo (>= 1.93),
+               rustc-1.95 | rustc (>= 1.95),
+               cargo-1.95 | cargo (>= 1.95),
                pkg-config,
                libssl-dev,
                protobuf-compiler,

--- a/debian/control.source
+++ b/debian/control.source
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.93 | rustc-1.94 | rustc-1.95 | rustc (>= 1.93),
-               cargo-1.93 | cargo-1.94 | cargo-1.95 | cargo (>= 1.93),
+               rustc-1.95 | rustc (>= 1.95),
+               cargo-1.95 | cargo (>= 1.95),
                libssl-dev,
                pkg-config,
                protobuf-compiler,

--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
-CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+RUSTC := $(shell for c in rustc-1.95 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
-		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
-		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad
+++ b/debian/rules.launchpad
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
-CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+RUSTC := $(shell for c in rustc-1.95 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
-		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
-		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad-simple
+++ b/debian/rules.launchpad-simple
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
-CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+RUSTC := $(shell for c in rustc-1.95 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@

--- a/debian/rules.source
+++ b/debian/rules.source
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell for c in rustc-1.95 rustc-1.94 rustc-1.93 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
-CARGO := $(shell for c in cargo-1.95 cargo-1.94 cargo-1.93 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+RUSTC := $(shell for c in rustc-1.95 rustc; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
+CARGO := $(shell for c in cargo-1.95 cargo; do command -v $$c >/dev/null 2>&1 && { printf '%s' "$$c"; break; }; done)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.93 || { \
-		echo "rustc 1.93+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.93 || { \
-		echo "cargo 1.93+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 


### PR DESCRIPTION
## Summary

`sysinfo` 0.39 raised its MSRV to Rust 1.95 (0.38 required 1.88), so adopting it requires moving the project MSRV, the Docker build base, and every Launchpad PPA toolchain reference from 1.93 to 1.95. The `~lablup/+archive/ubuntu/rustc-release` dependency PPA now provides `rustc-1.95`.

`sysinfo` 0.39's only breaking change is that MSRV bump; none of the public APIs this codebase uses changed, so no source edits were needed.

## Changes

- `Cargo.toml`: `sysinfo` 0.38 -> 0.39, `rust-version` 1.93 -> 1.95 (plus `Cargo.lock`, which moves to sysinfo 0.39.2 and pulls in its new objc2/dispatch2 deps)
- `Dockerfile`: `rust:1.93-slim` -> `rust:1.95-slim`
- `.github/workflows/launchpad_ppa.yml`: `vendor_rust` 1.93.0 -> 1.95.0 (3 matrix entries) and the "Rust 1.95+" toolchain descriptions
- `debian/control` + `debian/control.source`: build-deps to `rustc-1.95 | rustc (>= 1.95)` and `cargo-1.95 | cargo (>= 1.95)`
- `debian/rules`, `rules.source`, `rules.launchpad`, `rules.launchpad-simple`: toolchain detection prefers `rustc-1.95`/`cargo-1.95`, version guard requires `>= 1.95`
- `debian/README.packaging`: documents the 1.95 requirement; the Ubuntu 26.04 (Resolute) note now reflects that its archived 1.93 is below the new floor and also needs the PPA
- Historical `debian/changelog` entries left intact

## Verification (local Rust 1.95.0 toolchain)

- `cargo build --release`: Finished
- `cargo clippy --all-targets`: no warnings
- `cargo test`: all suites pass (1003 + 1169 + smaller suites + 23 doctests, 0 failed)
- No remaining 1.93 toolchain references (only the historical changelog and the factual Resolute note)

Note: `release.yml` already uses `dtolnay/rust-toolchain@stable` (currently 1.95), so it needs no pin change.

Closes #257
