### PR TITLE
fix: sample IOReport continuously and poll local mode at its own cadence

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -282,6 +282,14 @@ impl EnergyConfig {
 pub struct EnvConfig;
 
 impl EnvConfig {
+    /// Collection interval for the given number of *remote* nodes.
+    ///
+    /// Local monitoring is `node_count == 0`. Call [`local_interval`] rather
+    /// than passing a literal there: passing `1` reads as "one host" but
+    /// selects the 1-to-10-remote-nodes arm, which is how local mode ended up
+    /// polling at the remote cadence.
+    ///
+    /// [`local_interval`]: Self::local_interval
     pub fn adaptive_interval(node_count: usize) -> u64 {
         match node_count {
             0 => {
@@ -298,6 +306,14 @@ impl EnvConfig {
             51..=100 => 5,
             _ => 6,
         }
+    }
+
+    /// Collection interval for local monitoring (no remote nodes).
+    ///
+    /// The single name every local-mode call site uses, so the node count is
+    /// never spelled out as a literal there.
+    pub fn local_interval() -> u64 {
+        Self::adaptive_interval(0)
     }
 
     #[allow(dead_code)] // Future connection management
@@ -406,6 +422,26 @@ mod tests {
         assert_eq!(EnvConfig::adaptive_interval(200), 6);
         assert_eq!(EnvConfig::adaptive_interval(500), 6);
         assert_eq!(EnvConfig::adaptive_interval(1000), 6);
+    }
+
+    /// Local mode must use the no-remote-nodes cadence, not the arm for a
+    /// small remote cluster. `run_local_mode` used to call
+    /// `adaptive_interval(1)`, which reads as "one host" but selects the
+    /// 1-to-10-remote-nodes arm, so local polling ran at 3s instead of the
+    /// documented 1s / 2s.
+    #[test]
+    fn test_local_interval_is_the_no_remote_nodes_arm() {
+        assert_eq!(EnvConfig::local_interval(), EnvConfig::adaptive_interval(0));
+        assert_ne!(
+            EnvConfig::local_interval(),
+            EnvConfig::adaptive_interval(1),
+            "local cadence must differ from the 1-to-10-remote-nodes cadence"
+        );
+        assert!(
+            EnvConfig::local_interval() <= 2,
+            "local monitoring polls at 1s (Apple Silicon) or 2s, got {}",
+            EnvConfig::local_interval()
+        );
     }
 
     #[test]

--- a/src/device/macos_native/ioreport.rs
+++ b/src/device/macos_native/ioreport.rs
@@ -547,6 +547,12 @@ const CPU_PERF_STATES: &str = "CPU Core Performance States";
 const GPU_STATS: &str = "GPU Stats";
 const GPU_PERF_STATES: &str = "GPU Performance States";
 
+/// Shortest interval [`IOReport::get_sample_since_last`] will turn into a
+/// delta. Power and residency are counter deltas divided by elapsed time, so a
+/// window this short is dominated by sampling jitter; below it the call
+/// reports "no delta yet" instead of a wild rate.
+const MIN_DELTA_WINDOW: std::time::Duration = std::time::Duration::from_millis(50);
+
 /// IOReport subscription manager
 pub struct IOReport {
     subscription: IOReportSubscriptionRef,
@@ -619,7 +625,14 @@ impl IOReport {
         }
     }
 
-    /// Get a delta sample over the specified duration
+    /// Get a delta sample over the specified duration.
+    ///
+    /// This blocks the calling thread for `duration_ms` to open the delta
+    /// window, so it observes only that window out of however long the caller
+    /// waits between calls. Prefer [`get_sample_since_last`], which deltas
+    /// against the previous call and therefore covers the whole interval
+    /// without sleeping. This variant remains for the first sample of a
+    /// session, where there is no previous sample to delta against.
     pub fn get_sample(
         &mut self,
         duration_ms: u64,
@@ -645,6 +658,66 @@ impl IOReport {
         }
 
         Ok((IOReportIterator::new(delta), duration_ns))
+    }
+
+    /// Get a delta sample covering the time since the previous call, without
+    /// blocking.
+    ///
+    /// Every channel subscribed here is a cumulative counter (energy in the
+    /// Energy Model group, residency ticks in the CPU/GPU stats groups), so a
+    /// delta between two arbitrary samples is exactly the activity that
+    /// occurred between them. Retaining the newest sample and differencing the
+    /// next call against it therefore yields a window equal to the caller's
+    /// polling period, with no `sleep` and a single `IOReportCreateSamples`
+    /// call per poll.
+    ///
+    /// Returns `Ok(None)` when no usable delta is available, which happens in
+    /// two cases: the first call of a session (nothing to delta against yet),
+    /// and a call so soon after the previous one that the window would be
+    /// below [`MIN_DELTA_WINDOW`]. Rates derived from a near-zero window are
+    /// meaningless, so the baseline is left in place for the next call rather
+    /// than consumed. Callers that need a value immediately can fall back to
+    /// [`get_sample`].
+    ///
+    /// [`get_sample`]: Self::get_sample
+    /// [`get_sample_since_last`]: Self::get_sample_since_last
+    pub fn get_sample_since_last(
+        &mut self,
+    ) -> Result<Option<(IOReportIterator, u64)>, &'static str> {
+        let sample = self.take_sample()?;
+        let now = Instant::now();
+
+        // Peek before consuming: a too-short window must not discard a usable
+        // baseline, or a caller polling faster than MIN_DELTA_WINDOW would
+        // never accumulate one.
+        if let Some((_, prev_at)) = self.prev_sample.as_ref()
+            && now.duration_since(*prev_at) < MIN_DELTA_WINDOW
+        {
+            unsafe { CFRelease(sample as *const c_void) };
+            return Ok(None);
+        }
+
+        let Some((prev, prev_at)) = self.prev_sample.replace((sample, now)) else {
+            // First call: `sample` is now retained as the baseline.
+            return Ok(None);
+        };
+
+        let duration_ns = now.duration_since(prev_at).as_nanos() as u64;
+
+        // `IOReportCreateSamplesDelta` does not take ownership of either
+        // argument. `sample` stays retained as the new baseline (it is already
+        // stored in `prev_sample`), so only the old baseline is released here.
+        let delta = unsafe {
+            let d = IOReportCreateSamplesDelta(prev, sample, ptr::null());
+            CFRelease(prev as *const c_void);
+            d
+        };
+
+        if delta.is_null() {
+            return Err("Failed to create sample delta");
+        }
+
+        Ok(Some((IOReportIterator::new(delta), duration_ns)))
     }
 
     /// Take a single sample

--- a/src/device/macos_native/manager.rs
+++ b/src/device/macos_native/manager.rs
@@ -90,6 +90,19 @@ pub struct NativeMetricsManager {
 }
 
 impl NativeMetricsManager {
+    /// How long a collected sample is served from cache.
+    ///
+    /// Sized to cover one collection cycle's worth of reader calls without
+    /// reaching the next cycle: the shortest supported poll interval is one
+    /// second, and the readers within a cycle call microseconds apart.
+    ///
+    /// There used to be a 5-second window for the first ten calls, to absorb
+    /// the ~500ms of blocking each collection cost. Collection no longer
+    /// blocks (see `IOReport::get_sample_since_last`), and that window made
+    /// the first ~10 seconds of every history graph a staircase of repeated
+    /// values, so a single duration now applies from the first call.
+    const CACHE_DURATION_MS: u128 = 500;
+
     /// Create a new NativeMetricsManager
     ///
     /// Note: The `_interval_ms` parameter is kept for API compatibility but is not used.
@@ -291,18 +304,16 @@ impl NativeMetricsManager {
 
     /// Collect a single sample synchronously (for testing or one-shot use)
     ///
-    /// This method implements caching: if called within 500ms of a previous collection,
-    /// it returns the cached data instead of collecting new samples.
+    /// This method implements caching: if called within [`CACHE_DURATION_MS`]
+    /// of a previous collection, it returns the cached data instead of
+    /// collecting new samples. That window is what keeps the several readers
+    /// that run per collection cycle (GPU, CPU) from each opening their own
+    /// delta and splitting one interval into slivers.
     /// Uses double-checked locking to prevent concurrent collections.
+    ///
+    /// [`CACHE_DURATION_MS`]: Self::CACHE_DURATION_MS
     pub fn collect_once(&self) -> Result<NativeMetricsData, Box<dyn std::error::Error>> {
-        // Use longer cache duration during startup to handle tokio blocking
-        // After first few calls, use shorter duration for responsiveness
-        static CALL_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-        let call_num = CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-        // First 10 calls use 5 second cache (startup phase)
-        // After that, use 500ms cache (normal operation)
-        let cache_duration_ms: u128 = if call_num < 10 { 5000 } else { 500 };
+        let cache_duration_ms = Self::CACHE_DURATION_MS;
 
         // First check: quick read-only cache check (no lock)
         if let (Ok(time_guard), Ok(data_guard)) =
@@ -333,26 +344,27 @@ impl NativeMetricsManager {
         let mut ioreport_guard = self.ioreport.lock().map_err(|_| "IOReport lock poisoned")?;
         let ioreport = ioreport_guard.as_mut().ok_or("IOReport not initialized")?;
 
-        // For first collection, use fewer samples for faster startup
-        // Subsequent calls can use full sample count for accuracy
-        static FIRST_COLLECTION: std::sync::atomic::AtomicBool =
-            std::sync::atomic::AtomicBool::new(true);
-
-        let sample_count = if FIRST_COLLECTION.swap(false, std::sync::atomic::Ordering::Relaxed) {
-            1 // First call: single sample for fast startup (~100ms)
-        } else {
-            self.config.sample_count // Subsequent calls: full averaging
+        // Delta against the sample retained by the previous collection. Every
+        // subscribed channel is a cumulative counter, so this covers the whole
+        // interval since that collection rather than a short synthetic window,
+        // and it needs neither a `sleep` nor repeated samples to average: the
+        // long delta already *is* the interval's time average.
+        //
+        // Only the very first collection of a session has no baseline. It pays
+        // one blocking `sample_interval_ms` window so the caller gets data
+        // immediately instead of waiting a full poll for the second call.
+        let avg_metrics = match ioreport.get_sample_since_last()? {
+            Some((iterator, duration_ns)) => IOReportMetrics::from_sample(iterator, duration_ns),
+            None => {
+                // The call above already retained a baseline, so the next
+                // collection deltas against it and this branch runs once per
+                // session. The short window measured here overlaps the start of
+                // that first interval, which is harmless.
+                let (iterator, duration_ns) =
+                    ioreport.get_sample(self.config.sample_interval_ms)?;
+                IOReportMetrics::from_sample(iterator, duration_ns)
+            }
         };
-
-        // Collect samples
-        let mut samples: Vec<IOReportMetrics> = Vec::new();
-        for _ in 0..sample_count {
-            let (iterator, duration_ns) = ioreport.get_sample(self.config.sample_interval_ms)?;
-            samples.push(IOReportMetrics::from_sample(iterator, duration_ns));
-        }
-
-        // Average samples
-        let avg_metrics = Self::average_samples(&samples);
 
         // Collect SMC metrics
         let smc_metrics = SMCMetrics::collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,7 +329,9 @@ async fn run_command(cli: Cli, settings: Settings) {
             // Initialize native metrics manager (no sudo required)
             #[cfg(target_os = "macos")]
             if is_apple_silicon() {
-                let interval = args.interval.unwrap_or(2);
+                let interval = args
+                    .interval
+                    .unwrap_or_else(common::config::EnvConfig::local_interval);
                 if let Err(e) = initialize_native_metrics_manager(interval * 1000) {
                     eprintln!("Warning: Failed to initialize native metrics manager: {e}");
                 } else {
@@ -341,7 +343,9 @@ async fn run_command(cli: Cli, settings: Settings) {
             // Initialize hlsmi manager for Intel Gaudi on Linux
             #[cfg(target_os = "linux")]
             if has_gaudi() {
-                let interval = args.interval.unwrap_or(2);
+                let interval = args
+                    .interval
+                    .unwrap_or_else(common::config::EnvConfig::local_interval);
                 std::thread::spawn(move || match initialize_hlsmi_manager(interval) {
                     Err(e) => {
                         eprintln!("Warning: Failed to initialize hlsmi manager: {e}");

--- a/src/view/data_collector.rs
+++ b/src/view/data_collector.rs
@@ -148,11 +148,14 @@ impl DataCollector {
         let collector = LocalCollector::new();
         let mut first_iteration = true;
 
+        // Local mode has no remote nodes, so the cadence comes from
+        // `local_interval`. Resolved once: `args.interval` is fixed for the
+        // process and the adaptive value is a constant per platform.
+        let interval = args.interval.unwrap_or_else(EnvConfig::local_interval);
+
         loop {
             let mut config = CollectionConfig {
-                interval: args
-                    .interval
-                    .unwrap_or_else(|| EnvConfig::adaptive_interval(1)),
+                interval,
                 first_iteration,
                 hosts: Vec::new(),
             };
@@ -201,10 +204,6 @@ impl DataCollector {
                 config.first_iteration = false;
             }
 
-            // Use adaptive interval for local mode
-            let interval = args
-                .interval
-                .unwrap_or_else(|| EnvConfig::adaptive_interval(1));
             tokio::time::sleep(Duration::from_secs(interval)).await;
         }
     }


### PR DESCRIPTION
Follow-up to #285. While checking why the history graph's time axis was uneven, two defects turned up in the local-mode collection path that compounded each other.

## Problem 1: IOReport opened its own measurement window

`IOReport::get_sample` took a sample, slept 100ms, took a second one, and returned the delta. `collect_once` averaged four of those. So each collection blocked its caller ~495ms and observed 400ms of wall time. At the effective 3.5s period that is **14% of elapsed time**: whatever happened in the other 86% never reached the graphs. The blocking also ran directly inside a `tokio::join!` arm in `local_collector.rs:280-290`, while the process collection immediately below it uses `spawn_blocking` for exactly this reason.

## Problem 2: local mode asked for the remote cadence

`run_local_mode` called `EnvConfig::adaptive_interval(1)`. The `1` reads as "one host" but selects the `1..=10 => 3` remote-nodes arm, so local mode polled at 3s and the `node_count == 0` arm, commented `// Local monitoring only (no remote nodes)`, was unreachable. `main.rs:332,344` assumed `unwrap_or(2)` for the same run, so one binary carried three different local defaults.

## Change

**Continuous delta.** Every subscribed channel is a cumulative counter (energy in the Energy Model group, residency ticks in CPU/GPU stats), so a delta between any two samples is exactly the activity between them. `get_sample_since_last` retains the newest sample and differences the next call against it: no sleep, one `IOReportCreateSamples` per poll, and a window equal to the full polling interval. The `prev_sample` field this needs was already declared on `IOReport` but had never been written to. Deltas below `MIN_DELTA_WINDOW` (50ms) report no result instead of dividing counters by a near-zero interval, and leave the baseline in place so a fast caller still accumulates one. `get_sample` stays for the first collection of a session. Averaging four samples is gone: one long delta already is the interval's time average.

**Named local cadence.** Local call sites use `EnvConfig::local_interval()` and never spell out a node count, which removes the class of bug rather than the instance. `main.rs`'s two `unwrap_or(2)` sites use it too.

**Uniform cache.** The 5s window for the first ten `collect_once` calls existed to absorb the old blocking. It also made the first ~10 seconds of every history graph a staircase of repeated values. Replaced by a single `CACHE_DURATION_MS`, which still dedupes the several readers that run within one collection cycle.

## Measurements

M5 Max, release build, 200x50 tmux, 60s per run. (Corrected after merge: an earlier revision of this body said M1 Ultra, which was the machine in the reporting screenshots, not the machine these numbers were taken on.)

Collection cost in isolation:

| | before | after |
|---|---|---|
| collection | 495ms | **24ms** |
| worker occupancy @1s | 33.0% | **2.4%** |
| IOReport samples/cycle | 8 | **1** |
| observation coverage @3s | 14% | **100%** |

Full TUI CPU by interval:

| interval | before | after |
|---|---|---|
| 1s | 8.16% | 4.71% |
| 2s | 5.32% | 3.47% |
| 3s | 4.06% | 2.13% |

End to end, default local mode with no `-i`: **4.06% at 3s before, 3.52% at 1s after.** The sample rate triples at equal or lower cost, which is what makes problem 2's fix affordable.

## Correctness check

A/B of both code paths over the same period, to confirm this changes cost and coverage rather than the numbers:

```
blocking400  window=410ms  cpu_power=2.41W gpu_power=0.83W gpu_res=24.5% p_res=2.4%
blocking400  window=407ms  cpu_power=8.14W gpu_power=0.93W gpu_res=28.3% p_res=6.1%
blocking400  window=410ms  cpu_power=9.92W gpu_power=0.84W gpu_res=28.7% p_res=4.0%
continuous   window=1012ms cpu_power=2.63W gpu_power=0.77W gpu_res=25.4% p_res=1.5%
continuous   window=1012ms cpu_power=3.54W gpu_power=0.78W gpu_res=25.1% p_res=3.3%
continuous   window=1010ms cpu_power=19.29W gpu_power=0.79W gpu_res=24.6% p_res=14.9%
```

Every metric lands in the same range. CPU power is spiky in both, which is the metric's nature.

## Tests

- Added `test_local_interval_is_the_no_remote_nodes_arm`: the local cadence must equal `adaptive_interval(0)`, must differ from `adaptive_interval(1)`, and must be at most 2s.
- Verified by hand that a sub-`MIN_DELTA_WINDOW` call returns no delta and leaves the baseline armed for the next call.
- `cargo test` fully green, `cargo clippy --all-targets` clean, `cargo fmt` applied.

## Scope note

macOS Apple Silicon only for the sampling change; the interval fix applies to every local-mode platform (3s to 2s off Apple Silicon, matching what `main.rs` already assumed).

