### PR TITLE
fix: add local CPU sort shortcut to processes view (#300)

### DIFF
--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -342,45 +342,6 @@ fn fill_remaining<W: Write>(stdout: &mut W, cols: u16, used: usize) {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::print_function_keys;
-    use crate::app_state::{AppState, SortCriteria};
-
-    #[test]
-    fn local_status_bar_advertises_cpu_sort_shortcut_and_indicator() {
-        let mut state = AppState::new();
-        state.sort_criteria = SortCriteria::CpuPercent;
-
-        let mut output = Vec::new();
-        print_function_keys(&mut output, 200, 30, &state, false);
-        let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
-
-        assert!(
-            rendered.contains("c:CPU"),
-            "local status bar must advertise the CPU sort shortcut.\n--- status ---\n{rendered}"
-        );
-        assert!(
-            rendered.contains("Sort:CPU%"),
-            "local status bar must surface the active CPU sort indicator.\n--- status ---\n{rendered}"
-        );
-    }
-
-    #[test]
-    fn remote_status_bar_keeps_cpu_shortcut_hidden() {
-        let state = AppState::new();
-
-        let mut output = Vec::new();
-        print_function_keys(&mut output, 200, 30, &state, true);
-        let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
-
-        assert!(
-            !rendered.contains("c:CPU"),
-            "remote status bar must not advertise the local-only CPU shortcut.\n--- status ---\n{rendered}"
-        );
-    }
-}
-
 fn format_hms(total_seconds: u64) -> String {
     let h = total_seconds / 3600;
     let m = (total_seconds / 60) % 60;
@@ -426,5 +387,44 @@ fn print_filter_bar<W: Write>(stdout: &mut W, cols: u16, state: &AppState) {
     let remaining = (cols as usize).saturating_sub(used);
     if remaining > 0 {
         print_colored_text(stdout, &" ".repeat(remaining), Color::White, None, None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print_function_keys;
+    use crate::app_state::{AppState, SortCriteria};
+
+    #[test]
+    fn local_status_bar_advertises_cpu_sort_shortcut_and_indicator() {
+        let mut state = AppState::new();
+        state.sort_criteria = SortCriteria::CpuPercent;
+
+        let mut output = Vec::new();
+        print_function_keys(&mut output, 200, 30, &state, false);
+        let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
+
+        assert!(
+            rendered.contains("c:CPU"),
+            "local status bar must advertise the CPU sort shortcut.\n--- status ---\n{rendered}"
+        );
+        assert!(
+            rendered.contains("Sort:CPU%"),
+            "local status bar must surface the active CPU sort indicator.\n--- status ---\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn remote_status_bar_keeps_cpu_shortcut_hidden() {
+        let state = AppState::new();
+
+        let mut output = Vec::new();
+        print_function_keys(&mut output, 200, 30, &state, true);
+        let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
+
+        assert!(
+            !rendered.contains("c:CPU"),
+            "remote status bar must not advertise the local-only CPU shortcut.\n--- status ---\n{rendered}"
+        );
     }
 }

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -171,11 +171,11 @@ pub fn print_function_keys<W: Write>(
         // Local mode: both process and GPU sorting
         if state.gpu_filter_enabled {
             format!(
-                "h:Help q:Exit f:Filter ←→:Scroll ↑↓:Scroll p:PID m:Memory g:GPU-Mem [{sort_indicator}] [{filter_indicator}]"
+                "h:Help q:Exit f:Filter ←→:Scroll ↑↓:Scroll p:PID c:CPU m:Memory g:GPU-Mem [{sort_indicator}] [{filter_indicator}]"
             )
         } else {
             format!(
-                "h:Help q:Exit f:Filter ←→:Scroll ↑↓:Scroll p:PID m:Memory g:GPU-Mem [{sort_indicator}]"
+                "h:Help q:Exit f:Filter ←→:Scroll ↑↓:Scroll p:PID c:CPU m:Memory g:GPU-Mem [{sort_indicator}]"
             )
         }
     };
@@ -339,6 +339,45 @@ fn fill_remaining<W: Write>(stdout: &mut W, cols: u16, used: usize) {
     let remaining = (cols as usize).saturating_sub(used);
     if remaining > 0 {
         print_colored_text(stdout, &" ".repeat(remaining), Color::White, None, None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print_function_keys;
+    use crate::app_state::{AppState, SortCriteria};
+
+    #[test]
+    fn local_status_bar_advertises_cpu_sort_shortcut_and_indicator() {
+        let mut state = AppState::new();
+        state.sort_criteria = SortCriteria::CpuPercent;
+
+        let mut output = Vec::new();
+        print_function_keys(&mut output, 200, 30, &state, false);
+        let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
+
+        assert!(
+            rendered.contains("c:CPU"),
+            "local status bar must advertise the CPU sort shortcut.\n--- status ---\n{rendered}"
+        );
+        assert!(
+            rendered.contains("Sort:CPU%"),
+            "local status bar must surface the active CPU sort indicator.\n--- status ---\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn remote_status_bar_keeps_cpu_shortcut_hidden() {
+        let state = AppState::new();
+
+        let mut output = Vec::new();
+        print_function_keys(&mut output, 200, 30, &state, true);
+        let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
+
+        assert!(
+            !rendered.contains("c:CPU"),
+            "remote status bar must not advertise the local-only CPU shortcut.\n--- status ---\n{rendered}"
+        );
     }
 }
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -206,6 +206,7 @@ fn render_shortcuts_section(
     if !is_remote {
         left_column.extend(vec![
             ("  P", "Sort processes by PID", "shortcut"),
+            ("  C", "Sort processes by CPU%", "shortcut"),
             ("  M", "Sort processes by memory", "shortcut"),
         ]);
     }
@@ -587,4 +588,38 @@ fn get_current_sort_status(sort_criteria: &crate::app_state::SortCriteria) -> St
         crate::app_state::SortCriteria::Temperature => "Temperature",
     }
     .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_shortcuts_section;
+    use crate::app_state::AppState;
+
+    #[test]
+    fn local_help_advertises_cpu_sort_shortcut() {
+        let state = AppState::new();
+        let shortcuts: String = (0..40)
+            .map(|line| render_shortcuts_section(line, 118, &state, false))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            shortcuts.contains("Sort processes by CPU%"),
+            "local shortcuts must advertise the CPU sort shortcut.\n--- shortcuts ---\n{shortcuts}"
+        );
+    }
+
+    #[test]
+    fn remote_help_hides_local_cpu_sort_shortcut() {
+        let state = AppState::new();
+        let shortcuts: String = (0..40)
+            .map(|line| render_shortcuts_section(line, 118, &state, true))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            !shortcuts.contains("Sort processes by CPU%"),
+            "remote shortcuts must not advertise the local-only CPU sort shortcut.\n--- shortcuts ---\n{shortcuts}"
+        );
+    }
 }

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -346,6 +346,10 @@ fn handle_users_tab_keys(key_event: KeyEvent, state: &mut AppState) -> bool {
             change_users_sort(state, UserSortKey::User);
             true
         }
+        // Local-only CPU sort shortcut. Consume it on the Users tab so
+        // remote-mode behaviour stays unchanged instead of leaking into
+        // the global process-sort handler.
+        KeyCode::Char('c') => true,
         KeyCode::Char('m') => {
             change_users_sort(state, UserSortKey::Memory);
             true
@@ -978,6 +982,7 @@ fn handle_navigation_keys(key_event: KeyEvent, state: &mut AppState, args: &View
         KeyCode::PageUp => handle_page_up(state, args),
         KeyCode::PageDown => handle_page_down(state, args),
         KeyCode::Char('p') => state.sort_criteria = SortCriteria::Pid,
+        KeyCode::Char('c') => state.sort_criteria = SortCriteria::CpuPercent,
         KeyCode::Char('m') => state.sort_criteria = SortCriteria::MemoryPercent,
         KeyCode::Char('u') => state.sort_criteria = SortCriteria::Utilization,
         KeyCode::Char('g') => state.sort_criteria = SortCriteria::GpuMemory,
@@ -1730,6 +1735,34 @@ mod tests {
             state.sort_criteria,
             SortCriteria::MemoryPercent,
             "Users-tab `m` must not leak into the global GPU sort"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_c_key_changes_sort_to_cpu_percent() {
+        let mut state = AppState::new();
+        state.loading = false;
+        state.is_local_mode = true;
+
+        handle_key_event(key(KeyCode::Char('c')), &mut state, &args()).await;
+
+        assert_eq!(
+            state.sort_criteria,
+            SortCriteria::CpuPercent,
+            "`c` in local mode must switch to CPU% sorting"
+        );
+    }
+
+    #[tokio::test]
+    async fn users_tab_c_does_not_leak_into_global_cpu_sort() {
+        let mut state = state_with_users_tab();
+
+        handle_key_event(key(KeyCode::Char('c')), &mut state, &args()).await;
+
+        assert_ne!(
+            state.sort_criteria,
+            SortCriteria::CpuPercent,
+            "Users-tab `c` must not leak into the global CPU sort"
         );
     }
 


### PR DESCRIPTION
## Summary

Add the missing local `c` keyboard binding for CPU sorting in the Processes view and surface that shortcut in the local TUI chrome.

## What changed

- wire `c` in the local navigation handler to `SortCriteria::CpuPercent`
- consume `c` on the remote Users tab so the new local shortcut does not leak into remote-mode behavior
- advertise the CPU shortcut in the local help overlay and bottom status bar
- add regression coverage for the key routing plus the visible shortcut text in help and chrome

## Test plan

- [x] cargo test local_c_key_changes_sort_to_cpu_percent
- [x] cargo test users_tab_c_does_not_leak_into_global_cpu_sort
- [x] cargo test local_help_advertises_cpu_sort_shortcut
- [x] cargo test remote_help_hides_local_cpu_sort_shortcut
- [x] cargo test local_status_bar_advertises_cpu_sort_shortcut_and_indicator
- [x] cargo test remote_status_bar_keeps_cpu_shortcut_hidden
- [x] cargo check --lib --tests

Closes #300
