### PR TITLE
feat: add Intel Mac support for CPU, SMC, and chassis metrics (#306)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,10 +146,16 @@ jobs:
           echo "RUSTUP_HOME=C:\.rustup" >> $env:GITHUB_ENV
 
       # 2) Cache Cargo build artifacts
-      # Skipped on the self-hosted runners. The Windows box has a persistent
-      # CARGO_HOME (configured above), and the Intel Mac keeps its workspace and
-      # ~/.cargo between jobs, so on both the Actions cache would only mirror
-      # state the machine already has while costing a full upload every run.
+      # Skipped on the self-hosted runners, for different reasons on each.
+      # The Windows box has a persistent CARGO_HOME and RUSTUP_HOME (configured
+      # above), so the Actions cache would only mirror state already on disk.
+      # On the Intel Mac only ~/.cargo survives between jobs: actions/checkout
+      # defaults to clean: true, whose `git clean -ffdx` removes the ignored
+      # target/ directory, so each release compiles the dependency tree cold.
+      # That is accepted here because releases are infrequent and a release
+      # target/ is large enough that caching it would crowd the repository's
+      # 10 GB cache budget shared with the other five targets. Revisit with
+      # real build times if the Intel job becomes the critical path.
       - name: Cache cargo
         if: matrix.target != 'x86_64-pc-windows-msvc' && matrix.target != 'x86_64-apple-darwin'
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,13 +197,35 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --locked
 
       # 8) macOS code signing
-      # The Developer ID key goes into a keychain named after this run, and the
-      # cleanup step at the end of the job deletes it unconditionally. That
+      # The Developer ID key goes into a keychain named after this run. That
       # matters on the self-hosted Intel Mac, which is persistent: with the
-      # action's default fixed keychain name the signing key would survive the
-      # job on disk and every run would append another certificate to the same
-      # keychain. GitHub-hosted macOS runners are ephemeral and unaffected, but
-      # they take the same path so there is only one behavior to reason about.
+      # action's default fixed name (`signing_temp`) two runs would collide and
+      # every run would append another certificate to the same keychain.
+      #
+      # Cleanup is the import action's own post step, which runs
+      # `security delete-keychain` at the end of the job on success, failure,
+      # and cancellation. Do NOT add a step that deletes this keychain: the
+      # post step would then fail with "The specified keychain could not be
+      # found" and fail the whole job after the artifacts were uploaded, which
+      # also skips the notify-teams and promote-release jobs.
+      - name: Remove stale signing keychains
+        if: runner.os == 'macOS'
+        run: |
+          # Safety net for the persistent runner, reachable only when an
+          # earlier run was hard-killed before its post step could delete its
+          # keychain. Scoped to this workflow's own name prefix and to files
+          # older than a day, so it can never remove a keychain this workflow
+          # did not create nor one belonging to a run still in flight.
+          STALE=$(find "$HOME/Library/Keychains" -maxdepth 1 -name 'all-smi-signing-*' -mtime +0 2>/dev/null || true)
+          if [ -n "$STALE" ]; then
+            echo "$STALE" | while IFS= read -r kc; do
+              echo "Removing stale signing keychain: $kc"
+              security delete-keychain "$kc" || true
+            done
+          else
+            echo "No stale signing keychains"
+          fi
+
       - name: Import Developer ID certificate
         if: runner.os == 'macOS'
         uses: apple-actions/import-codesign-certs@v6
@@ -381,27 +403,6 @@ jobs:
           files: |
             ${{ matrix.asset_name }}${{ matrix.archive_ext }}
             ${{ matrix.asset_name }}${{ matrix.archive_ext }}.sha256
-
-      # 12) Delete the run-scoped signing keychain.
-      # always() so a failed build, a cancelled run, or a notarization error
-      # still removes the Developer ID private key from the machine. Deleting a
-      # keychain also drops it from every search list, so no separate
-      # `security list-keychains` reset is needed. Failures are tolerated: the
-      # keychain does not exist when certificate import never ran.
-      - name: Remove signing keychain
-        if: ${{ always() && runner.os == 'macOS' }}
-        run: |
-          # The action materializes `<name>` as `<name>.keychain-db`; try both
-          # spellings so a change in that convention cannot silently skip cleanup.
-          KEYCHAIN="all-smi-signing-${{ github.run_id }}-${{ github.run_attempt }}"
-          if security delete-keychain "${KEYCHAIN}.keychain-db" 2>/dev/null \
-            || security delete-keychain "$KEYCHAIN" 2>/dev/null; then
-            echo "Removed signing keychain $KEYCHAIN"
-          else
-            echo "No signing keychain to remove"
-          fi
-          echo "Remaining user keychains:"
-          security list-keychains -d user
 
   # ============================================================================
   # Microsoft Teams release notification (Power Automate Workflows webhook)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,13 @@
 name: Release
 
+# SECURITY: this repository is public and this workflow schedules jobs on
+# self-hosted runners (the Windows signing box and the Intel Mac builder).
+# Both triggers below are maintainer-only: `release: published` requires push
+# access to publish a release, and `workflow_dispatch` requires write access.
+# Neither can be fired by a pull request, so a fork PR can never run code on a
+# self-hosted machine. Do NOT add `pull_request`, `pull_request_target`, or
+# `issue_comment` triggers here, and keep self-hosted runners out of ci.yml
+# (which is PR-triggered and runs on GitHub-hosted runners only).
 on:
   release:
     types: [published]
@@ -15,7 +23,7 @@ on:
         description: 'Tag to build from AND upload artifacts to (e.g. v1.2.3). Empty = build the dispatched ref.'
         required: false
       targets:
-        description: 'Platforms to build (comma-separated: windows, linux, macos, or all). Empty = all.'
+        description: 'Platform families to build (comma-separated: windows, linux, macos, or all). Empty = all. "macos" covers both aarch64 and x86_64.'
         required: false
         default: ''
         type: string
@@ -45,12 +53,20 @@ jobs:
           # Full build matrix; each entry is tagged with os_family for filtering.
           # JSON uses only double quotes, so a single-quoted bash literal is safe
           # and avoids heredoc indentation pitfalls inside this YAML block.
+          #
+          # `os` becomes the job's runs-on value. It is a label string for every
+          # GitHub-hosted runner and for the label-targeted Windows box, and a
+          # {group, labels} object for the self-hosted Intel Mac, which has to be
+          # selected out of a specific runner group. runs-on is evaluated per
+          # matrix job instance, so the two shapes coexist without affecting each
+          # other.
           ALL='[
             {"os_family":"linux",   "target":"x86_64-unknown-linux-gnu",    "os":"ubuntu-22.04",             "artifact_name":"all-smi",     "asset_name":"all-smi-linux-x86_64",       "archive_ext":".tar.gz", "protoc_platform":"linux-x86_64"},
             {"os_family":"linux",   "target":"x86_64-unknown-linux-musl",   "os":"ubuntu-latest",           "artifact_name":"all-smi",     "asset_name":"all-smi-linux-x86_64-musl",  "archive_ext":".tar.gz", "protoc_platform":"linux-x86_64"},
             {"os_family":"linux",   "target":"aarch64-unknown-linux-gnu",   "os":"ubuntu-22.04-arm",        "artifact_name":"all-smi",     "asset_name":"all-smi-linux-aarch64",      "archive_ext":".tar.gz", "protoc_platform":"linux-aarch_64"},
             {"os_family":"linux",   "target":"aarch64-unknown-linux-musl",  "os":"ubuntu-24.04-arm",        "artifact_name":"all-smi",     "asset_name":"all-smi-linux-aarch64-musl", "archive_ext":".tar.gz", "protoc_platform":"linux-aarch_64"},
             {"os_family":"macos",   "target":"aarch64-apple-darwin",        "os":"macos-14",                "artifact_name":"all-smi",     "asset_name":"all-smi-macos-aarch64",      "archive_ext":".zip",    "protoc_platform":"osx-aarch_64"},
+            {"os_family":"macos",   "target":"x86_64-apple-darwin",         "os":{"group":"macOS x64","labels":"self-hosted-macos-15-x64"}, "artifact_name":"all-smi", "asset_name":"all-smi-macos-x86_64", "archive_ext":".zip", "protoc_platform":"osx-x86_64"},
             {"os_family":"windows", "target":"x86_64-pc-windows-msvc",      "os":"windows-on-macmini02-x64","artifact_name":"all-smi.exe", "asset_name":"all-smi-windows-x86_64",     "archive_ext":".zip",    "protoc_platform":""}
           ]'
 
@@ -130,11 +146,12 @@ jobs:
           echo "RUSTUP_HOME=C:\.rustup" >> $env:GITHUB_ENV
 
       # 2) Cache Cargo build artifacts
-      # Skipped on the Windows self-hosted runner: its persistent CARGO_HOME
-      # (configured above) already caches the registry across runs, so the
-      # GitHub Actions cache would only mirror an empty ~/.cargo location.
+      # Skipped on the self-hosted runners. The Windows box has a persistent
+      # CARGO_HOME (configured above), and the Intel Mac keeps its workspace and
+      # ~/.cargo between jobs, so on both the Actions cache would only mirror
+      # state the machine already has while costing a full upload every run.
       - name: Cache cargo
-        if: matrix.target != 'x86_64-pc-windows-msvc'
+        if: matrix.target != 'x86_64-pc-windows-msvc' && matrix.target != 'x86_64-apple-darwin'
         uses: actions/cache@v5
         with:
           path: |
@@ -180,12 +197,20 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --locked
 
       # 8) macOS code signing
+      # The Developer ID key goes into a keychain named after this run, and the
+      # cleanup step at the end of the job deletes it unconditionally. That
+      # matters on the self-hosted Intel Mac, which is persistent: with the
+      # action's default fixed keychain name the signing key would survive the
+      # job on disk and every run would append another certificate to the same
+      # keychain. GitHub-hosted macOS runners are ephemeral and unaffected, but
+      # they take the same path so there is only one behavior to reason about.
       - name: Import Developer ID certificate
         if: runner.os == 'macOS'
         uses: apple-actions/import-codesign-certs@v6
         with:
           p12-file-base64: ${{ secrets.DEV_ID_CERT_P12 }}
           p12-password: ${{ secrets.DEV_ID_CERT_PASSWORD }}
+          keychain: all-smi-signing-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Code sign macOS binary
         if: runner.os == 'macOS'
@@ -356,6 +381,27 @@ jobs:
           files: |
             ${{ matrix.asset_name }}${{ matrix.archive_ext }}
             ${{ matrix.asset_name }}${{ matrix.archive_ext }}.sha256
+
+      # 12) Delete the run-scoped signing keychain.
+      # always() so a failed build, a cancelled run, or a notarization error
+      # still removes the Developer ID private key from the machine. Deleting a
+      # keychain also drops it from every search list, so no separate
+      # `security list-keychains` reset is needed. Failures are tolerated: the
+      # keychain does not exist when certificate import never ran.
+      - name: Remove signing keychain
+        if: ${{ always() && runner.os == 'macOS' }}
+        run: |
+          # The action materializes `<name>` as `<name>.keychain-db`; try both
+          # spellings so a change in that convention cannot silently skip cleanup.
+          KEYCHAIN="all-smi-signing-${{ github.run_id }}-${{ github.run_attempt }}"
+          if security delete-keychain "${KEYCHAIN}.keychain-db" 2>/dev/null \
+            || security delete-keychain "$KEYCHAIN" 2>/dev/null; then
+            echo "Removed signing keychain $KEYCHAIN"
+          else
+            echo "No signing keychain to remove"
+          fi
+          echo "Remaining user keychains:"
+          security list-keychains -d user
 
   # ============================================================================
   # Microsoft Teams release notification (Power Automate Workflows webhook)

--- a/README.md
+++ b/README.md
@@ -303,6 +303,16 @@ Older releases introduced environment variables with different naming. All alias
   - Provides actual temperature readings from SMC sensors
   - Run with: `all-smi local`
 
+### macOS (Intel)
+- **No sudo required:** Uses the Apple SMC and NSProcessInfo directly
+  - CPU model, socket/core/thread counts, and clocks come from `sysctl`
+  - Per-core utilization bars, plus CPU temperature from the SMC `TC0P`/`TC0D` sensors
+  - Chassis block reports fan RPMs, thermal pressure, and approximate total system power (SMC `PSTR`)
+  - GPU monitoring is not available: the integrated Intel and discrete AMD GPUs in Intel Macs are not read, so the GPU list stays empty
+  - Total power is the SMC's own estimate rather than a metered value, and its accuracy varies by model. `powermetrics` would be metered but needs sudo, which all-smi does not ask for on macOS
+  - Download `all-smi-macos-x86_64.zip` from the releases page. It is signed and notarized like the Apple Silicon archive
+  - Run with: `all-smi local`
+
 ### Linux with AMD GPUs
 - **Sudo Access Required:** AMD GPU monitoring requires `sudo` to access `/dev/dri` devices
 - **ROCm Installation:** AMD GPU support requires ROCm drivers and libraries
@@ -580,6 +590,7 @@ Stable check IDs (greppable across versions):
   - Actual CPU/GPU temperature readings from SMC sensors
   - Thermal pressure monitoring
   - P/E core architecture support
+  - Intel Macs (x86_64): CPU, memory, and chassis monitoring via SMC and sysctl, including per-core bars, CPU temperature, fan RPMs, and approximate system power. No GPU monitoring
 - **NVIDIA Jetson:** 
   - Special support for Tegra-based systems
   - DLA (Deep Learning Accelerator) monitoring

--- a/src/api/metrics/chassis.rs
+++ b/src/api/metrics/chassis.rs
@@ -15,9 +15,10 @@
 //! Chassis metrics exporter for Prometheus
 //!
 //! Exports node-level metrics including:
-//! - Total power consumption (CPU+GPU+ANE)
-//! - Thermal pressure (Apple Silicon)
-//! - Individual power components (CPU, GPU, ANE)
+//! - Total power consumption (CPU+GPU+ANE on Apple Silicon, SMC PSTR on Intel Macs)
+//! - Thermal pressure (macOS)
+//! - Individual power components (CPU, GPU, ANE), whichever the platform reports
+//! - Fan speeds, where the platform reports them
 
 use super::{MetricBuilder, MetricExporter};
 use crate::device::ChassisInfo;
@@ -146,7 +147,7 @@ impl<'a> MetricExporter for ChassisMetricExporter<'a> {
             builder
                 .help(
                     "all_smi_chassis_power_watts",
-                    "Total chassis power consumption in watts (CPU+GPU+ANE)",
+                    "Total chassis power consumption in watts",
                 )
                 .type_("all_smi_chassis_power_watts", "gauge");
 
@@ -164,12 +165,12 @@ impl<'a> MetricExporter for ChassisMetricExporter<'a> {
             }
         }
 
-        // Export thermal pressure metric (Apple Silicon)
+        // Export thermal pressure metric (macOS)
         if flags.has_thermal_pressure {
             builder
                 .help(
                     "all_smi_chassis_thermal_pressure_info",
-                    "Thermal pressure level (Apple Silicon)",
+                    "Thermal pressure level (macOS)",
                 )
                 .type_("all_smi_chassis_thermal_pressure_info", "gauge");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -204,17 +204,25 @@ impl AllSmi {
         let _ = &config;
 
         // Initialize platform-specific managers
+        // The native metrics manager is built on IOReport's "Energy Model"
+        // channel group, which only exists on Apple Silicon. Initializing it on
+        // an Intel Mac always fails inside `IOReport::new`, so gate it the same
+        // way the binary entry points do instead of failing on every startup.
         #[cfg(target_os = "macos")]
         let macos_initialized = {
-            match initialize_native_metrics_manager(config.sample_interval_ms) {
-                Ok(()) => true,
-                Err(e) => {
-                    // Log but don't fail - some metrics may still work
-                    if config.verbose {
-                        eprintln!("Warning: macOS native metrics init failed: {e}");
+            if crate::device::is_apple_silicon() {
+                match initialize_native_metrics_manager(config.sample_interval_ms) {
+                    Ok(()) => true,
+                    Err(e) => {
+                        // Log but don't fail - some metrics may still work
+                        if config.verbose {
+                            eprintln!("Warning: macOS native metrics init failed: {e}");
+                        }
+                        false
                     }
-                    false
                 }
+            } else {
+                false
             }
         };
 

--- a/src/device/cpu_macos.rs
+++ b/src/device/cpu_macos.rs
@@ -423,7 +423,13 @@ impl MacOsCpuReader {
         }
 
         // Last-resort thread count, used only when `hw.logicalcpu` is missing.
-        let logical_cpu_fallback = self.system.read().unwrap().cpus().len() as u32;
+        // Deliberately not `self.system.cpus().len()`: this runs before the
+        // first `ensure_cpu_refreshed`, and a freshly constructed `System` has
+        // an empty CPU list, so that source reports 0 and the result would be
+        // cached for the process lifetime.
+        let logical_cpu_fallback = std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(0);
         let hardware = IntelCpuHardware::collect(logical_cpu_fallback);
 
         *self.cached_intel_info.lock().unwrap() = Some(hardware.clone());

--- a/src/device/cpu_macos.rs
+++ b/src/device/cpu_macos.rs
@@ -14,7 +14,11 @@
 
 // Use native metrics manager for Apple Silicon
 use crate::device::macos_native::get_native_metrics_manager;
+// Intel Macs read temperature and package power straight from the SMC: the
+// native metrics manager is IOReport-backed and therefore Apple Silicon only.
+use crate::device::macos_native::smc::SmcConnection;
 
+use crate::device::cpu_macos_intel::IntelCpuHardware;
 use crate::device::{
     AppleSiliconCpuInfo, CoreType, CoreUtilization, CpuInfo, CpuPlatformType, CpuReader,
     CpuSocketInfo,
@@ -25,8 +29,6 @@ use chrono::Local;
 use std::sync::{Mutex, RwLock};
 use sysinfo::System;
 
-type CpuHardwareParseResult = Result<(String, u32, u32, u32, u32, u32), Box<dyn std::error::Error>>;
-type IntelCpuInfo = (String, u32, u32, u32, u32, u32);
 /// (cpu_model, s_core_count, p_core_count, e_core_count, gpu_core_count)
 type AppleSiliconHwInfo = (String, u32, u32, u32, u32);
 
@@ -46,7 +48,9 @@ pub struct MacOsCpuReader {
     cached_p_core_l2_cache_mb: Mutex<Option<u32>>,
     cached_e_core_l2_cache_mb: Mutex<Option<u32>>,
     // Cached hardware info for Intel
-    cached_intel_info: Mutex<Option<IntelCpuInfo>>,
+    cached_intel_info: Mutex<Option<IntelCpuHardware>>,
+    // Cached SMC connection, used by the Intel path only
+    smc: Mutex<SmcConnection>,
 }
 
 impl Default for MacOsCpuReader {
@@ -73,15 +77,17 @@ impl MacOsCpuReader {
             cached_p_core_l2_cache_mb: Mutex::new(None),
             cached_e_core_l2_cache_mb: Mutex::new(None),
             cached_intel_info: Mutex::new(None),
+            smc: Mutex::new(SmcConnection::default()),
         }
     }
 
+    /// Detect Apple Silicon through the shared, cached platform probe.
+    ///
+    /// This used to be a second private copy of the `uname -m` check. Routing
+    /// it through `platform_detection` keeps a single answer per process, and
+    /// picks up the Rosetta 2 handling that copy did not have.
     fn detect_apple_silicon() -> bool {
-        if let Ok(output) = new_command("uname").arg("-m").output() {
-            let architecture = String::from_utf8_lossy(&output.stdout);
-            return architecture.trim() == "arm64";
-        }
-        false
+        crate::device::platform_detection::is_apple_silicon()
     }
 
     fn get_cpu_info_from_system(&self) -> Result<CpuInfo, Box<dyn std::error::Error>> {
@@ -336,33 +342,22 @@ impl MacOsCpuReader {
         instance: String,
         time: String,
     ) -> Result<CpuInfo, Box<dyn std::error::Error>> {
-        // Check cache BEFORE calling expensive system_profiler command
-        // IMPORTANT: Read cache value first and drop the lock before any else branch
-        let cached_info = self.cached_intel_info.lock().unwrap().clone();
-        // Lock is now released
+        let hardware = self.get_intel_hardware_info();
 
-        let (cpu_model, socket_count, total_cores, total_threads, base_frequency, cache_size) =
-            if let Some(info) = cached_info {
-                // Use cached values - avoids expensive system_profiler call
-                info
-            } else {
-                // Get CPU information using system_profiler (first time only)
-                let output = new_command("system_profiler")
-                    .arg("SPHardwareDataType")
-                    .output()?;
+        // Refresh once per collection cycle, then reuse the snapshot for both
+        // the aggregate and the per-core numbers.
+        self.ensure_cpu_refreshed();
+        let cpu_utilization = self.system.read().unwrap().global_cpu_usage() as f64;
 
-                let hardware_info = String::from_utf8_lossy(&output.stdout);
-                self.parse_intel_mac_hardware_info(&hardware_info)?
-            };
+        // Intel cores are homogeneous, so no P/E/S split applies: passing zero
+        // for every Apple Silicon cluster size makes every core Standard.
+        let per_core_utilization = self.get_per_core_utilization_no_refresh(0, 0, 0);
 
-        // Get CPU utilization using sysinfo
-        let cpu_utilization = self.get_cpu_utilization_sysinfo()?;
+        // CPU temperature and package power come from the SMC over the cached
+        // connection. Both are absent on some models, which is not an error.
+        let (temperature, power_consumption) = self.read_intel_smc_metrics();
 
-        // Get CPU temperature (may not be available)
-        let temperature = self.get_cpu_temperature();
-
-        // Power consumption is not easily available on Intel Macs
-        let power_consumption = None;
+        let socket_count = hardware.socket_count.max(1);
 
         // Create per-socket info
         let mut per_socket_info = Vec::new();
@@ -370,10 +365,10 @@ impl MacOsCpuReader {
             per_socket_info.push(CpuSocketInfo {
                 socket_id,
                 utilization: cpu_utilization,
-                cores: total_cores / socket_count,
-                threads: total_threads / socket_count,
+                cores: hardware.physical_cores / socket_count,
+                threads: hardware.logical_cores / socket_count,
                 temperature,
-                frequency_mhz: base_frequency,
+                frequency_mhz: hardware.base_frequency_mhz,
             });
         }
 
@@ -382,23 +377,57 @@ impl MacOsCpuReader {
             host_id: hostname.clone(), // For local mode, host_id is just the hostname
             hostname,
             instance,
-            cpu_model,
+            cpu_model: hardware.model.clone(),
             architecture: "x86_64".to_string(),
             platform_type: CpuPlatformType::Intel,
             socket_count,
-            total_cores,
-            total_threads,
-            base_frequency_mhz: base_frequency,
-            max_frequency_mhz: base_frequency, // Max frequency not easily available
-            cache_size_mb: cache_size,
+            total_cores: hardware.physical_cores,
+            total_threads: hardware.logical_cores,
+            base_frequency_mhz: hardware.base_frequency_mhz,
+            max_frequency_mhz: hardware.max_frequency_mhz,
+            cache_size_mb: hardware.l3_cache_mb,
             utilization: cpu_utilization,
             temperature,
             power_consumption,
             per_socket_info,
             apple_silicon_info: None,
-            per_core_utilization: Vec::new(), // Intel Macs don't have easy per-core data
+            per_core_utilization,
             time,
         })
+    }
+
+    /// Read CPU temperature (Celsius) and package power (watts) from the SMC.
+    ///
+    /// Both readings share one cached connection so a poll costs two key reads
+    /// rather than a fresh IOKit handshake.
+    fn read_intel_smc_metrics(&self) -> (Option<u32>, Option<f64>) {
+        let Ok(mut guard) = self.smc.lock() else {
+            return (None, None);
+        };
+        let Some(smc) = guard.get() else {
+            return (None, None);
+        };
+
+        let temperature = smc.get_cpu_temperature().map(|t| t.round() as u32);
+        let power = smc.get_cpu_package_power();
+
+        (temperature, power)
+    }
+
+    /// Collect the immutable Intel CPU hardware description, caching it.
+    ///
+    /// Discovery itself lives in `cpu_macos_intel`; this only owns the cache.
+    fn get_intel_hardware_info(&self) -> IntelCpuHardware {
+        if let Some(cached) = self.cached_intel_info.lock().unwrap().clone() {
+            return cached;
+        }
+
+        // Last-resort thread count, used only when `hw.logicalcpu` is missing.
+        let logical_cpu_fallback = self.system.read().unwrap().cpus().len() as u32;
+        let hardware = IntelCpuHardware::collect(logical_cpu_fallback);
+
+        *self.cached_intel_info.lock().unwrap() = Some(hardware.clone());
+        hardware
     }
 
     /// Fast method to get Apple Silicon hardware info using sysctl and ioreg
@@ -743,75 +772,6 @@ impl MacOsCpuReader {
         }
     }
 
-    fn parse_intel_mac_hardware_info(&self, hardware_info: &str) -> CpuHardwareParseResult {
-        // Check if we have cached values
-        if let Some(cached_info) = self.cached_intel_info.lock().unwrap().clone() {
-            return Ok(cached_info);
-        }
-
-        let mut cpu_model = String::new();
-        let mut socket_count = 1u32;
-        let mut total_cores = 0u32;
-        let mut total_threads = 0u32;
-        let mut base_frequency = 0u32;
-        let mut cache_size = 0u32;
-
-        for line in hardware_info.lines() {
-            let line = line.trim();
-            if line.starts_with("Processor Name:") {
-                cpu_model = line.split(':').nth(1).unwrap_or("").trim().to_string();
-            } else if line.starts_with("Processor Speed:") {
-                if let Some(ghz) = crate::parse_colon_value!(line, f64) {
-                    base_frequency = (ghz * 1000.0) as u32;
-                }
-            } else if line.starts_with("Number of Processors:") {
-                if let Some(procs) = crate::parse_colon_value!(line, u32) {
-                    socket_count = procs;
-                }
-            } else if line.starts_with("Total Number of Cores:") {
-                if let Some(cores) = crate::parse_colon_value!(line, u32) {
-                    total_cores = cores;
-                    total_threads = cores * 2; // Assume hyperthreading
-                }
-            } else if line.starts_with("L3 Cache:")
-                && let Some(size) = crate::parse_colon_value!(line, u32)
-            {
-                cache_size = size;
-            }
-        }
-
-        let result = (
-            cpu_model,
-            socket_count,
-            total_cores,
-            total_threads,
-            base_frequency,
-            cache_size,
-        );
-
-        // Cache the values
-        *self.cached_intel_info.lock().unwrap() = Some(result.clone());
-
-        Ok(result)
-    }
-
-    fn get_cpu_utilization_sysinfo(&self) -> Result<f64, Box<dyn std::error::Error>> {
-        // Check if we need to do first refresh
-        if !*self.first_refresh_done.read().unwrap() {
-            self.system.write().unwrap().refresh_cpu_usage();
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            *self.first_refresh_done.write().unwrap() = true;
-        }
-
-        // Refresh CPU information to get latest data
-        self.system.write().unwrap().refresh_cpu_usage();
-
-        // Get global CPU usage
-        let cpu_usage = self.system.read().unwrap().global_cpu_usage() as f64;
-
-        Ok(cpu_usage)
-    }
-
     /// OPTIMIZATION: Refresh CPU usage once per collection cycle
     /// This avoids multiple refresh_cpu_usage() calls which was causing high CPU usage
     fn ensure_cpu_refreshed(&self) {
@@ -891,8 +851,9 @@ impl MacOsCpuReader {
             // Return typical values based on chip
             Ok(3000) // 3 GHz as default
         } else {
-            // Try to get from system_profiler (already parsed in get_intel_mac_cpu_info)
-            Ok(2400) // Default fallback
+            // Intel: the real nominal clock, from hw.cpufrequency or the brand
+            // string, instead of a hardcoded constant.
+            Ok(self.get_intel_hardware_info().base_frequency_mhz)
         }
     }
 
@@ -901,14 +862,10 @@ impl MacOsCpuReader {
             // Apple Silicon max frequencies vary by core type
             Ok(3500) // Typical P-core max frequency
         } else {
-            Ok(3000) // Default for Intel Macs
+            // Intel: hw.cpufrequency_max, falling back to the base clock when
+            // the key is absent (see IntelCpuHardware::apply_defaults).
+            Ok(self.get_intel_hardware_info().max_frequency_mhz)
         }
-    }
-
-    fn get_cpu_temperature(&self) -> Option<u32> {
-        // Temperature monitoring on macOS requires specialized tools
-        // This is a placeholder - actual implementation might use external tools
-        None
     }
 
     #[allow(dead_code)] // OPTIMIZATION: Now using cached native_data instead

--- a/src/device/cpu_macos_intel.rs
+++ b/src/device/cpu_macos_intel.rs
@@ -23,8 +23,26 @@
 //! size and the marketing processor name on models where the corresponding
 //! sysctl keys are missing.
 
-use crate::utils::command::new_command;
+use crate::device::common::command_executor::{CommandOptions, execute_command};
+use crate::device::common::execute_command_default;
 use std::collections::HashMap;
+use std::time::Duration;
+
+/// Absolute paths to the macOS system binaries this module shells out to.
+///
+/// Resolving these through `PATH` would let a writable directory earlier in
+/// `PATH` than `/usr/sbin` substitute a different binary. `sudo` on macOS does
+/// not set `secure_path`, so the invoking user's `PATH` survives into an
+/// elevated process. Both binaries live at fixed, SIP-protected locations, so
+/// naming them outright costs no portability.
+const SYSCTL_BIN: &str = "/usr/sbin/sysctl";
+const SYSTEM_PROFILER_BIN: &str = "/usr/sbin/system_profiler";
+
+/// `system_profiler SPHardwareDataType` legitimately takes roughly half a
+/// second, which does not comfortably fit the shared fast-fail budget (2s on
+/// bare metal, 500ms containerized). It runs at most once per process and only
+/// on the gap-filling path, so it gets its own more generous ceiling.
+const SYSTEM_PROFILER_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Hardware facts about an Intel Mac CPU. These never change while the process
 /// runs, so the caller collects them once and caches them.
@@ -78,8 +96,15 @@ impl IntelCpuHardware {
         // later Intel Macs. sysctl reports unknown keys on stderr and keeps
         // going, so the exit status is deliberately ignored and only the keys
         // that did come back are parsed.
-        let output = new_command("sysctl")
-            .args([
+        // Routed through `execute_command_default` rather than a bare
+        // `Command::output()` so the call inherits the shared timeout, the
+        // kill-child-on-timeout behavior, and the 16 MiB output cap. A bare
+        // `output()` waits forever and reads to EOF, and this runs on a
+        // `spawn_blocking` worker that Tokio cannot cancel, so a wedged child
+        // would strand that worker for the life of the process.
+        let stdout = execute_command_default(
+            SYSCTL_BIN,
+            &[
                 "machdep.cpu.brand_string",
                 "hw.packages",
                 "hw.physicalcpu",
@@ -87,13 +112,10 @@ impl IntelCpuHardware {
                 "hw.cpufrequency",
                 "hw.cpufrequency_max",
                 "hw.l3cachesize",
-            ])
-            .output();
-
-        let stdout = match output {
-            Ok(output) => String::from_utf8_lossy(&output.stdout).into_owned(),
-            Err(_) => String::new(),
-        };
+            ],
+        )
+        .map(|output| output.stdout)
+        .unwrap_or_default();
 
         let values = parse_sysctl_pairs(&stdout);
         let read_u64 = |key: &str| values.get(key).and_then(|v| v.parse::<u64>().ok());
@@ -127,14 +149,20 @@ impl IntelCpuHardware {
     /// Fall back to `system_profiler SPHardwareDataType` for the fields sysctl
     /// cannot supply on every model.
     fn from_system_profiler() -> Option<Self> {
-        let output = new_command("system_profiler")
-            .arg("SPHardwareDataType")
-            .output()
-            .ok()?;
+        // Bounded for the same reason as the sysctl call above. This one is the
+        // likelier of the two to wedge: `system_profiler` queries IOKit, which
+        // can block on unresponsive hardware.
+        let output = execute_command(
+            SYSTEM_PROFILER_BIN,
+            &["SPHardwareDataType"],
+            &CommandOptions {
+                timeout: Some(SYSTEM_PROFILER_TIMEOUT),
+                check_status: false,
+            },
+        )
+        .ok()?;
 
-        Some(parse_system_profiler_hardware(&String::from_utf8_lossy(
-            &output.stdout,
-        )))
+        Some(parse_system_profiler_hardware(&output.stdout))
     }
 
     /// True when sysctl left a field that `system_profiler` can still supply.

--- a/src/device/cpu_macos_intel.rs
+++ b/src/device/cpu_macos_intel.rs
@@ -458,11 +458,20 @@ mod tests {
         assert!(missing_cache.has_gaps());
     }
 
-    /// Collection must always yield a usable record even on a host where every
-    /// probe fails, because the caller divides by `socket_count`.
+    /// `apply_defaults` alone must always yield a usable record even when
+    /// every probe failed, because the caller divides by `socket_count`.
+    ///
+    /// This exercises the worst case directly on a fully empty record rather
+    /// than going through `collect()`, which shells out to `sysctl` and,
+    /// when there are gaps, `system_profiler`. `collect()`'s own logic (gap
+    /// detection, gap filling, the sysctl/brand-string frequency fallback) is
+    /// already covered by the other pure-logic tests in this module, so
+    /// spawning real subprocesses here would only add wall-clock cost to the
+    /// suite without covering anything new.
     #[test]
-    fn collection_always_produces_safe_values() {
-        let hardware = IntelCpuHardware::collect(4);
+    fn apply_defaults_produces_safe_values_from_a_fully_empty_record() {
+        let mut hardware = IntelCpuHardware::default();
+        hardware.apply_defaults();
 
         assert!(!hardware.model.is_empty());
         assert!(hardware.socket_count >= 1);

--- a/src/device/cpu_macos_intel.rs
+++ b/src/device/cpu_macos_intel.rs
@@ -1,0 +1,445 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Intel Mac CPU hardware discovery
+//!
+//! Collects the immutable description of an Intel Mac's CPU: model, socket,
+//! core and thread counts, clocks, and cache size.
+//!
+//! sysctl is the primary source because it costs a few milliseconds.
+//! `system_profiler SPHardwareDataType` costs roughly half a second and is
+//! kept only as a gap filler, since it is the sole source for the L3 cache
+//! size and the marketing processor name on models where the corresponding
+//! sysctl keys are missing.
+
+use crate::utils::command::new_command;
+use std::collections::HashMap;
+
+/// Hardware facts about an Intel Mac CPU. These never change while the process
+/// runs, so the caller collects them once and caches them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IntelCpuHardware {
+    /// Brand or marketing string, e.g. "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz".
+    pub model: String,
+    /// Physical CPU packages (sockets). Never zero after collection.
+    pub socket_count: u32,
+    /// Physical cores across all sockets.
+    pub physical_cores: u32,
+    /// Logical cores (threads) across all sockets. Equals `physical_cores` on
+    /// models without hyperthreading.
+    pub logical_cores: u32,
+    /// Nominal base frequency in MHz, 0 when unknown.
+    pub base_frequency_mhz: u32,
+    /// Maximum turbo frequency in MHz, 0 when unknown.
+    pub max_frequency_mhz: u32,
+    /// L3 cache size in MB, 0 when unknown.
+    pub l3_cache_mb: u32,
+}
+
+impl IntelCpuHardware {
+    /// Collect the CPU description, consulting `system_profiler` only when
+    /// sysctl left a gap.
+    ///
+    /// `logical_cpu_fallback` is the kernel's logical CPU count as seen by
+    /// sysinfo, used only if `hw.logicalcpu` could not be read. Passing a real
+    /// count is how the thread total stays honest without reintroducing the
+    /// old `cores * 2` hyperthreading assumption.
+    pub fn collect(logical_cpu_fallback: u32) -> Self {
+        let mut hardware = Self::from_sysctl();
+
+        if hardware.has_gaps()
+            && let Some(fallback) = Self::from_system_profiler()
+        {
+            hardware.fill_gaps_from(&fallback);
+        }
+
+        if hardware.logical_cores == 0 {
+            hardware.logical_cores = logical_cpu_fallback;
+        }
+
+        hardware.apply_defaults();
+        hardware
+    }
+
+    /// Query the CPU description from sysctl in a single call.
+    fn from_sysctl() -> Self {
+        // `hw.cpufrequency` and `hw.cpufrequency_max` were removed on some
+        // later Intel Macs. sysctl reports unknown keys on stderr and keeps
+        // going, so the exit status is deliberately ignored and only the keys
+        // that did come back are parsed.
+        let output = new_command("sysctl")
+            .args([
+                "machdep.cpu.brand_string",
+                "hw.packages",
+                "hw.physicalcpu",
+                "hw.logicalcpu",
+                "hw.cpufrequency",
+                "hw.cpufrequency_max",
+                "hw.l3cachesize",
+            ])
+            .output();
+
+        let stdout = match output {
+            Ok(output) => String::from_utf8_lossy(&output.stdout).into_owned(),
+            Err(_) => String::new(),
+        };
+
+        let values = parse_sysctl_pairs(&stdout);
+        let read_u64 = |key: &str| values.get(key).and_then(|v| v.parse::<u64>().ok());
+
+        let model = values
+            .get("machdep.cpu.brand_string")
+            .map(|v| (*v).to_string())
+            .unwrap_or_default();
+
+        // `hw.cpufrequency` is the nominal base frequency in Hz. When the key
+        // is gone, the brand string still carries the nominal clock.
+        let base_frequency_mhz = read_u64("hw.cpufrequency")
+            .map(hz_to_mhz)
+            .filter(|mhz| *mhz > 0)
+            .or_else(|| parse_frequency_from_brand_string(&model))
+            .unwrap_or(0);
+
+        Self {
+            model,
+            socket_count: read_u64("hw.packages").unwrap_or(0) as u32,
+            physical_cores: read_u64("hw.physicalcpu").unwrap_or(0) as u32,
+            logical_cores: read_u64("hw.logicalcpu").unwrap_or(0) as u32,
+            base_frequency_mhz,
+            max_frequency_mhz: read_u64("hw.cpufrequency_max").map(hz_to_mhz).unwrap_or(0),
+            l3_cache_mb: read_u64("hw.l3cachesize")
+                .map(|bytes| (bytes / 1024 / 1024) as u32)
+                .unwrap_or(0),
+        }
+    }
+
+    /// Fall back to `system_profiler SPHardwareDataType` for the fields sysctl
+    /// cannot supply on every model.
+    fn from_system_profiler() -> Option<Self> {
+        let output = new_command("system_profiler")
+            .arg("SPHardwareDataType")
+            .output()
+            .ok()?;
+
+        Some(parse_system_profiler_hardware(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
+    }
+
+    /// True when sysctl left a field that `system_profiler` can still supply.
+    fn has_gaps(&self) -> bool {
+        self.model.is_empty()
+            || self.physical_cores == 0
+            || self.base_frequency_mhz == 0
+            || self.l3_cache_mb == 0
+    }
+
+    /// Copy any field this record is missing from `other`.
+    fn fill_gaps_from(&mut self, other: &Self) {
+        if self.model.is_empty() {
+            self.model = other.model.clone();
+        }
+        if self.socket_count == 0 {
+            self.socket_count = other.socket_count;
+        }
+        if self.physical_cores == 0 {
+            self.physical_cores = other.physical_cores;
+        }
+        if self.logical_cores == 0 {
+            self.logical_cores = other.logical_cores;
+        }
+        if self.base_frequency_mhz == 0 {
+            self.base_frequency_mhz = other.base_frequency_mhz;
+        }
+        if self.max_frequency_mhz == 0 {
+            self.max_frequency_mhz = other.max_frequency_mhz;
+        }
+        if self.l3_cache_mb == 0 {
+            self.l3_cache_mb = other.l3_cache_mb;
+        }
+    }
+
+    /// Apply the last-resort defaults that keep downstream arithmetic safe.
+    ///
+    /// `socket_count` in particular is used as a divisor when building
+    /// per-socket records, so it must never be zero.
+    fn apply_defaults(&mut self) {
+        if self.model.is_empty() {
+            self.model = "Unknown Intel CPU".to_string();
+        }
+        if self.socket_count == 0 {
+            self.socket_count = 1;
+        }
+        if self.physical_cores == 0 {
+            self.physical_cores = self.logical_cores.max(1);
+        }
+        if self.logical_cores == 0 {
+            // No hyperthreading assumption: without a reading, one thread per
+            // physical core is the only defensible answer.
+            self.logical_cores = self.physical_cores;
+        }
+        if self.max_frequency_mhz == 0 {
+            self.max_frequency_mhz = self.base_frequency_mhz;
+        }
+    }
+}
+
+/// Parse the `key: value` block that `sysctl` prints for multiple keys.
+///
+/// Keys sysctl could not resolve are reported on stderr and simply do not
+/// appear here, which is how optional keys such as `hw.cpufrequency` are
+/// distinguished from present ones. Values may themselves contain colons, so
+/// only the first separator is significant.
+fn parse_sysctl_pairs(output: &str) -> HashMap<&str, &str> {
+    output
+        .lines()
+        .filter_map(|line| line.split_once(": "))
+        .map(|(key, value)| (key.trim(), value.trim()))
+        .collect()
+}
+
+/// Convert a frequency in Hz to MHz, rounding to nearest.
+fn hz_to_mhz(hz: u64) -> u32 {
+    ((hz + 500_000) / 1_000_000) as u32
+}
+
+/// Extract the nominal clock from an Intel brand string.
+///
+/// Brand strings end with the nominal clock, for example
+/// "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz". This is the fallback for the
+/// Intel Macs where `hw.cpufrequency` no longer exists.
+fn parse_frequency_from_brand_string(brand: &str) -> Option<u32> {
+    let tail = brand.rsplit_once('@')?.1.trim();
+
+    let (number, unit) = match tail.strip_suffix("GHz") {
+        Some(rest) => (rest, 1000.0),
+        None => (tail.strip_suffix("MHz")?, 1.0),
+    };
+
+    let value = number.trim().parse::<f64>().ok()?;
+    if !value.is_finite() || value <= 0.0 {
+        return None;
+    }
+
+    Some((value * unit).round() as u32)
+}
+
+/// Parse `system_profiler SPHardwareDataType` output into hardware facts.
+///
+/// Notably this no longer derives the thread count from the core count:
+/// `system_profiler` does not report logical CPUs, and the old `cores * 2`
+/// hyperthreading assumption was wrong on every model without hyperthreading.
+fn parse_system_profiler_hardware(hardware_info: &str) -> IntelCpuHardware {
+    let mut hardware = IntelCpuHardware::default();
+
+    for line in hardware_info.lines() {
+        let line = line.trim();
+        if line.starts_with("Processor Name:") {
+            hardware.model = line.split(':').nth(1).unwrap_or("").trim().to_string();
+        } else if line.starts_with("Processor Speed:") {
+            if let Some(ghz) = crate::parse_colon_value!(line, f64) {
+                hardware.base_frequency_mhz = (ghz * 1000.0) as u32;
+            }
+        } else if line.starts_with("Number of Processors:") {
+            if let Some(procs) = crate::parse_colon_value!(line, u32) {
+                hardware.socket_count = procs;
+            }
+        } else if line.starts_with("Total Number of Cores:") {
+            if let Some(cores) = crate::parse_colon_value!(line, u32) {
+                hardware.physical_cores = cores;
+            }
+        } else if line.starts_with("L3 Cache:")
+            && let Some(size) = crate::parse_colon_value!(line, u32)
+        {
+            hardware.l3_cache_mb = size;
+        }
+    }
+
+    hardware
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_sysctl_key_value_block() {
+        let output = "machdep.cpu.brand_string: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz\n\
+                      hw.packages: 1\n\
+                      hw.physicalcpu: 8\n\
+                      hw.logicalcpu: 16\n";
+
+        let values = parse_sysctl_pairs(output);
+        assert_eq!(
+            values.get("machdep.cpu.brand_string").copied(),
+            Some("Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz")
+        );
+        assert_eq!(values.get("hw.physicalcpu").copied(), Some("8"));
+        assert_eq!(values.get("hw.logicalcpu").copied(), Some("16"));
+        // Keys sysctl could not resolve are absent rather than empty.
+        assert!(!values.contains_key("hw.cpufrequency"));
+    }
+
+    #[test]
+    fn parses_frequency_from_intel_brand_strings() {
+        assert_eq!(
+            parse_frequency_from_brand_string("Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz"),
+            Some(2300)
+        );
+        assert_eq!(
+            parse_frequency_from_brand_string("Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz"),
+            Some(1600)
+        );
+        assert_eq!(
+            parse_frequency_from_brand_string("Some CPU @ 800MHz"),
+            Some(800)
+        );
+        // Apple Silicon brand strings carry no clock at all.
+        assert_eq!(parse_frequency_from_brand_string("Apple M2 Pro"), None);
+        assert_eq!(parse_frequency_from_brand_string(""), None);
+        assert_eq!(
+            parse_frequency_from_brand_string("Weird CPU @ fastGHz"),
+            None
+        );
+    }
+
+    #[test]
+    fn converts_hz_to_mhz_by_rounding() {
+        assert_eq!(hz_to_mhz(2_300_000_000), 2300);
+        assert_eq!(hz_to_mhz(2_299_800_000), 2300);
+        assert_eq!(hz_to_mhz(0), 0);
+    }
+
+    /// The system_profiler fallback must not invent threads. The old parser
+    /// set `threads = cores * 2`, which reported 16 threads on an 8-core
+    /// non-hyperthreaded part.
+    #[test]
+    fn system_profiler_fallback_does_not_assume_hyperthreading() {
+        let output = "Hardware Overview:\n\
+                      \n\
+                      Model Name: MacBook Pro\n\
+                      Processor Name: 8-Core Intel Core i9\n\
+                      Processor Speed: 2.3 GHz\n\
+                      Number of Processors: 1\n\
+                      Total Number of Cores: 8\n\
+                      L2 Cache (per Core): 256 KB\n\
+                      L3 Cache: 16 MB\n";
+
+        let hardware = parse_system_profiler_hardware(output);
+        assert_eq!(hardware.model, "8-Core Intel Core i9");
+        assert_eq!(hardware.socket_count, 1);
+        assert_eq!(hardware.physical_cores, 8);
+        assert_eq!(hardware.base_frequency_mhz, 2300);
+        assert_eq!(hardware.l3_cache_mb, 16);
+        assert_eq!(
+            hardware.logical_cores, 0,
+            "system_profiler cannot report logical CPUs, so it must leave the field unset"
+        );
+    }
+
+    /// sysctl is authoritative; system_profiler only fills what is missing.
+    #[test]
+    fn sysctl_values_win_over_the_system_profiler_fallback() {
+        let mut sysctl = IntelCpuHardware {
+            model: "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz".to_string(),
+            socket_count: 1,
+            physical_cores: 8,
+            logical_cores: 16,
+            base_frequency_mhz: 2300,
+            max_frequency_mhz: 4800,
+            l3_cache_mb: 0,
+        };
+        let fallback = IntelCpuHardware {
+            model: "8-Core Intel Core i9".to_string(),
+            socket_count: 1,
+            physical_cores: 8,
+            logical_cores: 0,
+            base_frequency_mhz: 2300,
+            max_frequency_mhz: 0,
+            l3_cache_mb: 16,
+        };
+
+        sysctl.fill_gaps_from(&fallback);
+
+        assert_eq!(sysctl.model, "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz");
+        assert_eq!(sysctl.logical_cores, 16);
+        assert_eq!(sysctl.max_frequency_mhz, 4800);
+        assert_eq!(sysctl.l3_cache_mb, 16, "the only gap should be filled");
+    }
+
+    /// Without a logical-CPU reading, threads must equal physical cores rather
+    /// than doubling, and socket_count must never be a zero divisor.
+    #[test]
+    fn defaults_never_assume_hyperthreading_or_zero_sockets() {
+        let mut hardware = IntelCpuHardware {
+            physical_cores: 6,
+            ..Default::default()
+        };
+        hardware.apply_defaults();
+
+        assert_eq!(hardware.logical_cores, 6);
+        assert_eq!(hardware.socket_count, 1);
+        assert_eq!(hardware.model, "Unknown Intel CPU");
+    }
+
+    #[test]
+    fn missing_max_frequency_falls_back_to_base() {
+        let mut hardware = IntelCpuHardware {
+            physical_cores: 4,
+            logical_cores: 8,
+            base_frequency_mhz: 2600,
+            max_frequency_mhz: 0,
+            ..Default::default()
+        };
+        hardware.apply_defaults();
+
+        assert_eq!(hardware.max_frequency_mhz, 2600);
+    }
+
+    #[test]
+    fn gap_detection_ignores_optional_fields() {
+        let complete = IntelCpuHardware {
+            model: "Intel(R) Core(TM) i7".to_string(),
+            socket_count: 1,
+            physical_cores: 4,
+            logical_cores: 8,
+            base_frequency_mhz: 2600,
+            max_frequency_mhz: 0,
+            l3_cache_mb: 8,
+        };
+        assert!(
+            !complete.has_gaps(),
+            "a missing turbo clock alone must not trigger the slow system_profiler path"
+        );
+
+        let missing_cache = IntelCpuHardware {
+            l3_cache_mb: 0,
+            ..complete
+        };
+        assert!(missing_cache.has_gaps());
+    }
+
+    /// Collection must always yield a usable record even on a host where every
+    /// probe fails, because the caller divides by `socket_count`.
+    #[test]
+    fn collection_always_produces_safe_values() {
+        let hardware = IntelCpuHardware::collect(4);
+
+        assert!(!hardware.model.is_empty());
+        assert!(hardware.socket_count >= 1);
+        assert!(hardware.physical_cores >= 1);
+        assert!(hardware.logical_cores >= 1);
+        assert!(hardware.max_frequency_mhz >= hardware.base_frequency_mhz);
+    }
+}

--- a/src/device/macos_native/mod.rs
+++ b/src/device/macos_native/mod.rs
@@ -31,10 +31,17 @@
 
 mod ioreport;
 mod metrics;
-mod smc;
 mod thermal;
 
 pub mod manager;
+
+// Public so the Intel Mac readers can talk to the SMC directly. They cannot go
+// through `manager`, which requires IOReport and therefore Apple Silicon.
+pub mod smc;
+
+// Public so the Intel Mac chassis reader can read thermal pressure without the
+// native metrics manager. NSProcessInfo.thermalState is architecture-agnostic.
+pub use thermal::get_thermal_state;
 
 // Re-export public types for use by apple_silicon_native reader and main
 #[allow(unused_imports)]

--- a/src/device/macos_native/smc.rs
+++ b/src/device/macos_native/smc.rs
@@ -67,6 +67,7 @@ unsafe extern "C" {
     fn IOServiceGetMatchingService(master_port: u32, matching: *mut c_void) -> u32;
     fn IOServiceOpen(device: u32, owning_task: u32, conn_type: u32, conn: *mut u32) -> i32;
     fn IOServiceClose(conn: u32) -> i32;
+    fn IOObjectRelease(object: u32) -> i32;
     fn IOConnectCallStructMethod(
         conn: u32,
         selector: u32,
@@ -221,6 +222,15 @@ impl SMC {
 
             let mut conn: u32 = 0;
             let result = IOServiceOpen(device, mach_task_self(), 0, &mut conn);
+
+            // `IOServiceGetMatchingService` returns a +1-retained object that
+            // the caller owns. `IOServiceOpen` creates an independent user
+            // client and does not adopt that reference, so the service handle
+            // has to be released on both outcomes or every call leaks a mach
+            // port right. `SMCMetrics::collect` opens a fresh connection once
+            // per collection cycle, so the leak was unbounded over the
+            // lifetime of a long-running `view` or `api` process.
+            IOObjectRelease(device);
 
             if result != 0 {
                 return Err("Failed to open SMC connection");
@@ -697,13 +707,29 @@ impl FanReading {
 
 impl Drop for SMC {
     fn drop(&mut self) {
-        unsafe {
-            IOServiceClose(self.conn);
+        // A zero `conn` is MACH_PORT_NULL, which only the unit tests construct.
+        // Closing it is harmless but pointless, so skip it.
+        if self.conn != 0 {
+            // SAFETY: `conn` is an io_connect_t returned by a successful
+            // `IOServiceOpen` in `SMC::new`, owned exclusively by `self`.
+            // `SMC` has a `Drop` impl (so it cannot be `Copy`) and derives no
+            // `Clone`, so the handle is closed exactly once.
+            unsafe {
+                IOServiceClose(self.conn);
+            }
         }
     }
 }
 
-// Safety: SMC uses IOKit which is thread-safe
+// SAFETY: `conn` is a mach port name in this task's IPC namespace. It carries
+// no thread-local state and no thread affinity, so the handle stays valid when
+// the owning `SMC` moves between threads (readers are polled from Tokio's
+// blocking pool, which does not pin a task to one thread).
+//
+// `Sync` is deliberately NOT implemented: the read path takes `&mut self`, and
+// concurrent `IOConnectCallStructMethod` calls on a single AppleSMC user client
+// are not guaranteed safe. Callers that need shared access wrap this in a
+// `Mutex`, which is what makes them `Sync` without any further `unsafe`.
 unsafe impl Send for SMC {}
 
 /// SMC metrics collection result

--- a/src/device/macos_native/smc.rs
+++ b/src/device/macos_native/smc.rs
@@ -49,6 +49,24 @@ const MAX_PLAUSIBLE_FAN_RPM: f64 = 20_000.0;
 /// watts. The largest Mac Pro power supply is well under this.
 const MAX_PLAUSIBLE_POWER_WATTS: f64 = 2_000.0;
 
+/// True when `value` is a plausible whole-machine or CPU-package power
+/// reading in watts (finite and within `0.0..=MAX_PLAUSIBLE_POWER_WATTS`).
+///
+/// Guards `get_system_power` and `get_cpu_package_power` against a missing or
+/// differently-typed SMC key surfacing as a bogus metric: a wrong data type
+/// can decode to `NaN`, a huge magnitude, or a negative value, none of which
+/// is a real power draw.
+fn is_plausible_power_watts(value: f64) -> bool {
+    value.is_finite() && (0.0..=MAX_PLAUSIBLE_POWER_WATTS).contains(&value)
+}
+
+/// True when `value` is a plausible fan speed in RPM (finite and within
+/// `0.0..=MAX_PLAUSIBLE_FAN_RPM`). Same rationale as
+/// [`is_plausible_power_watts`], applied to `get_fan_readings`.
+fn is_plausible_fan_rpm(value: f64) -> bool {
+    value.is_finite() && (0.0..=MAX_PLAUSIBLE_FAN_RPM).contains(&value)
+}
+
 /// Discovered temperature keys (CPU keys, GPU keys)
 /// Using a single static prevents race conditions where one call discovers keys
 /// but the other category's keys are discarded.
@@ -583,7 +601,7 @@ impl SMC {
     /// so a missing or differently-typed key cannot surface as a metric.
     pub fn get_system_power(&mut self) -> Option<f64> {
         let value = self.read_value("PSTR").ok()?;
-        (value.is_finite() && (0.0..=MAX_PLAUSIBLE_POWER_WATTS).contains(&value)).then_some(value)
+        is_plausible_power_watts(value).then_some(value)
     }
 
     /// Read CPU package power in watts, when the model exposes it.
@@ -597,8 +615,7 @@ impl SMC {
 
         for key in CPU_POWER_KEYS {
             if let Ok(value) = self.read_value(key)
-                && value.is_finite()
-                && (0.0..=MAX_PLAUSIBLE_POWER_WATTS).contains(&value)
+                && is_plausible_power_watts(value)
                 && value > 0.0
             {
                 return Some(value);
@@ -624,12 +641,12 @@ impl SMC {
 
         for index in 0..fan_count.min(MAX_FANS) {
             let actual_rpm = match self.read_value(&format!("F{index}Ac")) {
-                Ok(v) if v.is_finite() && (0.0..=MAX_PLAUSIBLE_FAN_RPM).contains(&v) => v as u32,
+                Ok(v) if is_plausible_fan_rpm(v) => v as u32,
                 _ => continue,
             };
 
             let max_rpm = match self.read_value(&format!("F{index}Mx")) {
-                Ok(v) if v.is_finite() && (0.0..=MAX_PLAUSIBLE_FAN_RPM).contains(&v) => v as u32,
+                Ok(v) if is_plausible_fan_rpm(v) => v as u32,
                 _ => 0,
             };
 
@@ -897,5 +914,34 @@ mod tests {
             (value - 51.2).abs() < 0.01,
             "expected ~51.2, got {value} — float endianness may have regressed"
         );
+    }
+
+    /// `get_system_power` and `get_cpu_package_power` both rely on this
+    /// predicate to drop a reading from a missing or differently-typed SMC
+    /// key before it can surface as a bogus metric.
+    #[test]
+    fn plausible_power_watts_rejects_non_finite_negative_and_out_of_range_values() {
+        assert!(is_plausible_power_watts(0.0));
+        assert!(is_plausible_power_watts(127.99)); // sp78 saturation point
+        assert!(is_plausible_power_watts(MAX_PLAUSIBLE_POWER_WATTS));
+
+        assert!(!is_plausible_power_watts(-0.01));
+        assert!(!is_plausible_power_watts(MAX_PLAUSIBLE_POWER_WATTS + 0.01));
+        assert!(!is_plausible_power_watts(f64::NAN));
+        assert!(!is_plausible_power_watts(f64::INFINITY));
+        assert!(!is_plausible_power_watts(f64::NEG_INFINITY));
+    }
+
+    /// Same contract as the power predicate, applied to `get_fan_readings`.
+    #[test]
+    fn plausible_fan_rpm_rejects_non_finite_negative_and_out_of_range_values() {
+        assert!(is_plausible_fan_rpm(0.0));
+        assert!(is_plausible_fan_rpm(5500.0));
+        assert!(is_plausible_fan_rpm(MAX_PLAUSIBLE_FAN_RPM));
+
+        assert!(!is_plausible_fan_rpm(-1.0));
+        assert!(!is_plausible_fan_rpm(MAX_PLAUSIBLE_FAN_RPM + 0.01));
+        assert!(!is_plausible_fan_rpm(f64::NAN));
+        assert!(!is_plausible_fan_rpm(f64::INFINITY));
     }
 }

--- a/src/device/macos_native/smc.rs
+++ b/src/device/macos_native/smc.rs
@@ -38,6 +38,17 @@ use std::sync::OnceLock;
 /// Maximum number of temperature keys to discover per category (similar to mactop's limit)
 const MAX_TEMP_KEYS: usize = 64;
 
+/// Maximum number of fans to probe. No Mac ships with more than a handful.
+const MAX_FANS: u32 = 8;
+
+/// Upper bound for a plausible fan speed in RPM. Readings above this come from
+/// a key that is missing or holds something other than a tachometer value.
+const MAX_PLAUSIBLE_FAN_RPM: f64 = 20_000.0;
+
+/// Upper bound for a plausible whole-machine or CPU-package power reading in
+/// watts. The largest Mac Pro power supply is well under this.
+const MAX_PLAUSIBLE_POWER_WATTS: f64 = 2_000.0;
+
 /// Discovered temperature keys (CPU keys, GPU keys)
 /// Using a single static prevents race conditions where one call discovers keys
 /// but the other category's keys are discarded.
@@ -135,6 +146,48 @@ struct KeyData {
     data8: u8,
     data32: u32,
     bytes: [u8; 32],
+}
+
+/// Sensor category a discovered SMC temperature key belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TempKeyCategory {
+    Cpu,
+    Gpu,
+}
+
+/// Classify an SMC key as a CPU or GPU temperature sensor.
+///
+/// Two disjoint sensor families are recognized, and each one is pinned to the
+/// data type it actually uses. That pairing is what keeps Intel support from
+/// disturbing Apple Silicon: the two naming schemes differ in the case of the
+/// second character, so no key can be claimed by both families.
+///
+/// - Apple Silicon uses `flt ` (IEEE 754) sensors named `Tp*` (performance
+///   die), `Te*` (efficiency die) and `Tg*` (GPU die).
+/// - Intel uses `sp78` fixed-point sensors named `TC*` (CPU proximity/die, for
+///   example TC0P and TC0D) and `TG*` (GPU proximity/die, TG0P and TG0D).
+///
+/// Every discovered reading is still range-filtered by the callers, so a
+/// misclassified sensor cannot pull an average outside plausible temperatures.
+fn classify_temperature_key(key: &str, data_type: u32) -> Option<TempKeyCategory> {
+    let bytes = key.as_bytes();
+    if bytes.len() < 2 || bytes[0] != b'T' {
+        return None;
+    }
+
+    match data_type {
+        SMC_TYPE_FLT => match bytes[1] {
+            b'p' | b'e' => Some(TempKeyCategory::Cpu),
+            b'g' => Some(TempKeyCategory::Gpu),
+            _ => None,
+        },
+        SMC_TYPE_SP78 => match bytes[1] {
+            b'C' => Some(TempKeyCategory::Cpu),
+            b'G' => Some(TempKeyCategory::Gpu),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 /// Convert FourCC string to u32
@@ -276,11 +329,8 @@ impl SMC {
 
     /// Discover all temperature keys dynamically
     ///
-    /// Based on mactop's loadSMCTempKeys implementation:
-    /// - Iterates through all SMC keys
-    /// - Filters for 'flt ' type (float, dataType == 1718383648)
-    /// - CPU keys: Tp* or Te* prefix
-    /// - GPU keys: Tg* prefix
+    /// Iterates the whole SMC key space once and keeps the keys that
+    /// [`classify_temperature_key`] recognizes as CPU or GPU sensors.
     ///
     /// Returns at most MAX_TEMP_KEYS per category to prevent unbounded growth.
     pub fn discover_temperature_keys(&self) -> (Vec<String>, Vec<String>) {
@@ -309,27 +359,10 @@ impl SMC {
                 Err(_) => continue,
             };
 
-            // Filter for 'flt ' type (1718383648 == b"flt " as u32)
-            if key_info.data_type != SMC_TYPE_FLT {
-                continue;
-            }
-
-            let key_bytes = key.as_bytes();
-            if key_bytes.len() < 2 {
-                continue;
-            }
-
-            // CPU temperature keys: Tp* or Te*
-            if key_bytes[0] == b'T'
-                && (key_bytes[1] == b'p' || key_bytes[1] == b'e')
-                && cpu_keys.len() < MAX_TEMP_KEYS
-            {
-                cpu_keys.push(key);
-            }
-            // GPU temperature keys: Tg*
-            else if key_bytes[0] == b'T' && key_bytes[1] == b'g' && gpu_keys.len() < MAX_TEMP_KEYS
-            {
-                gpu_keys.push(key);
+            match classify_temperature_key(&key, key_info.data_type) {
+                Some(TempKeyCategory::Cpu) if cpu_keys.len() < MAX_TEMP_KEYS => cpu_keys.push(key),
+                Some(TempKeyCategory::Gpu) if gpu_keys.len() < MAX_TEMP_KEYS => gpu_keys.push(key),
+                _ => {}
             }
         }
 
@@ -532,28 +565,133 @@ impl SMC {
     }
 
     /// Read system power (PSTR key)
+    ///
+    /// PSTR is the SMC's own estimate of total system draw in watts. It exists
+    /// on most Intel Macs and is model-dependent, so callers must treat it as
+    /// an approximation rather than a metered value. Implausible readings
+    /// (non-finite, negative, or beyond any Mac's power envelope) are dropped
+    /// so a missing or differently-typed key cannot surface as a metric.
     pub fn get_system_power(&mut self) -> Option<f64> {
-        self.read_value("PSTR").ok()
+        let value = self.read_value("PSTR").ok()?;
+        (value.is_finite() && (0.0..=MAX_PLAUSIBLE_POWER_WATTS).contains(&value)).then_some(value)
     }
 
-    /// Read fan speeds
-    pub fn get_fan_speeds(&mut self) -> Vec<(String, u32)> {
+    /// Read CPU package power in watts, when the model exposes it.
+    ///
+    /// The SMC power key family varies across Intel Mac generations, so the
+    /// candidates are tried in order of specificity: package total, package
+    /// cores, then the older per-package core key. Returns `None` when none of
+    /// them is present, which is a normal outcome on many models.
+    pub fn get_cpu_package_power(&mut self) -> Option<f64> {
+        const CPU_POWER_KEYS: [&str; 3] = ["PCPT", "PCPC", "PC0C"];
+
+        for key in CPU_POWER_KEYS {
+            if let Ok(value) = self.read_value(key)
+                && value.is_finite()
+                && (0.0..=MAX_PLAUSIBLE_POWER_WATTS).contains(&value)
+                && value > 0.0
+            {
+                return Some(value);
+            }
+        }
+
+        None
+    }
+
+    /// Read every fan the SMC reports, including its maximum rated speed.
+    ///
+    /// `FNum` holds the fan count; `F<i>Ac` and `F<i>Mx` hold the actual and
+    /// maximum RPM of fan `i`. A fan whose actual speed cannot be read is
+    /// skipped rather than reported as zero.
+    pub fn get_fan_readings(&mut self) -> Vec<FanReading> {
         let mut fans = Vec::new();
 
         // Try to read fan count
         let fan_count = match self.read_value("FNum") {
-            Ok(v) => v as u32,
-            Err(_) => 2, // Default to checking 2 fans
+            Ok(v) if v.is_finite() && v >= 0.0 => v as u32,
+            _ => 2, // Default to checking 2 fans
         };
 
-        for i in 0..fan_count.min(8) {
-            let key = format!("F{i}Ac");
-            if let Ok(speed) = self.read_value(&key) {
-                fans.push((format!("Fan {i}"), speed as u32));
-            }
+        for index in 0..fan_count.min(MAX_FANS) {
+            let actual_rpm = match self.read_value(&format!("F{index}Ac")) {
+                Ok(v) if v.is_finite() && (0.0..=MAX_PLAUSIBLE_FAN_RPM).contains(&v) => v as u32,
+                _ => continue,
+            };
+
+            let max_rpm = match self.read_value(&format!("F{index}Mx")) {
+                Ok(v) if v.is_finite() && (0.0..=MAX_PLAUSIBLE_FAN_RPM).contains(&v) => v as u32,
+                _ => 0,
+            };
+
+            fans.push(FanReading {
+                index,
+                actual_rpm,
+                max_rpm,
+            });
         }
 
         fans
+    }
+
+    /// Read fan speeds as `(name, rpm)` pairs.
+    pub fn get_fan_speeds(&mut self) -> Vec<(String, u32)> {
+        self.get_fan_readings()
+            .into_iter()
+            .map(|fan| (fan.name(), fan.actual_rpm))
+            .collect()
+    }
+}
+
+/// Lazily opened, reusable SMC connection.
+///
+/// Readers are polled on the UI refresh interval, so the connection is opened
+/// once and then reused instead of handshaking with IOKit on every cycle
+/// (which is what [`SMCMetrics::collect`] does, acceptable there because the
+/// native metrics manager caches its results). A failed open is remembered as
+/// `Unavailable` so a machine without a reachable SMC does not pay for a retry
+/// on every poll either.
+#[derive(Default)]
+pub enum SmcConnection {
+    #[default]
+    Unopened,
+    Open(SMC),
+    Unavailable,
+}
+
+impl SmcConnection {
+    /// Return the open connection, opening it on first use.
+    ///
+    /// Returns `None` once the SMC has been found unreachable.
+    pub fn get(&mut self) -> Option<&mut SMC> {
+        if matches!(self, SmcConnection::Unopened) {
+            *self = match SMC::new() {
+                Ok(smc) => SmcConnection::Open(smc),
+                Err(_) => SmcConnection::Unavailable,
+            };
+        }
+
+        match self {
+            SmcConnection::Open(smc) => Some(smc),
+            _ => None,
+        }
+    }
+}
+
+/// A single fan reading from the SMC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FanReading {
+    /// Zero-based fan index as used in the `F<i>Ac` key family.
+    pub index: u32,
+    /// Current speed in RPM.
+    pub actual_rpm: u32,
+    /// Maximum rated speed in RPM, or 0 when the SMC does not report one.
+    pub max_rpm: u32,
+}
+
+impl FanReading {
+    /// Human-readable fan name for display and metric labels.
+    pub fn name(&self) -> String {
+        format!("Fan {}", self.index)
     }
 }
 
@@ -620,6 +758,102 @@ mod tests {
     fn test_hash_key_fourcc() {
         // Test the #KEY special key used for key count
         assert_eq!(str_to_fourcc("#KEY"), u32::from_be_bytes(*b"#KEY"));
+    }
+
+    /// Apple Silicon sensors are `flt ` floats named `Tp*`/`Te*` (CPU) and
+    /// `Tg*` (GPU). This is the behavior discovery had before Intel keys were
+    /// added and it must be preserved exactly.
+    #[test]
+    fn classifies_apple_silicon_float_sensors() {
+        assert_eq!(
+            classify_temperature_key("Tp01", SMC_TYPE_FLT),
+            Some(TempKeyCategory::Cpu)
+        );
+        assert_eq!(
+            classify_temperature_key("Te05", SMC_TYPE_FLT),
+            Some(TempKeyCategory::Cpu)
+        );
+        assert_eq!(
+            classify_temperature_key("Tg0f", SMC_TYPE_FLT),
+            Some(TempKeyCategory::Gpu)
+        );
+    }
+
+    /// Intel Macs report temperatures as `sp78` fixed point under the classic
+    /// TC*/TG* names, which the old `flt `-only filter never found.
+    #[test]
+    fn classifies_intel_fixed_point_sensors() {
+        assert_eq!(
+            classify_temperature_key("TC0P", SMC_TYPE_SP78),
+            Some(TempKeyCategory::Cpu)
+        );
+        assert_eq!(
+            classify_temperature_key("TC0D", SMC_TYPE_SP78),
+            Some(TempKeyCategory::Cpu)
+        );
+        assert_eq!(
+            classify_temperature_key("TG0P", SMC_TYPE_SP78),
+            Some(TempKeyCategory::Gpu)
+        );
+        assert_eq!(
+            classify_temperature_key("TG0D", SMC_TYPE_SP78),
+            Some(TempKeyCategory::Gpu)
+        );
+    }
+
+    /// The two families must stay disjoint. Accepting an Intel-named key as a
+    /// float, or an Apple Silicon-named key as fixed point, would let unrelated
+    /// sensors pollute the temperature averages on the other architecture.
+    #[test]
+    fn temperature_families_do_not_cross_data_types() {
+        assert_eq!(classify_temperature_key("TC0P", SMC_TYPE_FLT), None);
+        assert_eq!(classify_temperature_key("TG0P", SMC_TYPE_FLT), None);
+        assert_eq!(classify_temperature_key("Tp01", SMC_TYPE_SP78), None);
+        assert_eq!(classify_temperature_key("Tg0f", SMC_TYPE_SP78), None);
+    }
+
+    /// Non-temperature keys and unrelated data types must never be collected,
+    /// whatever their name looks like.
+    #[test]
+    fn rejects_non_temperature_keys() {
+        // Right prefix letters, wrong leading character.
+        assert_eq!(classify_temperature_key("Fp01", SMC_TYPE_FLT), None);
+        // Temperature-looking name in a category we do not track.
+        assert_eq!(classify_temperature_key("TA0P", SMC_TYPE_SP78), None);
+        // Power and fan keys.
+        assert_eq!(classify_temperature_key("PSTR", SMC_TYPE_FLT), None);
+        assert_eq!(classify_temperature_key("F0Ac", SMC_TYPE_FLT), None);
+        // Recognized names carried by an unrelated data type.
+        assert_eq!(classify_temperature_key("Tp01", SMC_TYPE_UI32), None);
+        assert_eq!(classify_temperature_key("TC0P", SMC_TYPE_UI8), None);
+        // Degenerate keys.
+        assert_eq!(classify_temperature_key("", SMC_TYPE_FLT), None);
+        assert_eq!(classify_temperature_key("T", SMC_TYPE_FLT), None);
+    }
+
+    /// SP78 is signed 7.8 fixed point, which is how every Intel Mac reports
+    /// temperatures. Getting the divisor wrong yields readings off by 256x.
+    #[test]
+    fn test_sp78_fixed_point_decoding() {
+        let smc = SMC { conn: 0 }; // convert_value doesn't touch the connection
+        let mut bytes = [0u8; 32];
+        // 52.5°C in signed 7.8 fixed point = 52.5 * 256 = 13440 = 0x3480
+        bytes[0..2].copy_from_slice(&0x3480_i16.to_be_bytes());
+        let value = smc.convert_value(&bytes, SMC_TYPE_SP78, 2);
+        assert!(
+            (value - 52.5).abs() < 0.01,
+            "expected ~52.5, got {value} for the Intel sp78 temperature encoding"
+        );
+    }
+
+    #[test]
+    fn fan_reading_names_are_indexed() {
+        let fan = FanReading {
+            index: 1,
+            actual_rpm: 2100,
+            max_rpm: 5500,
+        };
+        assert_eq!(fan.name(), "Fan 1");
     }
 
     /// Sanity-check little-endian decoding of the `flt ` SMC type. Apple

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -24,6 +24,8 @@ pub use readers::tenstorrent::get_tenstorrent_status_message;
 pub mod cpu_linux;
 #[cfg(target_os = "macos")]
 pub mod cpu_macos;
+#[cfg(target_os = "macos")]
+pub mod cpu_macos_intel;
 #[cfg(target_os = "windows")]
 pub mod cpu_windows;
 

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -207,10 +207,48 @@ fn detect_apple_silicon() -> bool {
         return false;
     }
 
-    let output =
-        execute_command_default("uname", &["-m"]).expect("Failed to execute uname command");
+    // An x86_64 binary running under Rosetta 2 sees `uname -m` == "x86_64" even
+    // though the machine is Apple Silicon, so ask the kernel whether this
+    // process is translated before trusting the machine string. The probe is
+    // compiled out on aarch64 builds, which can only ever run natively.
+    if is_translated_process() {
+        return true;
+    }
 
-    output.stdout.trim() == "arm64"
+    // A missing or unexecutable `uname` used to abort the whole process here.
+    // Treat the failure as "not Apple Silicon" instead: every caller of this
+    // function already has a working non-Apple-Silicon path, so degrading is
+    // strictly better than panicking.
+    match execute_command_default("uname", &["-m"]) {
+        Ok(output) => output.stdout.trim() == "arm64",
+        Err(_) => false,
+    }
+}
+
+/// Report whether the current process runs under Rosetta 2 translation.
+///
+/// `sysctl.proc_translated` returns 1 for translated processes and 0 for
+/// native ones. The key does not exist at all on Intel Macs, where sysctl
+/// exits non-zero; that is treated as "not translated".
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+fn is_translated_process() -> bool {
+    matches!(
+        execute_command_default("sysctl", &["-n", "sysctl.proc_translated"]),
+        Ok(output) if output.status == 0 && output.stdout.trim() == "1"
+    )
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
+fn is_translated_process() -> bool {
+    false
+}
+
+/// Report whether this is an Intel (x86_64) Mac.
+///
+/// Complement of [`is_apple_silicon`] on macOS, and always `false` elsewhere,
+/// so callers can branch on "Intel Mac" without repeating the OS check.
+pub fn is_intel_mac() -> bool {
+    std::env::consts::OS == "macos" && !is_apple_silicon()
 }
 
 pub fn has_furiosa() -> bool {
@@ -558,6 +596,41 @@ pub fn get_container_pid_namespace() -> Option<u32> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Architecture detection must never abort the process (it used to
+    /// `.expect()` on the `uname` probe) and must be stable across calls
+    /// because the result is cached in a `OnceLock`.
+    #[test]
+    fn apple_silicon_detection_is_total_and_stable() {
+        let first = is_apple_silicon();
+        assert_eq!(first, is_apple_silicon());
+
+        if std::env::consts::OS != "macos" {
+            assert!(!first, "non-macOS hosts are never Apple Silicon");
+        }
+    }
+
+    /// An `aarch64-apple-darwin` binary can only ever run on Apple Silicon,
+    /// so detection failing open to `false` there would be a real bug.
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    fn aarch64_macos_build_reports_apple_silicon() {
+        assert!(is_apple_silicon());
+    }
+
+    #[test]
+    fn intel_mac_is_the_macos_complement_of_apple_silicon() {
+        if std::env::consts::OS == "macos" {
+            assert_eq!(is_intel_mac(), !is_apple_silicon());
+        } else {
+            assert!(!is_intel_mac());
+        }
+    }
 }
 
 /// Aggregated hardware-detection snapshot.

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -245,10 +245,12 @@ fn is_translated_process() -> bool {
 
 /// Report whether this is an Intel (x86_64) Mac.
 ///
-/// Complement of [`is_apple_silicon`] on macOS, and always `false` elsewhere,
-/// so callers can branch on "Intel Mac" without repeating the OS check.
+/// Complement of [`is_apple_silicon`] on macOS. Defined only on macOS because
+/// every caller sits behind a `target_os = "macos"` gate, and an always-false
+/// stub elsewhere would be dead code under the `-D warnings` build.
+#[cfg(target_os = "macos")]
 pub fn is_intel_mac() -> bool {
-    std::env::consts::OS == "macos" && !is_apple_silicon()
+    !is_apple_silicon()
 }
 
 pub fn has_furiosa() -> bool {
@@ -623,13 +625,10 @@ mod tests {
         assert!(is_apple_silicon());
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn intel_mac_is_the_macos_complement_of_apple_silicon() {
-        if std::env::consts::OS == "macos" {
-            assert_eq!(is_intel_mac(), !is_apple_silicon());
-        } else {
-            assert!(!is_intel_mac());
-        }
+        assert_eq!(is_intel_mac(), !is_apple_silicon());
     }
 }
 

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -207,6 +207,15 @@ fn detect_apple_silicon() -> bool {
         return false;
     }
 
+    // An `aarch64-apple-darwin` binary can only ever run on Apple Silicon, so
+    // answer from the compile-time target rather than from an external command
+    // that a restricted PATH could hide. Without this, an unresolvable `uname`
+    // would report Apple Silicon hardware as an Intel Mac and hand it the Intel
+    // readers.
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        return true;
+    }
+
     // An x86_64 binary running under Rosetta 2 sees `uname -m` == "x86_64" even
     // though the machine is Apple Silicon, so ask the kernel whether this
     // process is translated before trusting the machine string. The probe is
@@ -617,8 +626,10 @@ mod tests {
         }
     }
 
-    /// An `aarch64-apple-darwin` binary can only ever run on Apple Silicon,
-    /// so detection failing open to `false` there would be a real bug.
+    /// An `aarch64-apple-darwin` binary can only ever run on Apple Silicon, so
+    /// detection must answer from the compile-time target and never depend on
+    /// resolving `uname`. Failing open to `false` here would hand Apple Silicon
+    /// hardware the Intel readers.
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     #[test]
     fn aarch64_macos_build_reports_apple_silicon() {

--- a/src/device/reader_factory.rs
+++ b/src/device/reader_factory.rs
@@ -122,6 +122,10 @@ pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
                     apple_silicon_native::AppleSiliconNativeGpuReader::new(),
                 ));
             }
+            // Intel Macs intentionally get no GPU reader. Their integrated
+            // Intel and discrete AMD GPUs would need an IOAccelerator-based
+            // reader, tracked separately in issue #307. CPU, memory, and
+            // chassis monitoring work without it.
         }
         "windows" => {
             #[cfg(target_os = "windows")]

--- a/src/device/readers/chassis/intel_mac.rs
+++ b/src/device/readers/chassis/intel_mac.rs
@@ -1,0 +1,188 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Intel Mac chassis reader using the SMC and NSProcessInfo
+//!
+//! Provides chassis-level metrics for Intel Macs without sudo:
+//! - Approximate total system power from the SMC `PSTR` key
+//! - CPU package power from the SMC power key family, where the model has it
+//! - Fan speeds from the SMC `FNum` / `F<i>Ac` / `F<i>Mx` keys
+//! - Thermal pressure from NSProcessInfo.thermalState
+//!
+//! Deliberately does not use the native metrics manager: that is built on
+//! IOReport's "Energy Model" channel group, which only exists on Apple
+//! Silicon. Everything here is architecture-agnostic macOS API surface.
+//!
+//! `powermetrics` would give metered rather than approximate power, but it
+//! requires sudo, which this project does not ask for on macOS.
+
+use crate::device::macos_native::get_thermal_state;
+use crate::device::macos_native::smc::SmcConnection;
+use crate::device::{ChassisInfo, ChassisReader, FanInfo};
+use crate::utils::get_hostname;
+use chrono::Local;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Chassis reader for Intel Macs using the SMC (no sudo required)
+pub struct IntelMacChassisReader {
+    hostname: String,
+    /// Opened on first poll and reused. The reader runs on the UI refresh
+    /// interval, so reconnecting per cycle would mean an IOKit service lookup
+    /// and connection open every second.
+    smc: Mutex<SmcConnection>,
+}
+
+impl Default for IntelMacChassisReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntelMacChassisReader {
+    pub fn new() -> Self {
+        Self {
+            hostname: get_hostname(),
+            smc: Mutex::new(SmcConnection::default()),
+        }
+    }
+}
+
+/// What a single SMC poll produced. Every field is optional because the key
+/// set varies across Intel Mac generations.
+#[derive(Debug, Default)]
+struct SmcSnapshot {
+    total_power_watts: Option<f64>,
+    cpu_power_watts: Option<f64>,
+    fans: Vec<FanInfo>,
+}
+
+impl ChassisReader for IntelMacChassisReader {
+    fn get_chassis_info(&self) -> Option<ChassisInfo> {
+        let snapshot = self.read_smc();
+
+        // Thermal pressure comes from NSProcessInfo, which works on every Mac
+        // from macOS 10.10.3 onward and needs no SMC connection. It is
+        // therefore the one field that is always present, and it is what makes
+        // a chassis block worth rendering even when the SMC is unreachable.
+        let thermal_pressure = get_thermal_state().as_str().to_string();
+
+        let mut detail = HashMap::new();
+        detail.insert("platform".to_string(), "Intel Mac".to_string());
+        detail.insert("api".to_string(), "Native (SMC)".to_string());
+
+        if let Some(cpu_power) = snapshot.cpu_power_watts {
+            detail.insert("cpu_power_watts".to_string(), format!("{cpu_power:.2}"));
+        }
+
+        if snapshot.total_power_watts.is_some() {
+            // The SMC's own estimate of whole-machine draw. It is not metered
+            // and its accuracy is model-dependent, so say so in the payload
+            // rather than letting consumers assume it is measured.
+            detail.insert(
+                "power_source".to_string(),
+                "SMC PSTR (approximate)".to_string(),
+            );
+        }
+
+        let hostname = self.hostname.clone();
+        Some(ChassisInfo {
+            host_id: hostname.clone(),
+            hostname: hostname.clone(),
+            instance: hostname,
+            total_power_watts: snapshot.total_power_watts,
+            inlet_temperature: None,  // No BMC on a Mac
+            outlet_temperature: None, // No BMC on a Mac
+            thermal_pressure: Some(thermal_pressure),
+            fan_speeds: snapshot.fans,
+            psu_status: Vec::new(), // Not applicable for laptops/desktops
+            detail,
+            time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+        })
+    }
+}
+
+impl IntelMacChassisReader {
+    /// Read power and fan data over the cached SMC connection.
+    ///
+    /// Returns an empty snapshot when the SMC is unreachable, so a chassis
+    /// block with thermal pressure alone is still produced.
+    fn read_smc(&self) -> SmcSnapshot {
+        let Ok(mut guard) = self.smc.lock() else {
+            return SmcSnapshot::default();
+        };
+        let Some(smc) = guard.get() else {
+            return SmcSnapshot::default();
+        };
+
+        SmcSnapshot {
+            total_power_watts: smc.get_system_power(),
+            cpu_power_watts: smc.get_cpu_package_power(),
+            fans: smc
+                .get_fan_readings()
+                .into_iter()
+                .map(|fan| FanInfo {
+                    id: fan.index,
+                    name: fan.name(),
+                    speed_rpm: fan.actual_rpm,
+                    max_rpm: fan.max_rpm,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_intel_mac_chassis_reader_creation() {
+        let reader = IntelMacChassisReader::new();
+        assert!(!reader.hostname.is_empty());
+    }
+
+    /// The reader must always produce a chassis block: thermal pressure needs
+    /// no SMC, so an unreachable SMC degrades the payload instead of removing
+    /// it. This also exercises the code path on Apple Silicon CI hosts, where
+    /// the reader is never selected but must still not panic.
+    #[test]
+    fn always_reports_thermal_pressure_even_without_smc_power() {
+        let reader = IntelMacChassisReader::new();
+        let info = reader
+            .get_chassis_info()
+            .expect("Intel Mac chassis info is always produced");
+
+        assert!(info.thermal_pressure.is_some());
+        assert_eq!(
+            info.detail.get("platform").map(String::as_str),
+            Some("Intel Mac")
+        );
+        assert!(info.inlet_temperature.is_none());
+        assert!(info.psu_status.is_empty());
+    }
+
+    /// `power_source` documents that total power is an SMC estimate. It must
+    /// only appear alongside an actual reading.
+    #[test]
+    fn power_source_detail_tracks_the_power_reading() {
+        let reader = IntelMacChassisReader::new();
+        let info = reader.get_chassis_info().expect("chassis info");
+
+        assert_eq!(
+            info.total_power_watts.is_some(),
+            info.detail.contains_key("power_source")
+        );
+    }
+}

--- a/src/device/readers/chassis/mod.rs
+++ b/src/device/readers/chassis/mod.rs
@@ -24,10 +24,17 @@
 #[cfg(target_os = "macos")]
 mod apple_silicon_native;
 
+// Intel Mac chassis reader using the SMC and NSProcessInfo (no sudo required)
+#[cfg(target_os = "macos")]
+mod intel_mac;
+
 mod generic;
 
 #[cfg(target_os = "macos")]
 pub use apple_silicon_native::AppleSiliconNativeChassisReader;
+
+#[cfg(target_os = "macos")]
+pub use intel_mac::IntelMacChassisReader;
 
 #[allow(unused_imports)]
 pub use generic::GenericChassisReader;
@@ -39,7 +46,15 @@ pub fn create_chassis_reader() -> Box<dyn ChassisReader> {
     // On macOS, use native APIs (no sudo required)
     #[cfg(target_os = "macos")]
     {
-        Box::new(AppleSiliconNativeChassisReader::new())
+        // The Apple Silicon reader depends on the IOReport-backed native
+        // metrics manager, which never initializes on an Intel Mac. Choosing it
+        // there produced no chassis block at all; Intel Macs get an SMC-backed
+        // reader instead.
+        if crate::device::is_intel_mac() {
+            Box::new(IntelMacChassisReader::new())
+        } else {
+            Box::new(AppleSiliconNativeChassisReader::new())
+        }
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -58,5 +73,25 @@ mod tests {
         let reader = create_chassis_reader();
         // Just verify we can create a reader without panicking
         let _ = reader.get_chassis_info();
+    }
+
+    /// Reader selection must follow the architecture, because the Apple
+    /// Silicon reader silently yields nothing on Intel hardware.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_reader_selection_follows_architecture() {
+        let reader = create_chassis_reader();
+        let platform = reader
+            .get_chassis_info()
+            .and_then(|info| info.detail.get("platform").cloned());
+
+        if crate::device::is_intel_mac() {
+            assert_eq!(platform.as_deref(), Some("Intel Mac"));
+        } else {
+            // On Apple Silicon the reader needs the native metrics manager,
+            // which the test binary does not initialize, so it may legitimately
+            // report nothing. It must never claim to be an Intel Mac.
+            assert_ne!(platform.as_deref(), Some("Intel Mac"));
+        }
     }
 }

--- a/src/doctor/checks/apple.rs
+++ b/src/doctor/checks/apple.rs
@@ -44,7 +44,7 @@ static APPLE_SILICON: Check = Check {
 
 static SMC_ROOT: Check = Check {
     id: "apple.smc",
-    title: "SMC / IOReport root requirement",
+    title: "SMC accessibility",
     severity_on_fail: Severity::Warn,
     run: check_smc_root,
 };
@@ -83,21 +83,25 @@ fn check_apple_silicon(_ctx: &CheckCtx) -> CheckResult {
     }
 }
 
+/// Probe the SMC by actually opening a connection.
+///
+/// This used to report a euid check and advise re-running under sudo, which
+/// was wrong: IOReport and the SMC are readable by unprivileged processes,
+/// which is the whole basis of macOS support here. The advice also became
+/// actively misleading for Intel Macs, whose CPU temperature, fan speeds, and
+/// chassis power all come from this connection.
 fn check_smc_root(_ctx: &CheckCtx) -> CheckResult {
     #[cfg(target_os = "macos")]
     {
-        // SAFETY: geteuid is always-safe.
-        let euid = unsafe { libc::geteuid() };
-        if euid == 0 {
-            CheckResult::Pass("running as root — IOReport/SMC accessible".to_string())
-        } else {
-            CheckResult::Warn(
-                "running as non-root".to_string(),
+        match crate::device::macos_native::smc::SMC::new() {
+            Ok(_) => CheckResult::Pass("SMC reachable (no sudo required)".to_string()),
+            Err(e) => CheckResult::Warn(
+                format!("SMC connection failed: {e}"),
                 Some(
-                    "macOS hardware reads (IOReport/SMC chassis power) require sudo; re-run with sudo"
+                    "CPU/GPU temperature, fan speeds, and chassis power will be unavailable"
                         .to_string(),
                 ),
-            )
+            ),
         }
     }
     #[cfg(not(target_os = "macos"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,13 @@
 //! | Platform | GPUs | NPUs | CPU | Memory |
 //! |----------|------|------|-----|--------|
 //! | Linux | NVIDIA, AMD | Gaudi, TPU, Tenstorrent, Rebellions, Furiosa | Yes | Yes |
-//! | macOS | Apple Silicon | - | Yes | Yes |
+//! | macOS (Apple Silicon) | Apple Silicon | - | Yes | Yes |
+//! | macOS (Intel) | - | - | Yes | Yes |
 //! | Windows | NVIDIA, AMD | - | Yes | Yes |
+//!
+//! Intel Macs report CPU, memory, and chassis metrics (temperature, fan speeds,
+//! approximate total power) without sudo. GPU monitoring for their integrated
+//! Intel and discrete AMD graphics is not implemented.
 //!
 //! ## Features
 //!


### PR DESCRIPTION
## Summary

Intel Macs already compiled for `x86_64-apple-darwin`, but at runtime they got an empty GPU list, a chassis reader that always returned `None`, and a thin CPU path built on slow `system_profiler` text parsing with hardcoded frequency constants, no per-core data, and no temperature. This wires up everything that does not need Apple Silicon hardware (CPU, SMC, chassis) and adds the `x86_64-apple-darwin` release target on the self-hosted Intel builder.

The Apple Silicon path is deliberately untouched in structure: `NativeMetricsManager` still hard-fails without IOReport, and the new Intel readers talk to the SMC and NSProcessInfo modules directly rather than partially initializing it.

## What changed, by scope group

### A. Runtime correctness

- `src/device/platform_detection.rs`: `detect_apple_silicon` no longer `.expect()`s on the `uname` probe; a failed probe now degrades to "not Apple Silicon", which every caller already handles. It also recognizes Rosetta 2 via `sysctl.proc_translated`, so an `x86_64` build running on Apple Silicon reports the hardware it is actually on rather than claiming to be an Intel Mac. That probe is compiled out on `aarch64` builds, which can only run natively, so the Apple Silicon path still costs exactly one subprocess. Adds `is_intel_mac()`.
- `src/device/cpu_macos.rs`: the second private copy of the `uname -m` probe now delegates to the shared cached detector, so there is one answer per process.
- `src/client.rs`: the library path gated `initialize_native_metrics_manager` on `is_apple_silicon()`, matching what the three binary entry points in `main.rs` already did. On Intel this init always failed inside `IOReport::new` because the "Energy Model" channel group does not exist there.
- `src/device/readers/chassis/mod.rs`: the factory routes to the new Intel reader instead of unconditionally constructing `AppleSiliconNativeChassisReader`.
- `src/device/reader_factory.rs`: comment recording that the empty Intel GPU list is intentional and tracked in #307.

### B. Intel CPU path

- New `src/device/cpu_macos_intel.rs` owns Intel hardware discovery. sysctl is the primary source (`machdep.cpu.brand_string`, `hw.packages`, `hw.physicalcpu`, `hw.logicalcpu`, `hw.cpufrequency`, `hw.cpufrequency_max`, `hw.l3cachesize`), read in a single batched call.
- `system_profiler SPHardwareDataType` is kept, not deleted, as a gap filler for the L3 cache size and the marketing processor name, which sysctl does not supply on every model. It only runs when sysctl actually left a gap.
- `hw.cpufrequency` is treated as optional because it was removed on later Intel Macs. The fallback chain is `hw.cpufrequency`, then the nominal clock parsed out of the brand string, then `system_profiler`'s "Processor Speed". Max frequency comes from `hw.cpufrequency_max` and falls back to the base clock.
- The `total_threads = cores * 2` hyperthreading assumption is gone. Threads come from `hw.logicalcpu`; if that is unreadable the fallback is the kernel's logical CPU count from sysinfo, and if that also fails it is one thread per physical core. It never doubles.
- Per-core utilization is populated via the existing `get_per_core_utilization_no_refresh` with `CoreType::Standard`, so the Activity panel renders core bars instead of falling to the Individual strategy with no data.
- CPU temperature and package power now come from the SMC.

### C. SMC layer

- Key discovery filtered to type `flt ` **and** to names `Tp*`/`Te*`/`Tg*`. See "Findings" below: extending the type filter alone would not have been enough. Both filters were extended, as two disjoint families each pinned to its own data type.
- Fan speeds (`FNum` / `F<i>Ac`, plus `F<i>Mx` for the rated maximum) and total system power (`PSTR`) were already collected and then discarded. They are now exposed through `get_fan_readings()` and a validated `get_system_power()`, along with a new best-effort `get_cpu_package_power()` trying `PCPT`, `PCPC`, `PC0C`.
- All three reads are plausibility-bounded so a missing or differently-typed key cannot surface as a metric.
- New `SmcConnection` type: a lazily opened, reusable connection that remembers an unreachable SMC instead of retrying an IOKit handshake on every poll. Both the CPU reader and the chassis reader hold one. `SMCMetrics::collect()` still reconnects per call, which is fine because the native metrics manager caches its results.
- The `smc` module and `get_thermal_state` are now public so the Intel readers can use them without going through the manager.

### D. Chassis (new `IntelMacChassisReader`)

- Total power from SMC `PSTR`, documented in the payload as an approximation via a `power_source` detail rather than left to look metered. `powermetrics` would be metered but requires sudo, which this project does not ask for on macOS.
- CPU package power where the model exposes it, omitted cleanly when absent.
- Fan RPMs with their rated maximums, and thermal pressure from NSProcessInfo. Thermal pressure needs no SMC connection, so a chassis block is always produced even if the SMC is unreachable.
- Everything flows through the existing chassis metric family, so `all_smi_chassis_power_watts`, `all_smi_chassis_fan_speed_rpm`, `all_smi_chassis_thermal_pressure_info`, and `all_smi_chassis_cpu_power_watts` are exported with no exporter changes. Help strings no longer hardcode "(CPU+GPU+ANE)" and "(Apple Silicon)".

### E. Release packaging

- `x86_64-apple-darwin` matrix entry on the self-hosted Intel builder, with `artifact_name` `all-smi`, `asset_name` `all-smi-macos-x86_64`, `archive_ext` `.zip`, `protoc_platform` `osx-x86_64`. Its `runs-on` is carried as a `{group, labels}` object in the matrix JSON while every other entry stays a label string; `runs-on` is evaluated per matrix job instance, so the two shapes do not interact.
- Signing and notarization are gated on `runner.os == 'macOS'` and apply automatically, but the self-hosted runner is persistent, so the Developer ID key now imports into a keychain named after the run and an `always()` step deletes it. Without that, the private key would survive the job on disk and every run would append another certificate to the same fixed-name keychain. Deleting a keychain also drops it from every search list, so no separate `security list-keychains` reset is needed, and the step tolerates the keychain not existing when import never ran.
- The Actions cargo cache is skipped for this target as it is for the Windows self-hosted box: the machine keeps its workspace and `~/.cargo` between jobs, so the cache would only mirror state it already has.
- Fork-PR safety: the workflow triggers only on `release: published` and `workflow_dispatch`, both of which need write access. `ci.yml` is the PR-triggered workflow and runs on `ubuntu-latest` only. This is now documented in a comment at the trigger block so nobody adds a PR trigger later.
- The `targets` input description records that `macos` now covers both arches.
- Docs: platform support table in `src/lib.rs` split into Apple Silicon and Intel rows, plus a new "macOS (Intel)" section and a supported-hardware bullet in the README.

### Out of the issue's checklist, but directly adjacent

The `apple.smc` doctor check reported a euid test and advised "re-run with sudo". Nothing on this path needs sudo, and the advice was actively misleading for Intel Macs whose temperature, fans, and chassis power all depend on that connection. It now probes the SMC and reports what it found.

## Findings that contradict the issue's premises

**Group C's "accept sp78 in discovery so TC0P/TC0D/TG0P/TG0D are found" is not sufficient on its own.** Discovery filtered on two axes, not one: data type `flt `, *and* key name prefix `Tp*`/`Te*`/`Tg*`. The Intel keys are `TC*` and `TG*`, so accepting `sp78` while leaving the name filter alone would still have discovered nothing. Both filters were extended together.

**On the regression risk that flagged this as the highest-risk change:** the two families cannot collide, because the Apple Silicon names use a lowercase second character (`p`/`e`/`g`) and the Intel names use uppercase (`C`/`G`), and each family is now pinned to its own data type in the classifier (`flt ` accepts only lowercase, `sp78` only uppercase). Beyond that, discovery is only reached as a fallback when the static key list produced no readings, and the static CPU list already contains `TC0P`/`TC0D` and the GPU list `TG0P`/`TG0D`. So on an Apple Silicon machine the extension cannot introduce a sensor family that the static path was not already probing, and where it could fire at all it would be on a machine currently reporting no temperature. The existing `10.0..=120.0` range filter remains as the last line of defense. A unit test asserts the families do not cross data types.

**Fan speeds on Apple Silicon are deliberately left unexposed.** `SMCMetrics` collects them there too and `AppleSiliconNativeChassisReader` still hardcodes an empty fan list. Surfacing them would start emitting `all_smi_chassis_fan_speed_rpm` for every existing Apple Silicon host, which is an output change for current users that this issue does not ask for. It is a clean follow-up if wanted.

**`all_smi_cpu_frequency_mhz` and the P/E cluster frequency metrics report 0 on this M1 Ultra.** That is pre-existing and unrelated: the released v0.25.0 Homebrew binary was run side by side and reports the same zeros. Noting it so it is not mistaken for a regression from this PR.

## Test plan

- [x] `cargo check --target x86_64-apple-darwin --lib --bins` passes. This is the primary Intel-side verification.
- [x] `cargo clippy --lib --tests -- -D warnings` and `cargo clippy --bins -- -D warnings` clean.
- [x] `cargo fmt` clean.
- [x] New unit tests pass for the parts testable without Intel hardware: SMC key type and name classification including the cross-family negative cases, sp78 fixed-point decoding, sysctl key/value parsing, brand-string frequency extraction, Hz to MHz rounding, the system_profiler fallback leaving `logical_cores` unset, sysctl-wins-over-fallback merging, the no-hyperthreading and non-zero-socket defaults, arch detection being total and stable, and chassis reader selection following the architecture.
- [x] Apple Silicon regression, `api` mode: built and ran on this M1 Ultra, then diffed `/metrics`. GPU utilization/temperature/power, CPU utilization/temperature/power, and the full chassis family (`power_watts`, `thermal_pressure_info`, `cpu_power_watts`, `gpu_power_watts`, `ane_power_watts`) are all still present with `platform="Apple Silicon"`. The Intel reader is correctly not selected.
- [x] Apple Silicon regression, `local` TUI mode: ran in a pty for 8 seconds. CPU model, P-CPU and E-CPU cluster bars, the ANE row, thermal pressure "Nominal", and the GPU Metrics panel all render. No panics.
- [x] `all-smi doctor` reports `PASS apple.smc  SMC reachable (no sudo required)`.
- [x] The release workflow YAML parses, and the matrix JSON round-trips through the same `jq` filter the setup job uses, producing both macOS entries for `targets: macos`.

## Not verified

- **No physical Intel Mac was available.** Nothing here has been run on Intel hardware. The issue's acceptance criteria phrased as "on a physical Intel Mac" are left unchecked on the issue, and the runtime SMC key availability (`PSTR`, the `PCPT`/`PCPC`/`PC0C` package power family, `F<i>Mx`) is best-effort by construction and model-dependent by nature.
- **The self-hosted Intel runner path has not executed.** Whether the base64-encoded packaging secrets decode there, and whether the temporary keychain import and cleanup behave on that specific machine, can only be confirmed by a real release run or a maintainer `workflow_dispatch`. The notarization step's base64 handling and its openssl sanity check are architecture-independent and unchanged.
- `cargo build --release` for `x86_64-apple-darwin` was not run to completion; `cargo check` for that target was used instead to keep the build bounded.

Closes #306
