### PR TITLE
fix: download releases from lablup/all-smi, not the old name

### DIFF
--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -58,7 +58,13 @@ jobs:
           VERSION="${RAW_VERSION#v}"  # Remove leading 'v'
           echo "VERSION_NO_V=$VERSION" >> $GITHUB_ENV  # Export version without 'v' to GitHub env
 
-          BASE="https://github.com/inureyes/all-smi/releases/download/v${VERSION}"
+          # This repository was renamed from inureyes/all-smi to lablup/all-smi.
+          # The old path still resolves through GitHub's rename redirect, but
+          # that redirect is not a guarantee: it disappears the moment anyone
+          # creates a new repository at the old name. The url written here also
+          # lands verbatim in the tap formula, so the redirect was load-bearing
+          # for every `brew install all-smi`, not just for this workflow.
+          BASE="https://github.com/lablup/all-smi/releases/download/v${VERSION}"
           mkdir -p tmp
 
           # `-f` so a missing or renamed asset fails here rather than leaving a


### PR DESCRIPTION
## Problem

The bump workflow fetched release assets from `github.com/inureyes/all-smi`. This repository was renamed to `lablup/all-smi`, so that path only resolves through GitHub's rename redirect.

The redirect is not a guarantee. It stops working the moment anyone creates a new repository at the old name, and GitHub allows that.

The url built here is also written verbatim into the tap formula's `url` stanzas, so the redirect was load-bearing for **every `brew install all-smi`**, not just for this workflow's own downloads. Someone claiming the old name would be serving the binaries.

The formula's `homepage` already pointed at `lablup/all-smi`. Only the download urls were stale.

## Verification

Content is unchanged. All three assets re-fetched from the lablup path produce exactly the checksums the tap formula already declares:

| asset | sha256 |
|---|---|
| `all-smi-macos-aarch64.zip` | `a0bdbccf61ab145a0a0547a59e708e18796a26407e4bb4a0924e52922c6bb5eb` |
| `all-smi-linux-aarch64.tar.gz` | `bbdc3e0ea1a4e368fe5593bcdd584bf605e20c161abfba223ecce9a328581ec9` |
| `all-smi-linux-x86_64.tar.gz` | `9909389e0db305a48573d3ec8635275e3802178949c358676b9643e5ef65d82b` |

So nothing downstream needs a new sha256, and the change is safe to land on its own.

Tap side validated in a scratch tap after the url swap: `brew readall --aliases`, `brew style` (8 files, no offenses), and `brew audit --strict` all clean.

## Related

- lablup/homebrew-tap `dac9b16` updates the checked-in formula to match, so the two agree immediately rather than only after the next release.
- lablup/all-smi#294 hardened this workflow's substitution logic; this is the follow-up it explicitly deferred.