### PR TITLE
feat: compute Xe GPU utilization from gtidle/idle_residency_ms

### DIFF
--- a/src/device/readers/intel_gpu_gtidle.rs
+++ b/src/device/readers/intel_gpu_gtidle.rs
@@ -1,0 +1,331 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Xe GT idle-residency utilization fallback.
+//!
+//! Xe does not expose the i915-style engine-busy sysfs counters on every
+//! kernel. In that case, the time a GT spends outside its deepest idle state
+//! is used as an activity estimate. It is deliberately treated as a fallback:
+//! active residency is not the same as engine busy time and must not replace a
+//! valid zero-percent engine-busy sample.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use crate::device::readers::intel_gpu_engine::{ENGINE_UNAVAILABLE_NOTE, EngineReadout};
+use crate::device::readers::intel_gpu_sysfs::read_gtidle_ms;
+
+const GTIDLE_SEEDING_NOTE: &str =
+    "Xe GT idle residency seeded (utilization available next refresh)";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum GtidleReadout {
+    Unavailable,
+    Seeded,
+    Available(f64),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GtidleSample {
+    idle_ms: u64,
+    tick: Instant,
+}
+
+#[derive(Debug, Default)]
+pub struct GtidleState {
+    samples: [Option<GtidleSample>; 2],
+}
+
+/// Replace an unavailable Xe engine-counter readout with GT active residency.
+/// Valid engine-counter data, including a true zero-percent sample, always wins.
+pub fn apply_fallback(
+    driver: &str,
+    engine_readout: &EngineReadout,
+    state: &Mutex<GtidleState>,
+    device_dir: &Path,
+    detail: &mut HashMap<String, String>,
+    utilization: &mut f64,
+) {
+    if driver != "xe" || engine_readout.status_note != Some(ENGINE_UNAVAILABLE_NOTE) {
+        return;
+    }
+
+    match refresh_with_lock(state, device_dir) {
+        GtidleReadout::Available(value) => {
+            *utilization = value;
+            detail.remove("Utilization");
+            detail.insert(
+                "Source: Utilization".to_string(),
+                "Xe GT idle residency".to_string(),
+            );
+        }
+        GtidleReadout::Seeded => {
+            detail.insert("Utilization".to_string(), GTIDLE_SEEDING_NOTE.to_string());
+            detail.insert(
+                "Source: Utilization".to_string(),
+                "Xe GT idle residency (seeded)".to_string(),
+            );
+        }
+        GtidleReadout::Unavailable => {}
+    }
+}
+
+impl GtidleState {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+fn refresh_with_lock(state: &Mutex<GtidleState>, device_dir: &Path) -> GtidleReadout {
+    let mut guard = match state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            eprintln!(
+                "Warning: Intel GPU gtidle-state mutex was poisoned for {}, recovering...",
+                device_dir.display()
+            );
+            let mut guard = poisoned.into_inner();
+            *guard = GtidleState::empty();
+            guard
+        }
+    };
+    refresh_at(&mut guard, device_dir, Instant::now())
+}
+
+fn refresh_at(state: &mut GtidleState, device_dir: &Path, now: Instant) -> GtidleReadout {
+    let readings = read_gtidle_ms(device_dir);
+    if readings.iter().all(Option::is_none) {
+        return GtidleReadout::Unavailable;
+    }
+
+    let mut max_utilization = 0.0_f64;
+    let mut has_delta = false;
+    let mut seeded = false;
+
+    for (sample, reading) in state.samples.iter_mut().zip(readings) {
+        let Some(current_idle_ms) = reading else {
+            // Keep the old sample: if the file becomes readable again, its
+            // delta must cover the entire interval in which it was missing.
+            continue;
+        };
+
+        let Some(previous) = *sample else {
+            *sample = Some(GtidleSample {
+                idle_ms: current_idle_ms,
+                tick: now,
+            });
+            seeded = true;
+            continue;
+        };
+
+        if current_idle_ms < previous.idle_ms {
+            // Driver reloads and device resets can reset the monotonic
+            // counter. Treat this sample as a new baseline instead of
+            // turning a zero saturating delta into a false 100% result.
+            *sample = Some(GtidleSample {
+                idle_ms: current_idle_ms,
+                tick: now,
+            });
+            seeded = true;
+            continue;
+        }
+
+        let elapsed_us = now.saturating_duration_since(previous.tick).as_micros();
+        if elapsed_us == 0 {
+            continue;
+        }
+
+        let idle_us = u128::from(current_idle_ms - previous.idle_ms) * 1_000;
+        let idle_fraction = idle_us as f64 / elapsed_us as f64;
+        let utilization = ((1.0 - idle_fraction) * 100.0).clamp(0.0, 100.0);
+        max_utilization = max_utilization.max(utilization);
+        has_delta = true;
+        *sample = Some(GtidleSample {
+            idle_ms: current_idle_ms,
+            tick: now,
+        });
+    }
+
+    if has_delta {
+        GtidleReadout::Available(max_utilization)
+    } else if seeded {
+        GtidleReadout::Seeded
+    } else {
+        GtidleReadout::Unavailable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn write_gt(device_dir: &Path, gt: usize, value: u64) {
+        let dir = device_dir
+            .join("tile0")
+            .join(format!("gt{gt}"))
+            .join("gtidle");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("idle_residency_ms"), value.to_string()).unwrap();
+    }
+
+    #[test]
+    fn computes_active_residency_after_seeding() {
+        let dir = tempdir().unwrap();
+        write_gt(dir.path(), 0, 1_000);
+        let start = Instant::now();
+        let mut state = GtidleState::empty();
+        assert_eq!(
+            refresh_at(&mut state, dir.path(), start),
+            GtidleReadout::Seeded
+        );
+
+        write_gt(dir.path(), 0, 1_500);
+        let result = refresh_at(&mut state, dir.path(), start + Duration::from_secs(1));
+        assert_eq!(result, GtidleReadout::Available(50.0));
+    }
+
+    #[test]
+    fn zero_percent_is_available_data() {
+        let dir = tempdir().unwrap();
+        write_gt(dir.path(), 0, 10);
+        let start = Instant::now();
+        let mut state = GtidleState::empty();
+        assert_eq!(
+            refresh_at(&mut state, dir.path(), start),
+            GtidleReadout::Seeded
+        );
+
+        write_gt(dir.path(), 0, 1_010);
+        let result = refresh_at(&mut state, dir.path(), start + Duration::from_secs(1));
+        assert_eq!(result, GtidleReadout::Available(0.0));
+    }
+
+    #[test]
+    fn counter_reset_reseeds_instead_of_reporting_full_utilization() {
+        let dir = tempdir().unwrap();
+        write_gt(dir.path(), 0, 10_000);
+        let start = Instant::now();
+        let mut state = GtidleState::empty();
+        assert_eq!(
+            refresh_at(&mut state, dir.path(), start),
+            GtidleReadout::Seeded
+        );
+
+        write_gt(dir.path(), 0, 5);
+        let result = refresh_at(&mut state, dir.path(), start + Duration::from_secs(1));
+        assert_eq!(result, GtidleReadout::Seeded);
+    }
+
+    #[test]
+    fn missing_gt_does_not_shift_another_gts_baseline() {
+        let dir = tempdir().unwrap();
+        write_gt(dir.path(), 1, 100);
+        let start = Instant::now();
+        let mut state = GtidleState::empty();
+        assert_eq!(
+            refresh_at(&mut state, dir.path(), start),
+            GtidleReadout::Seeded
+        );
+
+        write_gt(dir.path(), 0, 10_000);
+        write_gt(dir.path(), 1, 600);
+        let result = refresh_at(&mut state, dir.path(), start + Duration::from_secs(1));
+        assert_eq!(result, GtidleReadout::Available(50.0));
+    }
+
+    fn engine_readout(status_note: Option<&'static str>) -> EngineReadout {
+        EngineReadout {
+            primary_utilization: 0.0,
+            per_class: if status_note.is_none() {
+                vec![("render", 0.0)]
+            } else {
+                Vec::new()
+            },
+            status_note,
+        }
+    }
+
+    #[test]
+    fn valid_zero_engine_sample_is_not_replaced() {
+        let dir = tempdir().unwrap();
+        write_gt(dir.path(), 0, 0);
+        let state = Mutex::new(GtidleState::empty());
+        let mut detail = HashMap::from([(
+            "Source: Utilization".to_string(),
+            "DRM engine counters".to_string(),
+        )]);
+        let mut utilization = 0.0;
+
+        apply_fallback(
+            "xe",
+            &engine_readout(None),
+            &state,
+            dir.path(),
+            &mut detail,
+            &mut utilization,
+        );
+
+        assert_eq!(utilization, 0.0);
+        assert_eq!(
+            detail.get("Source: Utilization").map(String::as_str),
+            Some("DRM engine counters")
+        );
+        assert!(state.lock().unwrap().samples.iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn available_zero_gtidle_sample_is_labeled_as_live_data() {
+        let dir = tempdir().unwrap();
+        write_gt(dir.path(), 0, 1_000);
+        let start = Instant::now() - Duration::from_secs(1);
+        let mut seeded_state = GtidleState::empty();
+        assert_eq!(
+            refresh_at(&mut seeded_state, dir.path(), start),
+            GtidleReadout::Seeded
+        );
+        // More idle time than wall time clamps to a valid zero-percent
+        // activity sample, which must not be confused with unavailable data.
+        write_gt(dir.path(), 0, 3_000);
+
+        let state = Mutex::new(seeded_state);
+        let mut detail = HashMap::from([
+            (
+                "Utilization".to_string(),
+                ENGINE_UNAVAILABLE_NOTE.to_string(),
+            ),
+            ("Source: Utilization".to_string(), "unavailable".to_string()),
+        ]);
+        let mut utilization = 0.0;
+        apply_fallback(
+            "xe",
+            &engine_readout(Some(ENGINE_UNAVAILABLE_NOTE)),
+            &state,
+            dir.path(),
+            &mut detail,
+            &mut utilization,
+        );
+
+        assert_eq!(utilization, 0.0);
+        assert!(!detail.contains_key("Utilization"));
+        assert_eq!(
+            detail.get("Source: Utilization").map(String::as_str),
+            Some("Xe GT idle residency")
+        );
+    }
+}

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -49,8 +49,8 @@ use crate::device::readers::intel_gpu_names::{
     classify_intel_architecture, resolve_intel_gpu_name,
 };
 use crate::device::readers::intel_gpu_sysfs::{
-    MemoryVariant, has_nonzero_u64, read_fan_rpm, read_frequency_mhz, read_memory_bytes,
-    read_power_watts, read_temperature_celsius,
+    MemoryVariant, has_nonzero_u64, read_fan_rpm, read_frequency_mhz, read_gtidle_ms,
+    read_memory_bytes, read_power_watts, read_temperature_celsius,
 };
 use crate::device::types::{GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
@@ -93,6 +93,8 @@ struct IntelGpuCard {
     /// `vram_usage: Mutex<VramUsage>` pattern (including poisoning
     /// recovery via `refresh_with_lock`).
     engine_state: Mutex<EngineState>,
+    /// Per-card gtidle delta tracker for Xe driver utilization fallback.
+    gtidle_state: Mutex<GtidleState>,
     /// Per-card Level Zero handle state (issue #248). Mirrors
     /// `engine_state` — delta-tracked behind a `Mutex` for power
     /// readings, only present when `--features level_zero` is active.
@@ -102,6 +104,13 @@ struct IntelGpuCard {
 
 /// Render the discrete/integrated classification as the string we put in
 /// `detail["Variant"]`.
+
+/// Per-GT idle residency delta tracker for Xe driver.
+struct GtidleState {
+    timestamps: Vec<std::time::Instant>,
+    readings: Vec<u64>,
+}
+
 fn variant_label(variant: MemoryVariant) -> &'static str {
     match variant {
         MemoryVariant::Discrete => "Discrete",
@@ -210,6 +219,47 @@ impl IntelGpuReader {
     }
 }
 
+/// Compute GPU utilization from Xe driver gtidle counters. Returns 0.0 on
+/// the first call (seeds) and (1 - delta_idle/delta_time)*100 thereafter.
+fn compute_gtidle_utilization(
+    state: &std::sync::Mutex<GtidleState>,
+    device_dir: &std::path::Path,
+) -> f64 {
+    let mut guard = match state.lock() {
+        Ok(g) => g,
+        Err(_) => return 0.0,
+    };
+    let current = read_gtidle_ms(device_dir);
+    let now = std::time::Instant::now();
+
+    if current.is_empty() {
+        return 0.0;
+    }
+    let n = current.len();
+    if guard.readings.is_empty() {
+        // Seed: store first reading, return 0.
+        guard.readings = current;
+        guard.timestamps = vec![now; n];
+        return 0.0;
+    }
+
+    // Take the maximum utilization across all GTs.
+    let mut max_util = 0.0f64;
+    for i in 0..n.min(guard.readings.len()) {
+        let delta_idle = current[i].saturating_sub(guard.readings[i]);
+        let delta_us = (now - guard.timestamps[i]).as_micros() as u64;
+        if delta_us > 0 {
+            let idle_frac = delta_idle as f64 * 1000.0 / delta_us as f64;
+            let util = ((1.0 - idle_frac) * 100.0).clamp(0.0, 100.0);
+            max_util = max_util.max(util);
+        }
+    }
+
+    guard.readings = current;
+    guard.timestamps = vec![now; n];
+    max_util
+}
+
 impl GpuReader for IntelGpuReader {
     fn get_gpu_info(&self) -> Vec<GpuInfo> {
         let hostname = get_hostname();
@@ -248,9 +298,23 @@ impl GpuReader for IntelGpuReader {
 
             // Engine-busy refresh — guarded by a per-card mutex.
             let readout = refresh_with_lock(&card.engine_state, &device_dir);
-            let utilization = readout.primary_utilization.clamp(0.0, MAX_GPU_UTILIZATION);
+            let mut utilization = readout.primary_utilization.clamp(0.0, MAX_GPU_UTILIZATION);
             apply_engine_readout(&mut detail, &readout);
+            // Xe driver: fall back to gtidle when engine busy counters are unavailable.
+            if utilization == 0.0 {
+                let gtidle_util = compute_gtidle_utilization(&card.gtidle_state, &device_dir);
+                if gtidle_util > 0.0 {
+                    utilization = gtidle_util;
+                    detail.insert(
+                        "Utilization".to_string(),
+                        "Engine busy from gtidle (xe)".to_string(),
+                    );
+                }
+            }
             sources::decorate_utilization_source(&mut detail, &readout);
+            if utilization > 0.0 && readout.primary_utilization == 0.0 {
+                detail.insert("Source: Utilization".to_string(), "gtidle (xe)".to_string());
+            }
 
             let uuid = build_uuid(card, &device_dir);
 
@@ -366,6 +430,10 @@ fn discover_cards(drm_root: &Path) -> Vec<IntelGpuCard> {
             variant,
             static_info: OnceLock::new(),
             engine_state: Mutex::new(EngineState::empty()),
+            gtidle_state: Mutex::new(GtidleState {
+                timestamps: Vec::new(),
+                readings: Vec::new(),
+            }),
             #[cfg(feature = "level_zero")]
             level_zero_state: Mutex::new(
                 crate::device::readers::intel_gpu_level_zero::LevelZeroState::empty(),

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -20,15 +20,16 @@
 //! devices whose vendor is `0x8086` and whose driver is `i915` or `xe`.
 //!
 //! Surfaces device identity, memory, frequency, temperature, power,
-//! and engine-busy utilization. Engine-busy is delta-computed from
+//! and utilization. Engine-busy is delta-computed from
 //! sysfs counters by [`super::intel_gpu_engine`]: `max(render,
 //! compute)` becomes `GpuInfo.utilization`, the per-class breakdown
 //! lands in `detail["Engine: <class>"]`. The first refresh per card
 //! is a seeding call returning `0.0`; real values appear from the
 //! second refresh. When the kernel exposes no engine counters,
 //! `detail["Utilization"]` carries the note in
-//! `intel_gpu_engine::ENGINE_UNAVAILABLE_NOTE` and the PMU fallback is
-//! deferred. Intel client GPUs have no MIG/vGPU equivalent.
+//! `intel_gpu_engine::ENGINE_UNAVAILABLE_NOTE`. Xe cards then fall back to
+//! GT active residency derived from `gtidle/idle_residency_ms`; the PMU
+//! fallback remains deferred. Intel client GPUs have no MIG/vGPU equivalent.
 //!
 //! ## Memory semantics
 //!
@@ -45,12 +46,15 @@ use crate::device::readers::intel_gpu_engine::{
 use crate::device::readers::intel_gpu_fdinfo::{
     build_intel_drm_basenames, build_intel_process_infos,
 };
+use crate::device::readers::intel_gpu_gtidle::{
+    GtidleState, apply_fallback as apply_gtidle_fallback,
+};
 use crate::device::readers::intel_gpu_names::{
     classify_intel_architecture, resolve_intel_gpu_name,
 };
 use crate::device::readers::intel_gpu_sysfs::{
-    MemoryVariant, has_nonzero_u64, read_fan_rpm, read_frequency_mhz, read_gtidle_ms,
-    read_memory_bytes, read_power_watts, read_temperature_celsius,
+    MemoryVariant, has_nonzero_u64, read_fan_rpm, read_frequency_mhz, read_memory_bytes,
+    read_power_watts, read_temperature_celsius,
 };
 use crate::device::types::{GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
@@ -93,7 +97,7 @@ struct IntelGpuCard {
     /// `vram_usage: Mutex<VramUsage>` pattern (including poisoning
     /// recovery via `refresh_with_lock`).
     engine_state: Mutex<EngineState>,
-    /// Per-card gtidle delta tracker for Xe driver utilization fallback.
+    /// Per-card Xe GT idle-residency delta tracker.
     gtidle_state: Mutex<GtidleState>,
     /// Per-card Level Zero handle state (issue #248). Mirrors
     /// `engine_state` — delta-tracked behind a `Mutex` for power
@@ -104,13 +108,6 @@ struct IntelGpuCard {
 
 /// Render the discrete/integrated classification as the string we put in
 /// `detail["Variant"]`.
-
-/// Per-GT idle residency delta tracker for Xe driver.
-struct GtidleState {
-    timestamps: Vec<std::time::Instant>,
-    readings: Vec<u64>,
-}
-
 fn variant_label(variant: MemoryVariant) -> &'static str {
     match variant {
         MemoryVariant::Discrete => "Discrete",
@@ -219,47 +216,6 @@ impl IntelGpuReader {
     }
 }
 
-/// Compute GPU utilization from Xe driver gtidle counters. Returns 0.0 on
-/// the first call (seeds) and (1 - delta_idle/delta_time)*100 thereafter.
-fn compute_gtidle_utilization(
-    state: &std::sync::Mutex<GtidleState>,
-    device_dir: &std::path::Path,
-) -> f64 {
-    let mut guard = match state.lock() {
-        Ok(g) => g,
-        Err(_) => return 0.0,
-    };
-    let current = read_gtidle_ms(device_dir);
-    let now = std::time::Instant::now();
-
-    if current.is_empty() {
-        return 0.0;
-    }
-    let n = current.len();
-    if guard.readings.is_empty() {
-        // Seed: store first reading, return 0.
-        guard.readings = current;
-        guard.timestamps = vec![now; n];
-        return 0.0;
-    }
-
-    // Take the maximum utilization across all GTs.
-    let mut max_util = 0.0f64;
-    for i in 0..n.min(guard.readings.len()) {
-        let delta_idle = current[i].saturating_sub(guard.readings[i]);
-        let delta_us = (now - guard.timestamps[i]).as_micros() as u64;
-        if delta_us > 0 {
-            let idle_frac = delta_idle as f64 * 1000.0 / delta_us as f64;
-            let util = ((1.0 - idle_frac) * 100.0).clamp(0.0, 100.0);
-            max_util = max_util.max(util);
-        }
-    }
-
-    guard.readings = current;
-    guard.timestamps = vec![now; n];
-    max_util
-}
-
 impl GpuReader for IntelGpuReader {
     fn get_gpu_info(&self) -> Vec<GpuInfo> {
         let hostname = get_hostname();
@@ -300,21 +256,15 @@ impl GpuReader for IntelGpuReader {
             let readout = refresh_with_lock(&card.engine_state, &device_dir);
             let mut utilization = readout.primary_utilization.clamp(0.0, MAX_GPU_UTILIZATION);
             apply_engine_readout(&mut detail, &readout);
-            // Xe driver: fall back to gtidle when engine busy counters are unavailable.
-            if utilization == 0.0 {
-                let gtidle_util = compute_gtidle_utilization(&card.gtidle_state, &device_dir);
-                if gtidle_util > 0.0 {
-                    utilization = gtidle_util;
-                    detail.insert(
-                        "Utilization".to_string(),
-                        "Engine busy from gtidle (xe)".to_string(),
-                    );
-                }
-            }
             sources::decorate_utilization_source(&mut detail, &readout);
-            if utilization > 0.0 && readout.primary_utilization == 0.0 {
-                detail.insert("Source: Utilization".to_string(), "gtidle (xe)".to_string());
-            }
+            apply_gtidle_fallback(
+                &card.driver,
+                &readout,
+                &card.gtidle_state,
+                &device_dir,
+                &mut detail,
+                &mut utilization,
+            );
 
             let uuid = build_uuid(card, &device_dir);
 
@@ -430,10 +380,7 @@ fn discover_cards(drm_root: &Path) -> Vec<IntelGpuCard> {
             variant,
             static_info: OnceLock::new(),
             engine_state: Mutex::new(EngineState::empty()),
-            gtidle_state: Mutex::new(GtidleState {
-                timestamps: Vec::new(),
-                readings: Vec::new(),
-            }),
+            gtidle_state: Mutex::new(GtidleState::empty()),
             #[cfg(feature = "level_zero")]
             level_zero_state: Mutex::new(
                 crate::device::readers::intel_gpu_level_zero::LevelZeroState::empty(),

--- a/src/device/readers/intel_gpu_sysfs.rs
+++ b/src/device/readers/intel_gpu_sysfs.rs
@@ -174,6 +174,25 @@ pub fn has_nonzero_u64(path: &Path) -> bool {
     read_u64(path).map(|v| v > 0).unwrap_or(false)
 }
 
+/// Read GPU idle residency counter in milliseconds from the Xe driver
+/// gtidle interface. Returns values from all discovered GTs (typically
+/// gt0=render/compute, gt1=media). An empty vec means no gtidle support.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_gtidle_ms(device_dir: &Path) -> Vec<u64> {
+    let mut values = Vec::new();
+    for gt in 0..=1 {
+        let path = device_dir
+            .join("tile0")
+            .join(format!("gt{gt}"))
+            .join("gtidle")
+            .join("idle_residency_ms");
+        if let Some(v) = read_u64(&path) {
+            values.push(v);
+        }
+    }
+    values
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/device/readers/intel_gpu_sysfs.rs
+++ b/src/device/readers/intel_gpu_sysfs.rs
@@ -174,23 +174,20 @@ pub fn has_nonzero_u64(path: &Path) -> bool {
     read_u64(path).map(|v| v > 0).unwrap_or(false)
 }
 
-/// Read GPU idle residency counter in milliseconds from the Xe driver
-/// gtidle interface. Returns values from all discovered GTs (typically
-/// gt0=render/compute, gt1=media). An empty vec means no gtidle support.
+/// Read GPU idle residency counters in milliseconds from the Xe driver
+/// gtidle interface. The array slots preserve the GT number (`gt0`, `gt1`),
+/// including when one file is temporarily unreadable, so callers never
+/// compare one GT's counter against another GT's previous sample.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-pub fn read_gtidle_ms(device_dir: &Path) -> Vec<u64> {
-    let mut values = Vec::new();
-    for gt in 0..=1 {
+pub fn read_gtidle_ms(device_dir: &Path) -> [Option<u64>; 2] {
+    std::array::from_fn(|gt| {
         let path = device_dir
             .join("tile0")
             .join(format!("gt{gt}"))
             .join("gtidle")
             .join("idle_residency_ms");
-        if let Some(v) = read_u64(&path) {
-            values.push(v);
-        }
-    }
-    values
+        read_u64(&path)
+    })
 }
 
 #[cfg(test)]
@@ -298,5 +295,15 @@ mod tests {
         assert!(has_nonzero_u64(&f));
         // Missing file.
         assert!(!has_nonzero_u64(&dir.path().join("missing")));
+    }
+
+    #[test]
+    fn gtidle_readings_preserve_gt_identity() {
+        let dir = tempdir().unwrap();
+        let gt1 = dir.path().join("tile0").join("gt1").join("gtidle");
+        fs::create_dir_all(&gt1).unwrap();
+        fs::write(gt1.join("idle_residency_ms"), "42\n").unwrap();
+
+        assert_eq!(read_gtidle_ms(dir.path()), [None, Some(42)]);
     }
 }

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -63,6 +63,8 @@ pub mod amd_windows;
 pub mod intel_gpu_engine;
 #[cfg(target_os = "linux")]
 pub mod intel_gpu_fdinfo;
+#[cfg(target_os = "linux")]
+pub mod intel_gpu_gtidle;
 // Opt-in Intel Level Zero (oneAPI) backend. Cross-platform FFI shim that
 // prefers Sysman metrics per field when available, while keeping sysfs/WMI
 // as the baseline and fallback. Enabled with `--features level_zero`;


### PR DESCRIPTION
The Xe kernel driver does not expose engine busy counters via sysfs (unlike i915), so utilization was permanently 0 on Xe GPUs. The Xe driver does expose gtidle/idle_residency_ms. We compute utilization from the idle-time delta across scrape intervals, matching the semantics of the existing engine-busy delta tracker.

- Add read_gtidle_ms() to intel_gpu_sysfs.rs
- Add GtidleState delta tracker
- Fall back to gtidle in get_gpu_info() when engine busy is unavailable
- Override detail[Utilization] and Source: Utilization label when gtidle provides data after apply_engine_readout sets the unavailable note