### PR TITLE
fix: derive Apple Silicon CPU cluster frequency from the pmgr table

### DIFF
--- a/src/device/macos_native/ioreport.rs
+++ b/src/device/macos_native/ioreport.rs
@@ -188,20 +188,46 @@ unsafe extern "C" {
     fn IOObjectRelease(object: u32) -> i32;
 }
 
-/// GPU frequency table loaded from IOKit pmgr device
+/// Every `voltage-states*` table published by the IOKit pmgr/clpc device.
 ///
-/// This is loaded once at startup and cached for use when calculating
-/// weighted average GPU frequency from GPUPH residencies.
+/// IOReport's performance-state channels report residency per *state name*
+/// (`IDLE`, `V0P14`, `P3`, ...), never a clock. The `voltage-states*`
+/// properties on the `AppleARMIODevice` `pmgr` (or `clpc`) node are the only
+/// place the matching megahertz values live, so both the GPU path and the CPU
+/// path must join a residency histogram against one of these tables to produce
+/// a frequency at all.
+///
+/// Loaded once at startup. Entries are `(property name, frequencies in MHz,
+/// ascending)`, sorted by property name; tables that parse to nothing are
+/// dropped, which is how the several `voltage-states*` keys that hold clock
+/// periods or bare state indices instead of hertz get excluded.
+static PMGR_VOLTAGE_STATES: OnceLock<Vec<(String, Vec<u32>)>> = OnceLock::new();
+
+/// GPU frequency table, resolved once from [`PMGR_VOLTAGE_STATES`].
 static GPU_FREQUENCIES: OnceLock<Vec<u32>> = OnceLock::new();
 
-/// Load GPU frequencies from IOKit pmgr/clpc device
+/// pmgr keys holding the GPU performance-state table, most specific first.
+const GPU_TABLE_KEYS: [&str; 2] = ["voltage-states9-sram", "voltage-states9"];
+
+/// pmgr keys holding the efficiency-cluster table, most specific first.
 ///
-/// Based on mactop's loadGpuFrequencies implementation:
-/// - Matches AppleARMIODevice service
-/// - Looks for pmgr or clpc device
-/// - Reads voltage-states9-sram or voltage-states9 property
-/// - Parses frequency values (first 4 bytes of each 8-byte entry in Hz)
-fn load_gpu_frequencies() -> Vec<u32> {
+/// The plain key is listed as a fallback because some chips publish the clock
+/// there. On chips where both exist (M1 Ultra, for one) the plain key holds
+/// clock *periods* rather than hertz; those fail the plausibility range in
+/// [`parse_voltage_states_bytes`] and never reach this list, so listing the key
+/// costs nothing.
+const E_CLUSTER_TABLE_KEYS: [&str; 2] = ["voltage-states1-sram", "voltage-states1"];
+
+/// pmgr keys holding the performance-cluster table, most specific first.
+const P_CLUSTER_TABLE_KEYS: [&str; 2] = ["voltage-states5-sram", "voltage-states5"];
+
+/// Load every `voltage-states*` table from the IOKit pmgr/clpc device.
+///
+/// - Matches the `AppleARMIODevice` service
+/// - Looks for the `pmgr` or `clpc` node
+/// - Reads every `voltage-states*` property off it
+/// - Parses frequency values (first 4 bytes of each 8-byte entry, in Hz)
+fn load_pmgr_voltage_states() -> Vec<(String, Vec<u32>)> {
     unsafe {
         let matching = IOServiceMatching(c"AppleARMIODevice".as_ptr());
         if matching.is_null() {
@@ -214,7 +240,7 @@ fn load_gpu_frequencies() -> Vec<u32> {
             return vec![];
         }
 
-        let mut frequencies: Vec<u32> = vec![];
+        let mut tables: Vec<(String, Vec<u32>)> = vec![];
         let mut entry = IOIteratorNext(iterator);
 
         while entry != 0 {
@@ -231,48 +257,26 @@ fn load_gpu_frequencies() -> Vec<u32> {
                 if IORegistryEntryCreateCFProperties(entry, &mut properties, ptr::null(), 0) == 0
                     && !properties.is_null()
                 {
-                    frequencies = extract_gpu_frequencies_from_properties(properties);
+                    tables = extract_voltage_state_tables(properties);
                     CFRelease(properties as *const c_void);
                 }
             }
 
             IOObjectRelease(entry);
-            if !frequencies.is_empty() {
-                break; // Found frequencies, stop searching
+            if !tables.is_empty() {
+                break; // Found the frequency tables, stop searching
             }
             entry = IOIteratorNext(iterator);
         }
 
         IOObjectRelease(iterator);
-        frequencies
+        tables
     }
 }
 
-/// Extract GPU frequencies from pmgr device properties
-fn extract_gpu_frequencies_from_properties(properties: CFMutableDictionaryRef) -> Vec<u32> {
+/// Collect every parseable `voltage-states*` property from a pmgr node.
+fn extract_voltage_state_tables(properties: CFMutableDictionaryRef) -> Vec<(String, Vec<u32>)> {
     unsafe {
-        let cf_dict = CFDictionary::<CFType, CFType>::wrap_under_get_rule(properties);
-
-        // First try voltage-states9-sram or voltage-states9 (preferred keys)
-        let preferred_keys = ["voltage-states9-sram", "voltage-states9"];
-        for key_name in preferred_keys {
-            let key = CFString::new(key_name);
-            if let Some(value) = cf_dict.find(key.as_CFType().as_CFTypeRef()) {
-                let data_ref = value.as_CFTypeRef() as core_foundation::data::CFDataRef;
-                if !data_ref.is_null() {
-                    let frequencies = parse_voltage_states_data(data_ref);
-                    if !frequencies.is_empty() {
-                        return frequencies;
-                    }
-                }
-            }
-        }
-
-        // Fallback: search for any voltage-states* key with reasonable frequency range
-        // Look for the one with the lowest max frequency (GPU frequencies are lower than CPU)
-        let mut best_frequencies: Vec<u32> = vec![];
-        let mut best_max_freq: u32 = u32::MAX;
-
         let count = core_foundation::dictionary::CFDictionaryGetCount(properties) as usize;
         if count == 0 {
             return vec![];
@@ -285,6 +289,8 @@ fn extract_gpu_frequencies_from_properties(properties: CFMutableDictionaryRef) -
             keys.as_mut_ptr(),
             values.as_mut_ptr(),
         );
+
+        let mut tables: Vec<(String, Vec<u32>)> = Vec::new();
 
         for i in 0..count {
             let key_ref = keys[i] as CFStringRef;
@@ -307,26 +313,26 @@ fn extract_gpu_frequencies_from_properties(properties: CFMutableDictionaryRef) -
                 continue;
             }
 
-            // Find max frequency in this set
-            let max_freq = frequencies.iter().max().copied().unwrap_or(0);
-
-            // GPU frequencies are typically lower than CPU frequencies
-            // Select the set with the lowest maximum as GPU frequencies
-            if max_freq > 0 && max_freq < best_max_freq {
-                best_max_freq = max_freq;
-                best_frequencies = frequencies;
-            }
+            tables.push((key_str, frequencies));
         }
 
-        best_frequencies
+        // Sort so selection is deterministic across runs; IOKit does not
+        // guarantee dictionary ordering.
+        tables.sort_by(|a, b| a.0.cmp(&b.0));
+        tables
     }
 }
 
-/// Minimum valid GPU frequency in Hz (100 MHz)
-const MIN_GPU_FREQ_HZ: u32 = 100_000_000;
-/// Maximum valid GPU frequency in Hz (4 GHz - fits in u32)
-/// Apple Silicon GPUs typically max out around 1.4 GHz, so 4 GHz is generous
-const MAX_GPU_FREQ_HZ: u32 = 4_000_000_000;
+/// Minimum plausible clock in Hz (100 MHz).
+const MIN_FREQ_HZ: u64 = 100_000_000;
+/// Maximum plausible clock in Hz (6 GHz), comfortably above any shipping Apple
+/// Silicon CPU or GPU clock.
+const MAX_FREQ_HZ: u64 = 6_000_000_000;
+/// Range of the 32-bit hertz field, used to undo wraparound.
+const U32_SPAN_HZ: u64 = 1 << 32;
+/// A wrapped entry can only follow one already near the 32-bit ceiling
+/// (~4.295 GHz), so wrap correction is applied only above this threshold.
+const WRAP_GUARD_HZ: u64 = 4_000_000_000;
 /// Maximum number of frequency entries to parse
 const MAX_FREQ_ENTRIES: usize = 64;
 
@@ -334,43 +340,192 @@ const MAX_FREQ_ENTRIES: usize = 64;
 fn parse_voltage_states_data(data_ref: core_foundation::data::CFDataRef) -> Vec<u32> {
     unsafe {
         let data = CFData::wrap_under_get_rule(data_ref);
-        let bytes = data.bytes();
-        let len = bytes.len();
+        parse_voltage_states_bytes(data.bytes())
+    }
+}
 
-        // Each entry is 8 bytes: first 4 bytes are frequency in Hz
-        let total_entries = len / 8;
-        let mut frequencies: Vec<u32> = Vec::with_capacity(total_entries.min(MAX_FREQ_ENTRIES));
+/// Parse a `voltage-states*` payload into ascending MHz values.
+///
+/// Each entry is 8 bytes; the first 4 are the frequency in hertz as a
+/// little-endian u32, the rest is the matching voltage. Entries outside a
+/// plausible clock range are dropped, which is what keeps the keys that hold
+/// clock periods or bare state indices from being mistaken for frequency
+/// tables.
+fn parse_voltage_states_bytes(bytes: &[u8]) -> Vec<u32> {
+    let len = bytes.len();
+    let total_entries = (len / 8).min(MAX_FREQ_ENTRIES);
+    let mut frequencies: Vec<u32> = Vec::with_capacity(total_entries);
+    // Last accepted value, used to detect 32-bit wraparound. Rejected entries
+    // deliberately do not advance it, so a table of non-frequency data never
+    // arms the wrap correction.
+    let mut prev_hz: u64 = 0;
 
-        for i in 0..total_entries.min(MAX_FREQ_ENTRIES) {
-            let offset = i * 8;
-            if offset + 4 > len {
-                break;
-            }
-
-            // Read 4-byte little-endian frequency value in Hz
-            let freq_hz = u32::from_le_bytes([
-                bytes[offset],
-                bytes[offset + 1],
-                bytes[offset + 2],
-                bytes[offset + 3],
-            ]);
-
-            // Validate frequency is in reasonable range (100 MHz - 4 GHz)
-            // This filters out invalid/corrupted data
-            if (MIN_GPU_FREQ_HZ..=MAX_GPU_FREQ_HZ).contains(&freq_hz) {
-                // Convert to MHz
-                let freq_mhz = freq_hz / 1_000_000;
-                frequencies.push(freq_mhz);
-            }
+    for i in 0..total_entries {
+        let offset = i * 8;
+        if offset + 4 > len {
+            break;
         }
 
-        frequencies
+        // Read 4-byte little-endian frequency value in Hz
+        let raw_hz = u32::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]) as u64;
+
+        // Clocks above 4.295 GHz do not fit the 32-bit hertz field and wrap to
+        // a small value. These tables are ascending, so a value that drops
+        // right after an entry already near the ceiling is a wrap, not a real
+        // step down.
+        let freq_hz = if prev_hz >= WRAP_GUARD_HZ && raw_hz < prev_hz {
+            raw_hz + U32_SPAN_HZ
+        } else {
+            raw_hz
+        };
+
+        // Validate frequency is in a reasonable range; this filters out
+        // invalid/corrupted data and non-frequency payloads.
+        if !(MIN_FREQ_HZ..=MAX_FREQ_HZ).contains(&freq_hz) {
+            continue;
+        }
+
+        prev_hz = freq_hz;
+        frequencies.push((freq_hz / 1_000_000) as u32);
     }
+
+    frequencies
+}
+
+/// Get the cached pmgr frequency tables, loading them if necessary
+fn get_pmgr_voltage_states() -> &'static [(String, Vec<u32>)] {
+    PMGR_VOLTAGE_STATES.get_or_init(load_pmgr_voltage_states)
 }
 
 /// Get cached GPU frequencies, loading them if necessary
 pub fn get_gpu_frequencies() -> &'static [u32] {
-    GPU_FREQUENCIES.get_or_init(load_gpu_frequencies)
+    GPU_FREQUENCIES.get_or_init(|| select_gpu_frequency_table(get_pmgr_voltage_states()))
+}
+
+/// Pick the GPU performance-state table out of the pmgr tables.
+fn select_gpu_frequency_table(tables: &[(String, Vec<u32>)]) -> Vec<u32> {
+    for key in GPU_TABLE_KEYS {
+        if let Some((_, frequencies)) = tables.iter().find(|(k, _)| k == key) {
+            return frequencies.clone();
+        }
+    }
+
+    // Fallback for chips that number their rails differently: GPU clocks are
+    // the lowest of the published tables, so take the one with the smallest
+    // maximum.
+    tables
+        .iter()
+        .min_by_key(|(_, frequencies)| frequencies.iter().max().copied().unwrap_or(u32::MAX))
+        .map(|(_, frequencies)| frequencies.clone())
+        .unwrap_or_default()
+}
+
+/// Which CPU cluster an IOReport `CPU Core Performance States` channel belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CpuCluster {
+    /// M5 Pro/Max "Super" cores.
+    Super,
+    Efficiency,
+    Performance,
+}
+
+/// Strip the `DIE_<n>_` prefix that multi-die packages put on every channel.
+///
+/// M1/M2 Ultra fuse two dies into one package and report channels as
+/// `DIE_0_ECPU_CPU0`, `DIE_1_PCPU1_CPU3`, and so on. Single-die parts report
+/// the bare `ECPU0` / `PCPU1` names. Stripping the prefix lets one set of
+/// classification rules cover both.
+fn strip_die_prefix(channel: &str) -> &str {
+    let Some(rest) = channel.strip_prefix("DIE_") else {
+        return channel;
+    };
+    let digits_end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    if digits_end == 0 {
+        return channel;
+    }
+    rest[digits_end..].strip_prefix('_').unwrap_or(channel)
+}
+
+/// Classify a `CPU Core Performance States` channel into its cluster.
+///
+/// Returns `None` for channels that do not name a CPU cluster, so unknown
+/// channels are ignored rather than folded into the wrong average.
+fn classify_cpu_channel(channel: &str) -> Option<CpuCluster> {
+    let name = strip_die_prefix(channel);
+
+    // M5 Pro/Max uses MCPU0/MCPU0x for Super cores, MCPU1/MCPU1x for
+    // performance cluster 1, and PCPU/PCPUx for performance cluster 2.
+    // M1-M4 uses ECPU/ECPUx for efficiency cores and PCPU/PCPUx for
+    // performance cores.
+    if name.starts_with("MCPU0") {
+        Some(CpuCluster::Super)
+    } else if name.starts_with("MCPU1") {
+        Some(CpuCluster::Performance)
+    } else if name.contains("ECPU") || name.starts_with('E') {
+        Some(CpuCluster::Efficiency)
+    } else if name.contains("PCPU") || name.starts_with('P') {
+        Some(CpuCluster::Performance)
+    } else {
+        None
+    }
+}
+
+/// Pick the frequency table for a CPU cluster out of the pmgr tables.
+///
+/// `active_states` is the number of non-idle entries in the channel's residency
+/// histogram. Residency entry N maps to table entry N, so a table is only
+/// trustworthy when it has exactly one entry per active state; that count is
+/// also the most reliable way to identify the right table on chips whose pmgr
+/// key numbering is not the documented one.
+fn select_cpu_frequency_table(
+    tables: &[(String, Vec<u32>)],
+    cluster: CpuCluster,
+    active_states: usize,
+) -> Option<&[u32]> {
+    let preferred: &[&str] = match cluster {
+        CpuCluster::Efficiency => &E_CLUSTER_TABLE_KEYS,
+        CpuCluster::Performance => &P_CLUSTER_TABLE_KEYS,
+        // No documented key for the M5 Super cluster; fall through to the
+        // length match below.
+        CpuCluster::Super => &[],
+    };
+
+    for key in preferred {
+        if let Some((_, frequencies)) = tables.iter().find(|(k, _)| k == key)
+            && frequencies.len() == active_states
+        {
+            return Some(frequencies);
+        }
+    }
+
+    if active_states > 0 {
+        let matched = tables
+            .iter()
+            .find(|(k, f)| f.len() == active_states && k.ends_with("-sram"))
+            .or_else(|| tables.iter().find(|(_, f)| f.len() == active_states));
+        if let Some((_, frequencies)) = matched {
+            return Some(frequencies);
+        }
+    }
+
+    // Last resort: the documented key even though its length disagrees. A
+    // partially mapped clock still beats reporting 0 MHz.
+    preferred
+        .iter()
+        .find_map(|key| tables.iter().find(|(k, _)| k == key))
+        .map(|(_, frequencies)| frequencies.as_slice())
+}
+
+/// Names IOReport uses for performance states in which the block is not running.
+fn is_idle_state(name: &str) -> bool {
+    name.contains("IDLE") || name.contains("OFF") || name.contains("DOWN")
 }
 
 // Core Foundation helper functions
@@ -874,25 +1029,32 @@ impl IOReportMetrics {
             return;
         }
 
-        let (freq, residency) = Self::calc_freq_from_residencies(&residencies);
-        let channel = &item.channel;
+        let Some(cluster) = classify_cpu_channel(&item.channel) else {
+            return;
+        };
 
-        // Determine cluster type from channel name
-        // M5 Pro/Max uses MCPU0/MCPU0x for Super cores, MCPU1/MCPU1x for Performance cluster 1
-        // and PCPU/PCPUx for Performance cluster 2
-        // M1-M4 uses ECPU/ECPUx for Efficiency cores and PCPU/PCPUx for Performance cores
-        if channel.starts_with("MCPU0") {
-            // M5 Super core cluster (MCPU0, MCPU00-MCPU05)
-            s_cluster_freqs.push((freq, residency));
-        } else if channel.starts_with("MCPU1") {
-            // M5 Performance cluster 1 (MCPU1, MCPU10-MCPU15)
-            p_cluster_freqs.push((freq, residency));
-        } else if channel.starts_with('E') || channel.contains("ECPU") {
-            // M1-M4 Efficiency cores (ECPU, ECPUx)
-            e_cluster_freqs.push((freq, residency));
-        } else if channel.starts_with('P') || channel.contains("PCPU") {
-            // Performance cores: PCPU/PCPUx (shared by M1-M4 and M5 Performance cluster 2)
-            p_cluster_freqs.push((freq, residency));
+        // IOReport names CPU performance states symbolically (`IDLE`, `V0P14`,
+        // ... `V14P0`), never in megahertz, so the clock has to come from the
+        // pmgr voltage-states table for this cluster. Without that join every
+        // CPU frequency reads 0.
+        let active_states = residencies
+            .iter()
+            .filter(|(name, _)| !is_idle_state(name))
+            .count();
+        let table = select_cpu_frequency_table(get_pmgr_voltage_states(), cluster, active_states);
+
+        let (freq, residency) = match table {
+            Some(table) if !table.is_empty() => Self::calc_freq_with_table(&residencies, table),
+            // No usable table. Residency is still meaningful, so keep
+            // reporting it and let the frequency fall back to whatever the
+            // state names themselves yield (nothing, on current chips).
+            _ => Self::calc_freq_from_residencies(&residencies),
+        };
+
+        match cluster {
+            CpuCluster::Super => s_cluster_freqs.push((freq, residency)),
+            CpuCluster::Efficiency => e_cluster_freqs.push((freq, residency)),
+            CpuCluster::Performance => p_cluster_freqs.push((freq, residency)),
         }
     }
 
@@ -907,19 +1069,21 @@ impl IOReportMetrics {
 
         // Use IOKit frequencies if available, otherwise fall back to parsing state names
         let (freq, residency) = if !gpu_freq_table.is_empty() {
-            Self::calc_gpu_freq_with_table(&residencies, gpu_freq_table)
+            Self::calc_freq_with_table(&residencies, gpu_freq_table)
         } else {
             Self::calc_freq_from_residencies(&residencies)
         };
         gpu_freqs.push((freq, residency));
     }
 
-    /// Calculate GPU frequency using pre-loaded frequency table from IOKit
+    /// Calculate a block's frequency from its residency histogram and the
+    /// pre-loaded pmgr frequency table.
     ///
-    /// Based on mactop's approach:
+    /// Used by both the GPU (`GPUPH`) and the CPU cluster channels, whose
+    /// state names are symbolic in both cases:
     /// - Active states (non-OFF/IDLE/DOWN) are mapped to frequencies in order
-    /// - The frequency table from pmgr device provides accurate MHz values
-    fn calc_gpu_freq_with_table(residencies: &[(String, i64)], freq_table: &[u32]) -> (u32, f64) {
+    /// - The frequency table from the pmgr device provides accurate MHz values
+    fn calc_freq_with_table(residencies: &[(String, i64)], freq_table: &[u32]) -> (u32, f64) {
         let mut total_residency: i64 = 0;
         let mut active_residency: i64 = 0;
         let mut weighted_freq: f64 = 0.0;
@@ -929,7 +1093,7 @@ impl IOReportMetrics {
             total_residency += residency;
 
             // Skip idle/off states
-            if name.contains("IDLE") || name.contains("OFF") || name.contains("DOWN") {
+            if is_idle_state(name) {
                 continue;
             }
 
@@ -949,9 +1113,9 @@ impl IOReportMetrics {
         let avg_freq = if active_residency > 0 {
             (weighted_freq / active_residency as f64) as u32
         } else if !freq_table.is_empty() {
-            // The GPU is present (total_residency > 0) but spent the entire
+            // The block is present (total_residency > 0) but spent the entire
             // sampling window in IDLE/OFF/DOWN states. It is not running at
-            // 0 Hz — it is parked at its lowest P-state. Report the lowest
+            // 0 Hz, it is parked at its lowest P-state. Report the lowest
             // entry of the IOKit pmgr frequency table (sorted ascending) so
             // the renderer shows a truthful idle clock instead of letting
             // the Freq field flicker between a real value and 0 every
@@ -966,7 +1130,16 @@ impl IOReportMetrics {
         (avg_freq, residency_pct)
     }
 
-    /// Calculate frequency and residency from state residencies
+    /// Calculate frequency and residency from state residencies whose names are
+    /// themselves megahertz values.
+    ///
+    /// This is the last-resort path used when no pmgr frequency table is
+    /// available. No shipping Apple Silicon chip names its performance states
+    /// numerically (CPU clusters use `V0P14`-style names, the GPU uses
+    /// `P1`..`P15`), so in practice this yields residency only and the caller
+    /// gets 0 MHz. Prefer [`calc_freq_with_table`].
+    ///
+    /// [`calc_freq_with_table`]: Self::calc_freq_with_table
     fn calc_freq_from_residencies(residencies: &[(String, i64)]) -> (u32, f64) {
         let mut total_residency: i64 = 0;
         let mut weighted_freq: i64 = 0;
@@ -974,14 +1147,14 @@ impl IOReportMetrics {
         // Track the lowest parseable active-state frequency seen during the
         // scan. Used as the idle fallback when the cluster is present
         // (total_residency > 0) but spent the entire window in IDLE/OFF/DOWN
-        // states — that's its parked P-state, not 0 Hz.
+        // states, which is its parked P-state, not 0 Hz.
         let mut min_active_freq: Option<i64> = None;
 
         for (name, residency) in residencies {
             total_residency += residency;
 
             // Skip idle/off states
-            if name.contains("IDLE") || name.contains("OFF") || name.contains("DOWN") {
+            if is_idle_state(name) {
                 continue;
             }
 
@@ -1082,8 +1255,7 @@ mod tests {
         // GPU frequency table from IOKit (in MHz)
         let freq_table = [396, 720, 1398];
 
-        let (freq, residency) =
-            IOReportMetrics::calc_gpu_freq_with_table(&residencies, &freq_table);
+        let (freq, residency) = IOReportMetrics::calc_freq_with_table(&residencies, &freq_table);
 
         // Active residency: 200 + 200 + 100 = 500 out of 1000 total = 50%
         assert!((residency - 50.0).abs() < 0.1);
@@ -1101,8 +1273,7 @@ mod tests {
 
         let freq_table: [u32; 0] = [];
 
-        let (freq, residency) =
-            IOReportMetrics::calc_gpu_freq_with_table(&residencies, &freq_table);
+        let (freq, residency) = IOReportMetrics::calc_freq_with_table(&residencies, &freq_table);
 
         // Active residency: 200 out of 300 total = 66.67%
         assert!((residency - 66.67).abs() < 0.1);
@@ -1151,8 +1322,7 @@ mod tests {
 
         let freq_table = [396, 720, 1398];
 
-        let (freq, residency) =
-            IOReportMetrics::calc_gpu_freq_with_table(&residencies, &freq_table);
+        let (freq, residency) = IOReportMetrics::calc_freq_with_table(&residencies, &freq_table);
 
         assert_eq!(freq, 396);
         assert!((residency - 0.0).abs() < 0.1);
@@ -1167,10 +1337,347 @@ mod tests {
 
         let freq_table: [u32; 0] = [];
 
-        let (freq, residency) =
-            IOReportMetrics::calc_gpu_freq_with_table(&residencies, &freq_table);
+        let (freq, residency) = IOReportMetrics::calc_freq_with_table(&residencies, &freq_table);
 
         assert_eq!(freq, 0);
         assert!((residency - 0.0).abs() < 0.1);
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression coverage for issue #314: CPU frequency metrics reported 0 on
+    // Apple Silicon.
+    //
+    // Fixtures below are verbatim captures from an Apple M1 Ultra (macOS 26.6,
+    // Darwin 25.6.0): the IOReport `CPU Core Performance States` residency
+    // histograms and the IOKit `AppleARMIODevice` pmgr `voltage-states*`
+    // tables. They pin down the fact that CPU performance states are named
+    // symbolically (`V0P14`), never in megahertz, so the clock can only come
+    // from a pmgr table join.
+    // ---------------------------------------------------------------------
+
+    /// Apple M1 Ultra `voltage-states5-sram`: performance-cluster clocks, MHz.
+    const M1_ULTRA_P_TABLE: [u32; 15] = [
+        600, 828, 1056, 1296, 1524, 1752, 1980, 2208, 2448, 2676, 2904, 3036, 3132, 3168, 3228,
+    ];
+
+    /// Apple M1 Ultra `voltage-states1-sram`: efficiency-cluster clocks, MHz.
+    const M1_ULTRA_E_TABLE: [u32; 5] = [600, 972, 1332, 1704, 2064];
+
+    /// Apple M1 Ultra `voltage-states9-sram`: GPU clocks, MHz.
+    const M1_ULTRA_GPU_TABLE: [u32; 6] = [388, 486, 648, 777, 972, 1296];
+
+    /// Encode MHz values the way a pmgr `voltage-states*` blob does: 8 bytes
+    /// per entry, little-endian hertz in the first 4, voltage in the last 4.
+    fn encode_voltage_states(freqs_hz: &[u64]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(freqs_hz.len() * 8);
+        for (i, hz) in freqs_hz.iter().enumerate() {
+            bytes.extend_from_slice(&(*hz as u32).to_le_bytes());
+            bytes.extend_from_slice(&(700 + i as u32).to_le_bytes());
+        }
+        bytes
+    }
+
+    fn residencies(pairs: &[(&str, i64)]) -> Vec<(String, i64)> {
+        pairs.iter().map(|(n, r)| ((*n).to_string(), *r)).collect()
+    }
+
+    fn tables(entries: &[(&str, &[u32])]) -> Vec<(String, Vec<u32>)> {
+        let mut out: Vec<(String, Vec<u32>)> = entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.to_vec()))
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
+    /// The M1 Ultra pmgr table set, reduced to the keys that matter here.
+    fn m1_ultra_tables() -> Vec<(String, Vec<u32>)> {
+        tables(&[
+            ("voltage-states1-sram", &M1_ULTRA_E_TABLE),
+            ("voltage-states5-sram", &M1_ULTRA_P_TABLE),
+            ("voltage-states9-sram", &M1_ULTRA_GPU_TABLE),
+            ("voltage-states9", &M1_ULTRA_GPU_TABLE),
+            // Same length as the P table, different key. Present on real
+            // hardware; the documented key must win over it.
+            ("voltage-states13-sram", &M1_ULTRA_P_TABLE),
+        ])
+    }
+
+    #[test]
+    fn test_parse_voltage_states_bytes_reads_frequency_table() {
+        let hz: Vec<u64> = M1_ULTRA_P_TABLE
+            .iter()
+            .map(|m| *m as u64 * 1_000_000)
+            .collect();
+        let parsed = parse_voltage_states_bytes(&encode_voltage_states(&hz));
+        assert_eq!(parsed, M1_ULTRA_P_TABLE.to_vec());
+    }
+
+    #[test]
+    fn test_parse_voltage_states_bytes_rejects_period_table() {
+        // Verbatim `voltage-states5` (no `-sram`) from an M1 Ultra. Despite the
+        // key name this holds clock *periods*, not hertz, and must not be
+        // mistaken for a frequency table.
+        let periods: Vec<u64> = vec![
+            109226, 79149, 62060, 50567, 43002, 37406, 33098, 29681, 26771, 24490, 22567, 21586,
+            20924, 20686, 20302,
+        ];
+        let parsed = parse_voltage_states_bytes(&encode_voltage_states(&periods));
+        assert!(
+            parsed.is_empty(),
+            "period table must not parse as frequencies, got {parsed:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_voltage_states_bytes_undoes_u32_wraparound() {
+        // Clocks above 4.295 GHz overflow the 32-bit hertz field. The stored
+        // low bits must be lifted back over the wrap so later Apple Silicon
+        // P-cores do not read as a few hundred megahertz.
+        let hz: Vec<u64> = vec![3_000_000_000, 4_100_000_000, 4_512_000_000, 4_608_000_000];
+        let parsed = parse_voltage_states_bytes(&encode_voltage_states(&hz));
+        assert_eq!(parsed, vec![3000, 4100, 4512, 4608]);
+    }
+
+    #[test]
+    fn test_parse_voltage_states_bytes_ignores_trailing_partial_entry() {
+        let mut bytes = encode_voltage_states(&[600_000_000, 972_000_000]);
+        bytes.extend_from_slice(&[0x11, 0x22]);
+        assert_eq!(parse_voltage_states_bytes(&bytes), vec![600, 972]);
+    }
+
+    #[test]
+    fn test_strip_die_prefix() {
+        assert_eq!(strip_die_prefix("DIE_0_ECPU_CPU0"), "ECPU_CPU0");
+        assert_eq!(strip_die_prefix("DIE_1_PCPU1_CPU3"), "PCPU1_CPU3");
+        assert_eq!(strip_die_prefix("DIE_12_PCPU_CPU0"), "PCPU_CPU0");
+        // Nothing to strip, or a shape that is not a die prefix.
+        assert_eq!(strip_die_prefix("ECPU0"), "ECPU0");
+        assert_eq!(strip_die_prefix("DIE_ECPU"), "DIE_ECPU");
+    }
+
+    #[test]
+    fn test_classify_cpu_channel() {
+        // Multi-die names as reported by an M1 Ultra.
+        assert_eq!(
+            classify_cpu_channel("DIE_0_ECPU_CPU0"),
+            Some(CpuCluster::Efficiency)
+        );
+        assert_eq!(
+            classify_cpu_channel("DIE_1_ECPU_CPU1"),
+            Some(CpuCluster::Efficiency)
+        );
+        assert_eq!(
+            classify_cpu_channel("DIE_0_PCPU_CPU0"),
+            Some(CpuCluster::Performance)
+        );
+        assert_eq!(
+            classify_cpu_channel("DIE_1_PCPU1_CPU3"),
+            Some(CpuCluster::Performance)
+        );
+
+        // Single-die names.
+        assert_eq!(classify_cpu_channel("ECPU"), Some(CpuCluster::Efficiency));
+        assert_eq!(classify_cpu_channel("ECPU0"), Some(CpuCluster::Efficiency));
+        assert_eq!(classify_cpu_channel("PCPU"), Some(CpuCluster::Performance));
+        assert_eq!(classify_cpu_channel("PCPU1"), Some(CpuCluster::Performance));
+
+        // M5 Pro/Max cluster naming, with and without a die prefix.
+        assert_eq!(classify_cpu_channel("MCPU0"), Some(CpuCluster::Super));
+        assert_eq!(classify_cpu_channel("MCPU05"), Some(CpuCluster::Super));
+        assert_eq!(classify_cpu_channel("DIE_0_MCPU0"), Some(CpuCluster::Super));
+        assert_eq!(classify_cpu_channel("MCPU1"), Some(CpuCluster::Performance));
+        assert_eq!(
+            classify_cpu_channel("DIE_1_MCPU15"),
+            Some(CpuCluster::Performance)
+        );
+
+        // Unknown channels are dropped rather than folded into a cluster.
+        assert_eq!(classify_cpu_channel("GPUPH"), None);
+        assert_eq!(classify_cpu_channel(""), None);
+    }
+
+    #[test]
+    fn test_select_cpu_frequency_table_prefers_documented_key() {
+        let tables = m1_ultra_tables();
+
+        let e = select_cpu_frequency_table(&tables, CpuCluster::Efficiency, 5).unwrap();
+        assert_eq!(e, M1_ULTRA_E_TABLE);
+
+        // voltage-states13-sram has the same length as the P table, so the
+        // documented key has to be consulted first for the choice to be stable.
+        let p = select_cpu_frequency_table(&tables, CpuCluster::Performance, 15).unwrap();
+        assert_eq!(p, M1_ULTRA_P_TABLE);
+    }
+
+    #[test]
+    fn test_select_cpu_frequency_table_falls_back_on_length_mismatch() {
+        // A chip whose efficiency table lives under an undocumented key. The
+        // active-state count is the only usable discriminator.
+        let tables = tables(&[
+            ("voltage-states2-sram", &M1_ULTRA_E_TABLE),
+            ("voltage-states5-sram", &M1_ULTRA_P_TABLE),
+        ]);
+
+        let e = select_cpu_frequency_table(&tables, CpuCluster::Efficiency, 5).unwrap();
+        assert_eq!(e, M1_ULTRA_E_TABLE);
+    }
+
+    #[test]
+    fn test_select_cpu_frequency_table_super_cluster_uses_length_match() {
+        // No documented pmgr key exists for the M5 Super cluster, so selection
+        // rests entirely on the active-state count.
+        let super_table: [u32; 4] = [800, 1600, 2800, 4000];
+        let tables = tables(&[
+            ("voltage-states1-sram", &M1_ULTRA_E_TABLE),
+            ("voltage-states7-sram", &super_table),
+        ]);
+
+        let s = select_cpu_frequency_table(&tables, CpuCluster::Super, 4).unwrap();
+        assert_eq!(s, super_table);
+
+        // Nothing of that length: report no table rather than a wrong one.
+        assert!(select_cpu_frequency_table(&tables, CpuCluster::Super, 9).is_none());
+    }
+
+    #[test]
+    fn test_select_cpu_frequency_table_last_resort_uses_documented_key() {
+        // Length disagrees with every table. A partially mapped clock from the
+        // documented key still beats reporting 0 MHz.
+        let tables = tables(&[("voltage-states5-sram", &M1_ULTRA_P_TABLE)]);
+        let p = select_cpu_frequency_table(&tables, CpuCluster::Performance, 99).unwrap();
+        assert_eq!(p, M1_ULTRA_P_TABLE);
+
+        assert!(select_cpu_frequency_table(&[], CpuCluster::Performance, 15).is_none());
+    }
+
+    #[test]
+    fn test_select_gpu_frequency_table() {
+        assert_eq!(
+            select_gpu_frequency_table(&m1_ultra_tables()),
+            M1_ULTRA_GPU_TABLE.to_vec()
+        );
+
+        // No documented key: fall back to the table with the lowest maximum,
+        // GPU clocks being the lowest the package publishes.
+        let odd = tables(&[
+            ("voltage-states1-sram", &M1_ULTRA_E_TABLE),
+            ("voltage-states5-sram", &M1_ULTRA_P_TABLE),
+            ("voltage-states22-sram", &M1_ULTRA_GPU_TABLE),
+        ]);
+        assert_eq!(
+            select_gpu_frequency_table(&odd),
+            M1_ULTRA_GPU_TABLE.to_vec()
+        );
+
+        assert!(select_gpu_frequency_table(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_cpu_performance_states_are_not_numeric() {
+        // The heart of issue #314. Before the fix, CPU clusters went through
+        // calc_freq_from_residencies, which reads the megahertz value out of
+        // the state *name*. Apple Silicon names CPU states `V<volt>P<perf>`,
+        // so every parse failed and the reported clock collapsed to 0 while
+        // residency stayed correct.
+        let res = residencies(&[
+            ("IDLE", 2076468),
+            ("V0P14", 0),
+            ("V1P13", 0),
+            ("V2P12", 1874),
+            ("V3P11", 0),
+            ("V4P10", 0),
+            ("V5P9", 953),
+            ("V6P8", 0),
+            ("V7P7", 0),
+            ("V8P6", 0),
+            ("V9P5", 0),
+            ("V10P4", 0),
+            ("V11P3", 0),
+            ("V12P2", 0),
+            ("V13P1", 0),
+            ("V14P0", 5363773),
+        ]);
+
+        let (freq, residency) = IOReportMetrics::calc_freq_from_residencies(&res);
+        assert_eq!(freq, 0, "state names carry no megahertz value");
+        assert!((residency - 72.10).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_p_cluster_frequency_from_real_m1_ultra_sample() {
+        let res = residencies(&[
+            ("IDLE", 2076468),
+            ("V0P14", 0),
+            ("V1P13", 0),
+            ("V2P12", 1874),
+            ("V3P11", 0),
+            ("V4P10", 0),
+            ("V5P9", 953),
+            ("V6P8", 0),
+            ("V7P7", 0),
+            ("V8P6", 0),
+            ("V9P5", 0),
+            ("V10P4", 0),
+            ("V11P3", 0),
+            ("V12P2", 0),
+            ("V13P1", 0),
+            ("V14P0", 5363773),
+        ]);
+
+        let (freq, residency) = IOReportMetrics::calc_freq_with_table(&res, &M1_ULTRA_P_TABLE);
+
+        // Residency-weighted over the three occupied states:
+        // (1056*1874 + 1752*953 + 3228*5363773) / 5366600
+        assert_eq!(freq, 3226);
+        assert!((residency - 72.10).abs() < 0.01);
+        assert!(freq <= *M1_ULTRA_P_TABLE.last().unwrap());
+    }
+
+    #[test]
+    fn test_e_cluster_frequency_from_real_m1_ultra_sample() {
+        let res = residencies(&[
+            ("IDLE", 1999280),
+            ("V0P4", 0),
+            ("V1P3", 511855),
+            ("V2P2", 576745),
+            ("V3P1", 568251),
+            ("V4P0", 3786908),
+        ]);
+
+        let (freq, residency) = IOReportMetrics::calc_freq_with_table(&res, &M1_ULTRA_E_TABLE);
+
+        assert_eq!(freq, 1846);
+        assert!((residency - 73.14).abs() < 0.01);
+        assert!(freq >= M1_ULTRA_E_TABLE[0] && freq <= *M1_ULTRA_E_TABLE.last().unwrap());
+    }
+
+    #[test]
+    fn test_idle_cpu_cluster_reports_parked_clock_not_zero() {
+        // Every M1 Ultra core parks in IDLE when the machine is quiet. The
+        // cluster is not stopped, it sits at its lowest P-state, so the
+        // reported clock must be the bottom table entry rather than 0.
+        let mut pairs = vec![("IDLE", 7478905)];
+        for name in [
+            "V0P14", "V1P13", "V2P12", "V3P11", "V4P10", "V5P9", "V6P8", "V7P7", "V8P6", "V9P5",
+            "V10P4", "V11P3", "V12P2", "V13P1", "V14P0",
+        ] {
+            pairs.push((name, 0));
+        }
+
+        let (freq, residency) =
+            IOReportMetrics::calc_freq_with_table(&residencies(&pairs), &M1_ULTRA_P_TABLE);
+
+        assert_eq!(freq, 600);
+        assert!((residency - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_is_idle_state() {
+        assert!(is_idle_state("IDLE"));
+        assert!(is_idle_state("OFF"));
+        assert!(is_idle_state("DOWN"));
+        assert!(!is_idle_state("V0P14"));
+        assert!(!is_idle_state("P1"));
     }
 }


### PR DESCRIPTION
## Summary

CPU frequency metrics read 0 on every Apple Silicon machine because the CPU path never had a frequency table to join its residency histogram against. This adds one, sourced from the same IOKit pmgr node the GPU path already uses.

## Where the value was lost

`IOReportMetrics::process_cpu_channel` in `src/device/macos_native/ioreport.rs`, at the frequency computation itself. Everything upstream and downstream was fine: the `CPU Stats` / `CPU Core Performance States` channels were subscribed correctly, residency samples came back non-empty and with correct values (CPU utilization was always right), the manager averaged correctly, and `cpu_macos.rs` into `api/metrics/cpu.rs` passed the value through untouched. It was 0 by the time it left `process_cpu_channel`.

CPU cluster channels were routed through `calc_freq_from_residencies`, which recovers a clock by parsing the IOReport performance-state **name** as a megahertz integer (`"2064"` -> 2064 MHz). Apple Silicon never names CPU states that way. Captured from the M1 Ultra this was verified on:

```
channel="DIE_0_PCPU_CPU0"  states: IDLE, V0P14, V1P13, V2P12, ... V14P0   (15 active)
channel="DIE_0_ECPU_CPU0"  states: IDLE, V0P4, V1P3, V2P2, V3P1, V4P0     (5 active)
channel="GPUPH"            states: OFF, P1, P2, P3, ... P15
```

Every `parse::<i64>()` on those names failed, so the residency-weighted sum stayed 0 and the average collapsed to 0. Residency was computed on a separate accumulator, which is why utilization stayed correct and only the clock was wrong. The GPU escaped this because `process_gpu_channel` already joined against the IOKit `AppleARMIODevice` pmgr `voltage-states9*` table; `GPUPH`'s `P1..P15` names are just as unparseable. The CPU side simply had no equivalent lookup, which is why `all_smi_gpu_frequency_mhz` read 657 while all three CPU metrics read 0 in the same scrape.

This is pre-existing and not a regression from #312 or the Intel Mac work.

## Root cause and fix

The pmgr node publishes a table per clock domain. On this M1 Ultra:

```
voltage-states1-sram  [600, 972, 1332, 1704, 2064]                        5 entries = E-cluster active states
voltage-states5-sram  [600, 828, 1056, ... 3168, 3228]                   15 entries = P-cluster active states
voltage-states9-sram  [388, 486, 648, 777, 972, 1296]                     6 entries = GPU (already used)
```

`voltage-states*` properties are now loaded once into a shared `PMGR_VOLTAGE_STATES` list that both the GPU and the CPU paths select from. The efficiency cluster reads `voltage-states1-sram`, the performance cluster `voltage-states5-sram`, and selection validates the table length against the channel's active-state count before using it, falling back to a length match across all tables. That fallback is what lets the M5 Super cluster (`MCPU0*`), which has no documented key, resolve at all. `calc_gpu_freq_with_table` is renamed `calc_freq_with_table` since both paths now use it.

Two adjacent hardening changes came out of the same investigation:

- Channel classification strips the `DIE_<n>_` prefix that multi-die packages (M1/M2 Ultra) put on every channel before matching. The old rules covered multi-die `ECPU`/`PCPU` names only by substring accident, and the M5 `MCPU0`/`MCPU1` prefix rules used `starts_with`, so a hypothetical `DIE_0_MCPU0` would have been dropped entirely.
- Table parsing lifts values back over a 32-bit wrap. Clocks above 4.295 GHz do not fit the hertz field, and later Apple Silicon P-cores exceed it. Correction only applies after an entry already near the ceiling, so the non-frequency payloads described below cannot arm it.

The plain `voltage-states1` / `voltage-states5` keys are kept in the lookup order because some chips publish clocks there, but on this machine they hold clock **periods** rather than hertz (`[109226, 79149, 62060, ...]`). They fail the plausibility range and are dropped at load, so they can never be mistaken for a frequency table. There is a regression test pinning exactly that.

## Verification (Apple M1 Ultra, Darwin 25.6.0)

`/metrics` before, from a debug build of `main` at 16b564c:

```
all_smi_gpu_frequency_mhz{gpu="Apple M1 Ultra GPU",...} 657
all_smi_cpu_frequency_mhz{cpu_model="Apple M1 Ultra",...} 0
all_smi_cpu_p_cluster_frequency_mhz{cpu_model="Apple M1 Ultra",...} 0
all_smi_cpu_e_cluster_frequency_mhz{cpu_model="Apple M1 Ultra",...} 0
```

`/metrics` after:

```
all_smi_gpu_frequency_mhz{gpu="Apple M1 Ultra GPU",...} 639
all_smi_cpu_frequency_mhz{cpu_model="Apple M1 Ultra",...} 2646
all_smi_cpu_p_cluster_frequency_mhz{cpu_model="Apple M1 Ultra",...} 3228
all_smi_cpu_e_cluster_frequency_mhz{cpu_model="Apple M1 Ultra",...} 2064
```

Sampled repeatedly over a minute, the values track load and stay inside the hardware limits (P-cluster 3017 to 3228 MHz against a 3228 MHz table maximum, E-cluster 1106 to 2064 MHz against 2064 MHz). `all_smi_cpu_frequency_mhz` is the mean of the two, as `cpu_macos.rs` defines it. GPU frequency is unchanged.

TUI: `all-smi local` under `script` could not be captured because the pty has no window size and `ui/chrome.rs` panics on a zero-width terminal, so the P+E display was verified by driving the renderer directly instead. A temporary test built the real `MacOsCpuReader`, took a live `CpuInfo` off the hardware, and passed it to `print_cpu_info`, the same function the TUI calls. Before, on `main`:

```
p_cluster_frequency_mhz: Some(0), e_cluster_frequency_mhz: Some(0)
CPU  Apple M1 Ultra @ cube.loca  Arch:arm64  Sockets: 1  Cores:16P+ 4E  Freq:       0+0MHz  Temp: 56C
```

After:

```
p_cluster_frequency_mhz: Some(2583), e_cluster_frequency_mhz: Some(1195)
CPU  Apple M1 Ultra @ cube.loca  Arch:arm64  Sockets: 1  Cores:16P+ 4E  Freq: 2.58+1.20GHz  Temp: 53C
```

The probe was removed before committing; no test file other than `ioreport.rs` is touched.

## Regression tests

13 new tests in `src/device/macos_native/ioreport.rs`, using residency histograms and pmgr tables captured verbatim from the M1 Ultra. `test_cpu_performance_states_are_not_numeric` pins the bug itself: the real P-cluster histogram through `calc_freq_from_residencies` yields 0 MHz with correct residency. `test_p_cluster_frequency_from_real_m1_ultra_sample` and its E-cluster counterpart assert the corrected values (3226 MHz at 72.10% and 1846 MHz at 73.14%) off the same input. The rest cover table parsing (frequency, period rejection, 32-bit wraparound, truncated payload), `DIE_` prefix stripping, cluster classification across single-die, multi-die and M5 naming, and every branch of table selection.

## Test plan

- [x] `cargo test --lib device::macos_native` (49 passed)
- [x] `cargo test --lib device::cpu_macos` (9 passed)
- [x] `cargo test --lib ui::renderers::cpu_renderer` (8 passed)
- [x] `cargo clippy --lib --tests -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `all-smi api` on Apple M1 Ultra, `/metrics` before and after, captured above
- [x] TUI renderer driven with live hardware `CpuInfo`, before and after, captured above

Closes #314
