### PR TITLE
test: add a portable local-mode collection cost benchmark

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -223,6 +223,23 @@ SKIP_SUDO_TESTS=1 cargo test
 
 For comprehensive testing documentation, see [TESTING.md](TESTING.md).
 
+### Benchmarking Local-Mode Collection Cost
+
+`scripts/bench-local-interval.sh` measures how much CPU `all-smi local` uses at different collection intervals. Use it when changing the collection cadence, the sampling strategy, or anything a device reader does on every poll.
+
+```bash
+cargo build --release --bin all-smi
+scripts/bench-local-interval.sh                 # default: 60s window, intervals 1/2/3
+scripts/bench-local-interval.sh -d 120 -i "2 5" # longer window, custom intervals
+scripts/bench-local-interval.sh -h              # usage
+```
+
+It requires `tmux` (macOS and Linux only) so the TUI runs detached at a fixed 200x50 size; terminal size affects render cost, so fixing it is what makes results from different machines comparable. CPU is computed from the process CPU-time delta rather than `ps -o %cpu`, because that column is a decaying recent average on macOS and a lifetime average on Linux. Results are percent of one core.
+
+The script prints an environment block (OS, CPU, GPU, core count, process count) above the numbers. Include it whenever you report results: collection cost depends heavily on which device readers are active, so numbers without that context cannot be compared.
+
+Coverage is currently thin outside Apple Silicon. See issue #288 if you have Linux or Windows hardware and can contribute measurements.
+
 ## Code Style and Standards
 
 ### Formatting

--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 Lablup Inc. and Jeongkyu Shin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Measure all-smi local-mode CPU usage across collection intervals.
+#
+# Issue #288: the local-mode default interval moved from 3s to 1s on Apple
+# Silicon and to 2s elsewhere (PR #286). Only Apple Silicon was benchmarked.
+# This script exists so results from other platforms are produced the same way
+# and are therefore comparable.
+#
+# USAGE
+#
+#   scripts/bench-local-interval.sh [-d SECONDS] [-b PATH] [-i "LIST"]
+#
+#     -d SECONDS   measurement window per configuration (default 60)
+#     -b PATH      all-smi binary (default ./target/release/all-smi)
+#     -i "LIST"    space-separated intervals to test (default "1 2 3");
+#                  the no-flag default configuration is always measured
+#
+#   Build first:  cargo build --release --bin all-smi
+#
+# REQUIREMENTS
+#
+#   tmux, for a detached session at a fixed 200x50 size. Terminal size affects
+#   render cost, so a fixed size is what makes runs on different machines
+#   comparable. macOS and Linux only; on Windows, run under WSL or report that
+#   the platform is untested.
+#
+# METHOD
+#
+#   CPU is derived from the process CPU-time delta over the window, not from
+#   `ps -o %cpu`. That column means different things per platform: a decaying
+#   recent average on macOS, a lifetime average on Linux. A CPU-time delta
+#   divided by wall time is the same quantity everywhere. Values are percent of
+#   one core, so a fully busy single thread reads 100%.
+#
+#   The first WARMUP_SECS after launch are discarded so one-time startup work
+#   (reader initialisation, first collection, first render) does not land in
+#   the window.
+#
+# REPORTING
+#
+#   Paste the whole output, environment block included, into issue #288. The
+#   environment block is what lets a reader tell whether two results are
+#   comparable.
+
+set -euo pipefail
+
+DURATION=60
+BIN="./target/release/all-smi"
+INTERVALS="1 2 3"
+WARMUP_SECS=8
+TMUX_COLS=200
+TMUX_ROWS=50
+
+# Print the header comment block: everything from the first line after the
+# licence block down to the last comment line before the code starts. Derived
+# from the file rather than duplicated, so editing the header cannot leave the
+# help text stale.
+usage() {
+  awk '
+    /^# Measure all-smi/ { show = 1 }
+    show && !/^#/ { exit }
+    show { sub(/^# ?/, ""); print }
+  ' "$0"
+}
+
+while getopts "d:b:i:h" opt; do
+  case "$opt" in
+    d) DURATION="$OPTARG" ;;
+    b) BIN="$OPTARG" ;;
+    i) INTERVALS="$OPTARG" ;;
+    h) usage; exit 0 ;;
+    *) echo "run '$0 -h' for usage" >&2; exit 2 ;;
+  esac
+done
+
+command -v tmux >/dev/null 2>&1 || { echo "error: tmux is required" >&2; exit 1; }
+[ -x "$BIN" ] || { echo "error: no executable at $BIN (cargo build --release --bin all-smi)" >&2; exit 1; }
+
+OS="$(uname -s)"
+case "$OS" in
+  Linux)
+    CLK_TCK="$(getconf CLK_TCK 2>/dev/null || echo 100)"
+    # utime (field 14) + stime (field 15) in clock ticks. Fields are counted
+    # from after the comm field, which may itself contain spaces and
+    # parentheses, so split on the last ')' rather than on whitespace.
+    cpu_time_seconds() {
+      local stat rest
+      stat="$(cat "/proc/$1/stat" 2>/dev/null)" || return 1
+      rest="${stat##*) }"
+      awk -v t="$rest" -v hz="$CLK_TCK" 'BEGIN { split(t, f, " "); print (f[12] + f[13]) / hz }'
+    }
+    ;;
+  Darwin)
+    # `ps -o cputime=` prints [[DD-]HH:]MM:SS.CC on BSD ps, so centisecond
+    # resolution is available without reading kernel structures.
+    cpu_time_seconds() {
+      local t
+      t="$(ps -o cputime= -p "$1" 2>/dev/null | tr -d ' ')" || return 1
+      [ -n "$t" ] || return 1
+      awk -v t="$t" 'BEGIN {
+        n = split(t, p, ":")
+        # Optional leading DD- on the first field.
+        if (n >= 1 && index(p[1], "-") > 0) { split(p[1], d, "-"); days = d[1]; p[1] = d[2] }
+        s = 0
+        for (i = 1; i <= n; i++) s = s * 60 + p[i]
+        print s + days * 86400
+      }'
+    }
+    ;;
+  *)
+    echo "error: unsupported platform '$OS' (macOS and Linux only)" >&2
+    exit 1
+    ;;
+esac
+
+detect_gpu() {
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    local names
+    names="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | sort | uniq -c \
+             | awk '{ $1 = $1 "x"; print }' | paste -sd'; ' -)"
+    [ -n "$names" ] && { echo "$names"; return; }
+  fi
+  if command -v rocm-smi >/dev/null 2>&1; then
+    echo "AMD (rocm-smi present)"; return
+  fi
+  if [ "$OS" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+    # Integrated on Apple Silicon, so the SoC name is the GPU name.
+    echo "$(sysctl -n machdep.cpu.brand_string 2>/dev/null) (integrated)"; return
+  fi
+  echo "unknown"
+}
+
+detect_cpu() {
+  case "$OS" in
+    Darwin) sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown ;;
+    Linux) awk -F': ' '/model name/ { print $2; exit }' /proc/cpuinfo 2>/dev/null || echo unknown ;;
+  esac
+}
+
+core_count() {
+  case "$OS" in
+    Darwin) sysctl -n hw.ncpu 2>/dev/null || echo "?" ;;
+    Linux) nproc 2>/dev/null || echo "?" ;;
+  esac
+}
+
+echo "=== environment ==="
+printf '  all-smi       %s\n' "$("$BIN" --version 2>/dev/null | head -1 || echo unknown)"
+printf '  binary        %s\n' "$BIN"
+printf '  os            %s %s (%s)\n' "$OS" "$(uname -r)" "$(uname -m)"
+printf '  cpu           %s (%s cores)\n' "$(detect_cpu)" "$(core_count)"
+printf '  gpu           %s\n' "$(detect_gpu)"
+printf '  processes     %s\n' "$(($(ps -A 2>/dev/null | wc -l) - 1))"
+printf '  terminal      %sx%s (tmux)\n' "$TMUX_COLS" "$TMUX_ROWS"
+printf '  window        %ss measured after %ss warmup\n' "$DURATION" "$WARMUP_SECS"
+echo
+
+BIN_NAME="$(basename "$BIN")"
+
+# PIDs of every already-running process named like the binary. Used to tell our
+# own child apart from an all-smi the operator happens to be running, and from
+# the shell tmux wraps the command in. Matching on the command line instead
+# would pick up that wrapper shell, whose CPU and RSS are not what we want.
+existing_pids() { pgrep -x "$BIN_NAME" 2>/dev/null | sort || true; }
+
+# Measure one configuration. $1 is a label, the rest are extra binary args.
+measure() {
+  local label="$1"; shift
+  local session="all_smi_bench_$$_${label//[^0-9a-zA-Z]/_}"
+
+  local before after
+  before="$(existing_pids)"
+
+  tmux kill-session -t "$session" 2>/dev/null || true
+  tmux new-session -d -s "$session" -x "$TMUX_COLS" -y "$TMUX_ROWS" \
+    "$BIN local $*" 2>/dev/null
+
+  local pid=""
+  for _ in $(seq 1 20); do
+    sleep 0.5
+    after="$(existing_pids)"
+    pid="$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | head -1)"
+    [ -n "$pid" ] && break
+  done
+  if [ -z "$pid" ]; then
+    printf '  %-14s FAILED to start\n' "$label"
+    tmux kill-session -t "$session" 2>/dev/null || true
+    return
+  fi
+
+  sleep "$WARMUP_SECS"
+
+  local t0 c0 t1 c1
+  c0="$(cpu_time_seconds "$pid")" || { printf '  %-14s FAILED to read cpu time\n' "$label"; return; }
+  t0="$(date +%s)"
+  sleep "$DURATION"
+  c1="$(cpu_time_seconds "$pid")" || { printf '  %-14s process exited early\n' "$label"; return; }
+  t1="$(date +%s)"
+
+  local rss
+  rss="$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || echo 0)"
+
+  awk -v label="$label" -v c0="$c0" -v c1="$c1" -v t0="$t0" -v t1="$t1" -v rss="$rss" 'BEGIN {
+    wall = t1 - t0
+    if (wall <= 0) { printf "  %-14s invalid window\n", label; exit }
+    printf "  %-14s cpu=%6.2f%%   cpu_time=%.2fs / %ds   rss=%dMB\n",
+           label, (c1 - c0) / wall * 100, c1 - c0, wall, rss / 1024
+  }'
+
+  tmux kill-session -t "$session" 2>/dev/null || true
+  sleep 2
+}
+
+echo "=== results (percent of one core) ==="
+measure "default"
+for iv in $INTERVALS; do
+  measure "-i ${iv}s" -i "$iv"
+done
+echo
+echo "Report these numbers with the environment block above on issue #288."

--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -148,7 +148,23 @@ detect_gpu() {
 detect_cpu() {
   case "$OS" in
     Darwin) sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown ;;
-    Linux) awk -F': ' '/model name/ { print $2; exit }' /proc/cpuinfo 2>/dev/null || echo unknown ;;
+    Linux)
+      # `model name` is an x86 field. aarch64 /proc/cpuinfo carries
+      # `CPU implementer`/`CPU part` ID pairs instead, so the awk prints an
+      # empty string and still exits 0, which is why a trailing
+      # `|| echo unknown` does not catch it. lscpu decodes those IDs, and on
+      # a heterogeneous part prints one `Model name` per core cluster, so
+      # join them: which clusters exist is itself worth reporting, because
+      # the same work costs different CPU time on each.
+      local name
+      name="$(awk -F': ' '/model name/ { print $2; exit }' /proc/cpuinfo 2>/dev/null)"
+      if [ -z "$name" ]; then
+        name="$(lscpu 2>/dev/null | awk -F': +' '
+          /^Model name/ { if (seen[$2]++) next; n[++c] = $2 }
+          END { for (i = 1; i <= c; i++) printf "%s%s", (i > 1 ? " + " : ""), n[i] }')"
+      fi
+      echo "${name:-unknown}"
+      ;;
   esac
 }
 


### PR DESCRIPTION
Adds the benchmark tooling issue #288 asks for. Refs #288, and deliberately does not close it: #288 is satisfied by *results* from Linux and Windows hardware, which this PR cannot produce. It lands the instrument so those results are collectable and comparable.

## Why

PR #286 did two things, only one of which is cross-platform. It moved local mode's default collection interval from 3s to 1s on Apple Silicon and to 2s everywhere else, and it replaced the IOReport sampling strategy so a collection went from ~495ms to ~24ms. The sampling half is gated to macOS (`macos_native` is `#[cfg(target_os = "macos")]`), so Linux, Windows, and Intel Mac took the 1.5x polling increase with no offsetting reduction. Every number behind that decision came from one Apple Silicon machine.

## What the script does

`scripts/bench-local-interval.sh` measures `all-smi local` CPU across the default configuration plus a configurable set of explicit intervals.

```
$ scripts/bench-local-interval.sh -h        # usage
$ cargo build --release --bin all-smi
$ scripts/bench-local-interval.sh           # 60s window, intervals 1/2/3
$ scripts/bench-local-interval.sh -d 120 -i "2 5"
```

Two design points are what make results from different reporters worth comparing:

**Fixed terminal size.** The real TUI runs detached in tmux at 200x50. Render cost scales with terminal size, so an unfixed size would make two machines' numbers incomparable for reasons that have nothing to do with the collection path.

**CPU-time delta, not `ps -o %cpu`.** That column is a decaying recent average on macOS and a lifetime-since-start average on Linux. Reading it would produce two different quantities on the two platforms the script targets. The script reads the process CPU-time delta over the window instead: `/proc/PID/stat` (utime + stime over `CLK_TCK`) on Linux, `ps -o cputime=` on macOS, where BSD `ps` carries centisecond resolution that Linux's truncates away. Results are percent of one core.

An environment block (OS, kernel, CPU, core count, GPU, process count, all-smi version) prints above the numbers, because collection cost depends on which device readers are active and results without that context cannot be interpreted.

## Reference run

Apple M5 Max, 18 cores, 1035 processes, release build, 60s window after 8s warmup:

```
  default        cpu=  5.28%   cpu_time=3.17s / 60s   rss=20MB
  -i 1s          cpu=  5.44%   cpu_time=3.32s / 61s   rss=21MB
  -i 2s          cpu=  3.28%   cpu_time=1.97s / 60s   rss=20MB
  -i 3s          cpu=  2.40%   cpu_time=1.44s / 60s   rss=19MB
```

`default` matching `-i 1s` within noise independently confirms #286's interval fix is in effect on Apple Silicon. The 3s to 2s step, which is what non-Apple-Silicon platforms absorbed, costs about +37% on this cost profile. Whether it costs the same where the reader mix is NVML plus AMD plus Intel rather than IOReport is exactly the open question.

## Note on earlier numbers

Two corrections to what was reported on #286 and #287, both already applied to those threads:

- The benchmarking hardware was an Apple M5 Max, not an M1 Ultra. The M1 Ultra is the machine in the screenshots that started the investigation; I conflated it with the machine the benchmarks ran on.
- Those numbers used `ps -o %cpu`. On the same machine the CPU-time-delta method in this script reports a somewhat higher absolute figure for the same configuration, so the absolute values in those threads are indicative rather than exact. The before/after comparisons used one consistent method throughout and are unaffected.

## Linux run, and a fix it turned up

The Linux path has since been exercised on an NVIDIA GB10 (DGX Spark), Ubuntu 24.04.4, aarch64, 20 cores. Full numbers are on #288; the summary is that the `/proc/PID/stat` path is correct (validated against a busy loop pinned at one full core, where it reported 100.01%), `default` matches `-i 2s` to within 3.2% so #286's interval fix is confirmed live on Linux, and the 3s to 2s step costs +19.4% there against +37% on the M5 Max, which is 0.14s of CPU per minute or 0.0117% of that machine.

That run exposed a defect, fixed in the second commit. `detect_cpu` read `model name` from `/proc/cpuinfo`, an x86-only field, so on aarch64 the awk matched nothing, printed an empty string, and still exited 0, which meant the trailing `|| echo unknown` never fired and the environment block reported a blank CPU. Since GB10, GH200, and Grace are all aarch64, the platform this benchmark most needs results from was the one silently dropping its CPU identity. It now falls back to `lscpu`, joining the distinct `Model name` values so a heterogeneous part reads `Cortex-X925 + Cortex-A725`.

One limit of the metric is worth stating rather than leaving implicit, and is tracked separately as #290. On a heterogeneous CPU, "percent of one core" is not one quantity: pinning the same run to the GB10's X925 cluster versus its A725 cluster moves the result by about 1.5x, which is larger than the interval effect this script exists to measure. Ratios within a single host stay robust (+17.9% pinned to performance cores, +21.4% to efficiency cores, +19.4% unpinned), so conclusions drawn from them hold, but absolute percentages are comparable across machines only when core placement is stated. Apple Silicon P/E and Intel hybrid parts have the same property, so the M5 Max reference numbers above carry it too.

## Tests

Shell only, no Rust touched, so the existing suite is unaffected. `shellcheck` clean as of the first commit; it is not installed on the GB10 host, so the second commit's change was not re-linted there, and it declares `local name` before assigning so it does not introduce SC2155. Exercised on macOS at 15s, 20s, and 60s windows, and on Linux at 10s and 60s windows across four configurations and three repeats.

Building on Linux requires `libdrm-dev`: without it the link fails on `-ldrm` and `-ldrm_amdgpu` even on a host with no AMD GPU, because `libamdgpu_top` is a hard dependency of the glibc Linux target.

Also documents usage under Testing in `DEVELOPERS.md`.

