### PR TITLE
feat: multi-row braille sparklines with bucket max-pooling resampling

### DIFF
--- a/src/ui/braille.rs
+++ b/src/ui/braille.rs
@@ -486,4 +486,23 @@ mod tests {
         assert!(sparkline_braille_rows(&[], 8, 0, None).is_empty());
         assert!(sparkline_braille_rows(&[1.0], 0, 0, None).is_empty());
     }
+
+    // 18. Bucket stretching: when `data.len() < width * 2`, a bucket's
+    //     natural (possibly empty) span is pushed up to at least one sample,
+    //     so a sample is repeated across multiple sub-columns. The rightmost
+    //     sub-column must still cover the most recent sample.
+    #[test]
+    fn bucket_stretching_when_fewer_samples_than_subcolumns() {
+        // 2 samples, width = 2 -> 4 sub-columns, so each sample is stretched
+        // across 2 sub-columns: sub-columns 0,1 own data[0] = 0.0 (bottom
+        // dot only), sub-columns 2,3 own data[1] = 10.0 (fully filled, the
+        // most recent sample).
+        let data = [0.0, 10.0];
+        let result = sparkline_braille(&data, 2, Some((0.0, 10.0)));
+        assert_eq!(
+            result, "\u{28C0}\u{28FF}",
+            "stretched buckets should repeat data[0] into the first cell (bottom dot only) \
+             and data[1] into the second cell (fully filled, most recent sample)"
+        );
+    }
 }

--- a/src/ui/braille.rs
+++ b/src/ui/braille.rs
@@ -28,9 +28,35 @@
 //! Left sub-column uses dots 1,2,3,7 (bits 0x01,0x02,0x04,0x40).
 //! Right sub-column uses dots 4,5,6,8 (bits 0x08,0x10,0x20,0x80).
 //! Rows fill bottom-up (bar-chart style) for maximum legibility at 4px height.
+//!
+//! ## Multi-row model
+//!
+//! [`sparkline_braille_rows`] is the shared rendering core: it stacks `rows`
+//! terminal rows on top of each other, giving `rows * 4` vertical dot levels
+//! instead of the 4 levels a single row provides. The returned `Vec<String>`
+//! holds one string per terminal row, top row first. Fill order is bottom-up
+//! across the *entire* stack (btop-style): a value fills the bottom terminal
+//! row completely before any dot lights up in the row above it, and so on up
+//! the stack. [`sparkline_braille`] is a thin `rows == 1` wrapper over this
+//! shared core, so single-row callers are unaffected by the multi-row API.
+//!
+//! ## Resampling: bucket max-pooling
+//!
+//! Horizontal resampling maps `width * 2` braille sub-columns onto the input
+//! time series using bucket max-pooling rather than nearest-neighbour
+//! sampling. Each sub-column owns a contiguous bucket of input samples, and
+//! the rendered level is derived from the bucket's maximum finite value.
+//! Every input sample belongs to at least one bucket, every bucket is
+//! non-empty, and the rightmost sub-column always covers the most recent
+//! sample. When there are fewer samples than sub-columns, buckets are
+//! stretched (a sample is repeated across multiple sub-columns) so every
+//! sub-column still owns at least one sample. An all-non-finite bucket
+//! clamps to the range minimum. This keeps transient spikes visible at any
+//! output width, unlike nearest-neighbour resampling, which can skip a spike
+//! entirely if it does not land on a sampled index.
 
 /// Row bit masks for the left sub-column, ordered bottom→top.
-/// level=0 fills only the bottom row; level=3 fills all four rows.
+/// dots=1 fills only the bottom row; dots=4 fills all four rows.
 const LEFT_BITS: [u32; 4] = [
     0x40, // dot7 – bottom row
     0x04, // dot3 – lower-mid row
@@ -48,28 +74,70 @@ const RIGHT_BITS: [u32; 4] = [
 
 /// Render `data` as a braille-dot sparkline `width` columns wide.
 ///
+/// This is a thin wrapper over [`sparkline_braille_rows`] with `rows == 1`;
+/// see that function for the full behaviour contract (range handling,
+/// bucket max-pooling resampling, and edge cases).
+///
 /// # Arguments
 /// - `data`: time-series samples, most-recent sample last.
 /// - `width`: desired output width in terminal columns (each cell = 2 sub-columns).
 /// - `range`: optional fixed `(min, max)`. When `None`, the range is derived
 ///   from the data automatically.
-///
-/// # Behaviour
-/// - Empty `data` → returns `" ".repeat(width)` (ASCII spaces, preserves layout).
-/// - `width == 0` → returns an empty string.
-/// - Constant input with auto-range → renders the bottom-most row filled across
-///   all columns (`⣀` U+28C0, i.e. both bottom dots set), so callers can still
-///   see that data is present.
-/// - NaN / non-finite values are clamped to the minimum of the range.
-/// - Degenerate explicit range `(lo, hi)` where `hi <= lo` → treated as constant;
-///   all cells rendered at the bottom row.
 #[must_use]
 pub fn sparkline_braille(data: &[f64], width: usize, range: Option<(f64, f64)>) -> String {
+    let mut rows = sparkline_braille_rows(data, width, 1, range);
+    rows.pop().unwrap_or_default()
+}
+
+/// Render `data` as a multi-row braille-dot sparkline occupying `rows`
+/// stacked terminal rows.
+///
+/// # Arguments
+/// - `data`: time-series samples, most-recent sample last.
+/// - `width`: desired output width in terminal columns (each cell = 2 sub-columns).
+/// - `rows`: number of terminal rows to render. Vertical resolution is
+///   `rows * 4` dot levels, bar-filled bottom-up across the whole stack.
+/// - `range`: optional fixed `(min, max)`. When `None`, the range is derived
+///   from the data automatically.
+///
+/// # Returns
+///
+/// A `Vec<String>` with exactly `rows` entries, the first one being the
+/// *top* terminal row and the last one the *bottom* terminal row. Each
+/// string is exactly `width` characters long.
+///
+/// # Behaviour
+/// - `rows == 0` → returns an empty `Vec`.
+/// - Empty `data` → returns `rows` copies of `" ".repeat(width)` (ASCII
+///   spaces, preserves layout).
+/// - `width == 0` → returns `rows` empty strings.
+/// - Constant input with auto-range → only the single bottom-most dot row of
+///   the bottom terminal row is filled (`⣀` U+28C0 when `rows == 1`); all
+///   rows above stay blank, so callers can still see that data is present.
+/// - NaN / non-finite values are clamped to the minimum of the range.
+/// - Degenerate explicit range `(lo, hi)` where `hi <= lo` → treated as
+///   constant; only the bottom-most dot row is filled.
+///
+/// Resampling uses bucket max-pooling: see the module documentation for
+/// details. In short, each of the `width * 2` sub-columns owns a contiguous,
+/// non-empty bucket of `data`, and its level is derived from the bucket's
+/// maximum finite value, so a single-sample spike remains visible at any
+/// output width.
+#[must_use]
+pub fn sparkline_braille_rows(
+    data: &[f64],
+    width: usize,
+    rows: usize,
+    range: Option<(f64, f64)>,
+) -> Vec<String> {
+    if rows == 0 {
+        return Vec::new();
+    }
     if data.is_empty() {
-        return " ".repeat(width);
+        return vec![" ".repeat(width); rows];
     }
     if width == 0 {
-        return String::new();
+        return vec![String::new(); rows];
     }
 
     // Determine effective min/max.
@@ -105,55 +173,74 @@ pub fn sparkline_braille(data: &[f64], width: usize, range: Option<(f64, f64)>) 
 
     // Total sub-columns = width * 2 (each braille cell has 2 horizontal sub-pixels).
     let n_sub = width * 2;
+    let len = data.len();
 
-    // Resample data into n_sub sub-columns using nearest-neighbour interpolation.
-    // Maps sub-column index i → data index j.
-    let resample = |i: usize| -> f64 {
-        let j = if data.len() == 1 {
-            0
-        } else {
-            // Map [0, n_sub-1] → [0, data.len()-1] linearly (nearest neighbour).
-            let j_frac = i as f64 * (data.len() - 1) as f64 / (n_sub - 1).max(1) as f64;
-            j_frac.round() as usize
-        };
-        let v = data[j.min(data.len() - 1)];
-        if v.is_finite() { v } else { min }
+    // Bucket max-pooling: sub-column `i` owns `data[start..end)`.
+    //
+    // `start`/`end` form a standard floor partition of `data` into `n_sub`
+    // buckets, which is already non-empty for every bucket when
+    // `len >= n_sub`. When `len < n_sub`, the natural `end` can equal
+    // `start`, so it is pushed up to at least `start + 1` (stretching,
+    // i.e. repeating a sample across multiple sub-columns) to guarantee
+    // every sub-column owns at least one sample. The last sub-column's
+    // natural `end` is always exactly `len`, so it always covers the most
+    // recent sample regardless of stretching.
+    let bucket_max = |i: usize| -> f64 {
+        let start = i * len / n_sub;
+        let end = ((i + 1) * len / n_sub).max(start + 1).min(len);
+        let mut m = f64::NEG_INFINITY;
+        for &v in &data[start..end] {
+            if v.is_finite() && v > m {
+                m = v;
+            }
+        }
+        if m.is_finite() { m } else { min }
     };
 
-    // Compute vertical level (0=bottom, 3=top) for a value.
-    // When max == min (constant / degenerate range) always returns 0 (bottom row).
+    // Compute vertical level (0..rows*4, bottom→top) for a value.
+    // When max <= min (constant / degenerate range) always returns 0.
+    let total_levels = rows * 4;
     let level_of = |v: f64| -> usize {
         if max <= min {
             return 0;
         }
         let clamped = v.clamp(min, max);
         let norm = (clamped - min) / (max - min);
-        // norm ∈ [0.0, 1.0]; multiply by 4 and floor, clamped to [0, 3].
-        ((norm * 4.0).floor() as usize).min(3)
+        // norm ∈ [0.0, 1.0]; multiply by total_levels and floor, clamped to
+        // [0, total_levels - 1].
+        ((norm * total_levels as f64).floor() as usize).min(total_levels - 1)
     };
 
-    // Build output string: one braille character per pair of sub-columns.
-    let mut out = String::with_capacity(width * 3); // braille chars are 3 bytes in UTF-8
-    for cell in 0..width {
-        let left_val = resample(cell * 2);
-        let right_val = resample(cell * 2 + 1);
+    // Number of dots filled (1..=total_levels), bottom-up, for each sub-column.
+    let dots_filled: Vec<usize> = (0..n_sub).map(|i| level_of(bucket_max(i)) + 1).collect();
 
-        let left_level = level_of(left_val);
-        let right_level = level_of(right_val);
+    // Build one output string per terminal row, top row first. Each row's
+    // fill is derived by slicing the per-sub-column dot count into this
+    // row's 4-dot window.
+    let mut out_rows: Vec<String> = Vec::with_capacity(rows);
+    for r in 0..rows {
+        let row_from_bottom = rows - 1 - r;
+        let row_base = row_from_bottom * 4;
+        let mut row = String::with_capacity(width * 3); // braille chars are 3 bytes in UTF-8
+        for cell in 0..width {
+            let left_dots = dots_filled[cell * 2].saturating_sub(row_base).min(4);
+            let right_dots = dots_filled[cell * 2 + 1].saturating_sub(row_base).min(4);
 
-        // Bar-fill: fill all rows from bottom up to the computed level.
-        let mut bits: u32 = 0;
-        for &b in LEFT_BITS.iter().take(left_level + 1) {
-            bits |= b;
+            // Bar-fill: fill this row's dots from bottom up to the computed count.
+            let mut bits: u32 = 0;
+            for &b in LEFT_BITS.iter().take(left_dots) {
+                bits |= b;
+            }
+            for &b in RIGHT_BITS.iter().take(right_dots) {
+                bits |= b;
+            }
+
+            let ch = char::from_u32(0x2800 + bits).unwrap_or('⠀');
+            row.push(ch);
         }
-        for &b in RIGHT_BITS.iter().take(right_level + 1) {
-            bits |= b;
-        }
-
-        let ch = char::from_u32(0x2800 + bits).unwrap_or('⠀');
-        out.push(ch);
+        out_rows.push(row);
     }
-    out
+    out_rows
 }
 
 #[cfg(test)]
@@ -269,5 +356,134 @@ mod tests {
             4,
             "should return 4 chars even with infinite range bound"
         );
+    }
+
+    // 10. Multi-row dimensions: Vec length equals `rows`, each row's char
+    //     count equals `width`.
+    #[test]
+    fn multirow_dimensions() {
+        let data: Vec<f64> = (0..50).map(|i| (i as f64).sin() * 10.0 + 20.0).collect();
+        let rows = sparkline_braille_rows(&data, 6, 3, None);
+        assert_eq!(rows.len(), 3, "should return one string per row");
+        for row in &rows {
+            assert_eq!(char_count(row), 6, "each row should be `width` chars");
+            assert!(all_braille(row), "all chars should be braille codepoints");
+        }
+    }
+
+    // 11. Level continuity across row boundaries: a value at exactly 50% of
+    //     the range with rows=2 fills the entire bottom terminal row.
+    #[test]
+    fn level_continuity_fills_bottom_row_at_half_range() {
+        let data = vec![50.0; 8];
+        let rows = sparkline_braille_rows(&data, 4, 2, Some((0.0, 100.0)));
+        assert_eq!(rows.len(), 2);
+        let bottom_row = &rows[1]; // last element is the bottom terminal row
+        for ch in bottom_row.chars() {
+            assert_eq!(
+                ch, '\u{28FF}',
+                "bottom terminal row should be fully filled at exactly 50% of range, got {ch:?}"
+            );
+        }
+    }
+
+    // 12. Spike preservation: 99 zeros plus one 100.0 at width 8 renders at
+    //     least one top-level dot (bit 0x01 or 0x08).
+    #[test]
+    fn spike_preservation_width_8() {
+        let mut data = vec![0.0; 99];
+        data.push(100.0);
+        let result = sparkline_braille(&data, 8, None);
+        assert_eq!(char_count(&result), 8);
+        let has_top_dot = result.chars().any(|c| {
+            let bits = c as u32 - 0x2800;
+            bits & (0x01 | 0x08) != 0
+        });
+        assert!(
+            has_top_dot,
+            "a single-sample spike should render at least one top-level dot, got {result:?}"
+        );
+    }
+
+    // 13. rows == 1 parity: `sparkline_braille` must equal
+    //     `sparkline_braille_rows(..., rows = 1, ...)[0]` for representative
+    //     inputs, since the former is a thin wrapper over the latter.
+    #[test]
+    fn rows_one_matches_wrapper() {
+        type Case = (Vec<f64>, usize, Option<(f64, f64)>);
+        let cases: Vec<Case> = vec![
+            (vec![], 8, None),
+            (vec![1.0, 2.0, 3.0], 0, None),
+            (vec![42.0], 5, None),
+            (vec![7.0; 10], 4, None),
+            ((0..30).map(|i| i as f64).collect(), 8, None),
+            (vec![5.0, 10.0, 15.0], 3, Some((0.0, 20.0))),
+            (vec![f64::NAN, f64::INFINITY, 1.0, 2.0], 5, None),
+        ];
+        for (data, width, range) in cases {
+            let direct = sparkline_braille(&data, width, range);
+            let via_rows = sparkline_braille_rows(&data, width, 1, range);
+            assert_eq!(via_rows.len(), 1);
+            assert_eq!(
+                direct, via_rows[0],
+                "sparkline_braille should match sparkline_braille_rows(..., 1, ...)[0] for {data:?}"
+            );
+        }
+    }
+
+    // 14. Max-pooling correctness: a bucket's maximum, not its last or
+    //     nearest sample, determines the rendered level.
+    #[test]
+    fn bucket_max_pooling_uses_bucket_maximum() {
+        // 4 samples, width=1 -> 2 sub-columns, so each bucket holds 2 samples:
+        // left sub-column owns data[0..2] = {0.0, 0.0} (max 0.0),
+        // right sub-column owns data[2..4] = {5.0, 0.0} (max 5.0, not the
+        // trailing 0.0 that nearest-neighbour / last-sample would pick).
+        let data = [0.0, 0.0, 5.0, 0.0];
+        let result = sparkline_braille(&data, 1, Some((0.0, 5.0)));
+        assert_eq!(char_count(&result), 1);
+        let ch = result.chars().next().expect("single char");
+        let bits = ch as u32 - 0x2800;
+        // Left sub-column: bottom dot only (level 0 -> 1 dot, bucket max 0.0).
+        assert_eq!(bits & 0x40, 0x40, "left bottom dot should be set");
+        assert_eq!(bits & 0x01, 0, "left top dot should be clear");
+        // Right sub-column: fully filled (level 3 -> 4 dots, bucket max 5.0).
+        assert_eq!(
+            bits & (0x80 | 0x20 | 0x10 | 0x08),
+            0x80 | 0x20 | 0x10 | 0x08,
+            "right sub-column should be fully filled by the bucket maximum"
+        );
+    }
+
+    // 15. Multi-row API: empty data returns `rows` copies of `width` spaces.
+    #[test]
+    fn multirow_empty_data() {
+        let rows = sparkline_braille_rows(&[], 6, 3, None);
+        assert_eq!(rows.len(), 3);
+        for row in &rows {
+            assert_eq!(char_count(row), 6);
+            assert!(row.chars().all(|c| c == ' '));
+        }
+    }
+
+    // 16. Multi-row API: zero width returns `rows` empty strings.
+    #[test]
+    fn multirow_zero_width() {
+        let rows = sparkline_braille_rows(&[1.0, 2.0, 3.0], 0, 3, None);
+        assert_eq!(rows.len(), 3);
+        for row in &rows {
+            assert!(row.is_empty());
+        }
+    }
+
+    // 17. Multi-row API: zero rows returns an empty Vec.
+    #[test]
+    fn multirow_zero_rows() {
+        let rows = sparkline_braille_rows(&[1.0, 2.0, 3.0], 8, 0, None);
+        assert!(rows.is_empty());
+
+        // Also true for empty data / zero width combined with zero rows.
+        assert!(sparkline_braille_rows(&[], 8, 0, None).is_empty());
+        assert!(sparkline_braille_rows(&[1.0], 0, 0, None).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Reworks `src/ui/braille.rs` to add a multi-row braille sparkline API and replace nearest-neighbour resampling with bucket max-pooling, per Part 1 of the sparkline readability chain (#272 -> #273 -> #274). No call-site changes: `sparkline_braille` keeps its existing signature and behaviour contract, so the header, GPU Metrics panel, and remote panel sparklines automatically benefit from the improved resampling.

## What changed

- Added `sparkline_braille_rows(data, width, rows, range) -> Vec<String>` as the shared rendering core, returning one string per terminal row (top row first), with `rows * 4` vertical dot levels filled bottom-up across the whole stack (btop-style).
- Reimplemented `sparkline_braille` as a thin wrapper over `sparkline_braille_rows(..., rows = 1, ...)`, so `rows == 1` output is produced by the same shared code path rather than a separate implementation.
- Replaced the nearest-neighbour `resample` closure with bucket max-pooling: each of the `width * 2` braille sub-columns owns a contiguous, non-empty bucket of the input series, and the rendered level uses the bucket's maximum finite value. Buckets stretch (repeat samples) when `data.len() < width * 2`, the rightmost sub-column always covers the most recent sample, and an all-non-finite bucket clamps to the range minimum.
- Preserved all existing edge-case behaviour: empty data renders `width` spaces, `width == 0` renders empty output, constant data or a degenerate/non-finite range fills only the bottom dot row, and NaN/non-finite samples clamp to the range minimum.
- Extended the module doc comment to describe the multi-row model and the bucket max-pooling resampling scheme.
- Added unit tests covering multi-row dimensions, level continuity across row boundaries (a 50%-of-range value with `rows = 2` fills the entire bottom terminal row), spike preservation at width 8, `rows == 1` parity with the wrapper, bucket max-pooling correctness against a known bucket layout, bucket stretching when `data.len() < width * 2` (a sample repeated across sub-columns, with the rightmost sub-column still covering the most recent sample), and the multi-row empty/zero-width/zero-rows edge cases.

Note on the "rows == 1 parity" acceptance criterion: it is satisfied by construction, since `sparkline_braille` now calls `sparkline_braille_rows(..., 1, ...)` directly, not by byte-for-byte matching the old nearest-neighbour output. The resampling change intentionally alters rendered output in places where nearest-neighbour previously dropped peaks between sampled indices; all pre-existing unit tests (which assert lengths and edge cases, not nearest-neighbour-specific output strings) pass unmodified.

## Test plan

- [x] `cargo test --lib ui::braille` (18 tests, all pass)
- [x] `cargo test --lib ui::gpu_sparkline_panel` (20 tests, all pass, no call-site regression)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt --check`

Closes #272

