### PR TITLE
fix: report VRAM and power for Battlemage GPUs on the xe driver

### DIFF
--- a/src/device/readers/intel_gpu_fdinfo.rs
+++ b/src/device/readers/intel_gpu_fdinfo.rs
@@ -474,6 +474,81 @@ pub fn collect_intel_gpu_processes(
     out
 }
 
+/// Sum `drm-resident-vram0` bytes across all processes for a given
+/// card. Used as a fallback when the xe driver does not expose
+/// card-level VRAM usage counters in sysfs.
+///
+/// Deduplication: when a process holds multiple fds pointing at the
+/// same DRM client (same `drm-client-id`), the VRAM block is counted
+/// only once (max-wins). Distinct client ids within the same process
+/// do sum.
+pub fn sum_card_vram_from_fdinfo(
+    card_index: usize,
+    intel_drm_basenames: &HashMap<String, usize>,
+    proc_root: &Path,
+) -> u64 {
+    if intel_drm_basenames.is_empty() {
+        return 0;
+    }
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return 0;
+    };
+
+    let mut seen: HashMap<(u32, u64), u64> = HashMap::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<u32>() else {
+            continue;
+        };
+
+        let fds = intel_drm_fds_for_pid(pid, intel_drm_basenames, proc_root);
+        for fd in fds {
+            if fd.card_index != card_index {
+                continue;
+            }
+            let Some(content) = read_fdinfo_to_string(&fd.fdinfo_path) else {
+                continue;
+            };
+            let mut vram_bytes: u64 = 0;
+            let mut drm_client_id: Option<u64> = None;
+            let mut is_drm = false;
+            for line in content.lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let Some((key, value)) = line.split_once(':') else {
+                    continue;
+                };
+                match key.trim() {
+                    "drm-driver" => is_drm = true,
+                    "drm-client-id" => drm_client_id = value.trim().parse::<u64>().ok(),
+                    "drm-resident-vram0" => {
+                        if let Some(bytes) = parse_memory_value(value.trim()) {
+                            vram_bytes = bytes;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if !is_drm {
+                continue;
+            }
+            let key = (pid, drm_client_id.unwrap_or(0));
+            let entry = seen.entry(key).or_insert(0);
+            if vram_bytes > *entry {
+                *entry = vram_bytes;
+            }
+        }
+    }
+
+    seen.values().sum()
+}
+
 #[path = "intel_gpu_fdinfo/enrichment.rs"]
 mod enrichment;
 pub use enrichment::build_intel_process_infos;

--- a/src/device/readers/intel_gpu_fdinfo.rs
+++ b/src/device/readers/intel_gpu_fdinfo.rs
@@ -96,6 +96,12 @@ pub struct FdInfo {
     /// ever existed, including freed pages. Resident is what `top` and
     /// `intel_gpu_top -p` report.
     pub resident_bytes: u64,
+    /// Currently-resident device-local VRAM bytes only, a subset of
+    /// [`Self::resident_bytes`]: `drm-resident-vram*` on xe,
+    /// `drm-resident-local*` on i915. Zero on integrated GPUs. Consumed
+    /// by the card-level VRAM fallback, which must not count GTT/system
+    /// pages against the VRAM budget.
+    pub resident_vram_bytes: u64,
 }
 
 /// Parse one fdinfo file's contents.
@@ -115,6 +121,7 @@ pub fn parse_fdinfo(content: &str) -> Option<FdInfo> {
     let mut drm_pdev: Option<String> = None;
     let mut drm_client_id: Option<u64> = None;
     let mut resident_bytes: u64 = 0;
+    let mut resident_vram_bytes: u64 = 0;
 
     for raw_line in content.lines() {
         let line = raw_line.trim();
@@ -143,6 +150,12 @@ pub fn parse_fdinfo(content: &str) -> Option<FdInfo> {
             k if k.starts_with("drm-resident-") => {
                 if let Some(bytes) = parse_memory_value(value) {
                     resident_bytes = resident_bytes.saturating_add(bytes);
+                    // Device-local VRAM subset: xe emits
+                    // `drm-resident-vram<N>`, i915 emits
+                    // `drm-resident-local<N>`.
+                    if k.starts_with("drm-resident-vram") || k.starts_with("drm-resident-local") {
+                        resident_vram_bytes = resident_vram_bytes.saturating_add(bytes);
+                    }
                 }
             }
             _ => {}
@@ -163,6 +176,7 @@ pub fn parse_fdinfo(content: &str) -> Option<FdInfo> {
         drm_pdev,
         drm_client_id,
         resident_bytes,
+        resident_vram_bytes,
     })
 }
 
@@ -474,29 +488,47 @@ pub fn collect_intel_gpu_processes(
     out
 }
 
-/// Sum `drm-resident-vram0` bytes across all processes for a given
-/// card. Used as a fallback when the xe driver does not expose
-/// card-level VRAM usage counters in sysfs.
+/// Sum resident **VRAM** bytes per card across every Intel-GPU-using
+/// process, in a single `/proc` walk. Used by the Linux reader as a
+/// card-level `used_memory` fallback when the xe driver exposes no
+/// `tile0/vram0/used_bytes` counter in sysfs (Battlemage on kernels
+/// before 6.14).
 ///
-/// Deduplication: when a process holds multiple fds pointing at the
-/// same DRM client (same `drm-client-id`), the VRAM block is counted
-/// only once (max-wins). Distinct client ids within the same process
-/// do sum.
-pub fn sum_card_vram_from_fdinfo(
-    card_index: usize,
+/// Reuses [`parse_fdinfo`] (so foreign DRM drivers stay rejected) and
+/// honours the [`MAX_GPU_PROCESSES`] cap, matching
+/// [`collect_intel_gpu_processes`]. One walk covers all cards, so the
+/// caller runs this at most once per refresh regardless of how many
+/// cards need the fallback.
+///
+/// Deduplication intentionally differs from the per-process collector:
+/// `drm-client-id` is unique per DRM device open, so each client is
+/// counted once per **card** (max-wins across every fd referencing it,
+/// in any process). Crediting a fork-inherited fd to both pids is
+/// correct for per-process rows but would double count a card-level
+/// total. Fds without a client id cannot be deduped and are credited
+/// per fdinfo path, matching the collector's safety net.
+pub fn sum_vram_by_card_from_fdinfo(
     intel_drm_basenames: &HashMap<String, usize>,
     proc_root: &Path,
-) -> u64 {
+) -> HashMap<usize, u64> {
+    let mut out: HashMap<usize, u64> = HashMap::new();
     if intel_drm_basenames.is_empty() {
-        return 0;
+        return out;
     }
     let Ok(entries) = std::fs::read_dir(proc_root) else {
-        return 0;
+        return out;
     };
 
-    let mut seen: HashMap<(u32, u64), u64> = HashMap::new();
+    // Per-card aggregation: client-id keyed VRAM bytes (max-wins) plus
+    // a per-fdinfo-path bucket for fds whose fdinfo lacks a client id.
+    let mut per_client: HashMap<usize, HashMap<u64, u64>> = HashMap::new();
+    let mut no_client_id: HashMap<usize, HashMap<PathBuf, u64>> = HashMap::new();
+    let mut process_count: usize = 0;
 
     for entry in entries.flatten() {
+        if process_count >= MAX_GPU_PROCESSES {
+            break;
+        }
         let path = entry.path();
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
@@ -506,47 +538,52 @@ pub fn sum_card_vram_from_fdinfo(
         };
 
         let fds = intel_drm_fds_for_pid(pid, intel_drm_basenames, proc_root);
+        if fds.is_empty() {
+            continue;
+        }
+        process_count += 1;
+
         for fd in fds {
-            if fd.card_index != card_index {
-                continue;
-            }
             let Some(content) = read_fdinfo_to_string(&fd.fdinfo_path) else {
                 continue;
             };
-            let mut vram_bytes: u64 = 0;
-            let mut drm_client_id: Option<u64> = None;
-            let mut is_drm = false;
-            for line in content.lines() {
-                let line = line.trim();
-                if line.is_empty() {
-                    continue;
-                }
-                let Some((key, value)) = line.split_once(':') else {
-                    continue;
-                };
-                match key.trim() {
-                    "drm-driver" => is_drm = true,
-                    "drm-client-id" => drm_client_id = value.trim().parse::<u64>().ok(),
-                    "drm-resident-vram0" => {
-                        if let Some(bytes) = parse_memory_value(value.trim()) {
-                            vram_bytes = bytes;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            if !is_drm {
+            let Some(info) = parse_fdinfo(&content) else {
                 continue;
-            }
-            let key = (pid, drm_client_id.unwrap_or(0));
-            let entry = seen.entry(key).or_insert(0);
-            if vram_bytes > *entry {
-                *entry = vram_bytes;
+            };
+            match info.drm_client_id {
+                Some(cid) => {
+                    let entry = per_client
+                        .entry(fd.card_index)
+                        .or_default()
+                        .entry(cid)
+                        .or_insert(0);
+                    *entry = (*entry).max(info.resident_vram_bytes);
+                }
+                None => {
+                    let entry = no_client_id
+                        .entry(fd.card_index)
+                        .or_default()
+                        .entry(fd.fdinfo_path)
+                        .or_insert(0);
+                    *entry = (*entry).max(info.resident_vram_bytes);
+                }
             }
         }
     }
 
-    seen.values().sum()
+    for (card_index, by_client) in &per_client {
+        let slot = out.entry(*card_index).or_insert(0);
+        for bytes in by_client.values() {
+            *slot = slot.saturating_add(*bytes);
+        }
+    }
+    for (card_index, by_fd) in &no_client_id {
+        let slot = out.entry(*card_index).or_insert(0);
+        for bytes in by_fd.values() {
+            *slot = slot.saturating_add(*bytes);
+        }
+    }
+    out
 }
 
 #[path = "intel_gpu_fdinfo/enrichment.rs"]

--- a/src/device/readers/intel_gpu_fdinfo/tests.rs
+++ b/src/device/readers/intel_gpu_fdinfo/tests.rs
@@ -48,6 +48,8 @@ drm-engine-render: 1234567890 ns
     assert_eq!(info.drm_client_id, Some(42));
     // 32768 kB + 262144 kB = 294912 kB = 302_039_040 bytes
     assert_eq!(info.resident_bytes, (32_768u64 + 262_144) * 1024);
+    // VRAM subtotal counts only the device-local key (local0 on i915).
+    assert_eq!(info.resident_vram_bytes, 262_144 * 1024);
 }
 
 #[test]
@@ -62,6 +64,8 @@ drm-resident-system: 12288 kB
     let info = parse_fdinfo(content).expect("i915 integrated fdinfo should parse");
     assert_eq!(info.drm_driver, "i915");
     assert_eq!(info.resident_bytes, 12_288 * 1024);
+    // No device-local key on integrated parts: VRAM subtotal stays 0.
+    assert_eq!(info.resident_vram_bytes, 0);
 }
 
 #[test]
@@ -81,6 +85,8 @@ drm-engine-rcs: 9876543210 ns
     assert_eq!(info.drm_driver, "xe");
     assert_eq!(info.drm_client_id, Some(99));
     assert_eq!(info.resident_bytes, (524_288u64 + 32_768) * 1024);
+    // VRAM subtotal counts only vram0, never the GTT pages.
+    assert_eq!(info.resident_vram_bytes, 524_288 * 1024);
 }
 
 #[test]
@@ -489,4 +495,160 @@ fn collect_intel_gpu_processes_tolerates_missing_client_id() {
     let usages = collect_intel_gpu_processes(&basenames, proc_root);
     assert_eq!(usages.len(), 1);
     assert_eq!(usages[0].used_memory_bytes, 16_384 * 1024);
+}
+
+// ----- sum_vram_by_card_from_fdinfo -----
+
+#[test]
+fn sum_vram_by_card_counts_vram_not_gtt() {
+    let dir = tempfile::tempdir().unwrap();
+    let proc_root = dir.path();
+    make_proc_fd(
+        proc_root,
+        1234,
+        3,
+        "renderD128",
+        "drm-driver: xe\ndrm-client-id: 1\ndrm-resident-vram0: 524288 kB\ndrm-resident-gtt: 32768 kB\n",
+    );
+
+    let basenames = HashMap::from([("renderD128".to_string(), 0_usize)]);
+    let by_card = sum_vram_by_card_from_fdinfo(&basenames, proc_root);
+    assert_eq!(
+        by_card.get(&0).copied(),
+        Some(524_288 * 1024),
+        "GTT pages must not count against the VRAM budget"
+    );
+}
+
+#[test]
+fn sum_vram_by_card_dedupes_shared_client_across_pids() {
+    // A DRM client id is unique per device open; a fork-inherited fd
+    // shows the SAME client in two pids. The card-level total must
+    // count it once, unlike the per-process collector which correctly
+    // credits both processes.
+    let dir = tempfile::tempdir().unwrap();
+    let proc_root = dir.path();
+    let fdinfo = "drm-driver: xe\ndrm-client-id: 7\ndrm-resident-vram0: 65536 kB\n";
+    make_proc_fd(proc_root, 4242, 3, "renderD128", fdinfo);
+    make_proc_fd(proc_root, 4243, 3, "renderD128", fdinfo);
+
+    let basenames = HashMap::from([("renderD128".to_string(), 0_usize)]);
+    let by_card = sum_vram_by_card_from_fdinfo(&basenames, proc_root);
+    assert_eq!(by_card.get(&0).copied(), Some(65_536 * 1024));
+}
+
+#[test]
+fn sum_vram_by_card_sums_distinct_clients() {
+    let dir = tempfile::tempdir().unwrap();
+    let proc_root = dir.path();
+    make_proc_fd(
+        proc_root,
+        4242,
+        3,
+        "renderD128",
+        "drm-driver: xe\ndrm-client-id: 7\ndrm-resident-vram0: 16384 kB\n",
+    );
+    make_proc_fd(
+        proc_root,
+        4242,
+        4,
+        "renderD128",
+        "drm-driver: xe\ndrm-client-id: 8\ndrm-resident-vram0: 32768 kB\n",
+    );
+
+    let basenames = HashMap::from([("renderD128".to_string(), 0_usize)]);
+    let by_card = sum_vram_by_card_from_fdinfo(&basenames, proc_root);
+    assert_eq!(by_card.get(&0).copied(), Some((16_384 + 32_768) * 1024));
+}
+
+#[test]
+fn sum_vram_by_card_sums_no_client_id_fds_individually() {
+    // Without drm-client-id there is nothing to dedupe on: distinct
+    // fds are credited individually (same policy as
+    // collect_intel_gpu_processes) instead of collapsing into a single
+    // max-wins bucket that would undercount multi-context processes.
+    let dir = tempfile::tempdir().unwrap();
+    let proc_root = dir.path();
+    make_proc_fd(
+        proc_root,
+        1234,
+        3,
+        "renderD128",
+        "drm-driver: xe\ndrm-resident-vram0: 16384 kB\n",
+    );
+    make_proc_fd(
+        proc_root,
+        1234,
+        4,
+        "renderD128",
+        "drm-driver: xe\ndrm-resident-vram0: 32768 kB\n",
+    );
+
+    let basenames = HashMap::from([("renderD128".to_string(), 0_usize)]);
+    let by_card = sum_vram_by_card_from_fdinfo(&basenames, proc_root);
+    assert_eq!(by_card.get(&0).copied(), Some((16_384 + 32_768) * 1024));
+}
+
+#[test]
+fn sum_vram_by_card_groups_by_card() {
+    let dir = tempfile::tempdir().unwrap();
+    let proc_root = dir.path();
+    make_proc_fd(
+        proc_root,
+        4242,
+        3,
+        "renderD128",
+        "drm-driver: xe\ndrm-client-id: 1\ndrm-resident-vram0: 16384 kB\n",
+    );
+    make_proc_fd(
+        proc_root,
+        4242,
+        4,
+        "renderD129",
+        "drm-driver: xe\ndrm-client-id: 2\ndrm-resident-vram0: 32768 kB\n",
+    );
+
+    let basenames = HashMap::from([
+        ("renderD128".to_string(), 0_usize),
+        ("renderD129".to_string(), 1_usize),
+    ]);
+    let by_card = sum_vram_by_card_from_fdinfo(&basenames, proc_root);
+    assert_eq!(by_card.get(&0).copied(), Some(16_384 * 1024));
+    assert_eq!(by_card.get(&1).copied(), Some(32_768 * 1024));
+}
+
+#[test]
+fn sum_vram_by_card_rejects_foreign_drivers() {
+    // parse_fdinfo gates on i915/xe; an amdgpu fdinfo that somehow
+    // references an Intel node basename must not be counted.
+    let dir = tempfile::tempdir().unwrap();
+    let proc_root = dir.path();
+    make_proc_fd(
+        proc_root,
+        1234,
+        3,
+        "renderD128",
+        "drm-driver: amdgpu\ndrm-client-id: 1\ndrm-resident-vram0: 16384 kB\n",
+    );
+
+    let basenames = HashMap::from([("renderD128".to_string(), 0_usize)]);
+    let by_card = sum_vram_by_card_from_fdinfo(&basenames, proc_root);
+    assert!(by_card.is_empty());
+}
+
+#[test]
+fn sum_vram_by_card_empty_basenames_returns_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let proc_root = dir.path();
+    make_proc_fd(
+        proc_root,
+        1234,
+        3,
+        "renderD128",
+        "drm-driver: xe\ndrm-client-id: 1\ndrm-resident-vram0: 16384 kB\n",
+    );
+
+    let basenames: HashMap<String, usize> = HashMap::new();
+    let by_card = sum_vram_by_card_from_fdinfo(&basenames, proc_root);
+    assert!(by_card.is_empty());
 }

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -53,8 +53,8 @@ use crate::device::readers::intel_gpu_names::{
     classify_intel_architecture, resolve_intel_gpu_name,
 };
 use crate::device::readers::intel_gpu_sysfs::{
-    MemoryVariant, has_nonzero_u64, read_fan_rpm, read_frequency_mhz, read_memory_bytes,
-    read_power_watts, read_resource2_total_bytes, read_temperature_celsius,
+    MemoryVariant, has_nonzero_u64, read_energy_uj, read_fan_rpm, read_frequency_mhz,
+    read_memory_bytes, read_power_watts, read_resource2_total_bytes, read_temperature_celsius,
 };
 use crate::device::types::{GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
@@ -99,6 +99,11 @@ struct IntelGpuCard {
     engine_state: Mutex<EngineState>,
     /// Per-card Xe GT idle-residency delta tracker.
     gtidle_state: Mutex<GtidleState>,
+    /// Per-card energy-counter delta tracker for the xe driver. The xe
+    /// hwmon interface exposes cumulative energy (microjoules) rather
+    /// than instantaneous power on some kernels; power is derived as
+    /// ΔJ / Δs across samples.
+    energy_state: Mutex<EnergyState>,
     /// Per-card Level Zero handle state (issue #248). Mirrors
     /// `engine_state` — delta-tracked behind a `Mutex` for power
     /// readings, only present when `--features level_zero` is active.
@@ -113,6 +118,98 @@ fn variant_label(variant: MemoryVariant) -> &'static str {
         MemoryVariant::Discrete => "Discrete",
         MemoryVariant::Integrated => "Integrated",
     }
+}
+
+/// Per-card energy delta tracker for the xe driver. The xe hwmon
+/// interface exposes cumulative energy counters (microjoules) instead
+/// of instantaneous power — first sample seeds; subsequent samples
+/// compute average watts as ΔJ / Δs.
+struct EnergyState {
+    timestamp: Option<std::time::Instant>,
+    energy_uj: u64,
+}
+
+/// Compute average power (watts) from xe hwmon energy counters. First
+/// call seeds the counter (returns 0.0); subsequent calls return
+/// ΔJ / Δs. A file-based state cache at `/tmp/all-smi-energy-<pci>`
+/// bridges across process invocations so `all-smi snapshot` (one-shot)
+/// also sees power after the first sample.
+fn compute_power_from_energy(state: &Mutex<EnergyState>, device_dir: &Path) -> f64 {
+    let current_uj = read_energy_uj(device_dir);
+    if current_uj == 0 {
+        return 0.0;
+    }
+
+    let cache_path = energy_cache_path(device_dir);
+    let now_instant = std::time::Instant::now();
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let mut guard = match state.lock() {
+        Ok(g) => g,
+        Err(_) => return 0.0,
+    };
+
+    // Use in-memory state when available; otherwise fall back to the
+    // file cache so a one-shot `snapshot` invocation can still delta.
+    let (prev_instant, prev_uj) = match guard.timestamp {
+        Some(ts) => (Some(ts), guard.energy_uj),
+        None => {
+            if let Some((cached_ts, cached_uj)) = read_energy_cache(&cache_path) {
+                let delta_s = now_unix.saturating_sub(cached_ts) as f64;
+                if delta_s > 0.0 && delta_s < 3600.0 {
+                    let delta_j = current_uj.saturating_sub(cached_uj) as f64 / 1_000_000.0;
+                    let power = delta_j / delta_s;
+                    guard.timestamp = Some(now_instant);
+                    guard.energy_uj = current_uj;
+                    write_energy_cache(&cache_path, now_unix, current_uj);
+                    return power;
+                }
+            }
+            (None, 0)
+        }
+    };
+
+    let power = match prev_instant {
+        Some(prev_ts) => {
+            let delta_s = (now_instant - prev_ts).as_secs_f64();
+            if delta_s > 0.0 {
+                let delta_j = current_uj.saturating_sub(prev_uj) as f64 / 1_000_000.0;
+                delta_j / delta_s
+            } else {
+                0.0
+            }
+        }
+        None => 0.0,
+    };
+    guard.timestamp = Some(now_instant);
+    guard.energy_uj = current_uj;
+    write_energy_cache(&cache_path, now_unix, current_uj);
+    power
+}
+
+/// Derive a stable per-card cache path from the canonical PCI device
+/// symlink target (e.g. `/tmp/all-smi-energy-0000:03:00.0`).
+fn energy_cache_path(device_dir: &Path) -> PathBuf {
+    let pci = std::fs::canonicalize(device_dir)
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .unwrap_or_else(|| "unknown".to_string());
+    PathBuf::from("/tmp").join(format!("all-smi-energy-{pci}"))
+}
+
+fn read_energy_cache(path: &Path) -> Option<(u64, u64)> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut parts = content.split_whitespace();
+    let ts: u64 = parts.next()?.parse().ok()?;
+    let uj: u64 = parts.next()?.parse().ok()?;
+    Some((ts, uj))
+}
+
+fn write_energy_cache(path: &Path, ts: u64, uj: u64) {
+    let _ = std::fs::write(path, format!("{ts} {uj}"));
 }
 
 /// The reader itself. Holds a snapshot of cards discovered at
@@ -230,7 +327,7 @@ impl GpuReader for IntelGpuReader {
             let (mut used_memory, total_memory) = read_memory_bytes(&device_dir, card.variant);
             let frequency = read_frequency_mhz(&device_dir);
             let temperature = read_temperature_celsius(&device_dir);
-            let power_consumption = read_power_watts(&device_dir);
+            let mut power_consumption = read_power_watts(&device_dir);
             let fan_rpm = read_fan_rpm(&device_dir);
 
             // Round-trip values through the validation caps so that a
@@ -239,7 +336,7 @@ impl GpuReader for IntelGpuReader {
             // pattern.
             let temperature = temperature.min(MAX_GPU_TEMP_CELSIUS);
             let frequency = frequency.min(MAX_GPU_FREQ_MHZ);
-            let power_consumption = power_consumption.clamp(0.0, MAX_GPU_POWER_WATTS);
+            power_consumption = power_consumption.clamp(0.0, MAX_GPU_POWER_WATTS);
             let total_memory = total_memory.min(MAX_GPU_MEMORY_BYTES);
             used_memory = used_memory.min(total_memory);
 
@@ -251,6 +348,15 @@ impl GpuReader for IntelGpuReader {
                 frequency,
                 fan_rpm,
             );
+
+            // xe driver: derive power from the hwmon energy counter when
+            // instantaneous power (`power1_average`) is not exposed.
+            if power_consumption == 0.0 && card.driver == "xe" {
+                power_consumption = compute_power_from_energy(&card.energy_state, &device_dir);
+                if power_consumption > 0.0 {
+                    detail.insert("Source: Power".to_string(), "energy delta (xe)".to_string());
+                }
+            }
 
             // xe driver: fall back to fdinfo for VRAM usage when
             // card-level sysfs counters are unavailable.
@@ -395,6 +501,10 @@ fn discover_cards(drm_root: &Path) -> Vec<IntelGpuCard> {
             static_info: OnceLock::new(),
             engine_state: Mutex::new(EngineState::empty()),
             gtidle_state: Mutex::new(GtidleState::empty()),
+            energy_state: Mutex::new(EnergyState {
+                timestamp: None,
+                energy_uj: 0,
+            }),
             #[cfg(feature = "level_zero")]
             level_zero_state: Mutex::new(
                 crate::device::readers::intel_gpu_level_zero::LevelZeroState::empty(),

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -44,7 +44,7 @@ use crate::device::readers::intel_gpu_engine::{
     EngineState, apply_engine_readout, refresh_with_lock,
 };
 use crate::device::readers::intel_gpu_fdinfo::{
-    build_intel_drm_basenames, build_intel_process_infos,
+    build_intel_drm_basenames, build_intel_process_infos, sum_card_vram_from_fdinfo,
 };
 use crate::device::readers::intel_gpu_gtidle::{
     GtidleState, apply_fallback as apply_gtidle_fallback,
@@ -54,7 +54,7 @@ use crate::device::readers::intel_gpu_names::{
 };
 use crate::device::readers::intel_gpu_sysfs::{
     MemoryVariant, has_nonzero_u64, read_fan_rpm, read_frequency_mhz, read_memory_bytes,
-    read_power_watts, read_temperature_celsius,
+    read_power_watts, read_resource2_total_bytes, read_temperature_celsius,
 };
 use crate::device::types::{GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
@@ -222,12 +222,12 @@ impl GpuReader for IntelGpuReader {
         let time = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
         let mut out = Vec::with_capacity(self.cards.len());
 
-        for card in &self.cards {
+        for (card_index, card) in self.cards.iter().enumerate() {
             let static_info = self.ensure_static_info(card);
             let mut detail = static_info.detail.clone();
 
             let device_dir = card.card_path.join("device");
-            let (used_memory, total_memory) = read_memory_bytes(&device_dir, card.variant);
+            let (mut used_memory, total_memory) = read_memory_bytes(&device_dir, card.variant);
             let frequency = read_frequency_mhz(&device_dir);
             let temperature = read_temperature_celsius(&device_dir);
             let power_consumption = read_power_watts(&device_dir);
@@ -241,7 +241,7 @@ impl GpuReader for IntelGpuReader {
             let frequency = frequency.min(MAX_GPU_FREQ_MHZ);
             let power_consumption = power_consumption.clamp(0.0, MAX_GPU_POWER_WATTS);
             let total_memory = total_memory.min(MAX_GPU_MEMORY_BYTES);
-            let used_memory = used_memory.min(total_memory);
+            used_memory = used_memory.min(total_memory);
 
             sources::decorate_static_sources(
                 &mut detail,
@@ -251,6 +251,20 @@ impl GpuReader for IntelGpuReader {
                 frequency,
                 fan_rpm,
             );
+
+            // xe driver: fall back to fdinfo for VRAM usage when
+            // card-level sysfs counters are unavailable.
+            if used_memory == 0 && total_memory > 0 && card.driver == "xe" {
+                let fdinfo_vram = sum_card_vram_from_fdinfo(
+                    card_index,
+                    &self.intel_drm_basenames,
+                    &self.proc_root,
+                );
+                if fdinfo_vram > 0 {
+                    used_memory = fdinfo_vram.min(total_memory);
+                    detail.insert("Source: Memory".to_string(), "fdinfo (xe)".to_string());
+                }
+            }
 
             // Engine-busy refresh — guarded by a per-card mutex.
             let readout = refresh_with_lock(&card.engine_state, &device_dir);
@@ -464,6 +478,7 @@ fn build_uuid(card: &IntelGpuCard, device_dir: &Path) -> String {
 fn classify_variant(device_dir: &Path) -> MemoryVariant {
     if has_nonzero_u64(&device_dir.join("mem_info_vram_total"))
         || has_nonzero_u64(&device_dir.join("tile0").join("vram0").join("total_bytes"))
+        || read_resource2_total_bytes(device_dir) > 0
     {
         MemoryVariant::Discrete
     } else {

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -37,14 +37,21 @@
 //! (i915) or `device/tile0/vram0/total_bytes` (xe). Integrated GPUs have no
 //! dedicated VRAM, so the reader records `total_memory = 0` and explains that
 //! memory is shared system memory.
+//!
+//! On xe kernels that predate `tile0/vram0/*` (Battlemage before 6.14)
+//! the total falls back to the PCI BAR2 size when Resizable BAR makes
+//! the BAR span the whole VRAM, and `used_memory` falls back to a
+//! per-card sum of `drm-resident-vram0` from process fdinfo.
 
+use crate::common::paths::cache_dir;
+use crate::common::secure_write::write_atomic_secure;
 use crate::device::GpuReader;
 use crate::device::readers::common_cache::{DeviceStaticInfo, MAX_DEVICES};
 use crate::device::readers::intel_gpu_engine::{
     EngineState, apply_engine_readout, refresh_with_lock,
 };
 use crate::device::readers::intel_gpu_fdinfo::{
-    build_intel_drm_basenames, build_intel_process_infos, sum_card_vram_from_fdinfo,
+    build_intel_drm_basenames, build_intel_process_infos, sum_vram_by_card_from_fdinfo,
 };
 use crate::device::readers::intel_gpu_gtidle::{
     GtidleState, apply_fallback as apply_gtidle_fallback,
@@ -72,6 +79,13 @@ const MAX_GPU_TEMP_CELSIUS: u32 = 125; // package max across i915/xe
 const MAX_GPU_FREQ_MHZ: u32 = 5000;
 const MAX_GPU_MEMORY_BYTES: u64 = 96 * 1024 * 1024 * 1024; // 96GB headroom
 const MAX_GPU_UTILIZATION: f64 = 100.0; // Engine-busy is clamped to 100% per engine
+
+/// Minimum interval between energy-cache file writes. The file cache
+/// only bridges one-shot `snapshot` invocations (staleness tolerance is
+/// one hour), so a continuous 1 s sampling loop has no reason to
+/// rewrite and fsync the file on every tick. 60 s matches the energy
+/// WAL flush cadence in [`crate::metrics::energy_wal`].
+const ENERGY_CACHE_WRITE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
 // Per-card sysfs anchor.  We hold the absolute card path (e.g.
 // `/sys/class/drm/card0`) plus a one-time-cached identity (the name and
@@ -122,29 +136,43 @@ fn variant_label(variant: MemoryVariant) -> &'static str {
 
 /// Per-card energy delta tracker for the xe driver. The xe hwmon
 /// interface exposes cumulative energy counters (microjoules) instead
-/// of instantaneous power — first sample seeds; subsequent samples
+/// of instantaneous power: the first sample seeds, subsequent samples
 /// compute average watts as ΔJ / Δs.
 struct EnergyState {
     timestamp: Option<std::time::Instant>,
     energy_uj: u64,
+    /// When the file cache was last persisted. Cache writes are
+    /// throttled to [`ENERGY_CACHE_WRITE_INTERVAL`] so a 1 s sampling
+    /// loop does not fsync the cache file on every tick.
+    last_cache_write: Option<std::time::Instant>,
 }
 
-/// Compute average power (watts) from xe hwmon energy counters. First
-/// call seeds the counter (returns 0.0); subsequent calls return
-/// ΔJ / Δs. A file-based state cache at `/tmp/all-smi-energy-<pci>`
-/// bridges across process invocations so `all-smi snapshot` (one-shot)
-/// also sees power after the first sample.
-fn compute_power_from_energy(state: &Mutex<EnergyState>, device_dir: &Path) -> f64 {
+/// Compute average power (watts) from xe hwmon energy counters. The
+/// first call in a process seeds the counter (returns 0.0); subsequent
+/// calls return ΔJ / Δs from the monotonic clock. `cache_path`, when
+/// present, points at a per-card state file (see [`energy_cache_path`])
+/// that bridges across process invocations so `all-smi snapshot`
+/// (one-shot) also sees power after its first run.
+///
+/// Callers must re-apply the power validation cap to the returned
+/// value: the file-cache path trusts wall-clock timestamps, so clock
+/// skew or a corrupted cache could otherwise produce an absurd delta.
+/// Within this function the cache influence is already bounded by the
+/// one-hour staleness window and saturating counter arithmetic.
+fn compute_power_from_energy(
+    state: &Mutex<EnergyState>,
+    device_dir: &Path,
+    cache_path: Option<&Path>,
+) -> f64 {
     let current_uj = read_energy_uj(device_dir);
     if current_uj == 0 {
         return 0.0;
     }
 
-    let cache_path = energy_cache_path(device_dir);
     let now_instant = std::time::Instant::now();
-    let now_unix = std::time::SystemTime::now()
+    let now_unix_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
         .unwrap_or(0);
 
     let mut guard = match state.lock() {
@@ -152,64 +180,95 @@ fn compute_power_from_energy(state: &Mutex<EnergyState>, device_dir: &Path) -> f
         Err(_) => return 0.0,
     };
 
-    // Use in-memory state when available; otherwise fall back to the
-    // file cache so a one-shot `snapshot` invocation can still delta.
-    let (prev_instant, prev_uj) = match guard.timestamp {
-        Some(ts) => (Some(ts), guard.energy_uj),
-        None => {
-            if let Some((cached_ts, cached_uj)) = read_energy_cache(&cache_path) {
-                let delta_s = now_unix.saturating_sub(cached_ts) as f64;
-                if delta_s > 0.0 && delta_s < 3600.0 {
-                    let delta_j = current_uj.saturating_sub(cached_uj) as f64 / 1_000_000.0;
-                    let power = delta_j / delta_s;
-                    guard.timestamp = Some(now_instant);
-                    guard.energy_uj = current_uj;
-                    write_energy_cache(&cache_path, now_unix, current_uj);
-                    return power;
-                }
-            }
-            (None, 0)
-        }
-    };
-
-    let power = match prev_instant {
+    let power = match guard.timestamp {
+        // In-memory state available: monotonic-clock delta.
         Some(prev_ts) => {
-            let delta_s = (now_instant - prev_ts).as_secs_f64();
+            let delta_s = now_instant.duration_since(prev_ts).as_secs_f64();
             if delta_s > 0.0 {
-                let delta_j = current_uj.saturating_sub(prev_uj) as f64 / 1_000_000.0;
+                let delta_j = current_uj.saturating_sub(guard.energy_uj) as f64 / 1_000_000.0;
                 delta_j / delta_s
             } else {
                 0.0
             }
         }
-        None => 0.0,
+        // First sample in this process: bridge via the file cache so a
+        // one-shot `snapshot` invocation can still delta against the
+        // previous run. Entries older than an hour seed instead of
+        // deriving a meaningless average over the whole gap.
+        None => match cache_path.and_then(read_energy_cache) {
+            Some((cached_ts_ms, cached_uj)) => {
+                let delta_s = now_unix_ms.saturating_sub(cached_ts_ms) as f64 / 1000.0;
+                if delta_s > 0.0 && delta_s < 3600.0 {
+                    let delta_j = current_uj.saturating_sub(cached_uj) as f64 / 1_000_000.0;
+                    delta_j / delta_s
+                } else {
+                    0.0
+                }
+            }
+            None => 0.0,
+        },
+    };
+
+    let should_write_cache = match guard.last_cache_write {
+        None => true,
+        Some(last) => now_instant.duration_since(last) >= ENERGY_CACHE_WRITE_INTERVAL,
     };
     guard.timestamp = Some(now_instant);
     guard.energy_uj = current_uj;
-    write_energy_cache(&cache_path, now_unix, current_uj);
+    if should_write_cache && let Some(path) = cache_path {
+        write_energy_cache(path, now_unix_ms, current_uj);
+        guard.last_cache_write = Some(now_instant);
+    }
     power
 }
 
 /// Derive a stable per-card cache path from the canonical PCI device
-/// symlink target (e.g. `/tmp/all-smi-energy-0000:03:00.0`).
-fn energy_cache_path(device_dir: &Path) -> PathBuf {
+/// symlink target, rooted in the per-user cache directory (e.g.
+/// `~/.cache/all-smi/energy-hwmon-0000:03:00.0`, resolved via
+/// [`crate::common::paths::cache_dir`]). Returns `None` when no
+/// home-like directory exists; the caller then runs with in-memory
+/// state only, mirroring the energy WAL's downgrade behaviour.
+///
+/// The per-user location (instead of a fixed name in world-writable
+/// `/tmp`) is deliberate: a predictable `/tmp` path would let any local
+/// user pre-plant a symlink for a root-run all-smi to clobber, or
+/// poison the cached counter to skew the reported power.
+fn energy_cache_path(device_dir: &Path) -> Option<PathBuf> {
     let pci = std::fs::canonicalize(device_dir)
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
         .unwrap_or_else(|| "unknown".to_string());
-    PathBuf::from("/tmp").join(format!("all-smi-energy-{pci}"))
+    cache_dir().map(|d| d.join(format!("energy-hwmon-{pci}")))
 }
 
+/// Read `<unix_ms> <microjoules>` from the cache file. Refuses to read
+/// through a symlink, mirroring the energy WAL replay hardening in
+/// [`crate::metrics::energy_wal`], so a planted link cannot redirect
+/// the read. Any I/O or parse failure degrades to `None` (the caller
+/// seeds instead).
 fn read_energy_cache(path: &Path) -> Option<(u64, u64)> {
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    if meta.file_type().is_symlink() {
+        return None;
+    }
     let content = std::fs::read_to_string(path).ok()?;
     let mut parts = content.split_whitespace();
-    let ts: u64 = parts.next()?.parse().ok()?;
+    let ts_ms: u64 = parts.next()?.parse().ok()?;
     let uj: u64 = parts.next()?.parse().ok()?;
-    Some((ts, uj))
+    Some((ts_ms, uj))
 }
 
-fn write_energy_cache(path: &Path, ts: u64, uj: u64) {
-    let _ = std::fs::write(path, format!("{ts} {uj}"));
+/// Persist `<unix_ms> <microjoules>` through the shared hardened writer
+/// (`O_NOFOLLOW`, mode `0o600`, atomic rename; see
+/// [`crate::common::secure_write`]) so the write can never follow a
+/// symlink and concurrent snapshot invocations never observe a torn
+/// file. Best-effort: a failure only costs the one-shot bridging, never
+/// the in-memory delta.
+fn write_energy_cache(path: &Path, ts_ms: u64, uj: u64) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = write_atomic_secure(path, format!("{ts_ms} {uj}").as_bytes());
 }
 
 /// The reader itself. Holds a snapshot of cards discovered at
@@ -319,12 +378,24 @@ impl GpuReader for IntelGpuReader {
         let time = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
         let mut out = Vec::with_capacity(self.cards.len());
 
+        // Per-refresh lazy cache for the fdinfo VRAM fallback: one
+        // `/proc` walk serves every xe card that needs it this cycle,
+        // instead of each card re-walking `/proc` on its own.
+        let mut fdinfo_vram_by_card: Option<HashMap<usize, u64>> = None;
+
         for (card_index, card) in self.cards.iter().enumerate() {
             let static_info = self.ensure_static_info(card);
             let mut detail = static_info.detail.clone();
 
             let device_dir = card.card_path.join("device");
             let (mut used_memory, total_memory) = read_memory_bytes(&device_dir, card.variant);
+            // Whether the total came from the BAR2 heuristic rather
+            // than a real sysfs VRAM counter; drives the `Source:
+            // Memory` provenance label below. Only xe cards can be
+            // classified Discrete without `tile0/vram0/total_bytes`.
+            let total_from_bar2 = card.driver == "xe"
+                && total_memory > 0
+                && !has_nonzero_u64(&device_dir.join("tile0").join("vram0").join("total_bytes"));
             let frequency = read_frequency_mhz(&device_dir);
             let temperature = read_temperature_celsius(&device_dir);
             let mut power_consumption = read_power_watts(&device_dir);
@@ -349,26 +420,54 @@ impl GpuReader for IntelGpuReader {
                 fan_rpm,
             );
 
+            // `decorate_static_sources` labels any non-zero total as
+            // "DRM sysfs"; correct the provenance when the total is in
+            // fact the BAR2 size heuristic.
+            if total_from_bar2 {
+                detail.insert(
+                    "Source: Memory".to_string(),
+                    "PCI BAR2 size (xe)".to_string(),
+                );
+            }
+
             // xe driver: derive power from the hwmon energy counter when
-            // instantaneous power (`power1_average`) is not exposed.
+            // instantaneous power (`power1_average`) is not exposed. The
+            // derived value goes back through the MAX_GPU_POWER_WATTS
+            // cap because the file-cache bridge trusts wall-clock
+            // timestamps (see `compute_power_from_energy`).
             if power_consumption == 0.0 && card.driver == "xe" {
-                power_consumption = compute_power_from_energy(&card.energy_state, &device_dir);
-                if power_consumption > 0.0 {
+                let cache_path = energy_cache_path(&device_dir);
+                let derived = compute_power_from_energy(
+                    &card.energy_state,
+                    &device_dir,
+                    cache_path.as_deref(),
+                )
+                .clamp(0.0, MAX_GPU_POWER_WATTS);
+                if derived > 0.0 {
+                    power_consumption = derived;
                     detail.insert("Source: Power".to_string(), "energy delta (xe)".to_string());
                 }
             }
 
             // xe driver: fall back to fdinfo for VRAM usage when
-            // card-level sysfs counters are unavailable.
+            // card-level sysfs counters are unavailable. The per-card
+            // sums come from one shared `/proc` walk (see above).
             if used_memory == 0 && total_memory > 0 && card.driver == "xe" {
-                let fdinfo_vram = sum_card_vram_from_fdinfo(
-                    card_index,
-                    &self.intel_drm_basenames,
-                    &self.proc_root,
-                );
-                if fdinfo_vram > 0 {
+                let vram_by_card = fdinfo_vram_by_card.get_or_insert_with(|| {
+                    sum_vram_by_card_from_fdinfo(&self.intel_drm_basenames, &self.proc_root)
+                });
+                if let Some(&fdinfo_vram) = vram_by_card.get(&card_index)
+                    && fdinfo_vram > 0
+                {
                     used_memory = fdinfo_vram.min(total_memory);
-                    detail.insert("Source: Memory".to_string(), "fdinfo (xe)".to_string());
+                    detail.insert(
+                        "Source: Memory".to_string(),
+                        if total_from_bar2 {
+                            "fdinfo used, PCI BAR2 total (xe)".to_string()
+                        } else {
+                            "fdinfo (xe)".to_string()
+                        },
+                    );
                 }
             }
 
@@ -488,7 +587,7 @@ fn discover_cards(drm_root: &Path) -> Vec<IntelGpuCard> {
         }
 
         let device_id = read_device_id(&device_dir).unwrap_or(0);
-        let variant = classify_variant(&device_dir);
+        let variant = classify_variant(&device_dir, &driver);
 
         let index = parse_card_index(&name);
 
@@ -504,6 +603,7 @@ fn discover_cards(drm_root: &Path) -> Vec<IntelGpuCard> {
             energy_state: Mutex::new(EnergyState {
                 timestamp: None,
                 energy_uj: 0,
+                last_cache_write: None,
             }),
             #[cfg(feature = "level_zero")]
             level_zero_state: Mutex::new(
@@ -585,10 +685,17 @@ fn build_uuid(card: &IntelGpuCard, device_dir: &Path) -> String {
     }
 }
 
-fn classify_variant(device_dir: &Path) -> MemoryVariant {
+fn classify_variant(device_dir: &Path, driver: &str) -> MemoryVariant {
+    // The BAR2-size probe is limited to the xe driver: xe is where the
+    // sysfs VRAM counters can be missing (Battlemage on kernels before
+    // 6.14). i915 discrete parts always publish `mem_info_vram_total`,
+    // and i915-era integrated parts may expose GMADR apertures larger
+    // than the 256 MiB cutoff in `read_resource2_total_bytes`, which
+    // would misclassify a laptop iGPU as a discrete card with a
+    // fabricated VRAM total.
     if has_nonzero_u64(&device_dir.join("mem_info_vram_total"))
         || has_nonzero_u64(&device_dir.join("tile0").join("vram0").join("total_bytes"))
-        || read_resource2_total_bytes(device_dir) > 0
+        || (driver == "xe" && read_resource2_total_bytes(device_dir) > 0)
     {
         MemoryVariant::Discrete
     } else {

--- a/src/device/readers/intel_gpu_linux.rs
+++ b/src/device/readers/intel_gpu_linux.rs
@@ -43,7 +43,9 @@
 //! the BAR span the whole VRAM, and `used_memory` falls back to a
 //! per-card sum of `drm-resident-vram0` from process fdinfo.
 
+#[cfg(feature = "cli")]
 use crate::common::paths::cache_dir;
+#[cfg(feature = "cli")]
 use crate::common::secure_write::write_atomic_secure;
 use crate::device::GpuReader;
 use crate::device::readers::common_cache::{DeviceStaticInfo, MAX_DEVICES};
@@ -233,6 +235,11 @@ fn compute_power_from_energy(
 /// `/tmp`) is deliberate: a predictable `/tmp` path would let any local
 /// user pre-plant a symlink for a root-run all-smi to clobber, or
 /// poison the cached counter to skew the reported power.
+///
+/// `cli`-gated because `common::paths` / `common::secure_write` sit
+/// behind the `cli` feature (the optional `dirs` dependency); see the
+/// `cfg(not(feature = "cli"))` stubs below for the library-only build.
+#[cfg(feature = "cli")]
 fn energy_cache_path(device_dir: &Path) -> Option<PathBuf> {
     let pci = std::fs::canonicalize(device_dir)
         .ok()
@@ -246,6 +253,7 @@ fn energy_cache_path(device_dir: &Path) -> Option<PathBuf> {
 /// [`crate::metrics::energy_wal`], so a planted link cannot redirect
 /// the read. Any I/O or parse failure degrades to `None` (the caller
 /// seeds instead).
+#[cfg(feature = "cli")]
 fn read_energy_cache(path: &Path) -> Option<(u64, u64)> {
     let meta = std::fs::symlink_metadata(path).ok()?;
     if meta.file_type().is_symlink() {
@@ -264,12 +272,32 @@ fn read_energy_cache(path: &Path) -> Option<(u64, u64)> {
 /// symlink and concurrent snapshot invocations never observe a torn
 /// file. Best-effort: a failure only costs the one-shot bridging, never
 /// the in-memory delta.
+#[cfg(feature = "cli")]
 fn write_energy_cache(path: &Path, ts_ms: u64, uj: u64) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
     let _ = write_atomic_secure(path, format!("{ts_ms} {uj}").as_bytes());
 }
+
+// Library-only builds (`--no-default-features`) compile without
+// `common::paths` / `common::secure_write`, both gated behind the
+// `cli` feature for the optional `dirs` dependency. These stubs
+// disable the file cache there: library consumers poll continuously
+// and are fully served by the in-memory [`EnergyState`] delta; only
+// the one-shot CLI `snapshot` flow needs cross-invocation bridging.
+#[cfg(not(feature = "cli"))]
+fn energy_cache_path(_device_dir: &Path) -> Option<PathBuf> {
+    None
+}
+
+#[cfg(not(feature = "cli"))]
+fn read_energy_cache(_path: &Path) -> Option<(u64, u64)> {
+    None
+}
+
+#[cfg(not(feature = "cli"))]
+fn write_energy_cache(_path: &Path, _ts_ms: u64, _uj: u64) {}
 
 /// The reader itself. Holds a snapshot of cards discovered at
 /// construction time. Hot-plug is not supported in v1 — matching the AMD

--- a/src/device/readers/intel_gpu_linux/tests.rs
+++ b/src/device/readers/intel_gpu_linux/tests.rs
@@ -520,6 +520,7 @@ fn get_process_info_default_filter_keeps_uses_gpu_processes() {
 
 // ----- energy cache (xe power derivation) -----
 
+#[cfg(feature = "cli")]
 #[test]
 fn energy_cache_roundtrip() {
     let dir = tempdir().unwrap();
@@ -528,6 +529,7 @@ fn energy_cache_roundtrip() {
     assert_eq!(read_energy_cache(&path), Some((1_234_567, 89_000_000)));
 }
 
+#[cfg(feature = "cli")]
 #[test]
 fn read_energy_cache_refuses_symlink() {
     // A pre-planted symlink at the cache path must not be read through;
@@ -540,6 +542,7 @@ fn read_energy_cache_refuses_symlink() {
     assert_eq!(read_energy_cache(&link), None);
 }
 
+#[cfg(feature = "cli")]
 #[test]
 fn write_energy_cache_never_clobbers_symlink_target() {
     // A symlink planted where the cache should live must not cause its
@@ -579,6 +582,7 @@ fn compute_power_seeds_then_derives() {
     );
 }
 
+#[cfg(feature = "cli")]
 #[test]
 fn compute_power_bridges_via_file_cache() {
     // One-shot snapshot shape: fresh in-memory state, previous sample
@@ -608,6 +612,7 @@ fn compute_power_bridges_via_file_cache() {
     );
 }
 
+#[cfg(feature = "cli")]
 #[test]
 fn compute_power_ignores_stale_file_cache() {
     // Cache entries older than one hour must seed instead of deriving

--- a/src/device/readers/intel_gpu_linux/tests.rs
+++ b/src/device/readers/intel_gpu_linux/tests.rs
@@ -93,7 +93,7 @@ fn classify_variant_discrete_via_i915() {
     let device = card.join("device");
     fs::write(device.join("mem_info_vram_total"), "17179869184\n").unwrap();
 
-    assert_eq!(classify_variant(&device), MemoryVariant::Discrete);
+    assert_eq!(classify_variant(&device, "i915"), MemoryVariant::Discrete);
 }
 
 #[test]
@@ -105,7 +105,7 @@ fn classify_variant_discrete_via_xe() {
     fs::create_dir_all(&xe_dir).unwrap();
     fs::write(xe_dir.join("total_bytes"), "12884901888\n").unwrap();
 
-    assert_eq!(classify_variant(&device), MemoryVariant::Discrete);
+    assert_eq!(classify_variant(&device, "xe"), MemoryVariant::Discrete);
 }
 
 #[test]
@@ -114,7 +114,48 @@ fn classify_variant_integrated_when_no_vram() {
     let card = make_card(dir.path(), 0, "0x8086", "i915", "0x7D40");
     let device = card.join("device");
 
-    assert_eq!(classify_variant(&device), MemoryVariant::Integrated);
+    assert_eq!(classify_variant(&device, "i915"), MemoryVariant::Integrated);
+}
+
+#[test]
+fn classify_variant_discrete_via_xe_bar2_rebar() {
+    // Battlemage on kernels without `tile0/vram0/*`: a ReBAR-sized BAR2
+    // (larger than the 256 MiB aperture) marks the card as discrete.
+    let dir = tempdir().unwrap();
+    let card = make_card(dir.path(), 0, "0x8086", "xe", "0xE20B");
+    let device = card.join("device");
+    let bar2 = fs::File::create(device.join("resource2")).unwrap();
+    bar2.set_len(12 * 1024 * 1024 * 1024).unwrap();
+
+    assert_eq!(classify_variant(&device, "xe"), MemoryVariant::Discrete);
+}
+
+#[test]
+fn classify_variant_ignores_256mib_bar2_aperture() {
+    // Integrated xe GPUs (Meteor Lake / Lunar Lake) expose BAR2 as the
+    // fixed 256 MiB GMADR aperture; that must not flip them to
+    // Discrete with a fabricated 256 MiB VRAM total.
+    let dir = tempdir().unwrap();
+    let card = make_card(dir.path(), 0, "0x8086", "xe", "0x7D40");
+    let device = card.join("device");
+    let bar2 = fs::File::create(device.join("resource2")).unwrap();
+    bar2.set_len(256 * 1024 * 1024).unwrap();
+
+    assert_eq!(classify_variant(&device, "xe"), MemoryVariant::Integrated);
+}
+
+#[test]
+fn classify_variant_ignores_bar2_for_i915() {
+    // The BAR2 probe is xe-only: an i915 device with a large aperture
+    // (some BIOSes allow 512 MiB or more of GMADR) stays Integrated
+    // unless the i915 VRAM counter says otherwise.
+    let dir = tempdir().unwrap();
+    let card = make_card(dir.path(), 0, "0x8086", "i915", "0x7D40");
+    let device = card.join("device");
+    let bar2 = fs::File::create(device.join("resource2")).unwrap();
+    bar2.set_len(512 * 1024 * 1024).unwrap();
+
+    assert_eq!(classify_variant(&device, "i915"), MemoryVariant::Integrated);
 }
 
 #[test]
@@ -475,4 +516,119 @@ fn get_process_info_default_filter_keeps_uses_gpu_processes() {
     let (filtered, pids) = reader.get_gpu_processes();
     assert_eq!(filtered.len(), 1);
     assert!(pids.contains(&std::process::id()));
+}
+
+// ----- energy cache (xe power derivation) -----
+
+#[test]
+fn energy_cache_roundtrip() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("energy-hwmon-0000:03:00.0");
+    write_energy_cache(&path, 1_234_567, 89_000_000);
+    assert_eq!(read_energy_cache(&path), Some((1_234_567, 89_000_000)));
+}
+
+#[test]
+fn read_energy_cache_refuses_symlink() {
+    // A pre-planted symlink at the cache path must not be read through;
+    // same hardening as the energy WAL replay side.
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("target");
+    fs::write(&target, "0 0").unwrap();
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    assert_eq!(read_energy_cache(&link), None);
+}
+
+#[test]
+fn write_energy_cache_never_clobbers_symlink_target() {
+    // A symlink planted where the cache should live must not cause its
+    // target to be overwritten (the naive `std::fs::write` follows
+    // symlinks; the hardened writer replaces the link itself instead).
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("victim");
+    fs::write(&target, "do-not-clobber").unwrap();
+    let link = dir.path().join("cache");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    write_energy_cache(&link, 1, 2);
+    assert_eq!(fs::read_to_string(&target).unwrap(), "do-not-clobber");
+}
+
+#[test]
+fn compute_power_seeds_then_derives() {
+    let dir = tempdir().unwrap();
+    let device = dir.path();
+    let hwmon = device.join("hwmon").join("hwmon0");
+    fs::create_dir_all(&hwmon).unwrap();
+    fs::write(hwmon.join("energy1_input"), "1000000\n").unwrap();
+
+    let state = Mutex::new(EnergyState {
+        timestamp: None,
+        energy_uj: 0,
+        last_cache_write: None,
+    });
+    // First call seeds (no file cache in play) and reports 0 W.
+    assert_eq!(compute_power_from_energy(&state, device, None), 0.0);
+    // Bump the counter by 1 J and wait so the monotonic delta is > 0.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    fs::write(hwmon.join("energy1_input"), "2000000\n").unwrap();
+    let power = compute_power_from_energy(&state, device, None);
+    assert!(
+        power > 0.0,
+        "second sample must derive positive power, got {power}"
+    );
+}
+
+#[test]
+fn compute_power_bridges_via_file_cache() {
+    // One-shot snapshot shape: fresh in-memory state, previous sample
+    // only in the file cache. 10 J over 10 s must read back as ~1 W.
+    let dir = tempdir().unwrap();
+    let device = dir.path();
+    let hwmon = device.join("hwmon").join("hwmon0");
+    fs::create_dir_all(&hwmon).unwrap();
+    fs::write(hwmon.join("energy1_input"), "20000000\n").unwrap();
+
+    let cache = dir.path().join("cache");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    write_energy_cache(&cache, now_ms - 10_000, 10_000_000);
+
+    let state = Mutex::new(EnergyState {
+        timestamp: None,
+        energy_uj: 0,
+        last_cache_write: None,
+    });
+    let power = compute_power_from_energy(&state, device, Some(&cache));
+    assert!(
+        (0.9..=1.1).contains(&power),
+        "expected roughly 1 W, got {power}"
+    );
+}
+
+#[test]
+fn compute_power_ignores_stale_file_cache() {
+    // Cache entries older than one hour must seed instead of deriving
+    // a meaningless average over the whole gap.
+    let dir = tempdir().unwrap();
+    let device = dir.path();
+    let hwmon = device.join("hwmon").join("hwmon0");
+    fs::create_dir_all(&hwmon).unwrap();
+    fs::write(hwmon.join("energy1_input"), "20000000\n").unwrap();
+
+    let cache = dir.path().join("cache");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    write_energy_cache(&cache, now_ms - 2 * 3600 * 1000, 10_000_000);
+
+    let state = Mutex::new(EnergyState {
+        timestamp: None,
+        energy_uj: 0,
+        last_cache_write: None,
+    });
+    assert_eq!(compute_power_from_energy(&state, device, Some(&cache)), 0.0);
 }

--- a/src/device/readers/intel_gpu_sysfs.rs
+++ b/src/device/readers/intel_gpu_sysfs.rs
@@ -70,16 +70,25 @@ pub fn read_memory_bytes(device_dir: &Path, variant: MemoryVariant) -> (u64, u64
 }
 
 /// Read the PCI BAR2 (VRAM BAR) resource file size in bytes. Returns 0
-/// when the file is absent or the size is not a plausible VRAM BAR (less
-/// than 256 MiB). Used as a last-resort fallback when the xe driver does
-/// not expose `tile0/vram0/total_bytes` (Battlemage on kernels < 6.14).
+/// when the file is absent or the size is not a plausible VRAM BAR.
+/// Used as a last-resort fallback when the xe driver does not expose
+/// `tile0/vram0/total_bytes` (Battlemage on kernels before 6.14).
+///
+/// The size must be *strictly larger* than 256 MiB. Integrated GPUs
+/// expose BAR2 as the fixed 256 MiB GMADR aperture, and discrete parts
+/// without Resizable BAR also show a 256 MiB window that says nothing
+/// about the actual VRAM size (a 12 GB B580 would report 256 MiB).
+/// BAR2 equals the VRAM size only when Resizable BAR maps the whole
+/// VRAM, so anything at or below the aperture size is rejected rather
+/// than surfaced as a fabricated capacity.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub fn read_resource2_total_bytes(device_dir: &Path) -> u64 {
+    const BAR2_APERTURE_BYTES: u64 = 256 * 1024 * 1024;
     let path = device_dir.join("resource2");
     match std::fs::metadata(&path) {
         Ok(meta) => {
             let size = meta.len();
-            if size >= 256 * 1024 * 1024 { size } else { 0 }
+            if size > BAR2_APERTURE_BYTES { size } else { 0 }
         }
         Err(_) => 0,
     }
@@ -277,6 +286,50 @@ mod tests {
         let (used, total) = read_memory_bytes(dir.path(), MemoryVariant::Discrete);
         assert_eq!(total, 12_884_901_888);
         assert_eq!(used, 536_870_912);
+    }
+
+    #[test]
+    fn read_memory_discrete_via_resource2_rebar() {
+        // Battlemage on kernels without `tile0/vram0/*`: BAR2 spans the
+        // whole VRAM when Resizable BAR is active. A sparse file's
+        // metadata length stands in for the sysfs resource size.
+        let dir = tempdir().unwrap();
+        let bar2 = fs::File::create(dir.path().join("resource2")).unwrap();
+        bar2.set_len(12 * 1024 * 1024 * 1024).unwrap();
+        let (used, total) = read_memory_bytes(dir.path(), MemoryVariant::Discrete);
+        assert_eq!(total, 12 * 1024 * 1024 * 1024);
+        assert_eq!(used, 0);
+    }
+
+    #[test]
+    fn resource2_rejects_256mib_aperture() {
+        // Integrated GPUs (and non-ReBAR discrete parts) expose BAR2 as
+        // a 256 MiB window; that must NOT be reported as a VRAM total.
+        let dir = tempdir().unwrap();
+        let bar2 = fs::File::create(dir.path().join("resource2")).unwrap();
+        bar2.set_len(256 * 1024 * 1024).unwrap();
+        assert_eq!(read_resource2_total_bytes(dir.path()), 0);
+    }
+
+    #[test]
+    fn resource2_missing_returns_zero() {
+        let dir = tempdir().unwrap();
+        assert_eq!(read_resource2_total_bytes(dir.path()), 0);
+    }
+
+    #[test]
+    fn read_energy_uj_reads_hwmon_counter() {
+        let dir = tempdir().unwrap();
+        let hwmon = dir.path().join("hwmon").join("hwmon0");
+        fs::create_dir_all(&hwmon).unwrap();
+        fs::write(hwmon.join("energy1_input"), "123456789\n").unwrap();
+        assert_eq!(read_energy_uj(dir.path()), 123_456_789);
+    }
+
+    #[test]
+    fn read_energy_uj_missing_returns_zero() {
+        let dir = tempdir().unwrap();
+        assert_eq!(read_energy_uj(dir.path()), 0);
     }
 
     #[test]

--- a/src/device/readers/intel_gpu_sysfs.rs
+++ b/src/device/readers/intel_gpu_sysfs.rs
@@ -162,6 +162,25 @@ pub fn read_power_watts(device_dir: &Path) -> f64 {
     0.0
 }
 
+/// Walk `device/hwmon/hwmon*/energy1_input` (microjoules). Returns the
+/// first parseable value. The xe driver exposes cumulative energy
+/// counters instead of instantaneous power — the caller delta-tracks
+/// across samples to derive watts.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_energy_uj(device_dir: &Path) -> u64 {
+    let hwmon_root = device_dir.join("hwmon");
+    let iter = match std::fs::read_dir(&hwmon_root) {
+        Ok(i) => i,
+        Err(_) => return 0,
+    };
+    for entry in iter.flatten() {
+        if let Some(uj) = read_u64(&entry.path().join("energy1_input")) {
+            return uj;
+        }
+    }
+    0
+}
+
 /// Walk `device/hwmon/hwmon*/fan1_input` (RPM). Returns the first
 /// parseable non-zero value.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]

--- a/src/device/readers/intel_gpu_sysfs.rs
+++ b/src/device/readers/intel_gpu_sysfs.rs
@@ -60,7 +60,29 @@ pub fn read_memory_bytes(device_dir: &Path, variant: MemoryVariant) -> (u64, u64
         used = read_u64(&device_dir.join("tile0").join("vram0").join("used_bytes")).unwrap_or(0);
     }
 
+    // xe driver on Battlemage (kernel 6.12+) does not expose
+    // `tile0/vram0/*`; fall back to PCI BAR2 (VRAM BAR) size.
+    if total == 0 {
+        total = read_resource2_total_bytes(device_dir);
+    }
+
     (used, total)
+}
+
+/// Read the PCI BAR2 (VRAM BAR) resource file size in bytes. Returns 0
+/// when the file is absent or the size is not a plausible VRAM BAR (less
+/// than 256 MiB). Used as a last-resort fallback when the xe driver does
+/// not expose `tile0/vram0/total_bytes` (Battlemage on kernels < 6.14).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn read_resource2_total_bytes(device_dir: &Path) -> u64 {
+    let path = device_dir.join("resource2");
+    match std::fs::metadata(&path) {
+        Ok(meta) => {
+            let size = meta.len();
+            if size >= 256 * 1024 * 1024 { size } else { 0 }
+        }
+        Err(_) => 0,
+    }
 }
 
 /// Read the current GT0 frequency in MHz.


### PR DESCRIPTION
Fixes reporting of VRAM usage due to battlemage reporting it under a different path.

Also fixes reporting of power draw because intel only reports total energy (in Joules), so power draw has to be derived.