### PR TITLE
feat: soft auto-range and trend cues for single-row sparklines

### DIFF
--- a/src/ui/gpu_sparkline_panel.rs
+++ b/src/ui/gpu_sparkline_panel.rs
@@ -21,8 +21,11 @@
 //! <label>  <braille sparkline>  <latest>  <scale badge>
 //! ```
 //!
-//! The scale badge shows the row's fixed Y-axis range (e.g. `30-83`), not a
-//! per-frame observed min/max, so it reads as a stable legend for the height.
+//! The scale badge shows the row's soft-zoom Y-axis range actually in use
+//! (e.g. `40-60`), computed by [`soft_range`](crate::ui::scale::soft_range)
+//! from the visible history window with a per-metric minimum span, coarse-grid
+//! hysteresis, and hard-domain clamping. It keeps the axis honest: the badge
+//! always reports the exact bounds the sparkline is drawn against.
 //!
 //! Rows rendered (platform-dependent):
 //!
@@ -53,7 +56,11 @@ use crate::device::CpuInfo;
 use crate::ui::activity_panel;
 use crate::ui::braille::sparkline_braille;
 use crate::ui::buffer::BufferWriter;
-use crate::ui::scale::{ane_range, power_range, scale_badge, temp_range};
+use crate::ui::scale::{
+    ANE_SOFT_GRID, ANE_SOFT_MIN_SPAN, PERCENT_DOMAIN, PERCENT_SOFT_GRID, PERCENT_SOFT_MIN_SPAN,
+    TEMP_SOFT_GRID, TEMP_SOFT_MIN_SPAN, ane_range, power_range, power_soft_grid,
+    power_soft_min_span, scale_badge, soft_range, temp_range,
+};
 use crate::ui::text::print_colored_text;
 
 /// Width reserved for the label column (e.g. "GPU Util").
@@ -220,10 +227,16 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool, has_npu: bool) ->
     let mut rows = Vec::with_capacity(6);
     let gpu = state.gpu_info.first();
 
-    // 1. GPU Utilization
+    // 1. GPU Utilization — soft axis zoomed into the visible window (clamped to
+    //    0..100) so small variations around a typical load stay visible.
     let gpu_util: Vec<f64> = state.utilization_history.iter().copied().collect();
     let latest_util = gpu_util.last().copied().unwrap_or(0.0);
-    let util_range = (0.0, 100.0);
+    let util_range = soft_range(
+        &gpu_util,
+        PERCENT_SOFT_MIN_SPAN,
+        PERCENT_SOFT_GRID,
+        PERCENT_DOMAIN,
+    );
     rows.push(SparklineRow {
         label: "GPU Util",
         color: ThemeConfig::gpu_color(),
@@ -234,10 +247,15 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool, has_npu: bool) ->
         badge: None,
     });
 
-    // 2. GPU Memory
+    // 2. GPU Memory — soft axis over the memory-utilization (%) window.
     let gpu_mem: Vec<f64> = state.memory_history.iter().copied().collect();
     let latest_mem = gpu_mem.last().copied().unwrap_or(0.0);
-    let mem_range = (0.0, 100.0);
+    let mem_range = soft_range(
+        &gpu_mem,
+        PERCENT_SOFT_MIN_SPAN,
+        PERCENT_SOFT_GRID,
+        PERCENT_DOMAIN,
+    );
     rows.push(SparklineRow {
         label: "GPU Mem",
         color: ThemeConfig::memory_color(),
@@ -248,12 +266,18 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool, has_npu: bool) ->
         badge: None,
     });
 
-    // 3. GPU Temperature — fixed axis anchored to the reported thermal
-    //    threshold (or a 100°C fallback). The height then tracks how close the
-    //    GPU is to throttling instead of rescaling to per-window noise.
+    // 3. GPU Temperature — soft axis clamped to (0, thermal-threshold ceiling)
+    //    (100°C fallback). The floor is 0 so a cool GPU can zoom below 30°C
+    //    while the window still tracks small changes.
     let gpu_temp: Vec<f64> = state.temperature_history.iter().copied().collect();
     let latest_temp = gpu_temp.last().copied().unwrap_or(0.0);
-    let temp_rng = temp_range(gpu);
+    let temp_ceiling = temp_range(gpu).1;
+    let temp_rng = soft_range(
+        &gpu_temp,
+        TEMP_SOFT_MIN_SPAN,
+        TEMP_SOFT_GRID,
+        (0.0, temp_ceiling),
+    );
     rows.push(SparklineRow {
         label: "GPU Temp",
         color: ThemeConfig::thermal_color(),
@@ -278,7 +302,15 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool, has_npu: bool) ->
         } else {
             state.ane_power_history.iter().copied().collect()
         };
-        let ane_rng = ane_range(&ane_history);
+        // Soft axis clamped to (0, ane ceiling); the ceiling still comes from
+        // ane_range so a busy Neural Engine keeps a comparable top.
+        let ane_ceiling = ane_range(&ane_history).1;
+        let ane_rng = soft_range(
+            &ane_history,
+            ANE_SOFT_MIN_SPAN,
+            ANE_SOFT_GRID,
+            (0.0, ane_ceiling),
+        );
         rows.push(SparklineRow {
             label: "ANE",
             color: ThemeConfig::accelerator_color(),
@@ -303,17 +335,23 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool, has_npu: bool) ->
         });
     }
 
-    // 5. Pkg Power — fixed axis anchored to the enforced power limit when the
-    //    driver reports one, else a nice-rounded ceiling over the observed peak.
+    // 5. Pkg Power — soft axis clamped to (0, power ceiling), where the ceiling
+    //    is the summed enforced per-GPU limits (package power is summed across
+    //    all GPUs), else a nice-rounded peak. The soft min span and grid step
+    //    scale with that ceiling.
     let power_w = package_power(state, is_apple);
     let power_history: Vec<f64> = if state.package_power_history.is_empty() {
         vec![power_w]
     } else {
         state.package_power_history.iter().copied().collect()
     };
-    // Aggregate axis: package power is summed across all GPUs, so anchor the
-    // ceiling to the summed per-GPU limits (not just the first GPU's).
-    let power_rng = power_range(&state.gpu_info, &power_history);
+    let power_ceiling = power_range(&state.gpu_info, &power_history).1;
+    let power_rng = soft_range(
+        &power_history,
+        power_soft_min_span(power_ceiling),
+        power_soft_grid(power_ceiling),
+        (0.0, power_ceiling),
+    );
     rows.push(SparklineRow {
         label: "Pkg Power",
         color: ThemeConfig::power_color(),
@@ -749,13 +787,18 @@ mod tests {
         assert_eq!(rows[3].label, "ANE");
         assert_eq!(rows[4].label, "Pkg Power");
         assert!(rows[2].badge.is_none());
-        // Scale badges now show the fixed axis, not the observed window:
-        //   ANE  peak 3.8 W -> floored to 8 W -> nice_ceil 10 W
-        //   Pkg  peak 17.5 W (no power limit) -> nice_ceil 20 W
-        assert_eq!(rows[3].min_max_str, "0-10");
-        assert_eq!(rows[4].min_max_str, "0-20");
-        // GPU Temp uses the 30°C floor + 100°C fallback (no thresholds set).
-        assert_eq!(rows[2].min_max_str, "30-100");
+        // Scale badges now show the soft-zoom axis actually in use, computed by
+        // hand from the fixture histories (see make_apple_silicon_state):
+        //   GPU Util  data [0..76]   -> grid [0, 80]
+        //   GPU Mem   data [0..47.5] -> grid [0, 50]
+        //   GPU Temp  data [40..59]  -> grid [40, 60]  (domain 0..100)
+        //   ANE       data [0..3.8]  -> grid [0, 4]    (ceiling 10, min span 2)
+        //   Pkg Power data [8..17.5] -> grid [8, 18]   (ceiling 20, min span 4, grid 1)
+        assert_eq!(rows[0].min_max_str, "0-80");
+        assert_eq!(rows[1].min_max_str, "0-50");
+        assert_eq!(rows[2].min_max_str, "40-60");
+        assert_eq!(rows[3].min_max_str, "0-4");
+        assert_eq!(rows[4].min_max_str, "8-18");
     }
 
     #[test]

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -621,4 +621,75 @@ mod tests {
         // Buffer must be non-empty
         assert!(!buf.is_empty());
     }
+
+    /// [`trend_glyph`] is covered in isolation above, but nothing previously
+    /// checked that its result actually reaches the rendered byte stream in
+    /// the right column. Six-sample histories are used so `TREND_LOOKBACK`
+    /// (5) always compares against the oldest sample, and each metric is
+    /// engineered to land in a distinct classification bucket so the test can
+    /// pin down exactly which glyph is expected in which metric's segment of
+    /// the output.
+    #[test]
+    fn test_draw_local_header_bar_renders_trend_glyphs() {
+        use crate::app_state::AppState;
+        let mut state = AppState::new();
+        for v in [10.0, 10.0, 10.0, 10.0, 10.0, 60.0] {
+            state.cpu_utilization_history.push_back(v); // delta 50 -> steep rise
+        }
+        for v in [80.0, 80.0, 80.0, 80.0, 80.0, 20.0] {
+            state.utilization_history.push_back(v); // delta -60 -> steep fall
+        }
+        for v in [50.0, 50.0, 50.0, 50.0, 50.0, 50.5] {
+            state.system_memory_history.push_back(v); // delta 0.5 -> flat
+        }
+        for v in [10.0, 10.0, 10.0, 10.0, 10.0, 10.5] {
+            state.package_power_history.push_back(v); // delta 0.5 -> gentle rise
+        }
+        for v in [50.0, 50.0, 50.0, 50.0, 50.0, 49.0] {
+            state.cpu_temperature_history.push_back(v); // delta -1.0 -> gentle fall
+        }
+
+        let mut buf: Vec<u8> = Vec::new();
+        draw_local_header_bar(&mut buf, &state, 120);
+        let out = String::from_utf8_lossy(&buf);
+
+        // Locate each metric's label so the glyph search can be scoped to
+        // that metric's segment of line 2, confirming both the glyph value
+        // and that it lands in the correct column.
+        let cpu = out.find("CPU").expect("CPU label rendered");
+        let gpu = out.find("GPU").expect("GPU label rendered");
+        let ram = out.find("RAM").expect("RAM label rendered");
+        let pwr = out.find("Pwr").expect("Pwr label rendered");
+        let tmp = out.find("Tmp").expect("Tmp label rendered");
+        assert!(
+            cpu < gpu && gpu < ram && ram < pwr && pwr < tmp,
+            "metric labels rendered out of order: {out:?}"
+        );
+
+        assert!(
+            out[cpu..gpu].contains('\u{2191}'), // ↑
+            "CPU segment should contain the steep-rise glyph: {:?}",
+            &out[cpu..gpu]
+        );
+        assert!(
+            out[gpu..ram].contains('\u{2193}'), // ↓
+            "GPU segment should contain the steep-fall glyph: {:?}",
+            &out[gpu..ram]
+        );
+        assert!(
+            out[ram..pwr].contains('\u{2192}'), // →
+            "RAM segment should contain the level glyph: {:?}",
+            &out[ram..pwr]
+        );
+        assert!(
+            out[pwr..tmp].contains('\u{2197}'), // ↗
+            "Pwr segment should contain the gentle-rise glyph: {:?}",
+            &out[pwr..tmp]
+        );
+        assert!(
+            out[tmp..].contains('\u{2198}'), // ↘
+            "Tmp segment should contain the gentle-fall glyph: {:?}",
+            &out[tmp..]
+        );
+    }
 }

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -23,8 +23,16 @@
 //!
 //! **Line 2** — metrics sparkline row (8-cell braille sparklines):
 //! ```text
-//! CPU <pct>% ⣿⣷⣶…  GPU <pct>% ⣿⣷…  RAM <used>/<total>GB ⣿…  Pwr <W>W ⣿…  Tmp <°C>°C ⣿…
+//! CPU <pct>%<t> ⣿⣷⣶…  GPU <pct>%<t> ⣿⣷…  RAM <used>/<total>GB<t> ⣿…  Pwr <W>W<t> ⣿…  Tmp <°C>°C<t> ⣿…
 //! ```
+//!
+//! Each metric carries a one-cell trend glyph `<t>` (`↑ ↗ → ↘ ↓`) immediately
+//! after its latest value, coloured in the metric's theme colour, derived from
+//! the recent slope of that metric's history (see [`trend_glyph`]).
+//!
+//! Each sparkline uses a per-metric [`soft_range`](crate::ui::scale::soft_range)
+//! auto-axis (zoomed into the visible window with a minimum span, coarse-grid
+//! hysteresis, and hard-domain clamping) so small variations stay visible.
 //!
 //! Colors come from `ThemeConfig` — none are hardcoded.
 //! Sparklines are rendered via [`sparkline_braille`] from the braille utility module.
@@ -36,11 +44,29 @@ use crossterm::{queue, style::Color, style::Print};
 use crate::app_state::AppState;
 use crate::common::config::ThemeConfig;
 use crate::ui::braille::sparkline_braille;
-use crate::ui::scale::{power_range, temp_range};
+use crate::ui::scale::{
+    PERCENT_DOMAIN, PERCENT_SOFT_GRID, PERCENT_SOFT_MIN_SPAN, TEMP_SOFT_GRID, TEMP_SOFT_MIN_SPAN,
+    power_range, power_soft_grid, power_soft_min_span, soft_range, temp_range,
+};
 use crate::ui::text::print_colored_text;
 
 /// Width in braille cells for each metric sparkline.
 const SPARKLINE_WIDTH: usize = 8;
+
+/// Trend-classification thresholds `(flat, steep)` for percentage metrics
+/// (CPU / GPU / RAM), in percentage points. A recent change below `flat` reads
+/// as level (`→`), below `steep` as a gentle slope (`↗`/`↘`), otherwise steep
+/// (`↑`/`↓`).
+const TREND_PERCENT: (f64, f64) = (1.0, 5.0);
+
+/// Trend-classification thresholds `(flat, steep)` for temperature, in °C.
+const TREND_TEMP: (f64, f64) = (0.5, 2.0);
+
+/// Trend-classification thresholds `(flat, steep)` for package power, in W.
+const TREND_POWER: (f64, f64) = (0.2, 1.0);
+
+/// How many samples back the trend slope is measured over.
+const TREND_LOOKBACK: usize = 5;
 
 /// Render the two-line local-mode host summary bar.
 ///
@@ -117,33 +143,39 @@ fn draw_identity_line<W: Write>(stdout: &mut W, state: &AppState) {
 /// Render the metrics sparkline row.
 fn draw_metrics_line<W: Write>(stdout: &mut W, state: &AppState) {
     // CPU% — theme color Cyan
+    let cpu_history: Vec<f64> = state.cpu_utilization_history.iter().copied().collect();
     draw_metric_sparkline(
         stdout,
         "CPU",
-        &state
-            .cpu_utilization_history
-            .iter()
-            .copied()
-            .collect::<Vec<_>>(),
+        &cpu_history,
         format_pct(state.cpu_utilization_history.back().copied()),
         ThemeConfig::cpu_color(),
-        Some((0.0, 100.0)),
+        Some(soft_range(
+            &cpu_history,
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        )),
+        TREND_PERCENT,
     );
 
     print_colored_text(stdout, "  ", Color::White, None, None);
 
     // GPU% — theme color Blue
+    let gpu_history: Vec<f64> = state.utilization_history.iter().copied().collect();
     draw_metric_sparkline(
         stdout,
         "GPU",
-        &state
-            .utilization_history
-            .iter()
-            .copied()
-            .collect::<Vec<_>>(),
+        &gpu_history,
         format_pct(state.utilization_history.back().copied()),
         ThemeConfig::gpu_color(),
-        Some((0.0, 100.0)),
+        Some(soft_range(
+            &gpu_history,
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        )),
+        TREND_PERCENT,
     );
 
     print_colored_text(stdout, "  ", Color::White, None, None);
@@ -159,20 +191,24 @@ fn draw_metrics_line<W: Write>(stdout: &mut W, state: &AppState) {
     print_colored_text(stdout, "  ", Color::White, None, None);
 
     // Temperature — theme color Magenta
+    let temp_history: Vec<f64> = state.cpu_temperature_history.iter().copied().collect();
+    // Soft axis clamped to (0, temp ceiling): CPU sensors report no thermal
+    // threshold, so the ceiling is the 100°C fallback while the floor is 0 so a
+    // cool sensor can zoom below 30°C. The window then tracks small changes.
+    let temp_ceiling = temp_range(None).1;
     draw_metric_sparkline(
         stdout,
         "Tmp",
-        &state
-            .cpu_temperature_history
-            .iter()
-            .copied()
-            .collect::<Vec<_>>(),
+        &temp_history,
         format_temp(state.cpu_temperature_history.back().copied()),
         ThemeConfig::thermal_color(),
-        // Fixed axis (30°C floor, 100°C fallback ceiling): CPU sensors report no
-        // thermal threshold, so the height reflects absolute temperature rather
-        // than rescaling to per-window noise.
-        Some(temp_range(None)),
+        Some(soft_range(
+            &temp_history,
+            TEMP_SOFT_MIN_SPAN,
+            TEMP_SOFT_GRID,
+            (0.0, temp_ceiling),
+        )),
+        TREND_TEMP,
     );
 
     queue!(stdout, Print("\r\n")).unwrap();
@@ -180,7 +216,8 @@ fn draw_metrics_line<W: Write>(stdout: &mut W, state: &AppState) {
 
 /// Draw a single labelled metric with a braille sparkline.
 ///
-/// Format: `<label> <value> <sparkline>`
+/// Format: `<label> <value><trend> <sparkline>`, where `<trend>` is a one-cell
+/// glyph (`↑ ↗ → ↘ ↓`) coloured in the metric's theme colour.
 fn draw_metric_sparkline<W: Write>(
     stdout: &mut W,
     label: &str,
@@ -188,14 +225,54 @@ fn draw_metric_sparkline<W: Write>(
     value_str: String,
     color: Color,
     range: Option<(f64, f64)>,
+    trend: (f64, f64),
 ) {
     let sparkline = sparkline_braille(history, SPARKLINE_WIDTH, range);
+    let glyph = trend_glyph(history, trend.0, trend.1);
 
     print_colored_text(stdout, label, color, None, None);
     print_colored_text(stdout, " ", Color::White, None, None);
     print_colored_text(stdout, &value_str, Color::White, None, None);
+    print_colored_text(stdout, glyph, color, None, None);
     print_colored_text(stdout, " ", Color::DarkGrey, None, None);
     print_colored_text(stdout, &sparkline, color, None, None);
+}
+
+/// Classify the recent slope of `history` into one of five trend glyphs.
+///
+/// The slope is the delta between the latest sample and the sample
+/// [`TREND_LOOKBACK`] positions back (or the oldest available when the history
+/// is shorter). Classification, by the delta `d` against `(flat, steep)`:
+/// - `|d| < flat` → `→` (level)
+/// - `flat ≤ d < steep` → `↗`, `steep ≤ d` → `↑`
+/// - `flat ≤ -d < steep` → `↘`, `steep ≤ -d` → `↓`
+///
+/// Fewer than two samples yields a single space so the metric column stays
+/// aligned. A non-finite latest or reference sample reads as level (`→`).
+#[must_use]
+fn trend_glyph(history: &[f64], flat: f64, steep: f64) -> &'static str {
+    if history.len() < 2 {
+        return " ";
+    }
+    let latest = history[history.len() - 1];
+    let reference = history[history.len().saturating_sub(TREND_LOOKBACK + 1)];
+    if !latest.is_finite() || !reference.is_finite() {
+        return "\u{2192}"; // →
+    }
+    let delta = latest - reference;
+    if delta.abs() < flat {
+        "\u{2192}" // →
+    } else if delta > 0.0 {
+        if delta >= steep {
+            "\u{2191}" // ↑
+        } else {
+            "\u{2197}" // ↗
+        }
+    } else if delta <= -steep {
+        "\u{2193}" // ↓
+    } else {
+        "\u{2198}" // ↘
+    }
 }
 
 /// Draw the RAM metric: `RAM <used>/<total>GB <sparkline>`.
@@ -213,11 +290,20 @@ fn draw_ram_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
 
     let history: Vec<f64> = state.system_memory_history.iter().copied().collect();
 
-    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some((0.0, 100.0)));
+    // Soft axis over the memory-utilization (%) window.
+    let range = soft_range(
+        &history,
+        PERCENT_SOFT_MIN_SPAN,
+        PERCENT_SOFT_GRID,
+        PERCENT_DOMAIN,
+    );
+    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some(range));
+    let glyph = trend_glyph(&history, TREND_PERCENT.0, TREND_PERCENT.1);
 
     print_colored_text(stdout, "RAM", ThemeConfig::memory_color(), None, None);
     print_colored_text(stdout, " ", Color::White, None, None);
     print_colored_text(stdout, &value_str, Color::White, None, None);
+    print_colored_text(stdout, glyph, ThemeConfig::memory_color(), None, None);
     print_colored_text(stdout, " ", Color::DarkGrey, None, None);
     print_colored_text(stdout, &sparkline, ThemeConfig::memory_color(), None, None);
 }
@@ -258,16 +344,24 @@ fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
     let value_str = format!("{power_watts:>5.1}W");
 
     let history: Vec<f64> = state.package_power_history.iter().copied().collect();
-    // Fixed axis (0 .. summed enforced power limits, or a nice-rounded peak
-    // when no limit is reported) so the height tracks the power budget instead
-    // of rescaling every frame. Power is summed across all GPUs, so the
-    // ceiling is the aggregate limit.
-    let range = Some(power_range(&state.gpu_info, &history));
-    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, range);
+    // Soft axis clamped to (0, power ceiling), where the ceiling is the summed
+    // enforced power limits (or a nice-rounded peak when no limit is reported).
+    // The soft-axis min span and grid step scale with that ceiling, so the
+    // height zooms into the visible window without leaving the power budget.
+    let ceiling = power_range(&state.gpu_info, &history).1;
+    let range = soft_range(
+        &history,
+        power_soft_min_span(ceiling),
+        power_soft_grid(ceiling),
+        (0.0, ceiling),
+    );
+    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some(range));
+    let glyph = trend_glyph(&history, TREND_POWER.0, TREND_POWER.1);
 
     print_colored_text(stdout, "Pwr", ThemeConfig::power_color(), None, None);
     print_colored_text(stdout, " ", Color::White, None, None);
     print_colored_text(stdout, &value_str, Color::White, None, None);
+    print_colored_text(stdout, glyph, ThemeConfig::power_color(), None, None);
     print_colored_text(stdout, " ", Color::DarkGrey, None, None);
     print_colored_text(stdout, &sparkline, ThemeConfig::power_color(), None, None);
 }
@@ -448,6 +542,56 @@ mod tests {
                 "RAM format width should be stable for total={total}"
             );
         }
+    }
+
+    #[test]
+    fn test_trend_glyph_insufficient_history() {
+        // Fewer than two samples -> a single space to preserve column alignment.
+        assert_eq!(trend_glyph(&[], 1.0, 5.0), " ");
+        assert_eq!(trend_glyph(&[42.0], 1.0, 5.0), " ");
+    }
+
+    #[test]
+    fn test_trend_glyph_flat() {
+        // |delta| < flat threshold -> level arrow.
+        assert_eq!(trend_glyph(&[50.0, 50.5], 1.0, 5.0), "\u{2192}"); // →
+        assert_eq!(trend_glyph(&[50.0, 49.5], 1.0, 5.0), "\u{2192}"); // →
+    }
+
+    #[test]
+    fn test_trend_glyph_gentle_slopes() {
+        // flat <= |delta| < steep -> diagonal arrows.
+        assert_eq!(trend_glyph(&[50.0, 53.0], 1.0, 5.0), "\u{2197}"); // ↗
+        assert_eq!(trend_glyph(&[53.0, 50.0], 1.0, 5.0), "\u{2198}"); // ↘
+    }
+
+    #[test]
+    fn test_trend_glyph_steep_slopes() {
+        // |delta| >= steep -> vertical arrows.
+        assert_eq!(trend_glyph(&[50.0, 60.0], 1.0, 5.0), "\u{2191}"); // ↑
+        assert_eq!(trend_glyph(&[60.0, 50.0], 1.0, 5.0), "\u{2193}"); // ↓
+    }
+
+    #[test]
+    fn test_trend_glyph_uses_sample_lookback_not_oldest() {
+        // With more than TREND_LOOKBACK+1 samples the reference is the sample
+        // ~5 back, not the oldest. Here the oldest (0.0) would read as a steep
+        // rise, but the last 5 steps are flat, so the glyph must be level.
+        let h = [0.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.2];
+        assert_eq!(trend_glyph(&h, 1.0, 5.0), "\u{2192}"); // →
+    }
+
+    #[test]
+    fn test_trend_glyph_short_history_uses_oldest() {
+        // Between 2 and TREND_LOOKBACK+1 samples: reference is the oldest.
+        let h = [10.0, 20.0, 30.0];
+        assert_eq!(trend_glyph(&h, 1.0, 5.0), "\u{2191}"); // delta 20 -> ↑
+    }
+
+    #[test]
+    fn test_trend_glyph_non_finite_reads_level() {
+        assert_eq!(trend_glyph(&[f64::NAN, 50.0], 1.0, 5.0), "\u{2192}");
+        assert_eq!(trend_glyph(&[50.0, f64::NAN], 1.0, 5.0), "\u{2192}");
     }
 
     #[test]

--- a/src/ui/remote_sparkline_panel.rs
+++ b/src/ui/remote_sparkline_panel.rs
@@ -23,6 +23,10 @@
 //! ```text
 //! <label>  <braille sparkline>  <latest value>
 //! ```
+//!
+//! Each sparkline uses a per-metric [`soft_range`](crate::ui::scale::soft_range)
+//! auto-axis (zoomed into the visible window with a minimum span, coarse-grid
+//! hysteresis, and hard-domain clamping) so small variations stay visible.
 
 use std::io::Write;
 
@@ -30,7 +34,10 @@ use crossterm::{queue, style::Color, style::Print};
 
 use crate::app_state::AppState;
 use crate::ui::braille::sparkline_braille;
-use crate::ui::scale::temp_range;
+use crate::ui::scale::{
+    PERCENT_DOMAIN, PERCENT_SOFT_GRID, PERCENT_SOFT_MIN_SPAN, TEMP_SOFT_GRID, TEMP_SOFT_MIN_SPAN,
+    soft_range, temp_range,
+};
 use crate::ui::text::print_colored_text;
 
 /// Width reserved for the label column (e.g. "GPU Util.").
@@ -70,63 +77,81 @@ pub fn draw_remote_sparkline_panel<W: Write>(stdout: &mut W, state: &AppState, c
 
     let has_gpu = !state.gpu_info.is_empty();
 
-    // Row 1: Utilization
+    // Row 1: Utilization — soft axis over each window (clamped to 0..100).
+    let gpu_util = history_vec(&state.utilization_history);
+    let cpu_util = history_vec(&state.cpu_utilization_history);
     draw_sparkline_pair(
         stdout,
         SparklinePairParams {
             left_label: "GPU Util.",
             left_color: Color::Yellow,
-            left_history: &history_vec(&state.utilization_history),
+            left_history: &gpu_util,
             left_value: avg_str(&state.utilization_history, "%"),
-            left_range: Some((0.0, 100.0)),
+            left_range: Some(percent_soft_range(&gpu_util)),
             left_available: has_gpu,
             right_label: "CPU Util.",
             right_color: Color::Cyan,
-            right_history: &history_vec(&state.cpu_utilization_history),
+            right_history: &cpu_util,
             right_value: avg_str(&state.cpu_utilization_history, "%"),
-            right_range: Some((0.0, 100.0)),
+            right_range: Some(percent_soft_range(&cpu_util)),
             half_width,
         },
     );
     queue!(stdout, Print("\r\n")).unwrap();
 
-    // Row 2: Memory
+    // Row 2: Memory — soft axis over each window (clamped to 0..100).
+    let gpu_mem = history_vec(&state.memory_history);
+    let host_mem = history_vec(&state.system_memory_history);
     draw_sparkline_pair(
         stdout,
         SparklinePairParams {
             left_label: "GPU Mem. ",
             left_color: Color::Yellow,
-            left_history: &history_vec(&state.memory_history),
+            left_history: &gpu_mem,
             left_value: avg_str(&state.memory_history, "%"),
-            left_range: Some((0.0, 100.0)),
+            left_range: Some(percent_soft_range(&gpu_mem)),
             left_available: has_gpu,
             right_label: "Host Mem.",
             right_color: Color::Cyan,
-            right_history: &history_vec(&state.system_memory_history),
+            right_history: &host_mem,
             right_value: avg_str(&state.system_memory_history, "%"),
-            right_range: Some((0.0, 100.0)),
+            right_range: Some(percent_soft_range(&host_mem)),
             half_width,
         },
     );
     queue!(stdout, Print("\r\n")).unwrap();
 
-    // Row 3: Temperature
+    // Row 3: Temperature — soft axis clamped to (0, thermal-threshold ceiling);
+    // the GPU ceiling comes from its reported threshold, the CPU from the
+    // 100°C fallback. The floor is 0 so a cool sensor can zoom below 30°C.
+    let gpu_temp = history_vec(&state.temperature_history);
+    let cpu_temp = history_vec(&state.cpu_temperature_history);
+    let gpu_temp_ceiling = temp_range(state.gpu_info.first()).1;
+    let cpu_temp_ceiling = temp_range(None).1;
     draw_sparkline_pair(
         stdout,
         SparklinePairParams {
             left_label: "GPU Temp.",
             left_color: Color::Yellow,
-            left_history: &history_vec(&state.temperature_history),
+            left_history: &gpu_temp,
             left_value: avg_temp_str(&state.temperature_history),
-            // Fixed axis anchored to the GPU thermal threshold (100°C fallback).
-            left_range: Some(temp_range(state.gpu_info.first())),
+            left_range: Some(soft_range(
+                &gpu_temp,
+                TEMP_SOFT_MIN_SPAN,
+                TEMP_SOFT_GRID,
+                (0.0, gpu_temp_ceiling),
+            )),
             left_available: has_gpu,
             right_label: "CPU Temp.",
             right_color: Color::Cyan,
-            right_history: &history_vec(&state.cpu_temperature_history),
+            right_history: &cpu_temp,
             right_value: avg_temp_str(&state.cpu_temperature_history),
-            // CPU sensors report no threshold -> fixed 30..100°C axis.
-            right_range: Some(temp_range(None)),
+            right_range: Some(soft_range(
+                &cpu_temp,
+                TEMP_SOFT_MIN_SPAN,
+                TEMP_SOFT_GRID,
+                (0.0, cpu_temp_ceiling),
+            )),
             half_width,
         },
     );
@@ -233,6 +258,17 @@ fn history_vec(history: &std::collections::VecDeque<f64>) -> Vec<f64> {
     history.iter().copied().collect()
 }
 
+/// Soft auto-axis for a percentage metric (utilization / memory), clamped to
+/// `0..100`.
+fn percent_soft_range(history: &[f64]) -> (f64, f64) {
+    soft_range(
+        history,
+        PERCENT_SOFT_MIN_SPAN,
+        PERCENT_SOFT_GRID,
+        PERCENT_DOMAIN,
+    )
+}
+
 fn avg_str(history: &std::collections::VecDeque<f64>, suffix: &str) -> String {
     if history.is_empty() {
         return "N/A".to_string();
@@ -317,5 +353,22 @@ mod tests {
         h.push_back(60.0);
         h.push_back(70.0);
         assert_eq!(avg_temp_str(&h), " 65\u{00B0}C");
+    }
+
+    #[test]
+    fn test_percent_soft_range_zooms_and_clamps() {
+        // A near-constant window is expanded to the minimum span and rounded
+        // outward, while staying inside the 0..100 domain.
+        let (lo, hi) = percent_soft_range(&[41.0, 42.0, 41.0]);
+        assert!(hi - lo >= PERCENT_SOFT_MIN_SPAN);
+        assert!(lo >= 0.0 && hi <= 100.0);
+        // center 41.5 -> [31.5, 51.5] -> grid [30, 55].
+        assert_eq!((lo, hi), (30.0, 55.0));
+    }
+
+    #[test]
+    fn test_percent_soft_range_empty_history() {
+        // Empty history anchors a min-span window at the domain floor.
+        assert_eq!(percent_soft_range(&[]), (0.0, 20.0));
     }
 }

--- a/src/ui/scale.rs
+++ b/src/ui/scale.rs
@@ -296,7 +296,9 @@ pub fn power_soft_grid(ceiling: f64) -> f64 {
 /// storing anything in `AppState`.
 ///
 /// The algorithm, in order:
-/// 1. Take the finite min/max of `history`. Empty history or all-non-finite
+/// 1. Take the finite min/max of `history`, clamped into the hard `domain`
+///    (a sample can stray outside it, e.g. a mis-scaled remote reading, and
+///    must not drag the axis out with it). Empty history or all-non-finite
 ///    input yields a `min_span`-wide window anchored at the domain floor.
 /// 2. Enforce `min_span`: if the window is narrower, expand it symmetrically
 ///    around the data center, then slide it back inside the domain (preserving
@@ -349,6 +351,17 @@ pub fn soft_range(history: &[f64], min_span: f64, grid: f64, domain: (f64, f64))
         let base = if dlo.is_finite() { dlo } else { 0.0 };
         lo = base;
         hi = base + span;
+    }
+
+    // Clamp the raw extrema into the domain before span enforcement: when
+    // every sample lies outside the domain and the raw span already meets
+    // `min_span`, step 2 would be skipped and step 4 alone would collapse
+    // the axis to a zero-width range *outside* the domain (e.g. samples
+    // [95, 105] against a 0-90 domain). Clamping here keeps the axis
+    // in-domain and lets step 2 rebuild a min-span window from the edge.
+    if domain_valid {
+        lo = lo.clamp(dlo, dhi);
+        hi = hi.clamp(dlo, dhi);
     }
 
     // 2. Minimum-span enforcement.
@@ -785,7 +798,9 @@ mod tests {
 
     #[test]
     fn soft_range_clamps_to_temperature_domain() {
-        // Ceiling 90°C: span 10 (no expansion), grid [85, 95], clamp hi to 90.
+        // Ceiling 90°C: the 95°C sample is first clamped into the domain
+        // ([85, 90], span 5), then the min span (10) is rebuilt from the edge
+        // ([80, 90]), so clamping never shrinks the span below the minimum.
         let (lo, hi) = soft_range(
             &[85.0, 95.0],
             TEMP_SOFT_MIN_SPAN,
@@ -793,7 +808,7 @@ mod tests {
             (0.0, 90.0),
         );
         assert!(hi <= 90.0);
-        assert_eq!((lo, hi), (85.0, 90.0));
+        assert_eq!((lo, hi), (80.0, 90.0));
     }
 
     #[test]
@@ -874,6 +889,29 @@ mod tests {
         let (lo, hi) = soft_range(&[10.0, 20.0], 5.0, 5.0, (0.0, f64::INFINITY));
         assert!(lo.is_finite() && hi.is_finite());
         assert!(hi >= lo);
+    }
+
+    #[test]
+    fn soft_range_out_of_domain_data_stays_inside_domain() {
+        // All samples above the domain ceiling with a raw span already >=
+        // min_span: without the pre-clamp, span enforcement is skipped and
+        // the final clamp collapses to a zero-width axis outside the domain
+        // ((95, 95) here). The axis must instead land inside the domain with
+        // its minimum span rebuilt from the edge.
+        assert_eq!(
+            soft_range(&[95.0, 105.0], 10.0, 5.0, (0.0, 90.0)),
+            (80.0, 90.0)
+        );
+        // Symmetric case below the domain floor.
+        assert_eq!(
+            soft_range(&[-20.0, -5.0], 10.0, 5.0, (0.0, 90.0)),
+            (0.0, 10.0)
+        );
+        // Mixed in/out-of-domain samples keep the in-domain part.
+        assert_eq!(
+            soft_range(&[85.0, 105.0], 10.0, 5.0, (0.0, 90.0)),
+            (80.0, 90.0)
+        );
     }
 
     // --- badge formatting for soft ranges ----------------------------------

--- a/src/ui/scale.rs
+++ b/src/ui/scale.rs
@@ -12,26 +12,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Fixed Y-axis range helpers for the metric sparklines.
+//! Y-axis range helpers for the metric sparklines.
 //!
-//! Absolute-magnitude metrics (temperature, power) are only comparable over
-//! time when their sparkline axis is anchored to a stable, domain-meaningful
-//! range. The braille sparkline has just four vertical levels, so the old
-//! per-frame `[min(window), max(window)]` auto-ranging exaggerated noise
-//! (a ±1°C wiggle filled the full height), shifted the baseline every time
-//! the window slid, and collapsed any near-constant series to the bottom row
-//! — making a blazing 90°C indistinguishable from a cool 35°C.
+//! Two axis strategies coexist, one layered on the other.
 //!
-//! These helpers replace that with fixed ranges:
+//! ## Fixed domains (the hard bounds)
+//!
+//! Absolute-magnitude metrics are only comparable over time when their
+//! sparkline axis is anchored to a stable, domain-meaningful range. The
+//! per-frame `[min(window), max(window)]` auto-ranging this replaced
+//! exaggerated noise (a ±1°C wiggle filled the full height), shifted the
+//! baseline every time the window slid, and collapsed any near-constant series
+//! to the bottom row, making a blazing 90°C indistinguishable from a cool 35°C.
+//! The fixed-domain helpers pin each metric to a stable range instead:
 //! - temperature is anchored to a `30°C` idle floor and a thermal-threshold
-//!   ceiling (falling back to `100°C`),
+//!   ceiling (falling back to `100°C`) via [`temp_range`],
 //! - power is anchored to `0` and the device's enforced power limit (falling
-//!   back to a [`nice_ceil`] over the observed peak),
+//!   back to a [`nice_ceil`] over the observed peak) via [`power_range`],
 //! - ANE is anchored to `0` and a [`nice_ceil`] over the observed peak with a
-//!   small minimum so an idle Neural Engine reads as near-empty.
+//!   small minimum via [`ane_range`],
+//! - percentage metrics (utilization, memory) use a fixed `(0, 100)`.
 //!
-//! Percentage metrics (utilization, memory) already use a fixed `(0, 100)`
-//! range at their call sites and do not need a helper here.
+//! These remain the hard bounds of every metric. #272 kept them so the
+//! multi-row Activity graphs (Part 3, #274) can render on a fixed axis where a
+//! dot's height means the same thing every frame; they are still exported for
+//! those callers.
+//!
+//! ## Soft zoom (single-row sparklines)
+//!
+//! A single-row braille sparkline has just four vertical dot levels, far too
+//! little resolution to show texture inside a full fixed domain: a GPU parked
+//! at ~41% utilization always lands in the same quantization band of a `0..100`
+//! axis, so real variation is invisible. [`soft_range`] zooms the axis into the
+//! visible history window for those compact sparklines, with three guardrails
+//! so it does not reintroduce the instability the fixed axes were built to
+//! avoid:
+//!
+//! 1. a per-metric **minimum span**, so a near-constant series cannot blow
+//!    sensor noise up to full height;
+//! 2. bounds **rounded outward to a coarse grid**, a stateless hysteresis: two
+//!    overlapping sliding windows whose extremes differ slightly round to the
+//!    same axis, so the baseline does not flap frame-to-frame;
+//! 3. the result **clamped inside the metric's hard domain**, so the soft axis
+//!    can never exceed the fixed bounds above.
+//!
+//! The fixed-domain helpers double as the domain argument to [`soft_range`]:
+//! temperature's soft axis is clamped to `(0, temp_range(gpu).1)` (a `0` floor,
+//! not `TEMP_FLOOR_C`, so a genuinely cool sensor can still zoom below 30°C),
+//! power's to `(0, power_range(..).1)`, and ANE's to `(0, ane_range(..).1)`.
 
 use crate::device::GpuInfo;
 
@@ -193,6 +221,179 @@ fn history_peak(history: &[f64]) -> f64 {
 #[must_use]
 pub fn scale_badge(min: f64, max: f64) -> String {
     format!("{min:.0}-{max:.0}")
+}
+
+// ---------------------------------------------------------------------------
+// Soft auto-range (single-row sparklines)
+// ---------------------------------------------------------------------------
+
+/// Minimum soft-axis span for utilization / memory sparklines, in percentage
+/// points. Keeps a near-constant series from having its jitter magnified to the
+/// full height of the 4-dot row.
+pub const PERCENT_SOFT_MIN_SPAN: f64 = 20.0;
+
+/// Coarse grid, in percentage points, that utilization / memory soft-axis
+/// bounds round outward to (the stateless-hysteresis step).
+pub const PERCENT_SOFT_GRID: f64 = 5.0;
+
+/// Hard domain for utilization / memory soft axes: `0..100` percent.
+pub const PERCENT_DOMAIN: (f64, f64) = (0.0, 100.0);
+
+/// Minimum soft-axis span for temperature sparklines, in °C.
+pub const TEMP_SOFT_MIN_SPAN: f64 = 10.0;
+
+/// Coarse grid, in °C, that temperature soft-axis bounds round outward to.
+pub const TEMP_SOFT_GRID: f64 = 5.0;
+
+/// Minimum soft-axis span for ANE-power sparklines, in W. Small, since the ANE
+/// operates in the single-watt range.
+pub const ANE_SOFT_MIN_SPAN: f64 = 2.0;
+
+/// Coarse grid, in W, that ANE soft-axis bounds round outward to.
+pub const ANE_SOFT_GRID: f64 = 1.0;
+
+/// Absolute floor for the package-power soft-axis minimum span, in W. Applied
+/// when a fraction of the ceiling would be smaller (e.g. Apple Silicon, where
+/// the ceiling is only ~20 W).
+pub const POWER_SOFT_MIN_SPAN_FLOOR: f64 = 2.0;
+
+/// Fraction of the fixed power ceiling used as the soft-axis minimum span,
+/// floored at [`POWER_SOFT_MIN_SPAN_FLOOR`].
+pub const POWER_SOFT_MIN_SPAN_FRACTION: f64 = 0.2;
+
+/// Soft-axis minimum span (W) for package power, derived from the fixed
+/// `ceiling`: 20% of the ceiling, never below [`POWER_SOFT_MIN_SPAN_FLOOR`].
+///
+/// A non-finite ceiling degrades to the floor (`f64::max` ignores `NaN`).
+#[must_use]
+pub fn power_soft_min_span(ceiling: f64) -> f64 {
+    (POWER_SOFT_MIN_SPAN_FRACTION * ceiling).max(POWER_SOFT_MIN_SPAN_FLOOR)
+}
+
+/// Soft-axis grid step (W) for package power, chosen as a "nice" step for the
+/// magnitude of the fixed `ceiling`:
+/// - `1 W` for small budgets (`≤ 20 W`, e.g. a single Apple Silicon package),
+/// - `5 W` up to `100 W` (a single discrete GPU),
+/// - `25 W` above that (multi-GPU nodes with kilowatt budgets).
+///
+/// A non-finite ceiling degrades to the coarsest step.
+#[must_use]
+pub fn power_soft_grid(ceiling: f64) -> f64 {
+    if ceiling <= 20.0 {
+        1.0
+    } else if ceiling <= 100.0 {
+        5.0
+    } else {
+        25.0
+    }
+}
+
+/// Compute a soft-zoom sparkline axis `(min, max)` from the visible `history`
+/// window, for single-row sparklines.
+///
+/// This is a pure function of its arguments with no hidden state: the same
+/// inputs always yield the same axis, so it can be called every frame without
+/// storing anything in `AppState`.
+///
+/// The algorithm, in order:
+/// 1. Take the finite min/max of `history`. Empty history or all-non-finite
+///    input yields a `min_span`-wide window anchored at the domain floor.
+/// 2. Enforce `min_span`: if the window is narrower, expand it symmetrically
+///    around the data center, then slide it back inside the domain (preserving
+///    the span) if an edge is crossed. If the domain is narrower than
+///    `min_span`, the window collapses to the whole domain.
+/// 3. Round the bounds outward to `grid` (floor the low bound, ceil the high
+///    bound). This is the stateless hysteresis: overlapping windows whose
+///    extremes differ slightly round to the same axis.
+/// 4. Clamp to the hard `domain`. Because rounding only ever widens the axis
+///    and step 2 kept it inside the domain, clamping cannot shrink the span
+///    below `min_span` unless the domain itself is narrower.
+///
+/// Degenerate inputs degrade gracefully and never panic or invert the axis:
+/// `min_span <= 0` (or non-finite) disables step 2, `grid <= 0` (or
+/// non-finite) disables step 3, and an inverted / zero-width / non-finite
+/// `domain` disables steps 2's shifting and step 4's clamping (a data-driven
+/// axis is still returned).
+#[must_use]
+pub fn soft_range(history: &[f64], min_span: f64, grid: f64, domain: (f64, f64)) -> (f64, f64) {
+    let (dlo, dhi) = domain;
+    // A usable hard domain needs finite, correctly-ordered bounds. When it is
+    // degenerate or inverted we still return a sensible data-driven axis, just
+    // without domain shifting / clamping.
+    let domain_valid = dlo.is_finite() && dhi.is_finite() && dhi > dlo;
+    // Non-positive / non-finite guardrail parameters simply disable their step.
+    let span = if min_span.is_finite() && min_span > 0.0 {
+        min_span
+    } else {
+        0.0
+    };
+    let use_grid = grid.is_finite() && grid > 0.0;
+
+    // 1. Finite min/max over the window.
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for &v in history {
+        if v.is_finite() {
+            if v < lo {
+                lo = v;
+            }
+            if v > hi {
+                hi = v;
+            }
+        }
+    }
+
+    if !(lo.is_finite() && hi.is_finite()) {
+        // Empty history or all-non-finite: anchor a min-span window at the
+        // domain floor (0 when the domain is unusable).
+        let base = if dlo.is_finite() { dlo } else { 0.0 };
+        lo = base;
+        hi = base + span;
+    }
+
+    // 2. Minimum-span enforcement.
+    if hi - lo < span {
+        let center = (lo + hi) / 2.0;
+        lo = center - span / 2.0;
+        hi = center + span / 2.0;
+        if domain_valid {
+            if lo < dlo {
+                let shift = dlo - lo;
+                lo = dlo;
+                hi += shift;
+            }
+            if hi > dhi {
+                let shift = hi - dhi;
+                hi = dhi;
+                lo -= shift;
+                // Domain narrower than the span: collapse to the domain.
+                if lo < dlo {
+                    lo = dlo;
+                }
+            }
+        }
+    }
+
+    // 3. Round bounds outward to the coarse grid.
+    if use_grid {
+        lo = (lo / grid).floor() * grid;
+        hi = (hi / grid).ceil() * grid;
+    }
+
+    // 4. Clamp to the hard domain.
+    if domain_valid {
+        lo = lo.max(dlo);
+        hi = hi.min(dhi);
+    }
+
+    // Final safety: never emit a non-finite or inverted axis.
+    if !(lo.is_finite() && hi.is_finite()) {
+        return (0.0, 1.0);
+    }
+    if hi < lo {
+        return (lo, lo);
+    }
+    (lo, hi)
 }
 
 #[cfg(test)]
@@ -442,5 +643,250 @@ mod tests {
         assert_eq!(history_peak(&[1.0, f64::NAN, 5.0, f64::INFINITY]), 5.0);
         assert_eq!(history_peak(&[]), 0.0);
         assert_eq!(history_peak(&[f64::NAN]), 0.0);
+    }
+
+    // --- soft_range: minimum-span enforcement ------------------------------
+
+    #[test]
+    fn soft_range_min_span_percent_near_constant() {
+        // A near-constant utilization series is expanded to at least the
+        // per-metric minimum span so its jitter is not magnified to full height.
+        // center 41.3 -> expand to [31.3, 51.3] -> round outward to [30, 55].
+        let (lo, hi) = soft_range(
+            &[41.3, 41.3, 41.3],
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        );
+        assert!(hi - lo >= PERCENT_SOFT_MIN_SPAN);
+        assert_eq!((lo, hi), (30.0, 55.0));
+    }
+
+    #[test]
+    fn soft_range_min_span_hugging_zero() {
+        // Data hugging 0 slides the min-span window up so it stays inside the
+        // domain while keeping the full span. center 1 -> [-9, 11] -> shift up
+        // to [0, 20] -> grid [0, 20].
+        let (lo, hi) = soft_range(
+            &[0.0, 1.0, 2.0],
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        );
+        assert_eq!((lo, hi), (0.0, 20.0));
+        assert!(hi - lo >= PERCENT_SOFT_MIN_SPAN);
+    }
+
+    #[test]
+    fn soft_range_min_span_hugging_hundred() {
+        // Data hugging 100 slides the min-span window down. center 99 ->
+        // [89, 109] -> shift down to [80, 100] -> grid [80, 100].
+        let (lo, hi) = soft_range(
+            &[98.0, 99.0, 100.0],
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        );
+        assert_eq!((lo, hi), (80.0, 100.0));
+        assert!(hi - lo >= PERCENT_SOFT_MIN_SPAN);
+    }
+
+    #[test]
+    fn soft_range_min_span_temperature() {
+        // Near-constant 50°C: span 1 -> expand to [45, 55] -> grid [45, 55].
+        let (lo, hi) = soft_range(
+            &[49.5, 50.0, 50.5],
+            TEMP_SOFT_MIN_SPAN,
+            TEMP_SOFT_GRID,
+            (0.0, 100.0),
+        );
+        assert!(hi - lo >= TEMP_SOFT_MIN_SPAN);
+        assert_eq!((lo, hi), (45.0, 55.0));
+    }
+
+    #[test]
+    fn soft_range_min_span_ane() {
+        // Idle-ish ANE: span 0.5 -> expand around 0.25 to [-0.75, 1.25] ->
+        // shift up to [0, 2] -> grid (1 W) [0, 2].
+        let (lo, hi) = soft_range(
+            &[0.0, 0.3, 0.5],
+            ANE_SOFT_MIN_SPAN,
+            ANE_SOFT_GRID,
+            (0.0, 10.0),
+        );
+        assert!(hi - lo >= ANE_SOFT_MIN_SPAN);
+        assert_eq!((lo, hi), (0.0, 2.0));
+    }
+
+    // --- power soft-axis parameter ladders ---------------------------------
+
+    #[test]
+    fn power_soft_min_span_ladder() {
+        assert_eq!(power_soft_min_span(20.0), 4.0); // 20% of 20
+        assert_eq!(power_soft_min_span(5.0), 2.0); // 20% of 5 = 1 -> floored to 2
+        assert_eq!(power_soft_min_span(1000.0), 200.0);
+        assert_eq!(power_soft_min_span(f64::NAN), POWER_SOFT_MIN_SPAN_FLOOR);
+    }
+
+    #[test]
+    fn power_soft_grid_ladder() {
+        assert_eq!(power_soft_grid(10.0), 1.0);
+        assert_eq!(power_soft_grid(20.0), 1.0);
+        assert_eq!(power_soft_grid(80.0), 5.0);
+        assert_eq!(power_soft_grid(100.0), 5.0);
+        assert_eq!(power_soft_grid(700.0), 25.0);
+        assert_eq!(power_soft_grid(f64::NAN), 25.0);
+    }
+
+    #[test]
+    fn soft_range_min_span_power_apple_silicon() {
+        // Apple Silicon ceiling ~20 W -> min span 4 W, grid 1 W. Near-constant
+        // 12.5 W: span 0 -> expand to [10.5, 14.5] -> grid [10, 15].
+        let ceiling = 20.0;
+        let (lo, hi) = soft_range(
+            &[12.5, 12.5],
+            power_soft_min_span(ceiling),
+            power_soft_grid(ceiling),
+            (0.0, ceiling),
+        );
+        assert!(hi - lo >= power_soft_min_span(ceiling));
+        assert_eq!((lo, hi), (10.0, 15.0));
+    }
+
+    // --- grid-rounding stability (stateless hysteresis) --------------------
+
+    #[test]
+    fn soft_range_grid_rounding_is_stable_under_jitter() {
+        // Two overlapping windows whose extremes differ slightly round to the
+        // same axis, so the sparkline baseline does not flap frame-to-frame.
+        // Both spans (7) already exceed the small min-span used here, so no
+        // expansion occurs and the raw min/max round to identical bounds.
+        let a = soft_range(&[41.0, 44.0, 48.0], 5.0, 5.0, (0.0, 100.0));
+        let b = soft_range(&[42.0, 45.0, 49.0], 5.0, 5.0, (0.0, 100.0));
+        assert_eq!(a, b);
+        assert_eq!(a, (40.0, 50.0));
+    }
+
+    // --- hard-domain clamping ----------------------------------------------
+
+    #[test]
+    fn soft_range_clamps_to_percent_domain() {
+        // Out-of-range data (e.g. a bad remote scrape) is clamped to [0, 100].
+        // min -5 max 130 -> grid [-5, 130] -> clamp [0, 100].
+        let (lo, hi) = soft_range(
+            &[-5.0, 40.0, 130.0],
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        );
+        assert!(lo >= 0.0 && hi <= 100.0);
+        assert_eq!((lo, hi), (0.0, 100.0));
+    }
+
+    #[test]
+    fn soft_range_clamps_to_temperature_domain() {
+        // Ceiling 90°C: span 10 (no expansion), grid [85, 95], clamp hi to 90.
+        let (lo, hi) = soft_range(
+            &[85.0, 95.0],
+            TEMP_SOFT_MIN_SPAN,
+            TEMP_SOFT_GRID,
+            (0.0, 90.0),
+        );
+        assert!(hi <= 90.0);
+        assert_eq!((lo, hi), (85.0, 90.0));
+    }
+
+    #[test]
+    fn soft_range_clamps_to_power_domain() {
+        // Ceiling 100 W -> min span 20 W, grid 5 W. Data [95, 98] near the top:
+        // expand around 96.5 to [86.5, 106.5] -> shift down to [80, 100] ->
+        // grid [80, 100] -> clamp keeps hi at 100.
+        let ceiling = 100.0;
+        let (lo, hi) = soft_range(
+            &[95.0, 98.0],
+            power_soft_min_span(ceiling),
+            power_soft_grid(ceiling),
+            (0.0, ceiling),
+        );
+        assert!(hi <= ceiling);
+        assert_eq!((lo, hi), (80.0, 100.0));
+    }
+
+    // --- degenerate inputs -------------------------------------------------
+
+    #[test]
+    fn soft_range_empty_history_anchors_at_domain_floor() {
+        // Empty history -> a min-span window anchored at the domain floor.
+        let (lo, hi) = soft_range(
+            &[],
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        );
+        assert_eq!((lo, hi), (0.0, 20.0));
+    }
+
+    #[test]
+    fn soft_range_all_nan_history_anchors_at_domain_floor() {
+        let (lo, hi) = soft_range(
+            &[f64::NAN, f64::INFINITY, f64::NEG_INFINITY],
+            TEMP_SOFT_MIN_SPAN,
+            TEMP_SOFT_GRID,
+            (0.0, 90.0),
+        );
+        assert_eq!((lo, hi), (0.0, 10.0));
+        assert!(hi > lo);
+    }
+
+    #[test]
+    fn soft_range_min_span_wider_than_domain_returns_full_domain() {
+        // A min_span larger than the domain collapses to the whole domain
+        // rather than overflowing it (the allowed narrower-domain exception).
+        let (lo, hi) = soft_range(&[40.0, 50.0], 200.0, 5.0, (0.0, 100.0));
+        assert_eq!((lo, hi), (0.0, 100.0));
+    }
+
+    #[test]
+    fn soft_range_non_positive_grid_skips_rounding() {
+        // grid <= 0 disables rounding; the axis is still valid and honours the
+        // min span. min 41 max 42 span 1 -> expand around 41.5 to [31.5, 51.5].
+        let (lo, hi) = soft_range(&[41.0, 42.0], PERCENT_SOFT_MIN_SPAN, 0.0, PERCENT_DOMAIN);
+        assert!(hi - lo >= PERCENT_SOFT_MIN_SPAN);
+        assert!(lo >= 0.0 && hi <= 100.0);
+        assert_eq!((lo, hi), (31.5, 51.5));
+    }
+
+    #[test]
+    fn soft_range_never_inverts_on_degenerate_domain() {
+        // Inverted or zero-width domains must not produce an inverted axis; a
+        // data-driven axis is returned without clamping.
+        let (lo, hi) = soft_range(&[10.0, 20.0], 5.0, 5.0, (100.0, 0.0));
+        assert!(hi >= lo);
+        assert_eq!((lo, hi), (10.0, 20.0));
+        let (lo2, hi2) = soft_range(&[10.0, 20.0], 5.0, 5.0, (50.0, 50.0));
+        assert!(hi2 >= lo2);
+    }
+
+    #[test]
+    fn soft_range_non_finite_domain_degrades_gracefully() {
+        // A non-finite domain bound disables clamping but still returns a
+        // finite, non-inverted axis.
+        let (lo, hi) = soft_range(&[10.0, 20.0], 5.0, 5.0, (0.0, f64::INFINITY));
+        assert!(lo.is_finite() && hi.is_finite());
+        assert!(hi >= lo);
+    }
+
+    // --- badge formatting for soft ranges ----------------------------------
+
+    #[test]
+    fn scale_badge_shows_soft_range() {
+        // The badge must reflect the actual soft range in use, not a fixed one.
+        let (lo, hi) = soft_range(
+            &[41.3, 41.3, 41.3, 41.3],
+            PERCENT_SOFT_MIN_SPAN,
+            PERCENT_SOFT_GRID,
+            PERCENT_DOMAIN,
+        );
+        assert_eq!(scale_badge(lo, hi), "30-55");
     }
 }


### PR DESCRIPTION
## Summary

Part 2 of the sparkline-readability chain (#272 → #273 → #274). The single-row braille sparklines moved to fixed axes in #272 for stability, but a 4-dot column parks typical operating values inside a single quantization band: a GPU near 41% utilization always renders at level 1 of 4 on a 0..100 axis, so real variation is invisible. This PR restores visible texture for every single-row sparkline by softly zooming the axis into the visible history window, with guardrails so it does not reintroduce the flapping the fixed axes were built to avoid, and adds a per-metric trend glyph to the header.

## What changed

- `src/ui/scale.rs`: new pure `soft_range(history, min_span, grid, domain) -> (min, max)` helper. It takes the finite window min/max, enforces a per-metric minimum span (expanding symmetrically around the data center and sliding back inside the domain when an edge is crossed), rounds the bounds outward to a coarse grid (stateless hysteresis), and clamps to the hard domain. No new mutable state anywhere. Degenerate inputs (empty or all-non-finite history, `min_span` wider than the domain, `grid <= 0`, inverted or zero-width domain) degrade gracefully and never panic or invert the axis.
- `src/ui/scale.rs`: exported per-metric parameters as documented constants (`PERCENT_SOFT_MIN_SPAN` 20 / `PERCENT_SOFT_GRID` 5 / `PERCENT_DOMAIN` (0,100); `TEMP_SOFT_MIN_SPAN` 10 / `TEMP_SOFT_GRID` 5; `ANE_SOFT_MIN_SPAN` 2 / `ANE_SOFT_GRID` 1) plus `power_soft_min_span` (max(2 W, 20% of the ceiling)) and `power_soft_grid` (1 W ≤ 20 W, 5 W ≤ 100 W, else 25 W) derived from the fixed power ceiling. The existing fixed-domain helpers (`temp_range`, `power_range`, `ane_range`) are retained and now double as the domain argument to `soft_range`; they stay available for the multi-row fixed-axis graphs coming in #274. Temperature's soft domain uses a 0°C floor (not `TEMP_FLOOR_C`) so a genuinely cool sensor can zoom below 30°C.
- `src/ui/scale.rs` (follow-up fix): `soft_range` now pre-clamps the raw history min/max into the hard domain before minimum-span enforcement. Without this, a history lying entirely outside the domain (e.g. a mis-scaled remote reading) whose raw span already met `min_span` skipped the span-enforcement step, and the final domain clamp alone collapsed the axis to a zero-width range outside the domain instead of rebuilding a proper in-domain window. Covered by a new `soft_range_out_of_domain_data_stays_inside_domain` test; `soft_range_clamps_to_temperature_domain`'s expected bounds were updated to match the corrected (wider, in-domain) axis.
- `src/ui/local_header.rs`: all five header sparklines (CPU %, GPU %, RAM %, Pwr, Tmp) switched from fixed ranges to soft ranges. Added a one-cell trend glyph (`↑ ↗ → ↘ ↓`) immediately after each latest value, coloured in the metric's theme colour, via a pure `trend_glyph` helper. The slope is the delta between the latest sample and the sample ~5 back (oldest when the history is shorter), classified with per-metric thresholds (% 1.0/5.0, temp 0.5/2.0, power 0.2/1.0). Fewer than two samples renders a space so the columns stay aligned; inter-metric spacing is unchanged.
- `src/ui/gpu_sparkline_panel.rs`: the GPU Util / GPU Mem / GPU Temp / ANE / Pkg Power rows use soft ranges, and each row's `scale_badge` now reports the actual soft range in use (e.g. `40-60`) instead of the fixed axis.
- `src/ui/remote_sparkline_panel.rs`: the GPU/CPU util, memory, and temperature rows switched to soft ranges the same way.
- Module docs in `scale.rs`, `local_header.rs`, `gpu_sparkline_panel.rs`, and `remote_sparkline_panel.rs` updated to describe the fixed-domain + soft-zoom relationship and the trend glyph.
- Tests: `test_build_rows_apple_silicon` updated to assert the new soft-range badges (computed by hand from the fixture histories) since the axis semantics intentionally changed. Unit tests cover min-span enforcement per metric kind including near-domain-edge expansion (data hugging 0 and 100), grid-rounding stability under jitter, hard-domain clamping (%, temperature, power), out-of-domain history, degenerate inputs, soft-range badge formatting, and trend classification for all five glyphs plus the insufficient-history case. A render-level test (`test_draw_local_header_bar_renders_trend_glyphs`) was added to confirm the trend glyph actually lands in the right metric's column of the rendered output, not just that the pure classification helper returns the right glyph in isolation.

## Test plan

- [x] `cargo test --lib ui::scale` (38 passed)
- [x] `cargo test --lib ui::local_header` (22 passed)
- [x] `cargo test --lib ui::gpu_sparkline_panel` (20 passed)
- [x] `cargo test --lib ui::remote_sparkline_panel` (8 passed)
- [x] `cargo check --lib --tests` (clean)
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

Refs #272

Closes #273
