### PR TITLE
fix: suppress duplicate "cores in use" line when topology is unreadable

### DIFF
--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -86,7 +86,9 @@
 #   starts. The environment block reads the mask actually in force rather than
 #   only the flag, so an inherited mask is reported as inherited, the core count
 #   is stated as a subset of the online CPUs, and a "cores in use" line names
-#   the core types the mask really covers.
+#   the core types the mask really covers whenever those differ from the
+#   machine's. On a host whose topology cannot be read at all, they do not
+#   differ and that line is absent.
 #
 #   An inherited mask is also re-applied to the launch, because tmux forks the
 #   measured process from the tmux server rather than from this script, and the
@@ -577,15 +579,23 @@ fi
 TOPOLOGY="$(detect_topology)"
 
 # What the mask covers, as opposed to what the machine has. Printed only when
-# those differ, since otherwise it would repeat the line above verbatim. On a
-# host where the topology is unreadable, detect_topology returns the same
-# fixed "unknown" string regardless of which CPUs it was asked to look at, so
-# a narrowing mask alone is not enough to guarantee a difference: clear it
-# back out when it matches TOPOLOGY.
+# those differ, since otherwise it would repeat the line above verbatim.
+#
+# A narrowing mask does not guarantee they differ, because detect_topology is
+# not obliged to vary with it. On a host with neither cpufreq nor cpu_capacity
+# it returns a fixed "unknown" string whatever it is asked to enumerate, and on
+# a host where only some CPUs expose either file, a mask that drops only the
+# CPUs that were never counted leaves the string untouched. Both cases reach
+# the same answer twice, so compare rather than infer.
 TOPOLOGY_IN_USE=""
 if [ -n "$MASK_ARG" ]; then
   TOPOLOGY_IN_USE="$(detect_topology "$MASK_ARG")"
-  [ "$TOPOLOGY_IN_USE" = "$TOPOLOGY" ] && TOPOLOGY_IN_USE=""
+  # Not `[ ... ] && TOPOLOGY_IN_USE=""`: that form leaves the enclosing if
+  # returning 1 on the common path, which is harmless here and a trap for
+  # whoever later wraps this block in a function under set -e.
+  if [ "$TOPOLOGY_IN_USE" = "$TOPOLOGY" ]; then
+    TOPOLOGY_IN_USE=""
+  fi
 fi
 
 # On a heterogeneous host an unpinned run is a mix of core types, and the

--- a/scripts/bench-local-interval.sh
+++ b/scripts/bench-local-interval.sh
@@ -577,10 +577,15 @@ fi
 TOPOLOGY="$(detect_topology)"
 
 # What the mask covers, as opposed to what the machine has. Printed only when
-# those differ, since otherwise it would repeat the line above verbatim.
+# those differ, since otherwise it would repeat the line above verbatim. On a
+# host where the topology is unreadable, detect_topology returns the same
+# fixed "unknown" string regardless of which CPUs it was asked to look at, so
+# a narrowing mask alone is not enough to guarantee a difference: clear it
+# back out when it matches TOPOLOGY.
 TOPOLOGY_IN_USE=""
 if [ -n "$MASK_ARG" ]; then
   TOPOLOGY_IN_USE="$(detect_topology "$MASK_ARG")"
+  [ "$TOPOLOGY_IN_USE" = "$TOPOLOGY" ] && TOPOLOGY_IN_USE=""
 fi
 
 # On a heterogeneous host an unpinned run is a mix of core types, and the


### PR DESCRIPTION
## Summary

`scripts/bench-local-interval.sh` printed a "cores in use" line that duplicated the "topology" line verbatim whenever the affinity mask narrowed the machine but the underlying topology was unreadable (no `cpufreq/cpuinfo_max_freq` and no `cpu_capacity`), because `detect_topology` returns the same fixed `unknown (no cpufreq or cpu_capacity)` string regardless of which CPUs it enumerates.

## What changed

- `scripts/bench-local-interval.sh`: after computing `TOPOLOGY_IN_USE` under a narrowing mask, clear it back to empty when it equals `TOPOLOGY`, so the existing print guard (`if [ -n "$TOPOLOGY_IN_USE" ]`) suppresses the duplicate line instead of printing it twice.
- Updated the comment above the block so it accurately describes the condition being tested (string difference, not just mask narrowing).

## Second commit, from review

Review raised three points, none of which change behaviour: the harness output across all 20+ mask scenarios is byte-identical between the two commits.

- **Help text.** The header block that `-h` prints said a `cores in use` line names the core types the mask covers, with no qualification. On exactly the hosts this PR targets that line is now absent, so the help text promised output the script does not produce. It now says when the line appears.
- **The comment was narrower than the guard.** It credited string equality solely to a host whose topology cannot be read. The guard is wider: where only some CPUs expose `cpufreq` or `cpu_capacity`, a mask that drops only CPUs that were never counted also leaves the string untouched. Verified on a fake host exposing `cpufreq` for cpus 0-3 alone: masks `0-3` and `0-3,10-12` produced a verbatim duplicate before and are suppressed after, while masks `0-1` (`uniform: 2x 2.81GHz`) and `4-19` (`unknown (...)`) genuinely differ from the machine string and are still printed. The guard therefore removes a duplicate every time it fires and never costs a line that carried information.
- **Guard form.** `[ ... ] && TOPOLOGY_IN_USE=""` leaves the enclosing `if` returning 1 whenever the strings differ, which is the common path. Harmless here, since nothing reads the status and `set -e` exempts a non-final command of an AND-OR list, but it is a trap for whoever later wraps this block in a function. Replaced with `if/then/fi` plus a note explaining why.

## Test plan

- [x] `bash -n scripts/bench-local-interval.sh` (clean)
- [x] `shellcheck -x scripts/bench-local-interval.sh` (exit 0)
- [x] Ran the issue's simulation harness (fake sysfs trees for a readable GB10-style topology and for a host with neither cpufreq nor cpu_capacity, plus stub uname/nproc/taskset/lscpu/tmux) before and after the change and diffed the output. The only difference is the removal of three `cores in use  unknown (no cpufreq or cpu_capacity)` lines from the no-cpufreq tree under a narrowing mask (mask=0-2, mask=0-1,5-6, and `-c 0-2`). The readable-topology tree and every `affinity` line in both trees are byte-identical to the pre-fix baseline.
- [x] Confirmed `MIXED_CORE_TYPES` (derived a few lines below from `${TOPOLOGY_IN_USE:-$TOPOLOGY}`) is unaffected: in the no-cpufreq tree neither the direct value nor the fallback ever matches the `heterogeneous*` case pattern, so the affinity line's thread-migration warning stays identical before and after.

```
--- baseline (main)
+++ after (this branch)
@@ -10,7 +10,6 @@
 == mask=0-2 bindir=bin
   cpu           Cortex-A725 (3 of 20 cores)
   topology      unknown (no cpufreq or cpu_capacity)
-  cores in use  unknown (no cpufreq or cpu_capacity)
   affinity      cpus 0-2 (inherited from the environment, not -c)
 == mask=0-2 bindir=bin_nots
   cpu           Cortex-X925 + Cortex-A725 (3 of 20 cores)
@@ -19,7 +18,6 @@
 == mask=0-1,5-6 bindir=bin
   cpu           Cortex-A725 + Cortex-X925 (4 of 20 cores)
   topology      unknown (no cpufreq or cpu_capacity)
-  cores in use  unknown (no cpufreq or cpu_capacity)
   affinity      cpus 0-1,5-6 (inherited from the environment, not -c)
 == mask=0-1,5-6 bindir=bin_nots
   cpu           Cortex-X925 + Cortex-A725 (4 of 20 cores)
@@ -28,7 +26,6 @@
 == -c 0-2
   cpu           Cortex-A725 (3 of 20 cores)
   topology      unknown (no cpufreq or cpu_capacity)
-  cores in use  unknown (no cpufreq or cpu_capacity)
   affinity      cpus 0,1,2 (taskset, requested 0-2)

 ############ TREE: fakecpu (topology readable) -- must not change ############
```

Everything else in the harness output, including the entire readable-topology tree section and every `affinity` line, is byte-identical between baseline and after.

No Rust code changed; benchmark tooling only.

Closes #297

