### PR TITLE
fix: align Docker toolchain with current MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
     name: Docker Build Check
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/launchpad_ppa.yml
+++ b/.github/workflows/launchpad_ppa.yml
@@ -25,14 +25,14 @@ jobs:
       matrix:
         include:
           - distro: jammy
-            vendor_rust: "1.92.0"
+            vendor_rust: "1.95.0"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: noble
-            vendor_rust: "1.92.0"
+            vendor_rust: "1.95.0"
             toolchain_source: "Requires backend-ai PPA dependency on ~lablup/+archive/ubuntu/rustc-release"
           - distro: resolute
-            vendor_rust: "1.92.0"
-            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.92+ toolchain"
+            vendor_rust: "1.95.0"
+            toolchain_source: "Uses the official Ubuntu 26.04 archive Rust 1.95+ toolchain"
 
     steps:
     - name: Checkout code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["cli", "rust"]
 categories = ["command-line-utilities"]
 edition = "2024"
+rust-version = "1.95"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for optimal image size
-FROM rust:1.88-slim as builder
+FROM rust:1.95-slim AS builder
 
 # Install system dependencies for cross-compilation
 RUN apt-get update && apt-get install -y \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ docker-dev:
 		-v "$(PWD)":/all-smi \
 		-v "$(PWD)/tests/.cargo-cache":/usr/local/cargo/registry \
 		-w /all-smi \
-		rust:1.88 \
+		rust:1.95 \
 		/bin/bash -c "apt-get update && apt-get install -y pkg-config protobuf-compiler && \
 		bash"
 
@@ -53,7 +53,7 @@ docker-test-container-api:
 		-v "$(PWD)":/all-smi \
 		-v "$(PWD)/tests/.cargo-cache":/usr/local/cargo/registry \
 		-w /all-smi \
-		rust:1.88 \
+		rust:1.95 \
 		/bin/bash -c "apt-get update && apt-get install -y pkg-config protobuf-compiler && \
 		cargo build --release && \
 		./target/release/all-smi api --port 9090"
@@ -64,7 +64,7 @@ docker-test-container-view:
 		-v "$(PWD)":/all-smi \
 		-v "$(PWD)/tests/.cargo-cache":/usr/local/cargo/registry \
 		-w /all-smi \
-		rust:1.88 \
+		rust:1.95 \
 		/bin/bash -c "apt-get update && apt-get install -y pkg-config protobuf-compiler && \
 		cargo build --release && \
 		./target/release/all-smi local"

--- a/debian/README.packaging
+++ b/debian/README.packaging
@@ -10,8 +10,8 @@ Launchpad build environments do NOT have internet access. This means:
 
 ### Build Dependencies
 The following packages are required and must be available in the Ubuntu repository:
-- `rustc-1.92 | rustc (>= 1.92)` - Rust compiler for the current dependency set
-- `cargo-1.92 | cargo (>= 1.92)` - Cargo for the current lockfile/dependency set
+- `rustc-1.95 | rustc (>= 1.95)` - Rust compiler for the current dependency set
+- `cargo-1.95 | cargo (>= 1.95)` - Cargo for the current lockfile/dependency set
 - `pkg-config` - For finding system libraries
 - `libssl-dev` - OpenSSL development files
 - `protobuf-compiler` - Protocol buffer compiler
@@ -19,7 +19,7 @@ The following packages are required and must be available in the Ubuntu reposito
 - `cmake` - Build system
 
 ### Rust Version Requirements
-This project currently requires Rust 1.92 or newer. This means:
+This project currently requires Rust 1.95 or newer. This means:
 - Ubuntu 22.04 (Jammy): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA
 - Ubuntu 24.04 (Noble): needs the `~lablup/+archive/ubuntu/rustc-release` dependency PPA
 - Ubuntu 26.04 (Resolute): uses the official Ubuntu archive Rust toolchain
@@ -27,7 +27,7 @@ This project currently requires Rust 1.92 or newer. This means:
 ### Build Process
 1. The GitHub Actions workflow vendors dependencies into `vendor/`
 2. `debian/sanitize-vendor.py` removes hidden/orig checksum entries that break Launchpad source tarballs
-3. The debian/rules file uses system-provided `rustc-1.92` / `cargo-1.92` when present
+3. The debian/rules file uses system-provided `rustc-1.95` / `cargo-1.95` when present
 4. The project is built with `cargo build --release --frozen`
 5. The binary is installed to `/usr/bin/all-smi`
 
@@ -36,7 +36,7 @@ If the build fails on Launchpad:
 1. Check the build log for the exact error
 2. Common issues:
    - Missing build dependencies: Add them to debian/control
-   - Rust version incompatibility: Ensure Rust 1.92+ is available
+   - Rust version incompatibility: Ensure Rust 1.95+ is available
    - Network access attempts: Remove any code that downloads dependencies
    - Vendored checksum mismatch: Re-run the vendor sanitization step
    - Permission issues: Ensure proper file permissions in debian/rules

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.92 | rustc (>= 1.92),
-               cargo-1.92 | cargo (>= 1.92),
+               rustc-1.95 | rustc (>= 1.95),
+               cargo-1.95 | cargo (>= 1.95),
                pkg-config,
                libssl-dev,
                protobuf-compiler,

--- a/debian/control.source
+++ b/debian/control.source
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Jeongkyu Shin <jshin@lablup.com>
 Build-Depends: debhelper-compat (= 13),
                build-essential,
-               rustc-1.92 | rustc (>= 1.92),
-               cargo-1.92 | cargo (>= 1.92),
+               rustc-1.95 | rustc (>= 1.95),
+               cargo-1.95 | cargo (>= 1.95),
                libssl-dev,
                pkg-config,
                protobuf-compiler,

--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad
+++ b/debian/rules.launchpad
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/debian/rules.launchpad-simple
+++ b/debian/rules.launchpad-simple
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@

--- a/debian/rules.source
+++ b/debian/rules.source
@@ -9,8 +9,8 @@ export CARGO_HOME = $(HOME)/.cargo
 export CARGO_TARGET_DIR = $(CURDIR)/target
 export CARGO_NET_OFFLINE = true
 
-RUSTC := $(shell if command -v rustc-1.92 >/dev/null 2>&1; then printf '%s' rustc-1.92; else printf '%s' rustc; fi)
-CARGO := $(shell if command -v cargo-1.92 >/dev/null 2>&1; then printf '%s' cargo-1.92; else printf '%s' cargo; fi)
+RUSTC := $(shell if command -v rustc-1.95 >/dev/null 2>&1; then printf '%s' rustc-1.95; else printf '%s' rustc; fi)
+CARGO := $(shell if command -v cargo-1.95 >/dev/null 2>&1; then printf '%s' cargo-1.95; else printf '%s' cargo; fi)
 
 %:
 	dh $@
@@ -23,12 +23,12 @@ override_dh_auto_configure:
 	$(CARGO) --version
 	rustc_version=$$($(RUSTC) --version | awk '{print $$2}'); \
 	cargo_version=$$($(CARGO) --version | awk '{print $$2}'); \
-	dpkg --compare-versions "$$rustc_version" ge 1.92 || { \
-		echo "rustc 1.92+ is required for the current dependency set (found $$rustc_version)"; \
+	dpkg --compare-versions "$$rustc_version" ge 1.95 || { \
+		echo "rustc 1.95+ is required for the current dependency set (found $$rustc_version)"; \
 		exit 1; \
 	}; \
-	dpkg --compare-versions "$$cargo_version" ge 1.92 || { \
-		echo "cargo 1.92+ is required for the current dependency set (found $$cargo_version)"; \
+	dpkg --compare-versions "$$cargo_version" ge 1.95 || { \
+		echo "cargo 1.95+ is required for the current dependency set (found $$cargo_version)"; \
 		exit 1; \
 	}
 

--- a/tests/container-benchmark.sh
+++ b/tests/container-benchmark.sh
@@ -22,7 +22,7 @@ docker run -d --name all-smi-test-benchmark-api \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
     -p 9999:9999 \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Installing dependencies...'
         apt-get update -qq && apt-get install -y -qq pkg-config protobuf-compiler >/dev/null 2>&1

--- a/tests/container-build-test.sh
+++ b/tests/container-build-test.sh
@@ -49,7 +49,7 @@ docker run --rm \
     -v "$PROJECT_ROOT":/all-smi \
     -v "/tmp/run-build-test.sh":/tmp/run-build-test.sh \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         apt-get update && apt-get install -y pkg-config protobuf-compiler curl && 
         /tmp/run-build-test.sh

--- a/tests/container-cpu-test.sh
+++ b/tests/container-cpu-test.sh
@@ -21,7 +21,7 @@ docker run -d --name all-smi-test-cpu-limits \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
     -p 9999:9999 \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Installing dependencies...'
         apt-get update -qq && apt-get install -y -qq pkg-config protobuf-compiler stress-ng curl >/dev/null 2>&1

--- a/tests/container-memory-test.sh
+++ b/tests/container-memory-test.sh
@@ -51,7 +51,7 @@ docker run -d --name all-smi-test-memory-allocation \
     -v /tmp/memory-eater.c:/tmp/memory-eater.c \
     -w /all-smi \
     -p 9999:9999 \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Installing dependencies...'
         apt-get update -qq && apt-get install -y -qq pkg-config protobuf-compiler gcc curl >/dev/null 2>&1

--- a/tests/container-metrics-test.sh
+++ b/tests/container-metrics-test.sh
@@ -49,7 +49,7 @@ docker run -d --name all-smi-test-metrics-comparison \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
     -p 9999:9999 \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Installing dependencies...'
         apt-get update -qq && apt-get install -y -qq pkg-config protobuf-compiler curl >/dev/null 2>&1

--- a/tests/container-simple-test.sh
+++ b/tests/container-simple-test.sh
@@ -15,7 +15,7 @@ docker run --rm -it --name all-smi-test-simple-memory \
     -v "$PROJECT_ROOT":/all-smi \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Installing dependencies...'
         apt-get update -qq && apt-get install -y -qq pkg-config protobuf-compiler >/dev/null 2>&1

--- a/tests/debug-cargo-build.sh
+++ b/tests/debug-cargo-build.sh
@@ -20,7 +20,7 @@ docker run -it --rm \
     -v "$PROJECT_ROOT":/all-smi \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo '=== Container Info ==='
         echo 'Memory limits:'

--- a/tests/debug-container-cpu-frequency.sh
+++ b/tests/debug-container-cpu-frequency.sh
@@ -25,7 +25,7 @@ docker run -it --rm \
     -p 9090:9090 \
     -v "$PROJECT_ROOT":/all-smi \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo '=== Starting debug container ==='
         echo 'Current directory:'

--- a/tests/debug-container-status.sh
+++ b/tests/debug-container-status.sh
@@ -14,7 +14,7 @@ echo "1. Starting a simple test container..."
 docker run -d --name test-lifecycle \
     -v "$PROJECT_ROOT":/all-smi \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Container started successfully'
         echo 'Sleeping for 10 seconds...'
@@ -50,7 +50,7 @@ echo "6. Starting container with cargo build..."
 docker run -d --name test-build \
     -v "$PROJECT_ROOT":/all-smi \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Starting cargo build test'
         echo 'Checking environment:'

--- a/tests/quick-api-test.sh
+++ b/tests/quick-api-test.sh
@@ -20,7 +20,7 @@ docker run -d --name all-smi-test-quick-api \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
     -p 9999:9999 \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Installing dependencies...'
         apt-get update -qq && apt-get install -y -qq pkg-config protobuf-compiler >/dev/null 2>&1

--- a/tests/test-arm-cpu-frequency.sh
+++ b/tests/test-arm-cpu-frequency.sh
@@ -74,7 +74,7 @@ docker run -d --name all-smi-test-arm-freq-detection \
     -v "$PROJECT_ROOT":/all-smi \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo '[Container] Installing dependencies...'
         apt-get update -qq && apt-get install -y -qq pkg-config protobuf-compiler >/dev/null 2>&1

--- a/tests/test-container-cpu-frequency.sh
+++ b/tests/test-container-cpu-frequency.sh
@@ -67,7 +67,7 @@ docker run -d --name all-smi-test-cpu-freq-cpuset \
     -v "$PROJECT_ROOT":/all-smi \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo '[Container] Starting at: ' \$(date)
         echo '[Container] Container ID: ' \$(hostname)
@@ -121,7 +121,7 @@ docker run -d --name all-smi-test-cpu-freq-quota \
     -v "$PROJECT_ROOT":/all-smi \
     -v "$CARGO_CACHE_DIR":/usr/local/cargo/registry \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo '[Container] Starting at: ' \$(date)
         echo '[Container] Container ID: ' \$(hostname)

--- a/tests/test-minimal-cargo.sh
+++ b/tests/test-minimal-cargo.sh
@@ -15,7 +15,7 @@ docker run --rm \
     --name test-minimal \
     -v "$PROJECT_ROOT":/all-smi \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         echo 'Testing cargo version:'
         cargo --version
@@ -39,7 +39,7 @@ docker run --rm \
     --name test-strace \
     -v "$PROJECT_ROOT":/all-smi \
     -w /all-smi \
-    rust:1.88 \
+    rust:1.95 \
     /bin/bash -c "
         apt-get update -qq && apt-get install -y -qq strace
         echo 'Running cargo update with strace (last 50 lines):'


### PR DESCRIPTION
## Summary
- Update Docker builder and dev-container scripts from Rust 1.88 to Rust 1.95.
- Record the current crate MSRV in Cargo.toml.
- Align Debian/PPA packaging metadata and vendoring workflow with Rust 1.95.
- Run Docker Build Check on pull requests so Dockerfile/toolchain drift is caught before merge.

## Reason
The post-merge main CI for #232 failed only in Docker Build Check because the Dockerfile still used rust:1.88-slim, while the current lockfile resolves sysinfo@0.39.2, which requires rustc 1.95.

## Validation
- cargo metadata --format-version 1 --locked --no-deps
- cargo fmt --check
- env -u NO_COLOR RUSTFLAGS="-L /tmp/drmlinks" cargo build --release --bin all-smi
- env -u NO_COLOR RUSTFLAGS="-L /tmp/drmlinks" cargo build --no-default-features --lib

Docker build could not be run locally because this environment cannot access the Docker daemon socket; GitHub CI now runs that path on this pull request.

Refs #232