### PR TITLE
chore(ci): serve the Intel Mac artifact from the Homebrew formula

### DIFF
--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -92,6 +92,36 @@ jobs:
           fetch linux_arm "${BASE}/all-smi-linux-aarch64.tar.gz" tmp/linux-arm.tar.gz
           fetch linux_x86 "${BASE}/all-smi-linux-x86_64.tar.gz"  tmp/linux-x86.tar.gz
 
+          # The Intel Mac zip only exists from the release that first built
+          # x86_64-apple-darwin onwards (#306), so its absence is a normal state
+          # for older tags rather than an error, and re-running this workflow
+          # against one of them has to keep working.
+          #
+          # Presence is decided from the release's asset list, not from whether a
+          # download failed. curl cannot tell "this release never published that
+          # asset" apart from "the network dropped", and quietly reading a
+          # transient failure as absence is how an artifact stops being published
+          # without anyone noticing. The list is fetched into a variable first
+          # because a pipeline inside `if` suppresses errexit, which would put
+          # that same conflation back in through the API call. Whatever the
+          # release does list goes through the same hard-failing `fetch` as
+          # everything else, integrity check included. What absence means is
+          # decided in the next step, which knows whether the formula still
+          # expects an Intel artifact.
+          #
+          # -x because the release also carries `<asset>.sha256` sidecars, and an
+          # unanchored match would accept one of those as the asset itself.
+          ASSETS=$(gh api "repos/${{ github.repository }}/releases/tags/v${VERSION}" --jq '.assets[].name')
+          if printf '%s\n' "$ASSETS" | grep -qx "all-smi-macos-x86_64.zip"; then
+            fetch mac_x86 "${BASE}/all-smi-macos-x86_64.zip" tmp/mac-x86.zip
+            echo "mac_x86_present=true" >> "$GITHUB_ENV"
+          else
+            echo "::notice::v${VERSION} publishes no all-smi-macos-x86_64.zip."
+            echo "mac_x86_present=false" >> "$GITHUB_ENV"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update formula
         run: |
           cd homebrew-tap
@@ -125,11 +155,23 @@ jobs:
             gsed -i "s|^\([[:space:]]*\)version .*|\1version \"${version}\"|" "$file"
           }
 
+          # Number of url stanzas naming ARTIFACT. Artifact file names are what
+          # distinguishes stanzas here, and no two of them are substrings of one
+          # another (`all-smi-macos-aarch64.zip` cannot match the x86_64 url, and
+          # vice versa), so one macOS block per architecture addresses cleanly.
+          # Zero is a real state, not only an error: the formula lives in another
+          # repository and gains a stanza in a separate manual commit, so a new
+          # artifact exists here for a while before the tap has anywhere to put
+          # it. set_artifact still refuses anything but exactly one.
+          count_artifact() {  # file artifact
+            awk -v a="$2" '$0 ~ /^[[:space:]]*url / && index($0, a) { c++ } END { print c+0 }' "$1"
+          }
+
           # Rewrites the url stanza whose value contains ARTIFACT, then the
           # first sha256 stanza below it, preserving each line's indentation.
           set_artifact() {  # file artifact url sha
             local file="$1" artifact="$2" url="$3" sha="$4" n
-            n=$(awk -v a="$artifact" '$0 ~ /^[[:space:]]*url / && index($0, a) { c++ } END { print c+0 }' "$file")
+            n=$(count_artifact "$file" "$artifact")
             if [ "$n" -ne 1 ]; then
               echo "::error::${file}: expected exactly one url stanza for ${artifact}, found ${n}."
               exit 1
@@ -162,6 +204,50 @@ jobs:
           set_artifact Formula/all-smi.rb all-smi-linux-aarch64.tar.gz "$linux_arm_url" "$linux_arm_sha"
           set_artifact Formula/all-smi.rb all-smi-linux-x86_64.tar.gz  "$linux_x86_url" "$linux_x86_sha"
 
+          # The Intel Mac artifact and the formula stanza that serves it arrive
+          # independently: the asset appears in the first release built for
+          # x86_64-apple-darwin, the stanza in a hand-written commit to
+          # lablup/homebrew-tap. All four combinations occur, and each one is
+          # answered here rather than left to whatever the rewrite happens to do.
+          #
+          #   asset yes, stanza yes  update it, like any other artifact.
+          #   asset no,  stanza no   nothing to do. This is every release up to
+          #                          v0.25.0, and re-running against those tags
+          #                          has to stay a no-op.
+          #   asset yes, stanza no   update the rest and push, then end the job
+          #                          red in a later step. Failing here instead
+          #                          would hold the other three artifacts back
+          #                          over a tap that is merely incomplete, and a
+          #                          warning alone would leave Intel users
+          #                          unserved for as long as nobody reads the
+          #                          logs.
+          #   asset no,  stanza yes  refuse, before anything is pushed. Skipping
+          #                          would bump `version` while the Intel url
+          #                          still points at an older release: `brew
+          #                          install` then hands an Intel user a binary
+          #                          of a different version than the formula
+          #                          claims, and it passes `ruby -c` and `brew
+          #                          style` on the way out. Either the release
+          #                          lost an artifact it used to publish or the
+          #                          tag predates it; both want a human.
+          INTEL_MAC=all-smi-macos-x86_64.zip
+          stanzas=$(count_artifact Formula/all-smi.rb "$INTEL_MAC")
+
+          if [ "${mac_x86_present:-false}" != "true" ]; then
+            if [ "$stanzas" -ne 0 ]; then
+              echo "::error::Formula/all-smi.rb: the formula has an ${INTEL_MAC} stanza but v${VERSION} does not publish that asset. Refusing to bump the version while the Intel url still points at another release."
+              exit 1
+            fi
+            echo "::notice::v${VERSION} publishes no ${INTEL_MAC} and the formula has no stanza for it; the macOS section is left as is."
+            echo "mac_x86_state=skipped" >> "$GITHUB_ENV"
+          elif [ "$stanzas" -eq 0 ]; then
+            echo "::warning::v${VERSION} publishes ${INTEL_MAC} but Formula/all-smi.rb has no stanza for it, so Intel Macs are still served nothing. The other artifacts are updated and pushed; this job then fails on purpose."
+            echo "mac_x86_state=stanza-missing" >> "$GITHUB_ENV"
+          else
+            set_artifact Formula/all-smi.rb "$INTEL_MAC" "$mac_x86_url" "$mac_x86_sha"
+            echo "mac_x86_state=updated" >> "$GITHUB_ENV"
+          fi
+
       - name: Validate updated formula
         run: |
           cd homebrew-tap
@@ -185,18 +271,41 @@ jobs:
           fi
 
           # A substitution that silently no-ops would leave the previous
-          # release's checksum behind, so require the exact expected set.
+          # release's checksum behind, so require the exact expected set. The
+          # count comes from the list the previous step actually wrote rather
+          # than from a literal: the Intel macOS stanza is optional, so a fixed
+          # number is wrong in one of the two states, and a literal is the kind
+          # that quietly goes stale the next time an artifact is added.
+          shas=("$mac_sha" "$linux_arm_sha" "$linux_x86_sha")
+          if [ "${mac_x86_state:-skipped}" = "updated" ]; then
+            shas+=("$mac_x86_sha")
+          fi
+
           n=$(grep -c "^[[:space:]]*sha256 " Formula/all-smi.rb || true)
-          if [ "$n" -ne 3 ]; then
-            echo "::error::Formula/all-smi.rb: expected 3 sha256 stanzas, found ${n}."
+          if [ "$n" -ne "${#shas[@]}" ]; then
+            echo "::error::Formula/all-smi.rb: expected ${#shas[@]} sha256 stanzas, found ${n}."
             exit 1
           fi
-          for sha in "$mac_sha" "$linux_arm_sha" "$linux_x86_sha"; do
+          for sha in "${shas[@]}"; do
             if ! grep -q "^[[:space:]]*sha256 \"${sha}\"$" Formula/all-smi.rb; then
               echo "::error::Formula/all-smi.rb: sha256 ${sha} was not written."
               exit 1
             fi
           done
+
+          # Every release download has to name this release, whatever the
+          # checksums say. A stanza the update step declined to touch keeps its
+          # old url, and a formula whose version and urls disagree installs a
+          # binary of the wrong version through checksums that all verify. Same
+          # class of failure as the mlxcel corruption, caught from the other end.
+          # Scoped to releases/download urls so a url that is not a release asset
+          # is not read as a version mismatch.
+          urls=$(grep -c "^[[:space:]]*url \".*/releases/download/" Formula/all-smi.rb || true)
+          tagged=$(grep -c "^[[:space:]]*url \".*/releases/download/v${VERSION}/" Formula/all-smi.rb || true)
+          if [ "$urls" -ne "$tagged" ]; then
+            echo "::error::Formula/all-smi.rb: ${urls} release urls but only ${tagged} point at v${VERSION}."
+            exit 1
+          fi
 
       - name: Commit and push changes to tap
         run: |
@@ -214,3 +323,19 @@ jobs:
 
           git commit -m "bump: all-smi to v${{ env.VERSION_NO_V }}"
           git push origin main
+
+      # Deliberately last, and deliberately red. The release publishes an Intel
+      # Mac artifact that the formula has no stanza for, so the three artifacts
+      # it does describe were updated and pushed above and Intel users got
+      # nothing. Failing earlier would have withheld a correct update from every
+      # other platform; a warning would have been true, printed, and forgotten.
+      # Ending the job red leaves the tap current, the gap on the run summary,
+      # and the fix a two-line edit to lablup/homebrew-tap Formula/all-smi.rb
+      # (an `if Hardware::CPU.intel?` block inside `on_macos`, mirroring the one
+      # `on_linux` already has) plus a workflow_dispatch re-run for the same tag,
+      # which is a no-op for everything already committed.
+      - name: Report unpublished Intel macOS artifact
+        if: env.mac_x86_state == 'stanza-missing'
+        run: |
+          echo "::error::v${{ env.VERSION_NO_V }} publishes all-smi-macos-x86_64.zip but lablup/homebrew-tap Formula/all-smi.rb has no url stanza for it, so Intel Macs still install nothing. Add an 'if Hardware::CPU.intel?' block inside on_macos with that url and its sha256, then re-run this workflow for the same tag."
+          exit 1

--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -33,14 +33,26 @@ jobs:
       - name: Determine version tag
         id: get_version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.release_tag }}" ]; then
-            echo "VERSION=${{ github.event.inputs.release_tag }}" >> $GITHUB_ENV
+          set -euo pipefail
+
+          # The tag is read from the environment, never interpolated into the
+          # script. A workflow expression is substituted textually before bash
+          # parses the line, and a git tag may legally contain a double quote, a
+          # semicolon, a backtick, command substitution and `&&`: whitespace is
+          # refused by check-ref-format, but almost no shell metacharacter is.
+          # `v1.0.0";id;#` is a valid tag, and interpolated it runs `id` in this
+          # job, the job that holds the tap push token in its clone. The
+          # workflow_dispatch input is free text and reaches exactly as far.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$RELEASE_TAG_INPUT" ]; then
+            echo "VERSION=$RELEASE_TAG_INPUT" >> "$GITHUB_ENV"
           else
-            TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
-            echo "VERSION=$TAG" >> $GITHUB_ENV
+            TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
+            echo "VERSION=$TAG" >> "$GITHUB_ENV"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG_INPUT: ${{ github.event.inputs.release_tag }}
 
       - name: Clone Homebrew tap repository
         run: |
@@ -54,8 +66,27 @@ jobs:
           cd homebrew-tap
           set -euo pipefail
 
-          RAW_VERSION="${{ env.VERSION }}"
+          RAW_VERSION="${VERSION}"
           VERSION="${RAW_VERSION#v}"  # Remove leading 'v'
+
+          # VERSION is about to become a download url, a gh api path, a grep
+          # pattern and a line in the formula, so it is constrained once here,
+          # before any of those see it, rather than at each sink.
+          #
+          # Refusing `/` is what matters most: curl collapses `/../` in a path,
+          # so a version of the form `0.0.0/../../../owner/repo/releases/download/v1`
+          # silently retargets BASE at another repository, and both the binary
+          # that gets checksummed and the url written into the tap come from
+          # there. The version-tagged url guard in the validation step does not
+          # catch it, because the retargeted url still contains the version.
+          # Refusing `[`, `*` and `\` keeps the version from breaking that same
+          # grep, whose `|| true` turns a grep usage error into an empty string
+          # and lets the comparison be skipped instead of failing.
+          if ! [[ $VERSION =~ ^[0-9][0-9A-Za-z.+-]*$ ]]; then
+            echo "::error::Refusing to run for tag '${RAW_VERSION}': the version must start with a digit and contain only digits, letters, '.', '+' and '-'."
+            exit 1
+          fi
+
           echo "VERSION_NO_V=$VERSION" >> $GITHUB_ENV  # Export version without 'v' to GitHub env
 
           # This repository was renamed from inureyes/all-smi to lablup/all-smi.
@@ -110,9 +141,12 @@ jobs:
           # expects an Intel artifact.
           #
           # -x because the release also carries `<asset>.sha256` sidecars, and an
-          # unanchored match would accept one of those as the asset itself.
-          ASSETS=$(gh api "repos/${{ github.repository }}/releases/tags/v${VERSION}" --jq '.assets[].name')
-          if printf '%s\n' "$ASSETS" | grep -qx "all-smi-macos-x86_64.zip"; then
+          # unanchored match would accept one of those as the asset itself. -F
+          # because the name contains dots, and as a regex those match any
+          # character, so an asset named `all-smi-macos-x86_64Xzip` would read as
+          # this one being present.
+          ASSETS=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" --jq '.assets[].name')
+          if printf '%s\n' "$ASSETS" | grep -qxF "all-smi-macos-x86_64.zip"; then
             fetch mac_x86 "${BASE}/all-smi-macos-x86_64.zip" tmp/mac-x86.zip
             echo "mac_x86_present=true" >> "$GITHUB_ENV"
           else
@@ -127,7 +161,7 @@ jobs:
           cd homebrew-tap
           set -euo pipefail
 
-          VERSION="${{ env.VERSION_NO_V }}"  # Use version without 'v'
+          VERSION="$VERSION_NO_V"  # Use version without 'v'
 
           # Stanzas are located by name, never by line offset. This step used to
           # rewrite each checksum with
@@ -253,7 +287,7 @@ jobs:
           cd homebrew-tap
           set -euo pipefail
 
-          VERSION="${{ env.VERSION_NO_V }}"
+          VERSION="$VERSION_NO_V"
 
           echo "=== Formula/all-smi.rb ==="
           cat Formula/all-smi.rb
@@ -300,8 +334,13 @@ jobs:
           # class of failure as the mlxcel corruption, caught from the other end.
           # Scoped to releases/download urls so a url that is not a release asset
           # is not read as a version mismatch.
+          #
+          # The version is part of a regex here, so its dots are escaped:
+          # unescaped they match any character, and a url left behind at
+          # `v0X25X0` would be counted as pointing at v0.25.0.
+          version_re="${VERSION//./\\.}"
           urls=$(grep -c "^[[:space:]]*url \".*/releases/download/" Formula/all-smi.rb || true)
-          tagged=$(grep -c "^[[:space:]]*url \".*/releases/download/v${VERSION}/" Formula/all-smi.rb || true)
+          tagged=$(grep -c "^[[:space:]]*url \".*/releases/download/v${version_re}/" Formula/all-smi.rb || true)
           if [ "$urls" -ne "$tagged" ]; then
             echo "::error::Formula/all-smi.rb: ${urls} release urls but only ${tagged} point at v${VERSION}."
             exit 1
@@ -317,11 +356,11 @@ jobs:
           # Re-running the workflow for a version already in the tap is not an
           # error; `git commit` would fail on an empty index otherwise.
           if git diff --cached --quiet; then
-            echo "Formula already up to date for v${{ env.VERSION_NO_V }}, nothing to push."
+            echo "Formula already up to date for v${VERSION_NO_V}, nothing to push."
             exit 0
           fi
 
-          git commit -m "bump: all-smi to v${{ env.VERSION_NO_V }}"
+          git commit -m "bump: all-smi to v${VERSION_NO_V}"
           git push origin main
 
       # Deliberately last, and deliberately red. The release publishes an Intel
@@ -337,5 +376,5 @@ jobs:
       - name: Report unpublished Intel macOS artifact
         if: env.mac_x86_state == 'stanza-missing'
         run: |
-          echo "::error::v${{ env.VERSION_NO_V }} publishes all-smi-macos-x86_64.zip but lablup/homebrew-tap Formula/all-smi.rb has no url stanza for it, so Intel Macs still install nothing. Add an 'if Hardware::CPU.intel?' block inside on_macos with that url and its sha256, then re-run this workflow for the same tag."
+          echo "::error::v${VERSION_NO_V} publishes all-smi-macos-x86_64.zip but lablup/homebrew-tap Formula/all-smi.rb has no url stanza for it, so Intel Macs still install nothing. Add an 'if Hardware::CPU.intel?' block inside on_macos with that url and its sha256, then re-run this workflow for the same tag."
           exit 1


### PR DESCRIPTION
## Summary

The release matrix builds `x86_64-apple-darwin` as of #306, so every release from the next one on publishes `all-smi-macos-x86_64.zip`. The formula update workflow only ever knew about the aarch64 zip, so Intel Macs are served nothing. This teaches the workflow to publish the Intel artifact into the tap, and to behave predictably in every intermediate state along the way.

The formula itself lives in the external repo `lablup/homebrew-tap`, so it is deliberately not touched here. The exact stanza a maintainer needs to add is below, to be applied on purpose rather than by an automated run against a production tap.

## Two premises in the issue turned out to be wrong

**`set_artifact` does not need reworking.** The issue says it "asserts exactly ONE matching url stanza ... so it cannot express two macOS artifacts today". That assertion is per artifact file name, not per platform, and `all-smi-macos-aarch64.zip` and `all-smi-macos-x86_64.zip` are not substrings of each other, so each one addresses exactly one url stanza once both exist. Verified by running the shipped step against a two-stanza fixture: each macOS stanza got its own url and its own sha256, with no cross-contamination. The only change made to it is that its stanza counting moved out into a `count_artifact` helper, which the new Intel branch reuses to ask whether the tap has a stanza at all. The uniqueness assertion is unchanged and still fires: a fixture with two Intel stanzas is refused with "expected exactly one url stanza for all-smi-macos-x86_64.zip, found 2".

**The formula does not need an `on_arm`/`on_intel` DSL restructure.** The live formula uses `if Hardware::CPU.arm?` / `if Hardware::CPU.intel?` conditionals inside `on_macos do` / `on_linux do`, and `on_linux` already carries both branches. The macOS change is therefore to mirror a pattern the file already contains, which keeps the diff at four lines and leaves the working Linux stanzas alone. Introducing `on_arm`/`on_intel` blocks instead would rewrite stanzas that are currently correct and in use, for no behavioral gain.

## Formula diff for lablup/homebrew-tap (apply by hand, not from CI)

```diff
--- Formula/all-smi.rb
+++ Formula/all-smi.rb
@@ -9,6 +9,10 @@
       url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-macos-aarch64.zip"
       sha256 "d090d6abbda5ac0c2fc06c0924b70845b32fd02ce6d1fca8f3ddf6fce1cad814"
     end
+    if Hardware::CPU.intel?
+      url "https://github.com/lablup/all-smi/releases/download/v<VERSION>/all-smi-macos-x86_64.zip"
+      sha256 "<SHA256 of that asset>"
+    end
   end
 
   on_linux do
```

Apply it with the real url and checksum of a release that actually publishes the asset, not with a placeholder: between the tap commit and the next workflow run the formula is live for `brew install`, and a placeholder checksum is a broken install for Intel users during that window. `brew style Formula/all-smi.rb` passes on the result.

Recommended order:

1. Merge this PR.
2. Cut a release. It publishes `all-smi-macos-x86_64.zip`, and the formula update run for it ends red on the last step (see the state table below), having pushed the other three artifacts correctly.
3. Get the checksum: `curl -fLs https://github.com/lablup/all-smi/releases/download/v<VERSION>/all-smi-macos-x86_64.zip | shasum -a 256`, or read it from the `.sha256` sidecar the release already publishes.
4. Apply the diff above to `lablup/homebrew-tap` with that version and checksum.
5. Re-run "Update Homebrew Formula" via `workflow_dispatch` with the same tag. It is idempotent: the commit step already skips an empty diff, and validation should now report 4 sha256 stanzas.
6. Confirm `brew install lablup/tap/all-smi` on both an Apple Silicon and an Intel Mac.

## The four states, and why each behaves the way it does

The asset and the stanza arrive independently: the asset in a release, the stanza in a hand-written commit to the tap. All four combinations happen, so each one is answered explicitly rather than left to whatever the rewrite happens to do.

| release asset | formula stanza | behavior |
|---|---|---|
| present | present | update it, like any other artifact. Steady state. |
| absent | absent | no-op with a `::notice::`. This is every release up to and including v0.25.0, so re-running against those tags stays green. |
| present | absent | update and push the other three artifacts, then end the job red in a final step. |
| absent | present | refuse in the update step, before anything is pushed. |

**Why "asset present, stanza absent" pushes first and then fails.** Failing before the push would withhold a correct update from macOS aarch64 and both Linux targets over a tap that is merely incomplete, which punishes three platforms for a gap affecting a fourth. A warning alone would be true, printed, and forgotten, and Intel users would stay unserved for as long as nobody reads the logs, which is indefinitely. Ending the job red after the push keeps the tap current, puts the gap on the run summary where a failed check is visible, and makes the fix the four-line tap edit above plus an idempotent re-run. Since this workflow is triggered by `workflow_run` after every Release, that red run repeats every release until someone acts, which is the point.

**Why "asset absent, stanza present" hard-fails instead of skipping.** Skipping would bump `version` while the Intel url still points at an older release. `brew install` on an Intel Mac would then fetch that older binary, its recorded checksum would verify, and the user would silently get a version the formula does not claim to be. That state passes `ruby -c` and `brew style`, so nothing downstream catches it. It also means either the release lost an artifact it used to publish or the tag predates the artifact, both of which want a human rather than a best-effort write.

## What changed

- `.github/workflows/update_homebrew_formula.yml`, download step: reads the release's asset list through `gh api` and fetches `all-smi-macos-x86_64.zip` through the existing hard-failing `fetch` when it is listed. Presence is decided from the asset list rather than from a failed download because `curl` cannot tell "this release never published that asset" apart from "the network dropped", and reading a transient failure as absence is how an artifact stops being published without anyone noticing. The asset list is captured into a variable before the `grep`, because a pipeline inside `if` suppresses errexit and would reintroduce exactly that conflation through the API call. The match is `grep -qx` because the release also carries `<asset>.sha256` sidecars that an unanchored match would accept as the asset itself.
- Update step: `count_artifact` extracted from `set_artifact` (which is otherwise unchanged) so the Intel branch can distinguish "no stanza yet" from "malformed formula", plus the four-state decision above.
- Validate step: the expected sha256 count is derived from the checksums the run actually wrote instead of the hardcoded `3`, so it is 4 when the Intel stanza is updated and 3 when it is skipped, and it will not go stale the next time an artifact is added. A new guard additionally requires every `releases/download` url in the formula to name the version being written, which catches a stanza left behind at an older release even when every checksum in the file verifies. That is the same class of failure as the mlxcel corruption the file's existing comments document, caught from the other end.
- New final step `Report unpublished Intel macOS artifact`, gated on `env.mac_x86_state == 'stanza-missing'`, which is what turns the third state red after the push.

## Test plan

The shell logic was executed, not just reasoned about. `run-workflow-steps.sh` extracts the `Update formula` and `Validate updated formula` bodies straight out of the YAML being committed and runs them against fixture copies of the live tap formula, so the thing under test is the file in this PR rather than a paraphrase of it.

- [x] state 1, two-stanza fixture with the asset present: green, both macOS stanzas rewritten to the new version with their own checksums, 4 sha256 stanzas, `ruby -c` and `brew style` both clean.
- [x] state 2, live one-stanza fixture with the asset absent: green, `::notice::`, macOS section untouched, 3 sha256 stanzas.
- [x] state 3, live one-stanza fixture with the asset present: `::warning::`, formula valid at 3 sha256 stanzas, validation passes, push proceeds, job then fails on the final gate.
- [x] state 4, two-stanza fixture with the asset absent: fails in the update step with the version-skew error, before the commit step is reached.
- [x] malformed tap with two Intel stanzas: refused by `set_artifact`'s unchanged uniqueness assertion.
- [x] a formula whose Intel url is left at v0.25.0 while `version` says 0.26.0: caught by the new url guard (4 release urls, 3 matching the version). The sha256 count guard catches the same situation independently, verified by softening the state-4 refusal to a skip and watching validation reject the result at "expected 3 sha256 stanzas, found 4".
- [x] asset probe against real releases: `v0.25.0` reports the Intel asset absent (it is), the aarch64 asset present, and a nonexistent tag hard-fails rather than being read as "asset absent". `curl` of the real aarch64 zip reproduces the exact checksum currently in the tap, `d090d6ab...`, so the fetch path is verified against production data.
- [x] `unzip -qqt` on a truncated zip returns 9, so the existing integrity check that the Intel fetch reuses does catch a partial download.
- [x] `actionlint`: no new findings. The three `SC2086` infos it reports are present on `main` unchanged.
- [x] BSD awk only, no GNU extensions, and bash 3.2 compatible, matching what `macos-latest` provides.

Not verifiable before a release exists: the end-to-end `brew install` on both architectures, which is step 6 of the sequence above.

Closes #308
