### PR TITLE
fix: align Docker builder with Rust 1.96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for optimal image size
-FROM rust:1.95-slim AS builder
+FROM rust:1.96-slim AS builder
 
 # Install system dependencies for cross-compilation
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

- update the Docker builder image from Rust 1.95 to Rust 1.96
- restore the main-only Docker Build Check after the repository MSRV was raised

## Hardening context

This is a follow-up discovered while validating the merged implementation of #268. PR #268's own Test Suite and Build Check passed, but its post-merge main run exposed a pre-existing integration drift from #270: `Cargo.toml` requires Rust 1.96 while `Dockerfile` still selected `rust:1.95-slim`.

- **Target PR reviewed:** #268
- **Related MSRV PR:** #270
- **Linked original issues:** none
- **Failed main run:** https://github.com/lablup/all-smi/actions/runs/29689601819

## Review results

- **Correctness/reliability:** aligns the production container builder with the declared `rust-version = "1.96"` and Debian/PPA toolchain floor.
- **Security:** base image family and runtime image are unchanged; this only advances the pinned Rust builder minor version.
- **Performance:** no runtime code or container layer structure changes.

## Validation

- `docker manifest inspect rust:1.96-slim`
- repository pre-commit formatting and clippy hooks
- Docker Build Check in CI will exercise the complete image build

Refs #268
Refs #270
