### PR TITLE
test: record core topology and support CPU pinning in the benchmark

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -247,7 +247,7 @@ The script prints an environment block (OS, CPU, core topology, affinity, GPU, c
 
 So the durable number is the **ratio between two intervals measured on one host**, not the absolute percentage. Compare absolute percentages across machines only when both reports state their core placement. The `topology` and `affinity` lines in the environment block carry that context automatically.
 
-On a heterogeneous host, prefer `-c` to pin one cluster and say which one you pinned; it also cuts run-to-run variance substantially. Use `-r` to average several windows when the effect you are chasing is close to the spread between repeats. `-c` is Linux only, since macOS exposes no userspace CPU affinity control and a run cannot be pinned to P or E cores there. Background and measurements are in issue #290.
+On a heterogeneous host, prefer `-c` to pin one cluster and say which one you pinned; it also cuts run-to-run variance substantially. Use `-r` to average several windows when the effect you are chasing is close to the spread between repeats. Two limits on `-c`: it is Linux only, since macOS offers no way to select a specific CPU set (only E-core confinement is reachable at all, via `taskpolicy -b`, which also changes scheduling priority); and it should be run on bare metal, because inside a container without a cpuset `all-smi` sizes its own CPU view from `sched_getaffinity`, so pinning would shrink the set of cores it parses and renders rather than only relocating the same work. Background and measurements are in issue #290.
 
 Coverage is currently thin outside Apple Silicon. See issue #288 if you have Linux or Windows hardware and can contribute measurements.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -232,16 +232,17 @@ cargo build --release --bin all-smi
 scripts/bench-local-interval.sh                    # default: 60s window, intervals 1/2/3
 scripts/bench-local-interval.sh -d 120 -i "2 5"    # longer window, custom intervals
 scripts/bench-local-interval.sh -c 5-9,15-19 -r 3  # pin to one core cluster, average 3 windows
-scripts/bench-local-interval.sh -h                 # usage
+scripts/bench-local-interval.sh -b ~/bin/all-smi   # measure a binary built elsewhere
+scripts/bench-local-interval.sh -h                 # full usage and flag list
 ```
 
 It requires `tmux` (macOS and Linux only) so the TUI runs detached at a fixed 200x50 size; terminal size affects render cost, so fixing it is what makes results from different machines comparable. CPU is computed from the process CPU-time delta rather than `ps -o %cpu`, because that column is a decaying recent average on macOS and a lifetime average on Linux. Results are percent of one core.
 
 On Linux, building needs `libdrm-dev`. Without it the link fails on `-ldrm` and `-ldrm_amdgpu` even on a host with no AMD GPU, because `libamdgpu_top` is a hard dependency of the glibc Linux target.
 
-The script prints an environment block (OS, CPU, core topology, affinity, GPU, core count, process count) above the numbers. Include it whenever you report results: collection cost depends heavily on which device readers are active, so numbers without that context cannot be compared.
+The script prints an environment block (all-smi version, OS, CPU model and core topology, affinity, GPU, process count, terminal size, window length) above the numbers. Include it whenever you report results: collection cost depends heavily on which device readers are active, so numbers without that context cannot be compared.
 
-#### Comparing results across machines
+#### Comparing Results Across Machines
 
 "Percent of one core" is not a single quantity on a heterogeneous CPU. ARM big.LITTLE parts, Intel P/E hybrids, and Apple Silicon all mix core types, and identical work costs a different amount of CPU time on each type. On an NVIDIA GB10 (Cortex-X925 at 3.9 GHz plus Cortex-A725 at 2.8 GHz), pinning the same run to one cluster or the other moves the result by about 1.5x, which is larger than the interval effect the script is usually being used to measure. Unpinned runs land somewhere between the two depending on where the scheduler put the threads, which is also why they vary more between repeats.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -229,14 +229,25 @@ For comprehensive testing documentation, see [TESTING.md](TESTING.md).
 
 ```bash
 cargo build --release --bin all-smi
-scripts/bench-local-interval.sh                 # default: 60s window, intervals 1/2/3
-scripts/bench-local-interval.sh -d 120 -i "2 5" # longer window, custom intervals
-scripts/bench-local-interval.sh -h              # usage
+scripts/bench-local-interval.sh                    # default: 60s window, intervals 1/2/3
+scripts/bench-local-interval.sh -d 120 -i "2 5"    # longer window, custom intervals
+scripts/bench-local-interval.sh -c 5-9,15-19 -r 3  # pin to one core cluster, average 3 windows
+scripts/bench-local-interval.sh -h                 # usage
 ```
 
 It requires `tmux` (macOS and Linux only) so the TUI runs detached at a fixed 200x50 size; terminal size affects render cost, so fixing it is what makes results from different machines comparable. CPU is computed from the process CPU-time delta rather than `ps -o %cpu`, because that column is a decaying recent average on macOS and a lifetime average on Linux. Results are percent of one core.
 
-The script prints an environment block (OS, CPU, GPU, core count, process count) above the numbers. Include it whenever you report results: collection cost depends heavily on which device readers are active, so numbers without that context cannot be compared.
+On Linux, building needs `libdrm-dev`. Without it the link fails on `-ldrm` and `-ldrm_amdgpu` even on a host with no AMD GPU, because `libamdgpu_top` is a hard dependency of the glibc Linux target.
+
+The script prints an environment block (OS, CPU, core topology, affinity, GPU, core count, process count) above the numbers. Include it whenever you report results: collection cost depends heavily on which device readers are active, so numbers without that context cannot be compared.
+
+#### Comparing results across machines
+
+"Percent of one core" is not a single quantity on a heterogeneous CPU. ARM big.LITTLE parts, Intel P/E hybrids, and Apple Silicon all mix core types, and identical work costs a different amount of CPU time on each type. On an NVIDIA GB10 (Cortex-X925 at 3.9 GHz plus Cortex-A725 at 2.8 GHz), pinning the same run to one cluster or the other moves the result by about 1.5x, which is larger than the interval effect the script is usually being used to measure. Unpinned runs land somewhere between the two depending on where the scheduler put the threads, which is also why they vary more between repeats.
+
+So the durable number is the **ratio between two intervals measured on one host**, not the absolute percentage. Compare absolute percentages across machines only when both reports state their core placement. The `topology` and `affinity` lines in the environment block carry that context automatically.
+
+On a heterogeneous host, prefer `-c` to pin one cluster and say which one you pinned; it also cuts run-to-run variance substantially. Use `-r` to average several windows when the effect you are chasing is close to the spread between repeats. `-c` is Linux only, since macOS exposes no userspace CPU affinity control and a run cannot be pinned to P or E cores there. Background and measurements are in issue #290.
 
 Coverage is currently thin outside Apple Silicon. See issue #288 if you have Linux or Windows hardware and can contribute measurements.
 

--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -24,13 +24,22 @@
 # USAGE
 #
 #   scripts/bench-local-interval.sh [-d SECONDS] [-b PATH] [-i "LIST"]
+#                                   [-c CPUS] [-r COUNT]
 #
 #     -d SECONDS   measurement window per configuration (default 60)
 #     -b PATH      all-smi binary (default ./target/release/all-smi)
 #     -i "LIST"    space-separated intervals to test (default "1 2 3");
 #                  the no-flag default configuration is always measured
+#     -c CPUS      pin the run to a CPU list, e.g. "5-9,15-19" (Linux only).
+#                  On a heterogeneous machine, see COMPARABILITY below
+#     -r COUNT     repeats per configuration (default 1). With more than one,
+#                  the mean and standard deviation are reported
 #
 #   Build first:  cargo build --release --bin all-smi
+#                 On Linux this needs libdrm-dev: without it the link fails on
+#                 -ldrm and -ldrm_amdgpu even on a host with no AMD GPU,
+#                 because libamdgpu_top is a hard dependency of the glibc
+#                 Linux target
 #
 # REQUIREMENTS
 #
@@ -51,6 +60,28 @@
 #   (reader initialisation, first collection, first render) does not land in
 #   the window.
 #
+# COMPARABILITY ACROSS MACHINES
+#
+#   Percent of one core is not a single quantity on a heterogeneous CPU. ARM
+#   big.LITTLE parts, Intel P/E hybrids, and Apple Silicon all mix core types,
+#   and identical work costs a different amount of CPU time on each type. On an
+#   NVIDIA GB10 (Cortex-X925 at 3.9GHz plus Cortex-A725 at 2.8GHz), pinning the
+#   same run to one cluster or the other moves the result by about 1.5x, which
+#   is larger than the interval effect this script exists to measure. Unpinned
+#   runs land somewhere between the two, wherever the scheduler happened to put
+#   the threads, which is also why they vary more between repeats.
+#
+#   The durable number is therefore the ratio between two intervals measured on
+#   one host, not the absolute percentage. An absolute percentage is comparable
+#   to another machine's only when both state their core placement. The
+#   environment block prints the detected topology and the affinity in use so
+#   that context travels with the numbers.
+#
+#   On a heterogeneous host, prefer pinning one cluster with -c and say which
+#   one you pinned. Pinning also cuts run-to-run variance substantially. Use -r
+#   to average several windows when the effect you are measuring is close to
+#   the spread between repeats.
+#
 # REPORTING
 #
 #   Paste the whole output, environment block included, into issue #288. The
@@ -62,6 +93,8 @@ set -euo pipefail
 DURATION=60
 BIN="./target/release/all-smi"
 INTERVALS="1 2 3"
+CPUSET=""
+REPEATS=1
 WARMUP_SECS=8
 TMUX_COLS=200
 TMUX_ROWS=50
@@ -78,11 +111,13 @@ usage() {
   ' "$0"
 }
 
-while getopts "d:b:i:h" opt; do
+while getopts "d:b:i:c:r:h" opt; do
   case "$opt" in
     d) DURATION="$OPTARG" ;;
     b) BIN="$OPTARG" ;;
     i) INTERVALS="$OPTARG" ;;
+    c) CPUSET="$OPTARG" ;;
+    r) REPEATS="$OPTARG" ;;
     h) usage; exit 0 ;;
     *) echo "run '$0 -h' for usage" >&2; exit 2 ;;
   esac
@@ -90,6 +125,11 @@ done
 
 command -v tmux >/dev/null 2>&1 || { echo "error: tmux is required" >&2; exit 1; }
 [ -x "$BIN" ] || { echo "error: no executable at $BIN (cargo build --release --bin all-smi)" >&2; exit 1; }
+
+case "$REPEATS" in
+  ''|*[!0-9]*) echo "error: -r takes a positive integer, got '$REPEATS'" >&2; exit 2 ;;
+esac
+[ "$REPEATS" -ge 1 ] || { echo "error: -r must be at least 1" >&2; exit 2; }
 
 OS="$(uname -s)"
 case "$OS" in
@@ -127,6 +167,117 @@ case "$OS" in
     exit 1
     ;;
 esac
+
+# Prefix prepended to the launch command when -c is given. taskset execs the
+# target in place, so the running process keeps the binary's name and the
+# pgrep -x detection in measure_once() is unaffected; a wrapper that forked
+# instead would break it.
+LAUNCH_PREFIX=""
+AFFINITY_DESC="unpinned"
+if [ -n "$CPUSET" ]; then
+  case "$OS" in
+    Linux)
+      command -v taskset >/dev/null 2>&1 ||
+        { echo "error: -c requires taskset (util-linux)" >&2; exit 1; }
+      # Let taskset itself validate the list against this machine's CPUs,
+      # rather than reimplementing the range syntax here.
+      taskset -c "$CPUSET" true >/dev/null 2>&1 ||
+        { echo "error: -c '$CPUSET' is not a valid CPU list on this machine" >&2; exit 1; }
+      LAUNCH_PREFIX="taskset -c $CPUSET "
+      AFFINITY_DESC="cpus $CPUSET (taskset)"
+      ;;
+    Darwin)
+      echo "error: -c is not supported on macOS. The kernel exposes no userspace CPU affinity control, so a run cannot be pinned to P or E cores there." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+# Report core types, so a reader can tell a heterogeneous host from a uniform
+# one. Grouping by maximum frequency separates ARM big.LITTLE clusters and
+# Intel P/E cores alike; cpu_capacity is the device-tree fallback for ARM
+# systems without cpufreq. When neither is readable the topology is reported
+# as unknown rather than assumed uniform, because assuming uniform is exactly
+# the error this block exists to prevent.
+linux_topology() {
+  local src file cpu key lines=""
+  if [ -r /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq ]; then
+    src=cpufreq
+  elif [ -r /sys/devices/system/cpu/cpu0/cpu_capacity ]; then
+    src=capacity
+  else
+    echo "unknown (no cpufreq or cpu_capacity)"
+    return
+  fi
+
+  for d in /sys/devices/system/cpu/cpu[0-9]*; do
+    cpu="${d##*/cpu}"
+    case "$cpu" in ''|*[!0-9]*) continue ;; esac
+    if [ "$src" = cpufreq ]; then
+      file="$d/cpufreq/cpuinfo_max_freq"
+    else
+      file="$d/cpu_capacity"
+    fi
+    key="$(cat "$file" 2>/dev/null || true)"
+    [ -n "$key" ] || continue
+    lines="${lines}${key} ${cpu}
+"
+  done
+  [ -n "$lines" ] || { echo "unknown (no cpufreq or cpu_capacity)"; return; }
+
+  # Sort by key descending then CPU ascending, so awk sees whole groups in
+  # order and each group's CPU list is already ascending for range collapsing.
+  printf '%s' "$lines" | sort -k1,1nr -k2,2n | awk -v src="$src" '
+    function ranges(s,   a, n, i, j, out) {
+      n = split(s, a, " ")
+      out = ""
+      i = 1
+      while (i <= n) {
+        j = i
+        while (j + 1 <= n && a[j + 1] == a[j] + 1) j++
+        out = out (out == "" ? "" : ",") (i == j ? a[i] : a[i] "-" a[j])
+        i = j + 1
+      }
+      return out
+    }
+    { if ($1 != prev) { g++; gkey[g] = $1; prev = $1 } gcnt[g]++; glist[g] = glist[g] " " $2 }
+    END {
+      out = ""
+      for (i = 1; i <= g; i++) {
+        lbl = (src == "cpufreq") ? sprintf("%.2fGHz", gkey[i] / 1000000) : sprintf("capacity %d", gkey[i])
+        out = out (i > 1 ? ", " : "") gcnt[i] "x " lbl
+        if (g > 1) out = out " (cpus " ranges(glist[i]) ")"
+      }
+      printf "%s: %s\n", (g > 1 ? "heterogeneous" : "uniform"), out
+    }'
+}
+
+# macOS exposes perflevels rather than per-CPU frequencies, and gives no way
+# to address individual cores, so no CPU lists are printed here.
+darwin_topology() {
+  local levels i name count out=""
+  levels="$(sysctl -n hw.nperflevels 2>/dev/null || echo 1)"
+  case "$levels" in ''|*[!0-9]*) levels=1 ;; esac
+  if [ "$levels" -le 1 ]; then
+    echo "uniform: $(sysctl -n hw.logicalcpu 2>/dev/null || echo '?') logical cores"
+    return
+  fi
+  i=0
+  while [ "$i" -lt "$levels" ]; do
+    name="$(sysctl -n "hw.perflevel${i}.name" 2>/dev/null || echo "level${i}")"
+    count="$(sysctl -n "hw.perflevel${i}.logicalcpu" 2>/dev/null || echo '?')"
+    out="${out}${out:+, }${count}x ${name}"
+    i=$((i + 1))
+  done
+  echo "heterogeneous: $out"
+}
+
+detect_topology() {
+  case "$OS" in
+    Linux) linux_topology ;;
+    Darwin) darwin_topology ;;
+  esac
+}
 
 detect_gpu() {
   if command -v nvidia-smi >/dev/null 2>&1; then
@@ -175,15 +326,29 @@ core_count() {
   esac
 }
 
+TOPOLOGY="$(detect_topology)"
+
+# On a heterogeneous host an unpinned run is a mix of core types, and the
+# reader needs to know that before comparing the number to another machine's.
+case "$TOPOLOGY" in
+  heterogeneous*)
+    [ -n "$CPUSET" ] ||
+      AFFINITY_DESC="unpinned (mixed core types: threads may migrate, see -c)"
+    ;;
+esac
+
 echo "=== environment ==="
 printf '  all-smi       %s\n' "$("$BIN" --version 2>/dev/null | head -1 || echo unknown)"
 printf '  binary        %s\n' "$BIN"
 printf '  os            %s %s (%s)\n' "$OS" "$(uname -r)" "$(uname -m)"
 printf '  cpu           %s (%s cores)\n' "$(detect_cpu)" "$(core_count)"
+printf '  topology      %s\n' "$TOPOLOGY"
+printf '  affinity      %s\n' "$AFFINITY_DESC"
 printf '  gpu           %s\n' "$(detect_gpu)"
 printf '  processes     %s\n' "$(($(ps -A 2>/dev/null | wc -l) - 1))"
 printf '  terminal      %sx%s (tmux)\n' "$TMUX_COLS" "$TMUX_ROWS"
-printf '  window        %ss measured after %ss warmup\n' "$DURATION" "$WARMUP_SECS"
+printf '  window        %ss measured after %ss warmup%s\n' "$DURATION" "$WARMUP_SECS" \
+  "$([ "$REPEATS" -gt 1 ] && printf ', %s repeats' "$REPEATS" || true)"
 echo
 
 BIN_NAME="$(basename "$BIN")"
@@ -194,17 +359,20 @@ BIN_NAME="$(basename "$BIN")"
 # would pick up that wrapper shell, whose CPU and RSS are not what we want.
 existing_pids() { pgrep -x "$BIN_NAME" 2>/dev/null | sort || true; }
 
-# Measure one configuration. $1 is a label, the rest are extra binary args.
-measure() {
-  local label="$1"; shift
-  local session="all_smi_bench_$$_${label//[^0-9a-zA-Z]/_}"
+# Run one measurement window. Echoes "cpu_seconds wall_seconds rss_kb" on
+# success. Failures are reported through the exit code so the caller can name
+# the reason after all repeats have run: 1 could not start, 2 could not read
+# CPU time, 3 exited early, 4 window was not positive.
+measure_once() {
+  local label="$1" rep="$2"; shift 2
+  local session="all_smi_bench_$$_${label//[^0-9a-zA-Z]/_}_${rep}"
 
   local before after
   before="$(existing_pids)"
 
   tmux kill-session -t "$session" 2>/dev/null || true
   tmux new-session -d -s "$session" -x "$TMUX_COLS" -y "$TMUX_ROWS" \
-    "$BIN local $*" 2>/dev/null
+    "${LAUNCH_PREFIX}$BIN local $*" 2>/dev/null
 
   local pid=""
   for _ in $(seq 1 20); do
@@ -214,32 +382,80 @@ measure() {
     [ -n "$pid" ] && break
   done
   if [ -z "$pid" ]; then
-    printf '  %-14s FAILED to start\n' "$label"
     tmux kill-session -t "$session" 2>/dev/null || true
-    return
+    return 1
   fi
 
   sleep "$WARMUP_SECS"
 
-  local t0 c0 t1 c1
-  c0="$(cpu_time_seconds "$pid")" || { printf '  %-14s FAILED to read cpu time\n' "$label"; return; }
+  local t0 c0 t1 c1 rss
+  c0="$(cpu_time_seconds "$pid")" ||
+    { tmux kill-session -t "$session" 2>/dev/null || true; return 2; }
   t0="$(date +%s)"
   sleep "$DURATION"
-  c1="$(cpu_time_seconds "$pid")" || { printf '  %-14s process exited early\n' "$label"; return; }
+  c1="$(cpu_time_seconds "$pid")" ||
+    { tmux kill-session -t "$session" 2>/dev/null || true; return 3; }
   t1="$(date +%s)"
 
-  local rss
-  rss="$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || echo 0)"
-
-  awk -v label="$label" -v c0="$c0" -v c1="$c1" -v t0="$t0" -v t1="$t1" -v rss="$rss" 'BEGIN {
-    wall = t1 - t0
-    if (wall <= 0) { printf "  %-14s invalid window\n", label; exit }
-    printf "  %-14s cpu=%6.2f%%   cpu_time=%.2fs / %ds   rss=%dMB\n",
-           label, (c1 - c0) / wall * 100, c1 - c0, wall, rss / 1024
-  }'
+  rss="$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  [ -n "$rss" ] || rss=0
 
   tmux kill-session -t "$session" 2>/dev/null || true
-  sleep 2
+
+  awk -v c0="$c0" -v c1="$c1" -v t0="$t0" -v t1="$t1" -v rss="$rss" 'BEGIN {
+    wall = t1 - t0
+    if (wall <= 0) exit 1
+    printf "%.6f %d %d\n", c1 - c0, wall, rss
+  }' || return 4
+}
+
+# Measure one configuration REPEATS times and print a single summary line.
+# $1 is a label, the rest are extra binary args.
+measure() {
+  local label="$1"; shift
+  local samples="" failures="" sample rep=1 rc
+
+  while [ "$rep" -le "$REPEATS" ]; do
+    rc=0
+    sample="$(measure_once "$label" "$rep" "$@")" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      samples="${samples}${sample}
+"
+    else
+      case "$rc" in
+        1) failures="${failures}${failures:+, }could not start" ;;
+        2) failures="${failures}${failures:+, }could not read cpu time" ;;
+        3) failures="${failures}${failures:+, }exited early" ;;
+        *) failures="${failures}${failures:+, }invalid window" ;;
+      esac
+    fi
+    rep=$((rep + 1))
+    sleep 2
+  done
+
+  if [ -z "$samples" ]; then
+    printf '  %-14s FAILED (%s)\n' "$label" "$failures"
+    return
+  fi
+
+  # Averaging percentages per window rather than dividing summed CPU time by
+  # summed wall time keeps each window weighted equally even if one ran long.
+  printf '%s' "$samples" | awk -v label="$label" -v want="$REPEATS" '
+    { pct = $1 / $2 * 100; sum += pct; sumsq += pct * pct; ct += $1; wall += $2; rss += $3; n++ }
+    END {
+      mean = sum / n
+      if (n > 1) {
+        var = (sumsq - n * mean * mean) / (n - 1)
+        if (var < 0) var = 0
+        printf "  %-14s cpu=%6.2f%% +/- %.2f (n=%d)   cpu_time=%.2fs / %ds   rss=%dMB",
+               label, mean, sqrt(var), n, ct / n, wall / n, rss / n / 1024
+      } else {
+        printf "  %-14s cpu=%6.2f%%   cpu_time=%.2fs / %ds   rss=%dMB",
+               label, mean, ct, wall, rss / 1024
+      }
+      if (n < want) printf "   [%d/%d windows ok]", n, want
+      printf "\n"
+    }'
 }
 
 echo "=== results (percent of one core) ==="

--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -82,6 +82,11 @@
 #   to average several windows when the effect you are measuring is close to
 #   the spread between repeats.
 #
+#   Run -c on bare metal. Inside a container without a cpuset, all-smi sizes
+#   its own CPU view from sched_getaffinity, so pinning would also shrink the
+#   set of cores it parses and renders, changing the work being measured
+#   instead of only where that work runs.
+#
 # REPORTING
 #
 #   Paste the whole output, environment block included, into issue #288. The
@@ -179,15 +184,23 @@ if [ -n "$CPUSET" ]; then
     Linux)
       command -v taskset >/dev/null 2>&1 ||
         { echo "error: -c requires taskset (util-linux)" >&2; exit 1; }
-      # Let taskset itself validate the list against this machine's CPUs,
-      # rather than reimplementing the range syntax here.
+      # taskset only fails when *no* CPU in the list exists, so it rejects
+      # "99-200" but silently accepts "0,99" and narrows it to CPU 0. Use it
+      # to catch the wholly invalid case, then read back the mask actually in
+      # force so the affinity line reports what ran, not what was asked for.
       taskset -c "$CPUSET" true >/dev/null 2>&1 ||
-        { echo "error: -c '$CPUSET' is not a valid CPU list on this machine" >&2; exit 1; }
+        { echo "error: -c '$CPUSET' matches no CPU on this machine" >&2; exit 1; }
       LAUNCH_PREFIX="taskset -c $CPUSET "
-      AFFINITY_DESC="cpus $CPUSET (taskset)"
+      effective="$(taskset -c "$CPUSET" sh -c 'taskset -pc $$' 2>/dev/null |
+                   sed 's/.*list: *//' || true)"
+      if [ -n "$effective" ] && [ "$effective" != "$CPUSET" ]; then
+        AFFINITY_DESC="cpus $effective (taskset, requested $CPUSET)"
+      else
+        AFFINITY_DESC="cpus $CPUSET (taskset)"
+      fi
       ;;
     Darwin)
-      echo "error: -c is not supported on macOS. The kernel exposes no userspace CPU affinity control, so a run cannot be pinned to P or E cores there." >&2
+      echo "error: -c is not supported on macOS. There is no way to select a specific CPU set: thread_policy_set affinity is a cache-locality hint that Apple Silicon reports as unsupported, and only E-core confinement is reachable at all, via taskpolicy -b, which also changes scheduling priority." >&2
       exit 1
       ;;
   esac
@@ -200,7 +213,7 @@ fi
 # as unknown rather than assumed uniform, because assuming uniform is exactly
 # the error this block exists to prevent.
 linux_topology() {
-  local src file cpu key lines=""
+  local src d file cpu key lines=""
   if [ -r /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq ]; then
     src=cpufreq
   elif [ -r /sys/devices/system/cpu/cpu0/cpu_capacity ]; then
@@ -225,22 +238,43 @@ linux_topology() {
   done
   [ -n "$lines" ] || { echo "unknown (no cpufreq or cpu_capacity)"; return; }
 
-  # Sort by key descending then CPU ascending, so awk sees whole groups in
-  # order and each group's CPU list is already ascending for range collapsing.
-  printf '%s' "$lines" | sort -k1,1nr -k2,2n | awk -v src="$src" '
-    function ranges(s,   a, n, i, j, out) {
+  # Sort by key descending so awk walks from the fastest core type down and
+  # can bucket by proximity in one pass.
+  #
+  # Cores of one type do not all report an identical key. This machine's
+  # cpu_capacity reads 718, 731, 997, 1017, and 1024 across a two-cluster
+  # part, and Intel parts with per-core turbo binning give favoured P-cores a
+  # higher cpuinfo_max_freq than their siblings. Exact-equality grouping would
+  # report five tiers here, one of them a single CPU, which is worse than
+  # useless on precisely the hosts this exists for. Bucket keys within
+  # TOLERANCE of the group's fastest member instead, comparing against that
+  # fixed representative rather than the previous row so a long run of small
+  # steps cannot drift one bucket across a real cluster boundary.
+  printf '%s' "$lines" | sort -k1,1nr -k2,2n | awk -v src="$src" -v tol=0.05 '
+    function ranges(s,   a, n, i, j, t, out) {
       n = split(s, a, " ")
+      # A bucket can merge several keys, whose CPU runs interleave, so sort
+      # numerically before collapsing rather than trusting the input order.
+      for (i = 2; i <= n; i++) {
+        t = a[i] + 0
+        for (j = i - 1; j >= 1 && a[j] + 0 > t; j--) a[j + 1] = a[j]
+        a[j + 1] = t
+      }
       out = ""
       i = 1
       while (i <= n) {
         j = i
-        while (j + 1 <= n && a[j + 1] == a[j] + 1) j++
+        while (j + 1 <= n && a[j + 1] + 0 == a[j] + 0 + 1) j++
         out = out (out == "" ? "" : ",") (i == j ? a[i] : a[i] "-" a[j])
         i = j + 1
       }
       return out
     }
-    { if ($1 != prev) { g++; gkey[g] = $1; prev = $1 } gcnt[g]++; glist[g] = glist[g] " " $2 }
+    {
+      if (g == 0 || $1 + 0 < rep * (1 - tol)) { g++; rep = $1 + 0; gkey[g] = $1 + 0 }
+      gcnt[g]++
+      glist[g] = glist[g] " " $2
+    }
     END {
       out = ""
       for (i = 1; i <= g; i++) {
@@ -330,10 +364,17 @@ TOPOLOGY="$(detect_topology)"
 
 # On a heterogeneous host an unpinned run is a mix of core types, and the
 # reader needs to know that before comparing the number to another machine's.
+# Only Linux is pointed at -c: every Apple Silicon Mac reports two perflevels
+# and so lands here, and telling those runs to use a flag that macOS rejects
+# would be advice that never works.
 case "$TOPOLOGY" in
   heterogeneous*)
-    [ -n "$CPUSET" ] ||
-      AFFINITY_DESC="unpinned (mixed core types: threads may migrate, see -c)"
+    if [ -z "$CPUSET" ]; then
+      case "$OS" in
+        Linux) AFFINITY_DESC="unpinned (mixed core types: threads may migrate, see -c)" ;;
+        Darwin) AFFINITY_DESC="unpinned (mixed core types: threads may migrate; macOS has no CPU affinity control)" ;;
+      esac
+    fi
     ;;
 esac
 
@@ -370,9 +411,9 @@ measure_once() {
   local before after
   before="$(existing_pids)"
 
-  tmux kill-session -t "$session" 2>/dev/null || true
+  tmux kill-session -t "$session" >/dev/null 2>&1 || true
   tmux new-session -d -s "$session" -x "$TMUX_COLS" -y "$TMUX_ROWS" \
-    "${LAUNCH_PREFIX}$BIN local $*" 2>/dev/null
+    "${LAUNCH_PREFIX}$BIN local $*" >/dev/null 2>&1
 
   local pid=""
   for _ in $(seq 1 20); do
@@ -382,7 +423,7 @@ measure_once() {
     [ -n "$pid" ] && break
   done
   if [ -z "$pid" ]; then
-    tmux kill-session -t "$session" 2>/dev/null || true
+    tmux kill-session -t "$session" >/dev/null 2>&1 || true
     return 1
   fi
 
@@ -390,17 +431,17 @@ measure_once() {
 
   local t0 c0 t1 c1 rss
   c0="$(cpu_time_seconds "$pid")" ||
-    { tmux kill-session -t "$session" 2>/dev/null || true; return 2; }
+    { tmux kill-session -t "$session" >/dev/null 2>&1 || true; return 2; }
   t0="$(date +%s)"
   sleep "$DURATION"
   c1="$(cpu_time_seconds "$pid")" ||
-    { tmux kill-session -t "$session" 2>/dev/null || true; return 3; }
+    { tmux kill-session -t "$session" >/dev/null 2>&1 || true; return 3; }
   t1="$(date +%s)"
 
   rss="$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
   [ -n "$rss" ] || rss=0
 
-  tmux kill-session -t "$session" 2>/dev/null || true
+  tmux kill-session -t "$session" >/dev/null 2>&1 || true
 
   awk -v c0="$c0" -v c1="$c1" -v t0="$t0" -v t1="$t1" -v rss="$rss" 'BEGIN {
     wall = t1 - t0
@@ -440,7 +481,7 @@ measure() {
 
   # Averaging percentages per window rather than dividing summed CPU time by
   # summed wall time keeps each window weighted equally even if one ran long.
-  printf '%s' "$samples" | awk -v label="$label" -v want="$REPEATS" '
+  printf '%s' "$samples" | awk -v label="$label" -v want="$REPEATS" -v reasons="$failures" '
     { pct = $1 / $2 * 100; sum += pct; sumsq += pct * pct; ct += $1; wall += $2; rss += $3; n++ }
     END {
       mean = sum / n
@@ -448,12 +489,15 @@ measure() {
         var = (sumsq - n * mean * mean) / (n - 1)
         if (var < 0) var = 0
         printf "  %-14s cpu=%6.2f%% +/- %.2f (n=%d)   cpu_time=%.2fs / %ds   rss=%dMB",
-               label, mean, sqrt(var), n, ct / n, wall / n, rss / n / 1024
+               label, mean, sqrt(var), n, ct / n, wall / n + 0.5, rss / n / 1024
       } else {
         printf "  %-14s cpu=%6.2f%%   cpu_time=%.2fs / %ds   rss=%dMB",
                label, mean, ct, wall, rss / 1024
       }
-      if (n < want) printf "   [%d/%d windows ok]", n, want
+      # Name the failures here too, not only when every window failed: a
+      # partial run that silently reported a smaller n would look like a
+      # deliberately shorter measurement.
+      if (n < want) printf "   [%d/%d windows ok: %s]", n, want, reasons
       printf "\n"
     }'
 }

--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -136,6 +136,58 @@ case "$REPEATS" in
 esac
 [ "$REPEATS" -ge 1 ] || { echo "error: -r must be at least 1" >&2; exit 2; }
 
+case "$DURATION" in
+  ''|*[!0-9]*) echo "error: -d takes whole seconds, got '$DURATION'" >&2; exit 2 ;;
+esac
+# A fractional -d is worse than a rejected one: GNU sleep accepts 0.5, but the
+# window is then shorter than the clock's usable resolution and the result is
+# silently wrong rather than absent.
+[ "$DURATION" -ge 1 ] || { echo "error: -d must be at least 1 second" >&2; exit 2; }
+
+# Intervals are whole seconds because that is what all-smi's -i takes. Checking
+# them here also keeps a value out of the command string tmux hands to a shell,
+# and globbing is disabled for the walk so a bare -i '*' cannot turn filenames
+# in the working directory into intervals.
+set -f
+for iv in $INTERVALS; do
+  case "$iv" in
+    ''|*[!0-9]*) echo "error: -i takes whole seconds, got '$iv'" >&2; exit 2 ;;
+  esac
+  [ "$iv" -ge 1 ] || { echo "error: -i values must be at least 1, got '$iv'" >&2; exit 2; }
+done
+set +f
+
+# Wall clock for the window. `date +%s` truncates at both ends, so a 60s window
+# can measure as 59 or 61: a 1.7% error sitting on top of the very spread that
+# -r exists to expose. bash 5's EPOCHREALTIME avoids it where available, and
+# normalises the comma some locales use as the decimal separator.
+now_seconds() {
+  if [ -n "${EPOCHREALTIME:-}" ]; then
+    printf '%s\n' "${EPOCHREALTIME/,/.}"
+  else
+    date +%s
+  fi
+}
+
+# Kill only the sessions this invocation created. Without this an interrupt
+# during a window leaves an orphan rendering a 200x50 TUI forever, which then
+# competes for CPU with the operator's next run, and under -c for exactly the
+# cluster they pinned, biasing the numbers silently.
+cleanup() {
+  local s
+  for s in $(tmux list-sessions -F '#{session_name}' 2>/dev/null |
+             grep "^all_smi_bench_$$_" || true); do
+    tmux kill-session -t "$s" >/dev/null 2>&1 || true
+  done
+}
+# INT and TERM must exit, not merely clean up: a bash trap handler returns to
+# the point of interruption, so cleaning up without exiting would kill the
+# window in flight and then cheerfully open the next one. cleanup is idempotent,
+# so the EXIT trap running it a second time is harmless.
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
 OS="$(uname -s)"
 case "$OS" in
   Linux)
@@ -394,11 +446,32 @@ echo
 
 BIN_NAME="$(basename "$BIN")"
 
-# PIDs of every already-running process named like the binary. Used to tell our
-# own child apart from an all-smi the operator happens to be running, and from
-# the shell tmux wraps the command in. Matching on the command line instead
-# would pick up that wrapper shell, whose CPU and RSS are not what we want.
-existing_pids() { pgrep -x "$BIN_NAME" 2>/dev/null | sort || true; }
+# Basename of a running process, portably: Linux `ps -o comm=` gives the bare
+# name, macOS can give a full path.
+process_name() { ps -o comm= -p "$1" 2>/dev/null | tr -d ' ' | sed 's#.*/##'; }
+
+# The PID running in the session's pane. tmux execs the command in place, so
+# for both `all-smi ...` and `taskset -c LIST all-smi ...` this is the binary
+# itself, verified on both forms. If tmux ever wraps the command in a shell,
+# the binary is that shell's child, so fall back to looking one level down.
+#
+# Asking tmux which process it started is what makes the measurement immune to
+# a second all-smi appearing meanwhile. Diffing `pgrep` snapshots, as this did
+# before, would silently attach to whichever new PID sorted first, and this
+# script now actively invites concurrent runs by telling operators to pin one
+# cluster at a time.
+session_pid() {
+  local session="$1" pane child
+  pane="$(tmux list-panes -t "$session" -F '#{pane_pid}' 2>/dev/null | head -1)"
+  [ -n "$pane" ] || return 1
+  if [ "$(process_name "$pane")" = "$BIN_NAME" ]; then
+    printf '%s\n' "$pane"
+    return 0
+  fi
+  child="$(pgrep -P "$pane" -x "$BIN_NAME" 2>/dev/null | head -1)"
+  [ -n "$child" ] || return 1
+  printf '%s\n' "$child"
+}
 
 # Run one measurement window. Echoes "cpu_seconds wall_seconds rss_kb" on
 # success. Failures are reported through the exit code so the caller can name
@@ -408,21 +481,22 @@ measure_once() {
   local label="$1" rep="$2"; shift 2
   local session="all_smi_bench_$$_${label//[^0-9a-zA-Z]/_}_${rep}"
 
-  local before after
-  before="$(existing_pids)"
-
   tmux kill-session -t "$session" >/dev/null 2>&1 || true
-  tmux new-session -d -s "$session" -x "$TMUX_COLS" -y "$TMUX_ROWS" \
-    "${LAUNCH_PREFIX}$BIN local $*" >/dev/null 2>&1
+  # Keep stderr: a failure to launch is otherwise reported as a bare "could not
+  # start" after 10s of polling, with the actual reason discarded. stdout is
+  # dropped because this function's stdout is parsed as numbers by the caller.
+  local launch_err
+  launch_err="$(tmux new-session -d -s "$session" -x "$TMUX_COLS" -y "$TMUX_ROWS" \
+    "${LAUNCH_PREFIX}$BIN local $*" 2>&1 >/dev/null)" || true
 
   local pid=""
   for _ in $(seq 1 20); do
     sleep 0.5
-    after="$(existing_pids)"
-    pid="$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | head -1)"
+    pid="$(session_pid "$session" || true)"
     [ -n "$pid" ] && break
   done
   if [ -z "$pid" ]; then
+    [ -n "$launch_err" ] && printf 'note: tmux: %s\n' "$launch_err" >&2
     tmux kill-session -t "$session" >/dev/null 2>&1 || true
     return 1
   fi
@@ -432,11 +506,11 @@ measure_once() {
   local t0 c0 t1 c1 rss
   c0="$(cpu_time_seconds "$pid")" ||
     { tmux kill-session -t "$session" >/dev/null 2>&1 || true; return 2; }
-  t0="$(date +%s)"
+  t0="$(now_seconds)"
   sleep "$DURATION"
   c1="$(cpu_time_seconds "$pid")" ||
     { tmux kill-session -t "$session" >/dev/null 2>&1 || true; return 3; }
-  t1="$(date +%s)"
+  t1="$(now_seconds)"
 
   rss="$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
   [ -n "$rss" ] || rss=0
@@ -446,7 +520,7 @@ measure_once() {
   awk -v c0="$c0" -v c1="$c1" -v t0="$t0" -v t1="$t1" -v rss="$rss" 'BEGIN {
     wall = t1 - t0
     if (wall <= 0) exit 1
-    printf "%.6f %d %d\n", c1 - c0, wall, rss
+    printf "%.6f %.3f %d\n", c1 - c0, wall, rss
   }' || return 4
 }
 
@@ -492,7 +566,7 @@ measure() {
                label, mean, sqrt(var), n, ct / n, wall / n + 0.5, rss / n / 1024
       } else {
         printf "  %-14s cpu=%6.2f%%   cpu_time=%.2fs / %ds   rss=%dMB",
-               label, mean, ct, wall, rss / 1024
+               label, mean, ct, wall + 0.5, rss / 1024
       }
       # Name the failures here too, not only when every window failed: a
       # partial run that silently reported a smaller n would look like a

--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -24,16 +24,19 @@
 # USAGE
 #
 #   scripts/bench-local-interval.sh [-d SECONDS] [-b PATH] [-i "LIST"]
-#                                   [-c CPUS] [-r COUNT]
+#                                   [-c CPUS] [-r COUNT] [-h]
 #
-#     -d SECONDS   measurement window per configuration (default 60)
+#     -d SECONDS   measurement window per configuration, whole seconds
+#                  (default 60)
 #     -b PATH      all-smi binary (default ./target/release/all-smi)
-#     -i "LIST"    space-separated intervals to test (default "1 2 3");
-#                  the no-flag default configuration is always measured
+#     -i "LIST"    space-separated intervals to test, whole seconds
+#                  (default "1 2 3"); the no-flag default configuration is
+#                  always measured
 #     -c CPUS      pin the run to a CPU list, e.g. "5-9,15-19" (Linux only).
 #                  On a heterogeneous machine, see COMPARABILITY below
 #     -r COUNT     repeats per configuration (default 1). With more than one,
 #                  the mean and standard deviation are reported
+#     -h           print this text and exit
 #
 #   Build first:  cargo build --release --bin all-smi
 #                 On Linux this needs libdrm-dev: without it the link fails on


### PR DESCRIPTION
Closes #290.

## Why

`scripts/bench-local-interval.sh` reports CPU as percent of one core, and the whole point of its design (fixed 200x50 terminal, environment block, CPU-time delta instead of `ps -o %cpu`) is that results from different machines are comparable. On a heterogeneous CPU that does not hold, because "one core" is not one quantity. Identical work costs a different amount of CPU time on a performance core than on an efficiency core, and nothing in the output recorded which one ran.

Measured on an NVIDIA GB10 (Cortex-X925 at 3.9GHz plus Cortex-A725 at 2.8GHz), pinning the same run to one cluster or the other moves the result by about 1.5x. That is larger than the interval effect the script exists to measure, which was +19.4% on the same host. Intel P/E hybrids and Apple Silicon have the same property, so the existing M5 Max reference numbers carry it too.

## Changes

**`topology` line in the environment block.** Groups logical CPUs by maximum frequency, which separates ARM big.LITTLE clusters and Intel P/E cores alike, falling back to the device-tree `cpu_capacity` on ARM systems without cpufreq, and to `hw.nperflevels` on macOS. When none is readable it reports `unknown` rather than assuming uniform, since assuming uniform is the specific error this is meant to prevent. Uniform hosts print just count and speed; heterogeneous hosts additionally print each cluster's CPU list, range-collapsed so it can be pasted straight into the new flag.

**`-c CPUS` pins the run** via `taskset`, and the choice appears on a new `affinity` line. An unpinned run on a heterogeneous host now says so explicitly instead of quietly reporting a placement-dependent number. Rejected on macOS with an explanation rather than silently ignored, because the kernel exposes no userspace CPU affinity control and a run genuinely cannot be pinned to P or E cores there. Invalid lists are validated by handing them to `taskset` itself rather than reimplementing range syntax.

**`-r COUNT` repeats each configuration** and reports mean and standard deviation, because a single window on a low-cost host puts the effect close to the run-to-run spread. Default stays 1, so existing invocations keep both their runtime and their exact output format; the mean-and-deviation format appears only when repeats are requested. `measure` was split into `measure_once` plus an aggregating wrapper, with failures carried through exit codes so a partial run reports how many windows succeeded rather than silently averaging fewer.

## Output

```
  cpu           Cortex-X925 + Cortex-A725 (20 cores)
  topology      heterogeneous: 10x 3.90GHz (cpus 5-9,15-19), 10x 2.81GHz (cpus 0-4,10-14)
  affinity      cpus 0-4,10-14 (taskset)
  window        20s measured after 8s warmup, 2 repeats

=== results (percent of one core) ===
  default        cpu=  1.58% +/- 0.04 (n=2)   cpu_time=0.32s / 20s   rss=31MB
  -i 2s          cpu=  1.58% +/- 0.04 (n=2)   cpu_time=0.32s / 20s   rss=31MB
  -i 3s          cpu=  1.40% +/- 0.07 (n=2)   cpu_time=0.28s / 20s   rss=30MB
```

## Review findings, all fixed in later commits

Implementation and security review each found real defects, every one reproduced on hardware before being fixed.

**The affinity line could lie.** `taskset` does not validate a CPU list the way the first commit's comment claimed: it fails only when *no* CPU in the list exists, so it rejects `99-200` but silently accepts `0,99` and narrows it to CPU 0. The line then advertised `cpus 0,99` for a run pinned to one core, which is worse than printing nothing, since this line exists precisely so the context travels with the number. The effective mask is now read back after launch and reported, with the requested list shown alongside when they differ.

**Exact-key grouping over-split real hardware.** This machine's `cpu_capacity` reads 718, 731, 997, 1017, and 1024 across a two-cluster part, so the fallback reported five tiers, one of them a single CPU. Intel parts with per-core turbo binning have the same shape on the cpufreq path. Keys are now bucketed within 5% of the group's fastest member, compared against that fixed representative so small steps cannot drift a bucket across a real boundary, and the range collapser sorts numerically since a bucket can merge keys whose CPU runs interleave.

**The measured PID was a race.** It came from diffing `pgrep -x all-smi` snapshots and taking the first new PID. `-c` made that likely rather than theoretical, since the natural way to use it is one pinned run per cluster: running both at once made them report byte-identical numbers, cpu_time included, while each `affinity` line attested to a different placement. The PID now comes from `tmux list-panes -F '#{pane_pid}'`, the process tmux actually started. Two concurrent pinned runs now report distinct numbers in the expected direction.

**Nothing cleaned up on interrupt**, so Ctrl-C left an orphan rendering a 200x50 TUI forever, competing for CPU with the next run and, under `-c`, for exactly the pinned cluster. A trap now kills this invocation's sessions. The INT and TERM handlers exit rather than only cleaning up, because a bash trap returns to the point of interruption, so cleanup alone killed the window in flight and then opened the next one.

**Unvalidated input reached the shell command string.** `-i '$(touch /tmp/x)1'` created the file and a bare `-i '*'` glob-expanded so filenames became intervals; `-d 0.5` was accepted silently while being shorter than the clock resolution, understating CPU roughly twofold. Both are whole seconds by definition and are now checked, with globbing off for the interval walk.

Also: tmux stderr is surfaced on launch failure instead of a bare "could not start", and the window is timed with bash 5's `EPOCHREALTIME` where available, since whole-second truncation at both ends puts up to 1.7% of error on a 60s window, landing directly on the spread `-r` exists to expose.

## Tests

Validated on the GB10 host across unpinned, performance-pinned, and efficiency-pinned runs at 8s, 10s, 20s, and 30s windows with 1 and 2 repeats.

Pinning demonstrably does what it is for. Pinned to the efficiency cluster, `default` and `-i 2s` agreed **exactly** at 1.58%, where they should be identical because local mode resolves to 2s on Linux, and the deviation tightened to about 0.04 from the 0.08 to 0.13 measured unpinned.

Topology detection was exercised against the shipped awk for uniform x86, Intel P/E (8P+16E), Intel favoured-core binning, the real ARM capacity values, single core, non-contiguous clusters, three genuine tiers, and CPU indices past 9. The 5% bucket merges binned siblings without merging real tiers.

Interrupt handling was tested through a real terminal Ctrl-C rather than a background kill: bash sets SIGINT to ignored for asynchronous jobs and a signal ignored at entry cannot be trapped, which made the first test runs look like a script bug when the harness was at fault. Under a genuine Ctrl-C the session and child both go away.

Flag validation is covered: `-r 0`, `-r abc`, `-d abc`, `-d 0`, `-i '$(touch ...)'`, `-i '1;id'`, `-i '*'`, and an out-of-range `-c 99-200` are each rejected with a specific message.

`shellcheck` 0.11.0 is clean at default severity. The `-r 1` success-line format string is byte-identical to the pre-PR version, so existing reports stay comparable.

Shell only, no Rust touched, so the existing suite is unaffected and nothing about what `all-smi` collects or reports changes, satisfying #290's fourth acceptance criterion.

Also documents the comparability limit, all flags, and the container caveat for `-c` under Testing in `DEVELOPERS.md`, along with the `libdrm-dev` build prerequisite on Linux.

