### PR TITLE
Disable console window for subprocesses

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -14,3 +14,10 @@ too-many-arguments-threshold = 7
 
 # Allow mixed uninlined format args during transition
 allow-mixed-uninlined-format-args = false
+
+# Force all process spawning through utils::command::new_command so the
+# Windows CREATE_NO_WINDOW flag is always applied, preventing console-window
+# flashes when all-smi is used as a library in GUI apps (see issue #263).
+disallowed-methods = [
+    { path = "std::process::Command::new", reason = "use utils::command::new_command to suppress the Windows console window (#263)" },
+]

--- a/src/device/cpu_linux.rs
+++ b/src/device/cpu_linux.rs
@@ -24,6 +24,7 @@ use crate::device::container_info::{ContainerInfo, parse_cpu_stat_with_container
 use crate::device::{
     CoreType, CoreUtilization, CpuInfo, CpuPlatformType, CpuReader, CpuSocketInfo,
 };
+use crate::utils::command::new_command;
 use crate::utils::system::get_hostname;
 use crate::utils::{hz_to_mhz, khz_to_mhz, millicelsius_to_celsius};
 
@@ -90,7 +91,7 @@ impl LinuxCpuReader {
         }
 
         // Run lscpu once and cache the result
-        if let Ok(output) = std::process::Command::new("lscpu").output()
+        if let Ok(output) = new_command("lscpu").output()
             && let Ok(lscpu_output) = String::from_utf8(output.stdout)
         {
             *self.cached_lscpu_output.write().unwrap() = Some(lscpu_output.clone());
@@ -336,7 +337,7 @@ impl LinuxCpuReader {
         let total_cores = total_threads; // Default assumption, may be incorrect with hyperthreading
 
         // Try to get architecture from uname
-        if let Ok(output) = std::process::Command::new("uname").arg("-m").output() {
+        if let Ok(output) = new_command("uname").arg("-m").output() {
             architecture = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
             // If architecture is ARM and we don't have a CPU model, construct one

--- a/src/device/cpu_macos.rs
+++ b/src/device/cpu_macos.rs
@@ -19,6 +19,7 @@ use crate::device::{
     AppleSiliconCpuInfo, CoreType, CoreUtilization, CpuInfo, CpuPlatformType, CpuReader,
     CpuSocketInfo,
 };
+use crate::utils::command::new_command;
 use crate::utils::system::get_hostname;
 use chrono::Local;
 use std::process::Command;
@@ -77,7 +78,7 @@ impl MacOsCpuReader {
     }
 
     fn detect_apple_silicon() -> bool {
-        if let Ok(output) = Command::new("uname").arg("-m").output() {
+        if let Ok(output) = new_command("uname").arg("-m").output() {
             let architecture = String::from_utf8_lossy(&output.stdout);
             return architecture.trim() == "arm64";
         }
@@ -347,7 +348,7 @@ impl MacOsCpuReader {
                 info
             } else {
                 // Get CPU information using system_profiler (first time only)
-                let output = Command::new("system_profiler")
+                let output = new_command("system_profiler")
                     .arg("SPHardwareDataType")
                     .output()?;
 
@@ -436,7 +437,7 @@ impl MacOsCpuReader {
         // Read perflevel names and core counts to determine core types dynamically
         // M5 Pro/Max: perflevel0.name=Super, perflevel1.name=Performance (no E-cores)
         // M1-M4:      perflevel0.name=Performance (or absent), perflevel1.name=Efficiency
-        let output = Command::new("sysctl")
+        let output = new_command("sysctl")
             .args(["hw.perflevel0.physicalcpu", "hw.perflevel1.physicalcpu"])
             .output()?;
 
@@ -497,7 +498,7 @@ impl MacOsCpuReader {
     /// Returns None if the sysctl key does not exist (M1-M4 chips)
     fn get_perflevel_name(level: u32) -> Option<String> {
         let key = format!("hw.perflevel{level}.name");
-        let output = Command::new("sysctl").args(["-n", &key]).output().ok()?;
+        let output = new_command("sysctl").args(["-n", &key]).output().ok()?;
 
         if !output.status.success() {
             return None;
@@ -510,7 +511,7 @@ impl MacOsCpuReader {
     /// Get CPU model from sysctl machdep.cpu.brand_string
     /// This is significantly faster than system_profiler (~10ms vs ~500ms)
     fn get_cpu_model_sysctl(&self) -> Result<String, Box<dyn std::error::Error>> {
-        let output = Command::new("sysctl")
+        let output = new_command("sysctl")
             .args(["-n", "machdep.cpu.brand_string"])
             .output()?;
 
@@ -530,7 +531,7 @@ impl MacOsCpuReader {
 
     /// Get GPU core count using ioreg (faster than system_profiler)
     fn get_gpu_core_count_ioreg(&self) -> Result<u32, Box<dyn std::error::Error>> {
-        let output = Command::new("ioreg")
+        let output = new_command("ioreg")
             .args(["-rc", "AGXAccelerator", "-d1"])
             .output()?;
 
@@ -594,7 +595,7 @@ impl MacOsCpuReader {
     // These methods are no longer used since we fetch both values in a single sysctl call
     #[allow(dead_code)]
     fn get_p_core_count(&self) -> Result<u32, Box<dyn std::error::Error>> {
-        let output = Command::new("sysctl")
+        let output = new_command("sysctl")
             .arg("hw.perflevel0.physicalcpu")
             .output()?;
 
@@ -609,7 +610,7 @@ impl MacOsCpuReader {
 
     #[allow(dead_code)]
     fn get_e_core_count(&self) -> Result<u32, Box<dyn std::error::Error>> {
-        let output = Command::new("sysctl")
+        let output = new_command("sysctl")
             .arg("hw.perflevel1.physicalcpu")
             .output()?;
 
@@ -624,7 +625,7 @@ impl MacOsCpuReader {
 
     #[allow(dead_code)] // Kept as fallback, but get_gpu_core_count_ioreg() is preferred
     fn get_gpu_core_count(&self) -> Result<u32, Box<dyn std::error::Error>> {
-        let output = Command::new("system_profiler")
+        let output = new_command("system_profiler")
             .arg("SPDisplaysDataType")
             .arg("-json")
             .output()?;
@@ -664,7 +665,7 @@ impl MacOsCpuReader {
         }
 
         // On M5 Pro/Max, perflevel0 = Super cores
-        let output = Command::new("sysctl")
+        let output = new_command("sysctl")
             .arg("hw.perflevel0.l2cachesize")
             .output()?;
 
@@ -696,7 +697,7 @@ impl MacOsCpuReader {
             "hw.perflevel0.l2cachesize"
         };
 
-        let output = Command::new("sysctl").arg(perflevel).output()?;
+        let output = new_command("sysctl").arg(perflevel).output()?;
 
         let output_str = String::from_utf8_lossy(&output.stdout);
         if let Some(value_str) = output_str.split(':').nth(1) {
@@ -726,7 +727,7 @@ impl MacOsCpuReader {
         }
 
         // On M1-M4, E-cores are perflevel1
-        let output = Command::new("sysctl")
+        let output = new_command("sysctl")
             .arg("hw.perflevel1.l2cachesize")
             .output()?;
 
@@ -829,7 +830,7 @@ impl MacOsCpuReader {
     #[allow(dead_code)] // Kept as fallback method when sysinfo is unavailable
     fn get_cpu_utilization_iostat(&self) -> Result<f64, Box<dyn std::error::Error>> {
         // Fallback method using iostat (kept for compatibility)
-        let output = Command::new("iostat").args(["-c", "1"]).output()?;
+        let output = new_command("iostat").args(["-c", "1"]).output()?;
 
         let iostat_output = String::from_utf8_lossy(&output.stdout);
 

--- a/src/device/cpu_macos.rs
+++ b/src/device/cpu_macos.rs
@@ -22,7 +22,6 @@ use crate::device::{
 use crate::utils::command::new_command;
 use crate::utils::system::get_hostname;
 use chrono::Local;
-use std::process::Command;
 use std::sync::{Mutex, RwLock};
 use sysinfo::System;
 

--- a/src/device/hlsmi/process.rs
+++ b/src/device/hlsmi/process.rs
@@ -16,7 +16,7 @@ use crate::utils::command::new_command;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::panic::{self, AssertUnwindSafe};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Stdio};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;

--- a/src/device/hlsmi/process.rs
+++ b/src/device/hlsmi/process.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::utils::command::new_command;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::panic::{self, AssertUnwindSafe};
@@ -85,7 +86,7 @@ impl ProcessManager {
         &self,
         command_rx: Receiver<ReaderCommand>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut cmd = Command::new("hl-smi");
+        let mut cmd = new_command("hl-smi");
 
         let args = self.config.get_hlsmi_args();
         cmd.args(&args)
@@ -268,7 +269,7 @@ impl ProcessManager {
             }
         }
 
-        let mut cmd = Command::new("hl-smi");
+        let mut cmd = new_command("hl-smi");
         let args = config.get_hlsmi_args();
         cmd.args(&args)
             .stdin(Stdio::null())

--- a/src/device/process_list.rs
+++ b/src/device/process_list.rs
@@ -232,8 +232,10 @@ fn get_process_priority_nice(pid: u32) -> (i32, i32) {
 
     #[cfg(target_os = "macos")]
     {
+        use crate::utils::command::new_command;
+
         // On macOS, use ps command to get priority and nice
-        if let Ok(output) = std::process::Command::new("ps")
+        if let Ok(output) = new_command("ps")
             .args(["-p", &pid.to_string(), "-o", "pri,nice"])
             .output()
         {

--- a/src/device/process_utils.rs
+++ b/src/device/process_utils.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use std::fs;
-use std::process::Command;
 
 use crate::device::{platform_detection::get_os_type, types::ProcessInfoResult};
+use crate::utils::command::new_command;
 
 // Helper function to get system process information
 #[allow(dead_code)]
@@ -110,7 +110,7 @@ fn get_linux_process_info(pid: u32) -> ProcessInfoResult {
 #[allow(dead_code)]
 fn get_macos_process_info(pid: u32) -> ProcessInfoResult {
     // Use ps command to get process information on macOS
-    let output = Command::new("ps")
+    let output = new_command("ps")
         .args([
             "-p",
             &pid.to_string(),

--- a/src/device/readers/gaudi.rs
+++ b/src/device/readers/gaudi.rs
@@ -19,6 +19,8 @@ use crate::device::hlsmi::parser::{GaudiDeviceMetrics, map_device_name};
 use crate::device::readers::common_cache::{DetailBuilder, DeviceStaticInfo};
 use crate::device::types::{GpuInfo, ProcessInfo};
 #[cfg(target_os = "linux")]
+use crate::utils::command::new_command;
+#[cfg(target_os = "linux")]
 use crate::utils::get_hostname;
 #[cfg(target_os = "linux")]
 use chrono::Local;
@@ -126,7 +128,7 @@ impl GaudiNpuReader {
         }
 
         // Check if command is available in PATH
-        if let Ok(output) = std::process::Command::new("which").arg("hl-smi").output()
+        if let Ok(output) = new_command("which").arg("hl-smi").output()
             && output.status.success()
         {
             // Cache the result

--- a/src/device/readers/google_tpu.rs
+++ b/src/device/readers/google_tpu.rs
@@ -647,7 +647,7 @@ impl GoogleTpuReader {
     /// Try to get accelerator type from tpu-info CLI (fast, no heavy imports)
     #[cfg(target_os = "linux")]
     fn get_accelerator_type_from_tpu_info() -> Option<String> {
-        use std::process::Command;
+        use crate::utils::command::new_command;
         static ACCELERATOR_TYPE_CACHE: OnceLock<Option<String>> = OnceLock::new();
 
         ACCELERATOR_TYPE_CACHE
@@ -656,7 +656,7 @@ impl GoogleTpuReader {
                 // - tpu-info version: 0.8.0
                 // - libtpu version: 0.0.17
                 // - accelerator type: v6e
-                let output = Command::new("tpu-info").arg("-v").output().ok()?;
+                let output = new_command("tpu-info").arg("-v").output().ok()?;
 
                 if !output.status.success() {
                     return None;

--- a/src/device/readers/tpu_info_runner.rs
+++ b/src/device/readers/tpu_info_runner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::utils::command::new_command;
 use regex::Regex;
 use std::collections::HashMap;
 use std::process::Command;
@@ -152,7 +153,7 @@ impl TpuInfoRunner {
 
         // Run tpu-info in normal mode (NOT streaming mode)
         // Streaming mode uses Rich's Live display which doesn't work with pipes
-        let output_res = Command::new("tpu-info")
+        let output_res = new_command("tpu-info")
             .env("TERM", "dumb")
             .env("NO_COLOR", "1")
             .env("FORCE_COLOR", "0")

--- a/src/device/readers/tpu_info_runner.rs
+++ b/src/device/readers/tpu_info_runner.rs
@@ -15,7 +15,6 @@
 use crate::utils::command::new_command;
 use regex::Regex;
 use std::collections::HashMap;
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::thread;

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -214,11 +214,11 @@ impl NetworkClient {
         // Get system limits using sysctl or /proc
         #[cfg(unix)]
         {
-            use std::process::Command;
+            use crate::utils::command::new_command;
 
             // Try to get system file descriptor limit
             let limit = if cfg!(target_os = "macos") {
-                Command::new("sysctl")
+                new_command("sysctl")
                     .args(["kern.maxfiles"])
                     .output()
                     .ok()

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ffi::OsStr;
 use std::process::Command;
 
 /// Create a command with platform-dependent handling
@@ -20,8 +21,9 @@ use std::process::Command;
 /// prevent a console window from appearing. This is required when all-smi
 /// is used as a library for GUI applications.
 ///
-/// On non-Windows this function is equivalent to `std::process::Command::new`
-pub fn new_command(command: &str) -> Command {
+/// On non-Windows this function is equivalent to `std::process::Command::new`.
+#[allow(clippy::disallowed_methods)] // this is the sanctioned Command constructor
+pub fn new_command(program: impl AsRef<OsStr>) -> Command {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -30,11 +32,11 @@ pub fn new_command(command: &str) -> Command {
         // https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
         const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-        let mut cmd = Command::new(command);
+        let mut cmd = Command::new(program);
         cmd.creation_flags(CREATE_NO_WINDOW);
         cmd
     }
 
     #[cfg(not(windows))]
-    Command::new(command)
+    Command::new(program)
 }

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -1,12 +1,26 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::process::Command;
 
-/// Create a command with platform dependend handling
+/// Create a command with platform-dependent handling
 ///
 /// On Windows, the command is created with the `CREATE_NO_WINDOW` flag to
 /// prevent a console window from appearing. This is required when all-smi
 /// is used as a library for GUI applications.
 ///
-/// On non-Windows this function is equivalent to `std::process::Command`
+/// On non-Windows this function is equivalent to `std::process::Command::new`
 pub fn new_command(command: &str) -> Command {
     #[cfg(windows)]
     {

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+/// Create a command with platform dependend handling
+///
+/// On Windows, the command is created with the `CREATE_NO_WINDOW` flag to
+/// prevent a console window from appearing. This is required when all-smi
+/// is used as a library for GUI applications.
+///
+/// On non-Windows this function is equivalent to `std::process::Command`
+pub fn new_command(command: &str) -> Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        // CREATE_NO_WINDOW constant as described in Windows API docs
+        // https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        let mut cmd = Command::new(command);
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        cmd
+    }
+
+    #[cfg(not(windows))]
+    Command::new(command)
+}

--- a/src/utils/command_timeout.rs
+++ b/src/utils/command_timeout.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use std::io::{self, Read};
-use std::process::{Command, Output, Stdio};
+use std::process::{Output, Stdio};
 use std::time::{Duration, Instant};
+
+use crate::utils::command::new_command;
 
 /// Maximum bytes of stdout or stderr captured from a child process by
 /// [`run_command_with_timeout`]. Output beyond this cap is truncated and
@@ -94,7 +96,7 @@ pub fn run_command_with_timeout(
     timeout: Duration,
 ) -> io::Result<Output> {
     // Spawn the child process
-    let mut child = Command::new(command)
+    let mut child = new_command(command)
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod command;
 pub mod command_timeout;
 pub mod disk_filter;
 pub mod profiling;

--- a/src/utils/runtime_environment.rs
+++ b/src/utils/runtime_environment.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use crate::common::config::AppConfig;
+use crate::utils::command::new_command;
 #[cfg(feature = "cli")]
 use crossterm::style::Color;
 use std::env;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ContainerRuntime {
@@ -364,7 +364,7 @@ pub struct VirtualizationInfo {
 /// Detects if the current process is running inside a virtual machine
 pub fn detect_virtualization() -> VirtualizationInfo {
     // Try systemd-detect-virt first (most reliable if available)
-    if let Ok(output) = Command::new("systemd-detect-virt").output()
+    if let Ok(output) = new_command("systemd-detect-virt").output()
         && output.status.success()
     {
         let virt_type = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -602,7 +602,7 @@ fn check_aws_metadata() -> bool {
     }
 
     // Try to access AWS metadata service with very short timeout
-    match Command::new("curl")
+    match new_command("curl")
         .args([
             "-s",
             "--max-time",

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::utils::command::new_command;
 use once_cell::sync::Lazy;
 use std::io::{self, Write};
-use std::process::Command;
 use std::sync::Mutex;
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
@@ -59,7 +59,7 @@ pub fn refresh_global_processes() {
 
 /// Check if the current process already has sudo privileges
 pub fn has_sudo_privileges() -> bool {
-    Command::new("sudo")
+    new_command("sudo")
         .arg("-n") // Non-interactive mode
         .arg("-v") // Validate sudo timestamp
         .output()
@@ -292,7 +292,7 @@ fn request_sudo_with_explanation(platform: SudoPlatform, return_bool: bool) -> b
     io::stdout().flush().unwrap();
 
     // Attempt to get sudo privileges
-    let status = Command::new("sudo")
+    let status = new_command("sudo")
         .arg("-v")
         .status()
         .expect("Failed to execute sudo command");


### PR DESCRIPTION
Disable console window for subprocesses. This prevents from terminal windows flashing when using all-smi as a library in windows GUI applications.

Fixes #263