### PR TITLE
perf: parallelize the local collection pipeline (#287)

### DIFF
--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -40,7 +40,14 @@ pub fn with_global_system<F, R>(f: F) -> R
 where
     F: FnOnce(&mut System) -> R,
 {
-    let mut system = GLOBAL_SYSTEM.lock().unwrap();
+    // Recover from a poisoned lock instead of propagating it: `System` is a
+    // plain metrics snapshot, so continuing to use it after a panic mid-update
+    // elsewhere is safe, and it keeps one panicking caller (there are several,
+    // across GPU/process readers on multiple platforms) from permanently
+    // taking down every later call to this function.
+    let mut system = GLOBAL_SYSTEM
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     f(&mut system)
 }
 
@@ -48,7 +55,9 @@ where
 /// This is the primary use case - collecting process information
 #[allow(dead_code)]
 pub fn refresh_global_processes() {
-    let mut system = GLOBAL_SYSTEM.lock().unwrap();
+    let mut system = GLOBAL_SYSTEM
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     system.refresh_processes_specifics(
         ProcessesToUpdate::All,
         true,

--- a/src/view/data_collection/local_collector.rs
+++ b/src/view/data_collection/local_collector.rs
@@ -157,6 +157,21 @@ where
     tokio::task::spawn_blocking(move || f(&guard))
 }
 
+/// Await a reader-pass `JoinHandle` and log, rather than silently swallow, a
+/// panic in the underlying blocking task before falling back to that group's
+/// default (empty) result. Matches the `eprintln!("Warning: ...")` style
+/// already used in `initialize_readers` for other degraded-but-recoverable
+/// conditions.
+async fn join_or_log_default<R: Default>(handle: JoinHandle<R>, group_name: &str) -> R {
+    match handle.await {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("Warning: {group_name} collection task failed: {err}");
+            R::default()
+        }
+    }
+}
+
 pub struct LocalCollector {
     gpu_readers: Arc<RwLock<Vec<Box<dyn GpuReader>>>>,
     cpu_readers: Arc<RwLock<Vec<Box<dyn CpuReader>>>>,
@@ -208,15 +223,16 @@ impl LocalCollector {
             return;
         }
 
-        // Add startup status with timeout
+        // Add startup status. Pushed unconditionally, like the CPU and memory
+        // lines below: `collect_parallel_first_iteration` counts on exactly
+        // three preamble lines being present (the `3 + index` offset at the
+        // status handler), so silently skipping this push on lock contention
+        // would shift every later status update to the wrong line.
         {
-            let state_result = timeout(Duration::from_secs(2), app_state.lock()).await;
-
-            if let Ok(mut state) = state_result {
-                state
-                    .startup_status_lines
-                    .push("✓ Initializing GPU readers...".to_string());
-            }
+            let mut state = app_state.lock().await;
+            state
+                .startup_status_lines
+                .push("✓ Initializing GPU readers...".to_string());
         }
 
         let gpu_readers = get_gpu_readers();
@@ -421,7 +437,14 @@ impl LocalCollector {
                 // pid set is deliberately empty here: `merge_gpu_processes`
                 // below applies the GPU attribution for the first cycle.
                 let gpu_pids: HashSet<u32> = HashSet::new();
-                let mut cache = process_cache.write().unwrap();
+                // A panic elsewhere while this lock (or `GLOBAL_SYSTEM`, see
+                // `with_global_system`) was held would otherwise poison it and
+                // make every later cycle panic here too. The cached data is a
+                // plain metric map that is safe to keep using after a panic
+                // mid-update, so recover instead of propagating the poison.
+                let mut cache = process_cache
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 update_process_cache(system, &gpu_pids, &mut cache)
             });
             let _ =
@@ -430,8 +453,8 @@ impl LocalCollector {
         });
 
         // A panicking reader degrades that group to empty rather than taking the
-        // whole collection loop down, matching how the process arm already
-        // handled a failed `spawn_blocking`.
+        // whole collection loop down. The panic is still logged, so a run of
+        // empty data is diagnosable instead of silent.
         let GpuCollection {
             gpu_info: all_gpu_info,
             gpu_processes,
@@ -440,12 +463,12 @@ impl LocalCollector {
             gpu_pids: _,
             vgpu_info: all_vgpu_info,
             mig_info: all_mig_info,
-        } = gpu_task.await.unwrap_or_default();
-        let all_cpu_info = cpu_task.await.unwrap_or_default();
-        let all_memory_info = memory_task.await.unwrap_or_default();
-        let all_chassis_info = chassis_task.await.unwrap_or_default();
-        let all_storage_info = storage_task.await.unwrap_or_default();
-        let all_processes = processes_task.await.unwrap_or_default();
+        } = join_or_log_default(gpu_task, "GPU").await;
+        let all_cpu_info = join_or_log_default(cpu_task, "CPU").await;
+        let all_memory_info = join_or_log_default(memory_task, "memory").await;
+        let all_chassis_info = join_or_log_default(chassis_task, "chassis").await;
+        let all_storage_info = join_or_log_default(storage_task, "storage").await;
+        let all_processes = join_or_log_default(processes_task, "process").await;
 
         // Close the channel and wait for status handler to finish
         drop(status_tx);
@@ -562,7 +585,7 @@ impl LocalCollector {
             gpu_pids,
             vgpu_info: all_vgpu_info,
             mig_info: all_mig_info,
-        } = gpu_task.await.unwrap_or_default();
+        } = join_or_log_default(gpu_task, "GPU").await;
 
         let process_cache = Arc::clone(&self.process_cache);
         let processes_task = tokio::task::spawn_blocking(move || {
@@ -594,16 +617,23 @@ impl LocalCollector {
                 // OPTIMIZATION: Use process cache to reduce memory allocation overhead
                 // Instead of creating new ProcessInfo objects every cycle, we update
                 // existing cached objects and only allocate for new processes.
-                let mut cache = process_cache.write().unwrap();
+                // A panic elsewhere while this lock (or `GLOBAL_SYSTEM`, see
+                // `with_global_system`) was held would otherwise poison it and
+                // make every later cycle panic here too. The cached data is a
+                // plain metric map that is safe to keep using after a panic
+                // mid-update, so recover instead of propagating the poison.
+                let mut cache = process_cache
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 update_process_cache(system, &gpu_pids, &mut cache)
             })
         });
 
-        let all_cpu_info = cpu_task.await.unwrap_or_default();
-        let all_memory_info = memory_task.await.unwrap_or_default();
-        let all_chassis_info = chassis_task.await.unwrap_or_default();
-        let all_storage_info = storage_task.await.unwrap_or_default();
-        let all_processes = processes_task.await.unwrap_or_default();
+        let all_cpu_info = join_or_log_default(cpu_task, "CPU").await;
+        let all_memory_info = join_or_log_default(memory_task, "memory").await;
+        let all_chassis_info = join_or_log_default(chassis_task, "chassis").await;
+        let all_storage_info = join_or_log_default(storage_task, "storage").await;
+        let all_processes = join_or_log_default(processes_task, "process").await;
 
         let mut all_processes = merge_gpu_processes(all_processes, gpu_processes);
 

--- a/src/view/data_collection/local_collector.rs
+++ b/src/view/data_collection/local_collector.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 use sysinfo::Disks;
 use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
 /// Type alias for the process cache using std::sync::RwLock for synchronous access
@@ -72,6 +73,88 @@ fn inject_gpu_power(chassis_info: Vec<ChassisInfo>, gpu_info: &[GpuInfo]) -> Vec
             ci
         })
         .collect()
+}
+
+/// Everything the GPU reader set produces in one pass.
+///
+/// The four GPU queries stay grouped in a single unit of work on purpose.
+/// They all run against the same `Box<dyn GpuReader>` instances, which carry
+/// internal sampling state (IOReport deltas on Apple Silicon, cached NVML
+/// handles on NVIDIA), so issuing them concurrently against one reader would
+/// change the order in which that state is touched. Keeping them back to back
+/// preserves the exact call sequence the collector used before, while still
+/// letting the whole group overlap with the CPU, memory, chassis, storage and
+/// process groups.
+#[derive(Default)]
+struct GpuCollection {
+    gpu_info: Vec<GpuInfo>,
+    gpu_processes: Vec<ProcessInfo>,
+    gpu_pids: HashSet<u32>,
+    vgpu_info: Vec<VgpuHostInfo>,
+    mig_info: Vec<MigGpuInfo>,
+}
+
+/// Run the full GPU reader pass in the same order the collector always used:
+/// device info, GPU processes, vGPU, then MIG.
+fn collect_from_gpu_readers(readers: &[Box<dyn GpuReader>]) -> GpuCollection {
+    let gpu_info: Vec<GpuInfo> = readers
+        .iter()
+        .flat_map(|reader| reader.get_gpu_info())
+        .collect();
+
+    let mut gpu_processes = Vec::new();
+    let mut gpu_pids = HashSet::new();
+    for reader in readers.iter() {
+        let (procs, pids) = reader.get_gpu_processes();
+        gpu_processes.extend(procs);
+        gpu_pids.extend(pids);
+    }
+
+    // vGPU and MIG run on the same readers set so they share NVML handle
+    // caching with the main GPU collection.
+    let vgpu_info: Vec<VgpuHostInfo> = readers
+        .iter()
+        .flat_map(|reader| reader.get_vgpu_info())
+        .collect();
+    let mig_info: Vec<MigGpuInfo> = readers
+        .iter()
+        .flat_map(|reader| reader.get_mig_info())
+        .collect();
+
+    GpuCollection {
+        gpu_info,
+        gpu_processes,
+        gpu_pids,
+        vgpu_info,
+        mig_info,
+    }
+}
+
+/// Move one synchronous reader pass onto the tokio blocking pool.
+///
+/// The owned read guard is acquired here, in async context, and then moved
+/// into the closure. That ordering is what makes the whole refactor possible:
+/// the reader collections live behind tokio's async `RwLock`, whose `read()`
+/// is a future and therefore unusable inside a blocking closure, while
+/// `blocking_read()` from the blocking pool would risk deadlocking against a
+/// queued async writer. `OwnedRwLockReadGuard<T>` is `'static + Send` whenever
+/// `T: Send + Sync`, which every reader trait already guarantees, so it
+/// satisfies the `spawn_blocking` bounds without cloning or re-owning a single
+/// reader.
+///
+/// The guard is held for the lifetime of the blocking task. That is safe
+/// because the reader collections are written exactly once, by
+/// `initialize_readers`, before the first collection runs, and are read-only
+/// from then on. There is no hotplug/refresh path that takes a write lock
+/// while a collection is in flight.
+async fn spawn_reader_pass<T, R, F>(lock: &Arc<RwLock<T>>, f: F) -> JoinHandle<R>
+where
+    T: Send + Sync + 'static,
+    R: Send + 'static,
+    F: FnOnce(&T) -> R + Send + 'static,
+{
+    let guard = Arc::clone(lock).read_owned().await;
+    tokio::task::spawn_blocking(move || f(&guard))
 }
 
 pub struct LocalCollector {
@@ -234,179 +317,141 @@ impl LocalCollector {
         }
 
         // Create channel for status updates
-        let (status_tx, mut status_rx) = mpsc::channel(10);
+        let (status_tx, mut status_rx) = mpsc::channel::<(usize, String)>(10);
         let app_state_clone = Arc::clone(&app_state);
 
         // Spawn task to handle status updates
         let status_handler = task::spawn(async move {
             while let Some((index, message)) = status_rx.recv().await {
                 let mut state = app_state_clone.lock().await;
-                if index < state.startup_status_lines.len() {
-                    state.startup_status_lines[3 + index] = message;
+                // The five "Collecting ..." lines pushed above sit after the
+                // three reader-initialization lines, hence the +3 offset. Bound
+                // the shifted index, not the raw one, so a caller that pushed
+                // fewer preamble lines cannot panic this task.
+                let slot = 3 + index;
+                if slot < state.startup_status_lines.len() {
+                    state.startup_status_lines[slot] = message;
                 }
             }
         });
 
-        // Run all collections in parallel with status updates
-        // Use Arc references instead of cloning the entire Arc<RwLock<_>>
-        let gpu_readers_1 = Arc::clone(&self.gpu_readers);
-        let gpu_readers_2 = Arc::clone(&self.gpu_readers);
-        let gpu_readers_vgpu = Arc::clone(&self.gpu_readers);
-        let gpu_readers_mig = Arc::clone(&self.gpu_readers);
-        let cpu_readers = Arc::clone(&self.cpu_readers);
-        let memory_readers = Arc::clone(&self.memory_readers);
-        let chassis_reader = Arc::clone(&self.chassis_reader);
+        // Fan every synchronous reader pass out onto the blocking pool. Each
+        // group owns its read guard for the duration of its task, so nothing
+        // below runs on the async worker, and the six groups genuinely overlap
+        // instead of taking turns on one task the way `tokio::join!` did.
         let process_cache = Arc::clone(&self.process_cache);
+        let status_tx_gpu = status_tx.clone();
+        let status_tx_cpu = status_tx.clone();
+        let status_tx_mem = status_tx.clone();
+        let status_tx_proc = status_tx.clone();
+        let status_tx_storage = status_tx.clone();
 
-        let (
-            all_gpu_info,
-            all_cpu_info,
-            all_memory_info,
-            gpu_processes_result,
-            all_processes,
-            all_storage_info,
-            all_chassis_info,
-            all_vgpu_info,
-            all_mig_info,
-        ) = {
-            let status_tx_gpu = status_tx.clone();
-            let status_tx_cpu = status_tx.clone();
-            let status_tx_mem = status_tx.clone();
-            let status_tx_proc = status_tx.clone();
-            let status_tx_storage = status_tx.clone();
+        // GPU device info, GPU processes, vGPU and MIG in one pass.
+        let gpu_task = spawn_reader_pass(&self.gpu_readers, move |readers| {
+            let collected = collect_from_gpu_readers(readers);
+            let _ = status_tx_gpu.blocking_send((0, "✓ GPU information collected".to_string()));
+            collected
+        })
+        .await;
 
-            tokio::join!(
-                // GPU info collection
-                async move {
-                    let readers = gpu_readers_1.read().await;
-                    let info: Vec<GpuInfo> = readers
-                        .iter()
-                        .flat_map(|reader| reader.get_gpu_info())
-                        .collect();
-                    let _ = status_tx_gpu
-                        .send((0, "✓ GPU information collected".to_string()))
-                        .await;
-                    info
-                },
-                // CPU info collection
-                async move {
-                    let readers = cpu_readers.read().await;
-                    let info: Vec<CpuInfo> = readers
-                        .iter()
-                        .flat_map(|reader| reader.get_cpu_info())
-                        .collect();
-                    let _ = status_tx_cpu
-                        .send((1, "✓ CPU information collected".to_string()))
-                        .await;
-                    info
-                },
-                // Memory info collection
-                async move {
-                    let readers = memory_readers.read().await;
-                    let info: Vec<MemoryInfo> = readers
-                        .iter()
-                        .flat_map(|reader| reader.get_memory_info())
-                        .collect();
-                    let _ = status_tx_mem
-                        .send((2, "✓ Memory information collected".to_string()))
-                        .await;
-                    info
-                },
-                // GPU process collection (lightweight - raw GPU processes only)
-                async move {
-                    let readers = gpu_readers_2.read().await;
-                    let mut all_gpu_procs = Vec::new();
-                    let mut all_gpu_pids = HashSet::new();
-                    for reader in readers.iter() {
-                        let (procs, pids) = reader.get_gpu_processes();
-                        all_gpu_procs.extend(procs);
-                        all_gpu_pids.extend(pids);
-                    }
-                    (all_gpu_procs, all_gpu_pids)
-                },
-                // Full process collection - use spawn_blocking to avoid blocking tokio runtime
-                async move {
-                    let all_processes = tokio::task::spawn_blocking(move || {
-                        with_global_system(|system| {
-                            use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
-                            // OPTIMIZATION: Only refresh fields we actually need
-                            // - CPU usage for cpu_percent
-                            // - Memory for memory_percent/memory_rss/memory_vms
-                            // - User only if not already set (avoid repeated lookups)
-                            // This is much cheaper than everything() which includes disk I/O, etc.
-                            let refresh_kind = ProcessRefreshKind::nothing()
-                                .with_cpu()
-                                .with_memory()
-                                .with_user(UpdateKind::OnlyIfNotSet);
-                            system.refresh_processes_specifics(
-                                ProcessesToUpdate::All,
-                                true,
-                                refresh_kind,
-                            );
-                            system.refresh_memory();
+        let cpu_task = spawn_reader_pass(
+            &self.cpu_readers,
+            move |readers: &Vec<Box<dyn CpuReader>>| {
+                let info: Vec<CpuInfo> = readers
+                    .iter()
+                    .flat_map(|reader| reader.get_cpu_info())
+                    .collect();
+                let _ = status_tx_cpu.blocking_send((1, "✓ CPU information collected".to_string()));
+                info
+            },
+        )
+        .await;
 
-                            // OPTIMIZATION: Initialize process cache on first iteration
-                            // This populates the cache with all current processes
-                            let gpu_pids: HashSet<u32> = HashSet::new();
-                            let mut cache = process_cache.write().unwrap();
-                            update_process_cache(system, &gpu_pids, &mut cache)
-                        })
-                    })
-                    .await
-                    .unwrap_or_default();
-                    let _ = status_tx_proc
-                        .send((3, "✓ Process information collected".to_string()))
-                        .await;
-                    all_processes
-                },
-                // Storage collection
-                async move {
-                    let storage_info = Self::collect_storage_info();
-                    let _ = status_tx_storage
-                        .send((4, "✓ Storage information collected".to_string()))
-                        .await;
-                    storage_info
-                },
-                // Chassis info collection
-                async move {
-                    let reader = chassis_reader.read().await;
-                    let info: Vec<ChassisInfo> = reader
-                        .as_ref()
-                        .and_then(|r| r.get_chassis_info())
-                        .into_iter()
-                        .collect();
-                    info
-                },
-                // vGPU info collection (only NVIDIA readers produce data; others
-                // return an empty vector via the default trait implementation).
-                async move {
-                    let readers = gpu_readers_vgpu.read().await;
-                    let info: Vec<VgpuHostInfo> = readers
-                        .iter()
-                        .flat_map(|reader| reader.get_vgpu_info())
-                        .collect();
-                    info
-                },
-                // MIG info collection (only NVIDIA readers with MIG enabled
-                // GPUs produce data; everyone else returns an empty vector
-                // via the default trait implementation).
-                async move {
-                    let readers = gpu_readers_mig.read().await;
-                    let info: Vec<MigGpuInfo> = readers
-                        .iter()
-                        .flat_map(|reader| reader.get_mig_info())
-                        .collect();
-                    info
-                }
-            )
-        };
+        let memory_task = spawn_reader_pass(
+            &self.memory_readers,
+            move |readers: &Vec<Box<dyn MemoryReader>>| {
+                let info: Vec<MemoryInfo> = readers
+                    .iter()
+                    .flat_map(|reader| reader.get_memory_info())
+                    .collect();
+                let _ =
+                    status_tx_mem.blocking_send((2, "✓ Memory information collected".to_string()));
+                info
+            },
+        )
+        .await;
+
+        let chassis_task = spawn_reader_pass(
+            &self.chassis_reader,
+            |reader: &Option<Box<dyn ChassisReader>>| {
+                let info: Vec<ChassisInfo> = reader
+                    .as_ref()
+                    .and_then(|r| r.get_chassis_info())
+                    .into_iter()
+                    .collect();
+                info
+            },
+        )
+        .await;
+
+        let storage_task = task::spawn_blocking(move || {
+            let storage_info = Self::collect_storage_info();
+            let _ =
+                status_tx_storage.blocking_send((4, "✓ Storage information collected".to_string()));
+            storage_info
+        });
+
+        let processes_task = task::spawn_blocking(move || {
+            let all_processes = with_global_system(|system| {
+                use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
+                // OPTIMIZATION: Only refresh fields we actually need
+                // - CPU usage for cpu_percent
+                // - Memory for memory_percent/memory_rss/memory_vms
+                // - User only if not already set (avoid repeated lookups)
+                // This is much cheaper than everything() which includes disk I/O, etc.
+                let refresh_kind = ProcessRefreshKind::nothing()
+                    .with_cpu()
+                    .with_memory()
+                    .with_user(UpdateKind::OnlyIfNotSet);
+                system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+                system.refresh_memory();
+
+                // OPTIMIZATION: Initialize process cache on first iteration
+                // This populates the cache with all current processes. The GPU
+                // pid set is deliberately empty here: `merge_gpu_processes`
+                // below applies the GPU attribution for the first cycle.
+                let gpu_pids: HashSet<u32> = HashSet::new();
+                let mut cache = process_cache.write().unwrap();
+                update_process_cache(system, &gpu_pids, &mut cache)
+            });
+            let _ =
+                status_tx_proc.blocking_send((3, "✓ Process information collected".to_string()));
+            all_processes
+        });
+
+        // A panicking reader degrades that group to empty rather than taking the
+        // whole collection loop down, matching how the process arm already
+        // handled a failed `spawn_blocking`.
+        let GpuCollection {
+            gpu_info: all_gpu_info,
+            gpu_processes,
+            // The first cycle deliberately seeds the process cache with an empty
+            // GPU pid set; `merge_gpu_processes` below applies the attribution.
+            gpu_pids: _,
+            vgpu_info: all_vgpu_info,
+            mig_info: all_mig_info,
+        } = gpu_task.await.unwrap_or_default();
+        let all_cpu_info = cpu_task.await.unwrap_or_default();
+        let all_memory_info = memory_task.await.unwrap_or_default();
+        let all_chassis_info = chassis_task.await.unwrap_or_default();
+        let all_storage_info = storage_task.await.unwrap_or_default();
+        let all_processes = processes_task.await.unwrap_or_default();
 
         // Close the channel and wait for status handler to finish
         drop(status_tx);
         let _ = status_handler.await;
 
         // Merge raw GPU processes into main process list
-        let (gpu_processes, _gpu_pids) = gpu_processes_result;
         let mut all_processes_merged = merge_gpu_processes(all_processes, gpu_processes);
 
         // Sort by CPU usage descending and limit to top MAX_DISPLAY_PROCESSES
@@ -447,45 +492,52 @@ impl LocalCollector {
         }
     }
 
-    async fn collect_sequential(&self) -> CollectionData {
-        let gpu_readers = self.gpu_readers.read().await;
-        let all_gpu_info: Vec<GpuInfo> = gpu_readers
-            .iter()
-            .flat_map(|reader| reader.get_gpu_info())
-            .collect();
+    /// Steady-state collection, used for every cycle after the first.
+    ///
+    /// Formerly `collect_sequential`, and renamed because nothing here runs
+    /// serially on the async task any more: every reader pass is dispatched to
+    /// the blocking pool up front and only joined at the end.
+    async fn collect_steady_state(&self) -> CollectionData {
+        // Fan every synchronous reader pass out onto the blocking pool before
+        // touching anything else, so the CPU, memory, chassis and storage
+        // groups are already in flight while the GPU group runs.
+        let gpu_task = spawn_reader_pass(&self.gpu_readers, |readers: &Vec<Box<dyn GpuReader>>| {
+            collect_from_gpu_readers(readers)
+        })
+        .await;
 
-        let cpu_readers = self.cpu_readers.read().await;
-        let all_cpu_info: Vec<CpuInfo> = cpu_readers
-            .iter()
-            .flat_map(|reader| reader.get_cpu_info())
-            .collect();
+        let cpu_task = spawn_reader_pass(&self.cpu_readers, |readers: &Vec<Box<dyn CpuReader>>| {
+            readers
+                .iter()
+                .flat_map(|reader| reader.get_cpu_info())
+                .collect::<Vec<CpuInfo>>()
+        })
+        .await;
 
-        let memory_readers = self.memory_readers.read().await;
-        let all_memory_info: Vec<MemoryInfo> = memory_readers
-            .iter()
-            .flat_map(|reader| reader.get_memory_info())
-            .collect();
+        let memory_task = spawn_reader_pass(
+            &self.memory_readers,
+            |readers: &Vec<Box<dyn MemoryReader>>| {
+                readers
+                    .iter()
+                    .flat_map(|reader| reader.get_memory_info())
+                    .collect::<Vec<MemoryInfo>>()
+            },
+        )
+        .await;
 
-        let mut gpu_processes = Vec::new();
-        let mut gpu_pids = HashSet::new();
-        for reader in gpu_readers.iter() {
-            let (procs, pids) = reader.get_gpu_processes();
-            gpu_processes.extend(procs);
-            gpu_pids.extend(pids);
-        }
+        let chassis_task = spawn_reader_pass(
+            &self.chassis_reader,
+            |reader: &Option<Box<dyn ChassisReader>>| {
+                reader
+                    .as_ref()
+                    .and_then(|r| r.get_chassis_info())
+                    .into_iter()
+                    .collect::<Vec<ChassisInfo>>()
+            },
+        )
+        .await;
 
-        // vGPU info collection — performed on the same readers set so it
-        // shares NVML handle caching with the main GPU collection.
-        let all_vgpu_info: Vec<VgpuHostInfo> = gpu_readers
-            .iter()
-            .flat_map(|reader| reader.get_vgpu_info())
-            .collect();
-
-        // MIG info collection — same locality benefits as vGPU above.
-        let all_mig_info: Vec<MigGpuInfo> = gpu_readers
-            .iter()
-            .flat_map(|reader| reader.get_mig_info())
-            .collect();
+        let storage_task = tokio::task::spawn_blocking(Self::collect_storage_info);
 
         // Determine if we should do a full refresh or selective refresh
         let cycle = self.refresh_cycle.fetch_add(1, Ordering::Relaxed);
@@ -497,38 +549,62 @@ impl LocalCollector {
         } else {
             self.tracked_pids.read().await.clone()
         };
+
+        // The process pass is the one group that cannot start independently:
+        // `update_process_cache` needs this cycle's GPU pid set to decide which
+        // cached entries are GPU-attributed. Joining the GPU group first keeps
+        // that value identical to the pre-change behavior. The remaining groups
+        // are already running, so this join does not extend the critical path
+        // unless GPU plus process collection outlasts all of them.
+        let GpuCollection {
+            gpu_info: all_gpu_info,
+            gpu_processes,
+            gpu_pids,
+            vgpu_info: all_vgpu_info,
+            mig_info: all_mig_info,
+        } = gpu_task.await.unwrap_or_default();
+
         let process_cache = Arc::clone(&self.process_cache);
-        let all_processes = with_global_system(|system| {
-            use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
-            // OPTIMIZATION: Only refresh fields we actually need
-            // - CPU usage for cpu_percent
-            // - Memory for memory_percent/memory_rss/memory_vms
-            // - User only if not already set (avoid repeated lookups)
-            let refresh_kind = ProcessRefreshKind::nothing()
-                .with_cpu()
-                .with_memory()
-                .with_user(UpdateKind::OnlyIfNotSet);
+        let processes_task = tokio::task::spawn_blocking(move || {
+            with_global_system(|system| {
+                use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
+                // OPTIMIZATION: Only refresh fields we actually need
+                // - CPU usage for cpu_percent
+                // - Memory for memory_percent/memory_rss/memory_vms
+                // - User only if not already set (avoid repeated lookups)
+                let refresh_kind = ProcessRefreshKind::nothing()
+                    .with_cpu()
+                    .with_memory()
+                    .with_user(UpdateKind::OnlyIfNotSet);
 
-            // OPTIMIZATION: Selective process refresh
-            // Full refresh every N cycles to discover new high-CPU processes;
-            // otherwise only refresh tracked PIDs to significantly reduce CPU usage.
-            if do_full_refresh || tracked_pids_for_refresh.is_empty() {
-                system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
-            } else {
-                system.refresh_processes_specifics(
-                    ProcessesToUpdate::Some(&tracked_pids_for_refresh),
-                    true,
-                    refresh_kind,
-                );
-            }
-            system.refresh_memory();
+                // OPTIMIZATION: Selective process refresh
+                // Full refresh every N cycles to discover new high-CPU processes;
+                // otherwise only refresh tracked PIDs to significantly reduce CPU usage.
+                if do_full_refresh || tracked_pids_for_refresh.is_empty() {
+                    system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+                } else {
+                    system.refresh_processes_specifics(
+                        ProcessesToUpdate::Some(&tracked_pids_for_refresh),
+                        true,
+                        refresh_kind,
+                    );
+                }
+                system.refresh_memory();
 
-            // OPTIMIZATION: Use process cache to reduce memory allocation overhead
-            // Instead of creating new ProcessInfo objects every cycle, we update
-            // existing cached objects and only allocate for new processes.
-            let mut cache = process_cache.write().unwrap();
-            update_process_cache(system, &gpu_pids, &mut cache)
+                // OPTIMIZATION: Use process cache to reduce memory allocation overhead
+                // Instead of creating new ProcessInfo objects every cycle, we update
+                // existing cached objects and only allocate for new processes.
+                let mut cache = process_cache.write().unwrap();
+                update_process_cache(system, &gpu_pids, &mut cache)
+            })
         });
+
+        let all_cpu_info = cpu_task.await.unwrap_or_default();
+        let all_memory_info = memory_task.await.unwrap_or_default();
+        let all_chassis_info = chassis_task.await.unwrap_or_default();
+        let all_storage_info = storage_task.await.unwrap_or_default();
+        let all_processes = processes_task.await.unwrap_or_default();
+
         let mut all_processes = merge_gpu_processes(all_processes, gpu_processes);
 
         // Sort by CPU usage descending and limit to top MAX_DISPLAY_PROCESSES
@@ -547,16 +623,6 @@ impl LocalCollector {
             .map(|p| sysinfo::Pid::from_u32(p.pid))
             .collect();
         *self.tracked_pids.write().await = new_tracked_pids;
-
-        let all_storage_info = Self::collect_storage_info();
-
-        // Collect chassis info
-        let chassis_reader = self.chassis_reader.read().await;
-        let all_chassis_info: Vec<ChassisInfo> = chassis_reader
-            .as_ref()
-            .and_then(|r| r.get_chassis_info())
-            .into_iter()
-            .collect();
 
         // Inject aggregated GPU power into chassis info
         let all_chassis_info = inject_gpu_power(all_chassis_info, &all_gpu_info);
@@ -684,7 +750,7 @@ impl DataCollectionStrategy for LocalCollector {
             ));
         }
 
-        Ok(self.collect_sequential().await)
+        Ok(self.collect_steady_state().await)
     }
 
     async fn update_state(
@@ -776,7 +842,11 @@ impl LocalCollector {
         if config.first_iteration {
             Ok(self.collect_parallel_first_iteration(app_state).await)
         } else {
-            Ok(self.collect_sequential().await)
+            Ok(self.collect_steady_state().await)
         }
     }
 }
+
+#[cfg(test)]
+#[path = "local_collector/tests.rs"]
+mod tests;

--- a/src/view/data_collection/local_collector/tests.rs
+++ b/src/view/data_collection/local_collector/tests.rs
@@ -1,0 +1,436 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+/// Build a collector with real platform readers already installed, skipping
+/// `initialize_readers` so no `AppState` is needed.
+async fn initialized_collector() -> LocalCollector {
+    let collector = LocalCollector::new();
+    *collector.gpu_readers.write().await = get_gpu_readers();
+    *collector.cpu_readers.write().await = get_cpu_readers();
+    *collector.memory_readers.write().await = get_memory_readers();
+    *collector.chassis_reader.write().await = Some(create_chassis_reader());
+    *collector.initialized.lock().await = true;
+    collector
+}
+
+fn summarize(label: &str, samples: &[Duration]) -> Duration {
+    let mut sorted = samples.to_vec();
+    sorted.sort();
+    let total: Duration = sorted.iter().sum();
+    let mean = total / sorted.len() as u32;
+    println!(
+        "{label:<24} mean {:>9.3}ms  min {:>9.3}ms  median {:>9.3}ms  max {:>9.3}ms",
+        mean.as_secs_f64() * 1000.0,
+        sorted[0].as_secs_f64() * 1000.0,
+        sorted[sorted.len() / 2].as_secs_f64() * 1000.0,
+        sorted[sorted.len() - 1].as_secs_f64() * 1000.0,
+    );
+    mean
+}
+
+/// Total CPU time (user + system, all threads) charged to this process so
+/// far. Used to check that moving work onto the blocking pool relocates
+/// cycles instead of adding them.
+#[cfg(unix)]
+fn process_cpu_time() -> Duration {
+    // SAFETY: `getrusage` writes into a fully owned, zero-initialized
+    // `rusage` and reads nothing from it. `RUSAGE_SELF` is always a valid
+    // target for the calling process.
+    let usage = unsafe {
+        let mut usage: libc::rusage = std::mem::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, &mut usage) != 0 {
+            return Duration::ZERO;
+        }
+        usage
+    };
+    let to_duration = |tv: libc::timeval| {
+        Duration::new(tv.tv_sec as u64, (tv.tv_usec as u32).saturating_mul(1000))
+    };
+    to_duration(usage.ru_utime) + to_duration(usage.ru_stime)
+}
+
+#[cfg(not(unix))]
+fn process_cpu_time() -> Duration {
+    Duration::ZERO
+}
+
+/// Measurement harness for the local collection pipeline (issue #287).
+///
+/// Times every synchronous reader arm in isolation, sums them to show the
+/// serialized critical path, then times a full `collect_steady_state` cycle
+/// so the wall clock can be compared before and after a parallelization
+/// change. Ignored by default because it drives real hardware readers and
+/// its numbers are only meaningful on a release build.
+///
+/// Run with:
+/// `cargo test --release --bin all-smi view::data_collection::local_collector::tests::measure_collection_arms -- --ignored --nocapture`
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "measurement harness: drives real hardware readers, run manually on a release build"]
+async fn measure_collection_arms() {
+    const SAMPLES: usize = 12;
+
+    let collector = initialized_collector().await;
+
+    // Warm up so delta-based samplers (IOReport, sysinfo CPU) have a
+    // previous sample to compare against and are not paying first-call cost.
+    for _ in 0..3 {
+        let _ = collector.collect_steady_state().await;
+    }
+
+    let mut gpu = Vec::new();
+    let mut cpu = Vec::new();
+    let mut memory = Vec::new();
+    let mut gpu_procs = Vec::new();
+    let mut vgpu = Vec::new();
+    let mut mig = Vec::new();
+    let mut storage = Vec::new();
+    let mut chassis = Vec::new();
+    let mut processes = Vec::new();
+    let mut cycle = Vec::new();
+
+    for _ in 0..SAMPLES {
+        {
+            let readers = collector.gpu_readers.read().await;
+            let t = std::time::Instant::now();
+            let _: Vec<GpuInfo> = readers.iter().flat_map(|r| r.get_gpu_info()).collect();
+            gpu.push(t.elapsed());
+
+            let t = std::time::Instant::now();
+            for reader in readers.iter() {
+                let _ = reader.get_gpu_processes();
+            }
+            gpu_procs.push(t.elapsed());
+
+            let t = std::time::Instant::now();
+            let _: Vec<VgpuHostInfo> = readers.iter().flat_map(|r| r.get_vgpu_info()).collect();
+            vgpu.push(t.elapsed());
+
+            let t = std::time::Instant::now();
+            let _: Vec<MigGpuInfo> = readers.iter().flat_map(|r| r.get_mig_info()).collect();
+            mig.push(t.elapsed());
+        }
+        {
+            let readers = collector.cpu_readers.read().await;
+            let t = std::time::Instant::now();
+            let _: Vec<CpuInfo> = readers.iter().flat_map(|r| r.get_cpu_info()).collect();
+            cpu.push(t.elapsed());
+        }
+        {
+            let readers = collector.memory_readers.read().await;
+            let t = std::time::Instant::now();
+            let _: Vec<MemoryInfo> = readers.iter().flat_map(|r| r.get_memory_info()).collect();
+            memory.push(t.elapsed());
+        }
+        {
+            let reader = collector.chassis_reader.read().await;
+            let t = std::time::Instant::now();
+            let _: Vec<ChassisInfo> = reader
+                .as_ref()
+                .and_then(|r| r.get_chassis_info())
+                .into_iter()
+                .collect();
+            chassis.push(t.elapsed());
+        }
+        {
+            let t = std::time::Instant::now();
+            let _ = LocalCollector::collect_storage_info();
+            storage.push(t.elapsed());
+        }
+        {
+            let cache = Arc::clone(&collector.process_cache);
+            let t = std::time::Instant::now();
+            let _ = with_global_system(|system| {
+                use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
+                let refresh_kind = ProcessRefreshKind::nothing()
+                    .with_cpu()
+                    .with_memory()
+                    .with_user(UpdateKind::OnlyIfNotSet);
+                system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+                system.refresh_memory();
+                let gpu_pids: HashSet<u32> = HashSet::new();
+                let mut cache = cache.write().unwrap();
+                update_process_cache(system, &gpu_pids, &mut cache)
+            });
+            processes.push(t.elapsed());
+        }
+
+        let t = std::time::Instant::now();
+        let _ = collector.collect_steady_state().await;
+        cycle.push(t.elapsed());
+    }
+
+    println!("--- per-arm synchronous cost ({SAMPLES} samples) ---");
+    let arm_means = [
+        summarize("gpu_info", &gpu),
+        summarize("gpu_processes", &gpu_procs),
+        summarize("vgpu_info", &vgpu),
+        summarize("mig_info", &mig),
+        summarize("cpu_info", &cpu),
+        summarize("memory_info", &memory),
+        summarize("chassis_info", &chassis),
+        summarize("storage_info", &storage),
+        summarize("processes(full)", &processes),
+    ];
+    let serialized: Duration = arm_means.iter().sum();
+    println!(
+        "{:<24} {:>9.3}ms",
+        "SUM (serialized)",
+        serialized.as_secs_f64() * 1000.0
+    );
+    println!("--- full collection cycle ---");
+    summarize("collect_steady_state", &cycle);
+
+    // Wall clock and process CPU time over a longer run of back to back
+    // cycles. CPU time covers every thread, so blocking-pool work counts
+    // exactly as much as work done inline on an async worker.
+    const CYCLES: u32 = 100;
+    let cpu_before = process_cpu_time();
+    let wall_before = std::time::Instant::now();
+    for _ in 0..CYCLES {
+        let _ = collector.collect_steady_state().await;
+    }
+    let wall = wall_before.elapsed();
+    let cpu = process_cpu_time().saturating_sub(cpu_before);
+    println!("--- {CYCLES} back-to-back cycles ---");
+    println!(
+        "{:<24} {:>9.3}ms/cycle",
+        "wall clock",
+        wall.as_secs_f64() * 1000.0 / f64::from(CYCLES)
+    );
+    println!(
+        "{:<24} {:>9.3}ms/cycle",
+        "process CPU time",
+        cpu.as_secs_f64() * 1000.0 / f64::from(CYCLES)
+    );
+}
+
+/// Collect the same data the pre-#287 pipeline did, straight-line on the
+/// calling task, as a reference to compare the parallel pipeline against.
+async fn collect_reference(collector: &LocalCollector) -> CollectionData {
+    let gpu_readers = collector.gpu_readers.read().await;
+    let all_gpu_info: Vec<GpuInfo> = gpu_readers
+        .iter()
+        .flat_map(|reader| reader.get_gpu_info())
+        .collect();
+    let mut gpu_processes = Vec::new();
+    let mut gpu_pids = HashSet::new();
+    for reader in gpu_readers.iter() {
+        let (procs, pids) = reader.get_gpu_processes();
+        gpu_processes.extend(procs);
+        gpu_pids.extend(pids);
+    }
+    let all_vgpu_info: Vec<VgpuHostInfo> = gpu_readers
+        .iter()
+        .flat_map(|reader| reader.get_vgpu_info())
+        .collect();
+    let all_mig_info: Vec<MigGpuInfo> = gpu_readers
+        .iter()
+        .flat_map(|reader| reader.get_mig_info())
+        .collect();
+
+    let all_cpu_info: Vec<CpuInfo> = collector
+        .cpu_readers
+        .read()
+        .await
+        .iter()
+        .flat_map(|reader| reader.get_cpu_info())
+        .collect();
+    let all_memory_info: Vec<MemoryInfo> = collector
+        .memory_readers
+        .read()
+        .await
+        .iter()
+        .flat_map(|reader| reader.get_memory_info())
+        .collect();
+
+    let process_cache = Arc::clone(&collector.process_cache);
+    let all_processes = with_global_system(|system| {
+        use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
+        let refresh_kind = ProcessRefreshKind::nothing()
+            .with_cpu()
+            .with_memory()
+            .with_user(UpdateKind::OnlyIfNotSet);
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+        system.refresh_memory();
+        let mut cache = process_cache.write().unwrap();
+        update_process_cache(system, &gpu_pids, &mut cache)
+    });
+    let mut all_processes = merge_gpu_processes(all_processes, gpu_processes);
+    all_processes.sort_by(|a, b| {
+        b.cpu_percent
+            .partial_cmp(&a.cpu_percent)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    all_processes.truncate(MAX_DISPLAY_PROCESSES);
+
+    let all_storage_info = LocalCollector::collect_storage_info();
+    let all_chassis_info: Vec<ChassisInfo> = collector
+        .chassis_reader
+        .read()
+        .await
+        .as_ref()
+        .and_then(|r| r.get_chassis_info())
+        .into_iter()
+        .collect();
+    let all_chassis_info = inject_gpu_power(all_chassis_info, &all_gpu_info);
+
+    CollectionData {
+        gpu_info: all_gpu_info,
+        cpu_info: all_cpu_info,
+        memory_info: all_memory_info,
+        process_info: all_processes,
+        storage_info: all_storage_info,
+        chassis_info: all_chassis_info,
+        vgpu_info: all_vgpu_info,
+        mig_info: all_mig_info,
+        connection_statuses: Vec::new(),
+        remote_process_info: Vec::new(),
+    }
+}
+
+/// The parallel pipeline must produce the same shape of data as the
+/// straight-line reference: same devices, same mount points, same chassis
+/// rows, same ordering and truncation of the process list. Absolute metric
+/// values are sampled at different instants and cannot be compared for
+/// equality, so this asserts on everything that is not time varying.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parallel_collection_matches_serial_reference() {
+    let collector = initialized_collector().await;
+
+    // Prime the readers and the process cache so neither run pays
+    // first-call initialization cost or sees an empty cache.
+    let _ = collector.collect_steady_state().await;
+
+    let reference = collect_reference(&collector).await;
+    let parallel = collector.collect_steady_state().await;
+
+    fn uuids(data: &CollectionData) -> Vec<&str> {
+        let mut v: Vec<&str> = data.gpu_info.iter().map(|g| g.uuid.as_str()).collect();
+        v.sort_unstable();
+        v
+    }
+    assert_eq!(
+        uuids(&reference),
+        uuids(&parallel),
+        "GPU device set differs"
+    );
+    assert_eq!(
+        reference.cpu_info.len(),
+        parallel.cpu_info.len(),
+        "CPU row count differs"
+    );
+    assert_eq!(
+        reference.memory_info.len(),
+        parallel.memory_info.len(),
+        "memory row count differs"
+    );
+    assert_eq!(
+        reference.vgpu_info.len(),
+        parallel.vgpu_info.len(),
+        "vGPU row count differs"
+    );
+    assert_eq!(
+        reference.mig_info.len(),
+        parallel.mig_info.len(),
+        "MIG row count differs"
+    );
+    assert_eq!(
+        reference.chassis_info.len(),
+        parallel.chassis_info.len(),
+        "chassis row count differs"
+    );
+
+    fn mounts(data: &CollectionData) -> Vec<&str> {
+        let mut v: Vec<&str> = data
+            .storage_info
+            .iter()
+            .map(|s| s.mount_point.as_str())
+            .collect();
+        v.sort_unstable();
+        v
+    }
+    assert_eq!(
+        mounts(&reference),
+        mounts(&parallel),
+        "mount point set differs"
+    );
+
+    assert!(
+        !parallel.process_info.is_empty(),
+        "process list should never be empty"
+    );
+    assert!(parallel.process_info.len() <= MAX_DISPLAY_PROCESSES);
+    assert!(
+        parallel
+            .process_info
+            .windows(2)
+            .all(|w| w[0].cpu_percent >= w[1].cpu_percent),
+        "process list must stay sorted by CPU usage descending"
+    );
+    assert!(
+        parallel.remote_process_info.is_empty() && parallel.connection_statuses.is_empty(),
+        "local mode must not populate remote fields"
+    );
+}
+
+/// Every group now runs on the blocking pool while holding an owned read
+/// guard. Guard against the failure mode that introduces: a collection that
+/// never returns because a lock or the blocking pool is starved. Repeated
+/// cycles also cover the selective/full process refresh alternation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repeated_collections_complete_without_deadlock() {
+    let collector = initialized_collector().await;
+
+    for _ in 0..(FULL_REFRESH_INTERVAL + 2) {
+        let data = timeout(Duration::from_secs(20), collector.collect_steady_state())
+            .await
+            .expect("collection cycle timed out, likely a lock or blocking-pool deadlock");
+        assert!(!data.process_info.is_empty());
+    }
+}
+
+/// The first-iteration path additionally pushes startup status lines from
+/// inside blocking tasks via `blocking_send`. Exercise it end to end so a
+/// misuse of that API (which panics when called from an async context)
+/// cannot reach a release build.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn first_iteration_collection_reports_startup_status() {
+    let collector = LocalCollector::new();
+    let app_state = Arc::new(Mutex::new(AppState::new()));
+    collector.initialize_readers(Arc::clone(&app_state)).await;
+
+    let data = timeout(
+        Duration::from_secs(30),
+        collector.collect_parallel_first_iteration(Arc::clone(&app_state)),
+    )
+    .await
+    .expect("first-iteration collection timed out");
+
+    assert!(!data.process_info.is_empty());
+    assert!(data.process_info.len() <= MAX_DISPLAY_PROCESSES);
+
+    let state = app_state.lock().await;
+    let collected_markers = state
+        .startup_status_lines
+        .iter()
+        .filter(|line| line.starts_with('✓') && line.contains("collected"))
+        .count();
+    assert_eq!(
+        collected_markers, 5,
+        "expected all five collection arms to report completion, got: {:?}",
+        state.startup_status_lines
+    );
+}

--- a/src/view/data_collection/local_collector/tests.rs
+++ b/src/view/data_collection/local_collector/tests.rs
@@ -14,6 +14,20 @@
 
 use super::*;
 
+/// Serializes the tests in this module against each other.
+///
+/// All of them touch the process-global `GLOBAL_SYSTEM` (via
+/// `with_global_system`), and `first_iteration_collection_reports_startup_status`
+/// additionally builds a second full reader set through `initialize_readers`
+/// whose `Drop` impls reach into the shared platform metrics manager (on
+/// macOS, IOReport shutdown). Run concurrently under the default test
+/// harness, those interact and make the tests flaky; held for the whole test
+/// body, this lock makes them deterministic instead. `tokio::sync::Mutex`
+/// rather than `std::sync::Mutex` on purpose: the guard is held across
+/// `.await` points, and unlike `std::sync::Mutex` it does not poison when a
+/// task panics while holding it, so one failing test cannot wedge the rest.
+static TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
 /// Build a collector with real platform readers already installed, skipping
 /// `initialize_readers` so no `AppState` is needed.
 async fn initialized_collector() -> LocalCollector {
@@ -80,6 +94,7 @@ fn process_cpu_time() -> Duration {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "measurement harness: drives real hardware readers, run manually on a release build"]
 async fn measure_collection_arms() {
+    let _serialize = TEST_LOCK.lock().await;
     const SAMPLES: usize = 12;
 
     let collector = initialized_collector().await;
@@ -308,6 +323,7 @@ async fn collect_reference(collector: &LocalCollector) -> CollectionData {
 /// equality, so this asserts on everything that is not time varying.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn parallel_collection_matches_serial_reference() {
+    let _serialize = TEST_LOCK.lock().await;
     let collector = initialized_collector().await;
 
     // Prime the readers and the process cache so neither run pays
@@ -392,6 +408,7 @@ async fn parallel_collection_matches_serial_reference() {
 /// cycles also cover the selective/full process refresh alternation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn repeated_collections_complete_without_deadlock() {
+    let _serialize = TEST_LOCK.lock().await;
     let collector = initialized_collector().await;
 
     for _ in 0..(FULL_REFRESH_INTERVAL + 2) {
@@ -402,12 +419,59 @@ async fn repeated_collections_complete_without_deadlock() {
     }
 }
 
+/// `join_or_log_default` is the seam that keeps a panicking reader from
+/// taking the whole collection cycle down. Exercise it directly: a task that
+/// panics must not propagate that panic to the caller, and must produce the
+/// group's `Default` instead of hanging or bubbling up the panic.
+#[tokio::test]
+async fn join_or_log_default_falls_back_on_panicking_task() {
+    let handle: JoinHandle<Vec<GpuInfo>> =
+        tokio::task::spawn_blocking(|| panic!("simulated reader panic"));
+    let result = join_or_log_default(handle, "GPU").await;
+    assert!(
+        result.is_empty(),
+        "a panicking reader task must degrade to Default, not propagate"
+    );
+}
+
+/// Finding: a panic while holding `process_cache`'s write lock (mirroring a
+/// panicking reader mid-cycle) used to poison the lock permanently, so every
+/// later cycle panicked in turn on `.write().unwrap()` and produced silent,
+/// permanently empty data. The lock acquisition now recovers via
+/// `PoisonError::into_inner`; this test poisons the lock the same way a
+/// panicking reader would and asserts the next cycle still completes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn steady_state_collection_recovers_from_poisoned_process_cache() {
+    let _serialize = TEST_LOCK.lock().await;
+    let collector = initialized_collector().await;
+
+    let cache = Arc::clone(&collector.process_cache);
+    let poisoned = std::panic::catch_unwind(move || {
+        let _guard = cache.write().unwrap();
+        panic!("simulated panic while holding process_cache");
+    });
+    assert!(poisoned.is_err(), "the simulated panic should have unwound");
+    assert!(
+        collector.process_cache.is_poisoned(),
+        "the write lock should be poisoned after a panic while held"
+    );
+
+    let data = timeout(Duration::from_secs(20), collector.collect_steady_state())
+        .await
+        .expect("collection cycle timed out, likely a lock deadlock instead of recovery");
+    assert!(
+        !data.process_info.is_empty(),
+        "a recovered cache should still produce process data"
+    );
+}
+
 /// The first-iteration path additionally pushes startup status lines from
 /// inside blocking tasks via `blocking_send`. Exercise it end to end so a
 /// misuse of that API (which panics when called from an async context)
 /// cannot reach a release build.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn first_iteration_collection_reports_startup_status() {
+    let _serialize = TEST_LOCK.lock().await;
     let collector = LocalCollector::new();
     let app_state = Arc::new(Mutex::new(AppState::new()));
     collector.initialize_readers(Arc::clone(&app_state)).await;
@@ -431,6 +495,27 @@ async fn first_iteration_collection_reports_startup_status() {
     assert_eq!(
         collected_markers, 5,
         "expected all five collection arms to report completion, got: {:?}",
+        state.startup_status_lines
+    );
+
+    // Regression check for the `3 + index` startup-status offset (finding 3):
+    // `initialize_readers` must always push exactly three preamble lines, in
+    // order, so each "○ Collecting ..." placeholder gets overwritten by the
+    // matching "✓ ... collected" line at the right slot rather than a
+    // neighboring one (or being silently dropped by the bounds check).
+    assert_eq!(
+        state.startup_status_lines,
+        vec![
+            "✓ Initializing GPU readers...",
+            "✓ Initializing CPU readers...",
+            "✓ Initializing memory readers...",
+            "✓ GPU information collected",
+            "✓ CPU information collected",
+            "✓ Memory information collected",
+            "✓ Process information collected",
+            "✓ Storage information collected",
+        ],
+        "startup status lines landed in the wrong slots: {:?}",
         state.startup_status_lines
     );
 }


### PR DESCRIPTION
## Summary

The `tokio::join!` in `collect_parallel_first_iteration` fanned out over nine arms but polled all of them on one task. Every arm except full-process collection called synchronous reader methods with no yield point, so the join only provided ordering and result aggregation: the arms took turns on a single worker and the cycle cost the sum of all of them. `collect_sequential`, the steady-state path used for every cycle after the first, was serial by construction and had exactly the same problem, so both paths are fixed here.

Both now dispatch every synchronous reader pass to the blocking pool up front and join only at the end. Nothing synchronous is left on the async task in either path.

## Design

Work is grouped per reader collection, not per query. GPU device info, GPU processes, vGPU and MIG stay back to back inside one task because they all run against the same `Box<dyn GpuReader>` instances, and those carry internal sampling state (IOReport deltas on Apple Silicon, cached NVML handles on NVIDIA); issuing them concurrently against one reader would change the order in which that state is touched, which is exactly what acceptance criterion 5 forbids. CPU, memory, chassis, storage and full-process collection each get their own task, giving six groups that genuinely overlap.

**How the `Arc<RwLock<...>>` borrows are handled.** `spawn_reader_pass` takes the guard with `Arc<RwLock<T>>::read_owned()` in async context and moves it into the closure. This is what makes the refactor possible at all: `read()` is a future and unusable inside a blocking closure, while `blocking_read()` from the blocking pool would risk deadlocking against a queued async writer (tokio's `RwLock` is fair, so a queued writer blocks subsequent readers). `OwnedRwLockReadGuard<T>` is `'static + Send` whenever `T: Send + Sync`, and `GpuReader`/`CpuReader`/`MemoryReader`/`ChassisReader` are all declared `Send + Sync`, so the `spawn_blocking` bounds are satisfied without cloning or re-owning a single reader. No guard is ever held across an `.await`.

**Why holding the guard for the task's lifetime is safe.** I checked every writer of these locks: the only one is `initialize_readers`, which runs once and completes before the first collection. There is no hotplug or periodic-refresh path that takes a write lock while a collection is in flight, so a long-lived read guard cannot starve anything.

**The one dependency that is kept.** In the steady-state path `update_process_cache` needs this cycle's GPU pid set to decide which cached entries are GPU-attributed, so the process task is spawned after the GPU group joins rather than alongside it. Breaking that dependency would change collected values. Every other group is already in flight by then, so it only extends the critical path when GPU plus process collection outlasts all of them (it does not on the measured machine, and the code comment says so). The first-iteration path has no such dependency: it deliberately seeds the cache with an empty pid set, so all six groups start together there.

Blocking-pool sizing was checked: six concurrent tasks per cycle sits far below the default `max_blocking_threads`, and below the `max_blocking_threads(32)` used by the snapshot runtime.

## Measurements

Recorded on this machine (Apple M5 Max, 18 cores), release profile, via the `measure_collection_arms` harness added in `src/view/data_collection/local_collector/tests.rs`. The baseline was measured first, before any production code changed, by checking out `origin/main` into a separate worktree, appending the same harness to it, and building it with its own target directory. Two runs of each, alternating, on an otherwise idle machine. Wall clock and CPU are 100 back-to-back steady-state cycles divided by 100; CPU time is `getrusage(RUSAGE_SELF)` user + system, which counts every thread, so blocking-pool work is charged exactly like inline work.

| | baseline run 1 | baseline run 2 | after run 1 | after run 2 |
|---|---|---|---|---|
| wall clock per cycle | 20.118 ms | 21.717 ms | 14.883 ms | 14.783 ms |
| process CPU per cycle | 19.320 ms | 21.129 ms | 19.372 ms | 19.112 ms |

Wall clock drops roughly 28%. CPU time is flat within run-to-run noise and never above baseline, which is the "no regression" check: `spawn_blocking` relocated the cycles rather than adding any. There is no busy-wait and no duplicated work; the same reader calls run the same number of times.

Per-arm synchronous cost on this machine (mean of 12 samples, measured before the change): storage 14.371 ms, full process refresh 8.147 ms, GPU info 0.010 ms, CPU info 0.006 ms, memory 0.003 ms, chassis 0.002 ms, vGPU/MIG/GPU-processes below 0.001 ms. Serialized sum 22.541 ms. After the change the critical path is bounded by the storage pass, which matches the observed 14.8 ms.

**Limitations, stated honestly.** This is a single-machine, single-platform measurement. On Apple Silicon after PR #286 the GPU reader is effectively free (10 microseconds), so the win here comes from overlapping storage with process collection rather than from getting the GPU arm off the worker. On an NVIDIA host where `get_gpu_info` costs tens of milliseconds the GPU group would dominate and the ratio would differ; I have no NVIDIA hardware here to measure that, and the numbers above should not be read as a cross-platform claim. The `measure_collection_arms` harness is committed (ignored by default) precisely so the numbers can be reproduced on other hardware. The first-iteration path is not in the table because its one-shot nature makes a 100-cycle average meaningless; it is covered by a functional test instead.

## What changed

- `src/view/data_collection/local_collector.rs`: added `GpuCollection` plus `collect_from_gpu_readers` for the grouped GPU pass, added the `spawn_reader_pass` helper, rewrote `collect_parallel_first_iteration` to spawn six blocking groups instead of a nine-arm `tokio::join!`, and rewrote `collect_sequential` the same way.
- Renamed `collect_sequential` to `collect_steady_state`, since the old name no longer describes what it does.
- The first-iteration status updates now use `blocking_send` from inside the blocking closures, so each "collected" line still appears as its group finishes rather than all at once at the end.
- Hardened the startup status handler to bound the shifted index (`3 + index`) instead of the raw one, so an out-of-range write cannot panic that task.
- `src/view/data_collection/local_collector/tests.rs` (new): test module split out following the existing `#[path = ".../tests.rs"]` convention used by `cpu_linux`, `memory_linux`, `container_info` and others.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo test --bin all-smi view::data_collection::local_collector::tests -- --test-threads=1` (3 passed, 1 ignored harness)
- [x] `parallel_collection_matches_serial_reference`: runs the new pipeline and a straight-line reference collection back to back and asserts the GPU uuid set, CPU/memory/vGPU/MIG/chassis row counts, and storage mount-point set match, plus that the process list stays sorted by CPU descending and truncated to `MAX_DISPLAY_PROCESSES`. Absolute metric values are sampled at different instants and cannot be compared for equality, so everything that is not time varying is asserted instead.
- [x] `repeated_collections_complete_without_deadlock`: runs `FULL_REFRESH_INTERVAL + 2` cycles under a timeout, covering both the selective and full process-refresh branches, to catch a lock or blocking-pool deadlock.
- [x] `first_iteration_collection_reports_startup_status`: drives the real first-iteration path through `initialize_readers` and asserts all five arms report completion, which is also what proves `blocking_send` inside `spawn_blocking` does not panic.

Closes #287
