### PR TITLE
fix: sanitize colons in Prometheus label names

### DIFF
--- a/src/api/metrics/gpu.rs
+++ b/src/api/metrics/gpu.rs
@@ -513,6 +513,27 @@ mod tests {
     }
 
     #[test]
+    fn exporter_sanitizes_dynamic_detail_label_names() {
+        let mut gpu = make_nvidia_gpu();
+        gpu.detail
+            .insert("Source: Fan".to_string(), "hwmon".to_string());
+        gpu.detail
+            .insert("3D Engine".to_string(), "busy".to_string());
+        gpu.detail
+            .insert("GPU.Temp/Limit".to_string(), "90".to_string());
+        let gpus = vec![gpu];
+        let output = GpuMetricExporter::new(&gpus).export_metrics();
+        let info_line = output
+            .lines()
+            .find(|line| line.starts_with("all_smi_gpu_info{"))
+            .expect("GPU info metric");
+
+        assert!(info_line.contains("source__fan=\"hwmon\""));
+        assert!(info_line.contains("_3d_engine=\"busy\""));
+        assert!(info_line.contains("gpu_temp_limit=\"90\""));
+    }
+
+    #[test]
     fn exporter_emits_pstate_from_structured_field() {
         let gpu = make_nvidia_gpu();
         let gpus = vec![gpu];

--- a/src/parsing/common.rs
+++ b/src/parsing/common.rs
@@ -84,10 +84,29 @@ pub fn sanitize_label_value(s: &str) -> String {
 }
 
 /// Sanitize a label name for Prometheus compatibility.
-/// Converts spaces to underscores and makes lowercase.
+/// Replaces invalid characters with underscores, makes ASCII letters lowercase,
+/// and prefixes names that start with a digit.
 /// Prometheus label names must match: [a-zA-Z_][a-zA-Z0-9_]*
 pub fn sanitize_label_name(s: &str) -> String {
-    s.replace([' ', '-', ':'], "_").to_lowercase()
+    let mut sanitized = String::with_capacity(s.len().max(1));
+
+    for (index, character) in s.chars().enumerate() {
+        if index == 0 && character.is_ascii_digit() {
+            sanitized.push('_');
+        }
+
+        if character.is_ascii_alphanumeric() {
+            sanitized.push(character.to_ascii_lowercase());
+        } else {
+            sanitized.push('_');
+        }
+    }
+
+    if sanitized.is_empty() {
+        sanitized.push('_');
+    }
+
+    sanitized
 }
 
 /// Extract the substring that appears after the first ':' character, trimmed.
@@ -171,6 +190,35 @@ mod tests {
         assert_eq!(sanitize_label_name("UPPER_CASE"), "upper_case");
         assert_eq!(sanitize_label_name("already_valid"), "already_valid");
         assert_eq!(sanitize_label_name("Source: Fan"), "source__fan");
+        assert_eq!(sanitize_label_name("3D Engine"), "_3d_engine");
+        assert_eq!(sanitize_label_name("GPU.Temp/Limit"), "gpu_temp_limit");
+        assert_eq!(sanitize_label_name("온도"), "__");
+        assert_eq!(sanitize_label_name(""), "_");
+    }
+
+    #[test]
+    fn sanitized_label_names_always_match_prometheus_grammar() {
+        for input in [
+            "Source: Fan",
+            "3D Engine",
+            "GPU.Temp/Limit",
+            "punctuation!@#$%^&*()",
+            "온도",
+            "",
+        ] {
+            let sanitized = sanitize_label_name(input);
+            let mut characters = sanitized.chars();
+            let first = characters.next().expect("sanitized name is never empty");
+
+            assert!(
+                first.is_ascii_alphabetic() || first == '_',
+                "invalid first character in {sanitized:?} from {input:?}"
+            );
+            assert!(
+                characters.all(|character| character.is_ascii_alphanumeric() || character == '_'),
+                "invalid character in {sanitized:?} from {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/parsing/common.rs
+++ b/src/parsing/common.rs
@@ -87,7 +87,7 @@ pub fn sanitize_label_value(s: &str) -> String {
 /// Converts spaces to underscores and makes lowercase.
 /// Prometheus label names must match: [a-zA-Z_][a-zA-Z0-9_]*
 pub fn sanitize_label_name(s: &str) -> String {
-    s.replace([' ', '-'], "_").to_lowercase()
+    s.replace([' ', '-', ':'], "_").to_lowercase()
 }
 
 /// Extract the substring that appears after the first ':' character, trimmed.
@@ -170,6 +170,7 @@ mod tests {
         assert_eq!(sanitize_label_name("pcie-gen-current"), "pcie_gen_current");
         assert_eq!(sanitize_label_name("UPPER_CASE"), "upper_case");
         assert_eq!(sanitize_label_name("already_valid"), "already_valid");
+        assert_eq!(sanitize_label_name("Source: Fan"), "source__fan");
     }
 
     #[test]


### PR DESCRIPTION
Prometheus label names must match [a-zA-Z_][a-zA-Z0-9_]* but sanitize_label_name only replaced spaces and hyphens with underscores. Labels containing colons (e.g. 'Source: Fan' from the nvidia-smi compatibility layer) would produce invalid metric names, causing Prometheus scrapes to fail with a parse error.

Add ':' to the character replacement set so 'Source: Fan' becomes 'source__fan'.