### PR TITLE
docs: remove obsolete sudo help entry

### DIFF
--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -374,11 +374,6 @@ fn render_terminal_section(line_idx: usize, width: usize) -> String {
         ("", "", ""),
         ("Local Monitoring:", "", "header"),
         ("  all-smi", "Monitor local GPUs (default mode)", "command"),
-        (
-            "  sudo all-smi local",
-            "Monitor local GPUs (requires sudo on macOS)",
-            "command",
-        ),
         ("", "", ""),
         ("Remote Monitoring:", "", "header"),
         (
@@ -587,4 +582,29 @@ fn get_current_sort_status(sort_criteria: &crate::app_state::SortCriteria) -> St
         crate::app_state::SortCriteria::Temperature => "Temperature",
     }
     .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_help_omits_obsolete_macos_sudo_command() {
+        let output = render_terminal_section(0, 120)
+            + "\n"
+            + &render_terminal_section(1, 120)
+            + "\n"
+            + &render_terminal_section(2, 120)
+            + "\n"
+            + &render_terminal_section(3, 120)
+            + "\n"
+            + &render_terminal_section(4, 120)
+            + "\n"
+            + &render_terminal_section(5, 120);
+
+        assert!(output.contains("Local Monitoring:"));
+        assert!(output.contains("all-smi"));
+        assert!(!output.contains("sudo all-smi local"));
+        assert!(!output.contains("requires sudo on macOS"));
+    }
 }


### PR DESCRIPTION
## Summary

Remove the obsolete macOS sudo guidance from the TUI help page's Local Monitoring section and keep the non-privileged `all-smi` example as the only local-mode command.

## What changed

- removed the `sudo all-smi local` help row and its "requires sudo on macOS" description from `src/ui/help.rs`
- added a focused regression test that asserts the local help section no longer renders the obsolete sudo command or text

## Test plan

- [x] cargo fmt --check
- [x] cargo test --lib ui::help::tests::local_help_omits_obsolete_macos_sudo_command -- --exact
- [x] cargo check --lib --tests

Closes #301
