### PR TITLE
chore(ci): reduce the blast radius of the Homebrew tap token

### DIFF
--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -505,13 +505,14 @@ jobs:
           #
           # Not in argv either, which rules out the usual replacement,
           # `-c http.extraheader="Authorization: Basic $(...)"`. Command lines
-          # are world-readable through `ps` for as long as the process runs, and
-          # any step that later turns on `set -x` prints the expanded line into
-          # the workflow log. What is written below survives both: `$HOMEBREW_TAP_TOKEN`
-          # sits inside single quotes, so bash passes the eleven characters of
-          # the variable's name to git and expands nothing, and a trace of this
-          # line shows the same name. Only the shell that git spawns to run the
-          # helper resolves it, from its inherited environment.
+          # are readable through `ps` for as long as the process runs, and any
+          # step that later turns on `set -x` prints the expanded line into the
+          # workflow log. What is written below survives both: the helper string
+          # sits inside single quotes, so bash hands git the name
+          # `$HOMEBREW_TAP_TOKEN` and expands nothing, and a trace of this line
+          # shows that same name. Only the shell that git spawns to run the
+          # helper resolves it, from its inherited environment, and xtrace does
+          # not reach that shell.
           #
           # The empty `-c credential.helper=` first is not redundant. An empty
           # value resets the helper list, which drops whatever the runner image

--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -12,20 +12,62 @@ on:
     types:
       - completed
 
+# This job reads this repository's releases through `gh api` and writes nothing
+# back to it. The only write target anywhere in the run is lablup/homebrew-tap,
+# which is reached with HOMEBREW_TAP_TOKEN and not with GITHUB_TOKEN, so read is
+# the whole requirement. Declaring it here also drops every other scope to none,
+# which is what keeps a compromised step from, say, opening a pull request or
+# writing a deployment on the strength of this job's GITHUB_TOKEN.
 permissions:
-  contents: write
+  contents: read
+
+# One formula file, one tap, one branch. Two releases published close together
+# otherwise put two runs on the same file: both clone the tap at the same
+# commit, both rewrite Formula/all-smi.rb from different tags, and the second
+# push is refused as a non-fast-forward. That run ends red having done nothing,
+# and the tap keeps whichever tag happened to push first, which is as likely to
+# be the older one. Nobody looking at a green release notices. Serializing makes
+# the second run clone what the first one pushed, so the tags land in the order
+# they were published.
+#
+# The group is a constant rather than a ref or a tag, because the contended
+# resource is the tap and not anything in this repository.
+# `cancel-in-progress: false` because a cancelled run can be interrupted between
+# `git commit` and `git push`, and there is nothing here that reasons about
+# resuming from that.
+concurrency:
+  group: update-homebrew-formula
+  cancel-in-progress: false
 
 jobs:
   update-homebrew:
     name: Update Homebrew Formula
     runs-on: macos-latest
+
+    # Recorded decision, per issue #316: the `packaging` environment has
+    # `protection_rules: []` and `deployment_branch_policy: null`, so naming it
+    # here scopes HOMEBREW_TAP_TOKEN to this job but gates nothing. Adding
+    # required reviewers or a branch policy is a repository administration
+    # change rather than a workflow change, it changes who is able to ship a
+    # release, and it is therefore left to a human to decide and apply. It was
+    # deliberately not done as part of #316. Until it is, the environment is
+    # bookkeeping, and what actually limits the token's reach is below: the tap
+    # is cloned anonymously, the credential is supplied to the single `git push`
+    # invocation from the environment, and it is never written to disk.
     environment: packaging
 
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
 
     steps:
+      # `persist-credentials: false` for the same reason the tap clone below
+      # carries no credential: by default actions/checkout writes GITHUB_TOKEN
+      # into .git/config as an http.extraheader, where it stays readable by
+      # every later step and by anything those steps run. No step here performs
+      # a git operation in this checkout, so nothing needs it.
       - name: Checkout this repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install gnu-sed
         run: brew install gnu-sed
@@ -56,14 +98,26 @@ jobs:
 
       - name: Clone Homebrew tap repository
         run: |
-          git clone https://x-access-token:${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/lablup/homebrew-tap.git
+          set -euo pipefail
+
+          # Cloned anonymously, on purpose. lablup/homebrew-tap is public, and
+          # has to be for `brew tap lablup/tap` to work without credentials, so
+          # reading it needs no token at all. This used to clone from
+          # `https://x-access-token:<token>@github.com/lablup/homebrew-tap.git`,
+          # which git records verbatim as the `origin` url in
+          # homebrew-tap/.git/config. The token then sat in the workspace for
+          # the rest of the job, readable by every subsequent step and by
+          # anything those steps invoke, third-party actions included, and any
+          # code execution anywhere in the job was a tap compromise rather than
+          # a nuisance. Only the push needs the credential, and the push step
+          # takes it from the environment for the length of one command.
+          git clone https://github.com/lablup/homebrew-tap.git
           cd homebrew-tap
           git config user.name "GitHub Action"
           git config user.email "actions@github.com"
 
       - name: Download release artifacts and calculate SHA256
         run: |
-          cd homebrew-tap
           set -euo pipefail
 
           RAW_VERSION="${VERSION}"
@@ -87,7 +141,7 @@ jobs:
             exit 1
           fi
 
-          echo "VERSION_NO_V=$VERSION" >> $GITHUB_ENV  # Export version without 'v' to GitHub env
+          echo "VERSION_NO_V=$VERSION" >> "$GITHUB_ENV"  # Export version without 'v' to GitHub env
 
           # This repository was renamed from inureyes/all-smi to lablup/all-smi.
           # The old path still resolves through GitHub's rename redirect, but
@@ -96,7 +150,16 @@ jobs:
           # lands verbatim in the tap formula, so the redirect was load-bearing
           # for every `brew install all-smi`, not just for this workflow.
           BASE="https://github.com/lablup/all-smi/releases/download/v${VERSION}"
-          mkdir -p tmp
+
+          # Downloads land in RUNNER_TEMP, outside the tap clone. They used to
+          # go to homebrew-tap/tmp, which meant four release archives sat inside
+          # a git working tree whose next two steps rewrite a tracked file and
+          # commit it, and the only thing keeping them out of that commit was
+          # the commit step naming Formula/all-smi.rb explicitly. That is one
+          # `git add -A` away from publishing binaries into a Homebrew tap, and
+          # nothing about the download needs to be there in the first place.
+          ARTIFACT_DIR="${RUNNER_TEMP}/all-smi-artifacts"
+          mkdir -p "$ARTIFACT_DIR"
 
           # `-f` so a missing or renamed asset fails here rather than leaving a
           # zero-byte file whose checksum gets committed to the tap, and an
@@ -119,9 +182,9 @@ jobs:
             } >> "$GITHUB_ENV"
           }
 
-          fetch mac       "${BASE}/all-smi-macos-aarch64.zip"    tmp/mac.zip
-          fetch linux_arm "${BASE}/all-smi-linux-aarch64.tar.gz" tmp/linux-arm.tar.gz
-          fetch linux_x86 "${BASE}/all-smi-linux-x86_64.tar.gz"  tmp/linux-x86.tar.gz
+          fetch mac       "${BASE}/all-smi-macos-aarch64.zip"    "${ARTIFACT_DIR}/mac.zip"
+          fetch linux_arm "${BASE}/all-smi-linux-aarch64.tar.gz" "${ARTIFACT_DIR}/linux-arm.tar.gz"
+          fetch linux_x86 "${BASE}/all-smi-linux-x86_64.tar.gz"  "${ARTIFACT_DIR}/linux-x86.tar.gz"
 
           # The Intel Mac zip only exists from the release that first built
           # x86_64-apple-darwin onwards (#306), so its absence is a normal state
@@ -145,9 +208,26 @@ jobs:
           # because the name contains dots, and as a regex those match any
           # character, so an asset named `all-smi-macos-x86_64Xzip` would read as
           # this one being present.
-          ASSETS=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" --jq '.assets[].name')
+          #
+          # The names come from the paginated assets collection, not from the
+          # `assets` array that the release object embeds. That array carries no
+          # pagination controls and no Link header, so its completeness is not
+          # something the API promises, and this workflow reads absence from it
+          # as a decision: a truncated list is a silent "the release does not
+          # publish an Intel zip", which either skips an artifact that exists or
+          # trips the version-skew refusal in the next step. Releases here
+          # already publish 18 assets and gain more with every added target, so
+          # the safe reading is the one with a documented contract. `--paginate`
+          # follows the Link header to the end; `per_page=100` keeps that to a
+          # single request at the current asset count.
+          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" --jq '.id')
+          if ! [[ $RELEASE_ID =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not resolve a numeric release id for v${VERSION}."
+            exit 1
+          fi
+          ASSETS=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?per_page=100" --jq '.[].name')
           if printf '%s\n' "$ASSETS" | grep -qxF "all-smi-macos-x86_64.zip"; then
-            fetch mac_x86 "${BASE}/all-smi-macos-x86_64.zip" tmp/mac-x86.zip
+            fetch mac_x86 "${BASE}/all-smi-macos-x86_64.zip" "${ARTIFACT_DIR}/mac-x86.zip"
             echo "mac_x86_present=true" >> "$GITHUB_ENV"
           else
             echo "::notice::v${VERSION} publishes no all-smi-macos-x86_64.zip."
@@ -304,27 +384,76 @@ jobs:
             exit 1
           fi
 
-          # A substitution that silently no-ops would leave the previous
-          # release's checksum behind, so require the exact expected set. The
-          # count comes from the list the previous step actually wrote rather
-          # than from a literal: the Intel macOS stanza is optional, so a fixed
-          # number is wrong in one of the two states, and a literal is the kind
-          # that quietly goes stale the next time an artifact is added.
-          shas=("$mac_sha" "$linux_arm_sha" "$linux_x86_sha")
+          # The expected artifacts, as the (url, sha256) pairs they have to form
+          # in the formula. The count comes from the list the previous step
+          # actually wrote rather than from a literal: the Intel macOS stanza is
+          # optional, so a fixed number is wrong in one of the two states, and a
+          # literal is the kind that quietly goes stale the next time an
+          # artifact is added.
+          expected_urls=("$mac_url" "$linux_arm_url" "$linux_x86_url")
+          expected_shas=("$mac_sha" "$linux_arm_sha" "$linux_x86_sha")
           if [ "${mac_x86_state:-skipped}" = "updated" ]; then
-            shas+=("$mac_x86_sha")
+            expected_urls+=("$mac_x86_url")
+            expected_shas+=("$mac_x86_sha")
           fi
 
+          # A substitution that silently no-ops would leave the previous
+          # release's checksum behind, so require the exact expected count.
+          # Counted over sha256 stanzas rather than over pairs, so a checksum
+          # with no url above it is caught too.
           n=$(grep -c "^[[:space:]]*sha256 " Formula/all-smi.rb || true)
-          if [ "$n" -ne "${#shas[@]}" ]; then
-            echo "::error::Formula/all-smi.rb: expected ${#shas[@]} sha256 stanzas, found ${n}."
+          if [ "$n" -ne "${#expected_shas[@]}" ]; then
+            echo "::error::Formula/all-smi.rb: expected ${#expected_shas[@]} sha256 stanzas, found ${n}."
             exit 1
           fi
-          for sha in "${shas[@]}"; do
-            if ! grep -q "^[[:space:]]*sha256 \"${sha}\"$" Formula/all-smi.rb; then
-              echo "::error::Formula/all-smi.rb: sha256 ${sha} was not written."
+
+          # url and checksum are then checked together, as the pair `brew
+          # install` will act on. Checking them independently, which is what this
+          # used to do, accepts a formula in which two artifacts have exchanged
+          # checksums: every expected checksum is present, every url names the
+          # right release, and each stanza describes a file that exists. Swapped
+          # is not a hypothetical shape either, it is precisely what a rewrite
+          # that matched one stanza and wrote into another produces, which is the
+          # failure mode the whole update step is built around avoiding. The
+          # result installs a Linux tarball whose sha256 is a macOS zip's, so it
+          # fails at the checksum for a reason that says nothing about the cause.
+          #
+          # Pairs are read out of the file the same way set_artifact writes
+          # them: a url stanza, then the first sha256 stanza below it. A url
+          # with no sha256 beneath it yields no pair, so the count comes up
+          # short and the comparison below rejects the file.
+          TAB=$'\t'
+          pairs="${RUNNER_TEMP}/formula-url-sha-pairs.txt"
+          awk '
+            /^[[:space:]]*url "/ {
+              u = $0
+              sub(/^[[:space:]]*url "/, "", u)
+              sub(/".*$/, "", u)
+              pending = 1
+              next
+            }
+            pending && /^[[:space:]]*sha256 "/ {
+              s = $0
+              sub(/^[[:space:]]*sha256 "/, "", s)
+              sub(/".*$/, "", s)
+              printf "%s\t%s\n", u, s
+              pending = 0
+            }
+          ' Formula/all-smi.rb > "$pairs"
+
+          found=$(wc -l < "$pairs" | tr -d '[:space:]')
+          if [ "$found" -ne "${#expected_urls[@]}" ]; then
+            echo "::error::Formula/all-smi.rb: expected ${#expected_urls[@]} url/sha256 pairs, found ${found}."
+            exit 1
+          fi
+
+          i=0
+          while [ "$i" -lt "${#expected_urls[@]}" ]; do
+            if ! grep -qxF "${expected_urls[$i]}${TAB}${expected_shas[$i]}" "$pairs"; then
+              echo "::error::Formula/all-smi.rb: no url stanza for ${expected_urls[$i]} is followed by sha256 ${expected_shas[$i]}."
               exit 1
             fi
+            i=$((i + 1))
           done
 
           # Every release download has to name this release, whatever the
@@ -347,6 +476,10 @@ jobs:
           fi
 
       - name: Commit and push changes to tap
+        env:
+          # The only step in the job that the tap token is exposed to, and the
+          # only one that needs it. Every step above reads public data.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd homebrew-tap
           set -euo pipefail
@@ -361,7 +494,42 @@ jobs:
           fi
 
           git commit -m "bump: all-smi to v${VERSION_NO_V}"
-          git push origin main
+
+          # The credential exists for the duration of this one command, and in
+          # only one place: this process's environment.
+          #
+          # Not in the remote url, which is where it used to live. `git clone
+          # https://x-access-token:<token>@...` records the url in .git/config,
+          # so the token outlives the command that used it and is readable by
+          # everything that runs afterwards in the job.
+          #
+          # Not in argv either, which rules out the usual replacement,
+          # `-c http.extraheader="Authorization: Basic $(...)"`. Command lines
+          # are world-readable through `ps` for as long as the process runs, and
+          # any step that later turns on `set -x` prints the expanded line into
+          # the workflow log. What is written below survives both: `$HOMEBREW_TAP_TOKEN`
+          # sits inside single quotes, so bash passes the eleven characters of
+          # the variable's name to git and expands nothing, and a trace of this
+          # line shows the same name. Only the shell that git spawns to run the
+          # helper resolves it, from its inherited environment.
+          #
+          # The empty `-c credential.helper=` first is not redundant. An empty
+          # value resets the helper list, which drops whatever the runner image
+          # configures globally, osxkeychain on macOS among them. Without it a
+          # successful authentication is handed to that helper for storage, and
+          # the token lands in the keychain, which is disk. The helper below
+          # answers `get` and nothing else, so git's post-authentication `store`
+          # call is a no-op, and the `if` makes it exit 0 so git does not treat
+          # the silence as a failed helper.
+          #
+          # SC2016 is the point, not an oversight: the single quotes are what
+          # keep bash from expanding the variable, so only the helper's own
+          # shell ever sees the value.
+          # shellcheck disable=SC2016
+          git \
+            -c credential.helper= \
+            -c 'credential.helper=!f() { if [ "$1" = get ]; then printf "username=x-access-token\npassword=%s\n" "$HOMEBREW_TAP_TOKEN"; fi; }; f' \
+            push origin main
 
       # Deliberately last, and deliberately red. The release publishes an Intel
       # Mac artifact that the formula has no stanza for, so the three artifacts

--- a/TESTING.md
+++ b/TESTING.md
@@ -125,6 +125,29 @@ For detailed information about shell script tests, see: [tests/README.md](tests/
 - **Memory Limit Detection**: Test cgroups v1/v2 memory limit detection
 - **Build-in-Container Tests**: All tests build all-smi inside containers for realistic scenarios
 
+### Homebrew Formula Workflow Tests
+
+`.github/workflows/update_homebrew_formula.yml` pushes to `lablup/homebrew-tap`, a production Homebrew tap, so it cannot be exercised by running it. `tests/homebrew-formula-workflow/` runs its step bodies instead, read out of the committed YAML by step name so the thing under test is the file that ships.
+
+```bash
+# All case groups
+./tests/homebrew-formula-workflow/run-workflow-steps.sh
+
+# One group: formula | download | token
+./tests/homebrew-formula-workflow/run-workflow-steps.sh formula
+
+# Point it at a deliberately broken copy, to check a case would really fail
+ALL_SMI_WORKFLOW=/tmp/mutant.yml ./tests/homebrew-formula-workflow/run-workflow-steps.sh token
+```
+
+Requires macOS, matching the workflow's `runs-on: macos-latest`: the step bodies call `gsed`, `brew style` and BSD `awk`. Also needs `python3` with PyYAML.
+
+- **formula**: the four release-asset / formula-stanza states, a malformed tap with duplicate stanzas, the url/sha256 pairing guard, and a stanza left behind at an older release.
+- **download**: artifacts landing outside the tap clone, and the release asset list being read from the paginated assets collection. `gh` and `curl` are stubbed, so the group is offline and cannot be turned red by the state of a real release.
+- **token**: the push step run for real against a local authenticating Git smart-HTTP server, asserting the tap credential reaches the wire and appears in no file, no execution trace, and no credential store.
+
+Nothing here pushes to the tap or contacts GitHub.
+
 ## Troubleshooting
 
 #### "sudo: a terminal is required to read the password"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all container-cpu-frequency arm-cpu-frequency container-benchmark container-cpu container-memory container-simple quick-api clean
+.PHONY: help all container-cpu-frequency arm-cpu-frequency container-benchmark container-cpu container-memory container-simple quick-api homebrew-formula-workflow clean
 
 # Default target
 help:
@@ -22,6 +22,9 @@ help:
 	@echo "Performance Tests:"
 	@echo "  high-scale-monitoring       Test monitoring 100+ remote nodes (TODO)"
 	@echo "  api-load-test              Test API performance under load (TODO)"
+	@echo ""
+	@echo "Workflow Tests:"
+	@echo "  homebrew-formula-workflow   Run the Homebrew tap workflow's step bodies (macOS only)"
 	@echo ""
 	@echo "Utility:"
 	@echo "  all                        Run all available tests"
@@ -94,6 +97,13 @@ high-scale-monitoring:
 api-load-test:
 	@echo "=== API load test not yet implemented ==="
 	@echo "TODO: Create test-api-load.sh"
+
+# Run the update_homebrew_formula.yml step bodies against fixtures. Offline, and
+# deliberately not part of `all`: the bodies call gsed, brew style and BSD awk,
+# so this needs macOS, matching the workflow's own runs-on.
+homebrew-formula-workflow:
+	@echo "=== Running Homebrew formula workflow step tests ==="
+	@./homebrew-formula-workflow/run-workflow-steps.sh
 
 # Clean up test artifacts
 clean:

--- a/tests/homebrew-formula-workflow/cases-download.sh
+++ b/tests/homebrew-formula-workflow/cases-download.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# The `Download release artifacts and calculate SHA256` step, executed against
+# stubbed `gh` and `curl`. Offline, so it can run anywhere and cannot be made
+# green or red by the state of a real release.
+#
+# The stubs are assertions in their own right. The `gh` stub refuses to answer
+# an assets listing that arrives without --paginate, and refuses to hand back
+# the `assets` array embedded in the release object at all, so reverting either
+# of those fails here rather than years later on the release that first grows
+# past a page.
+#
+# Sourced by run-workflow-steps.sh.
+
+# SC2030/SC2031: the step bodies are deliberately run inside a subshell so their
+# environment cannot leak between cases. Locality is the point.
+# shellcheck disable=SC2030,SC2031
+
+write_download_stubs() {  # bindir
+    local bindir="$1"
+    mkdir -p "$bindir"
+
+    cat > "${bindir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+printf 'gh %s\n' "$*" >> "$STUB_LOG"
+[ "${1:-}" = "api" ] || { echo "stub gh: unsupported subcommand: ${1:-}" >&2; exit 2; }
+shift
+paginate=0
+path=""
+jq_filter=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --paginate) paginate=1; shift ;;
+    --jq) jq_filter="${2:-}"; shift 2 ;;
+    -*) shift ;;
+    *) path="$1"; shift ;;
+  esac
+done
+case "$path" in
+  */releases/tags/*)
+    case "$jq_filter" in
+      *assets*)
+        echo "stub gh: read the assets array embedded in the release object; use the paginated assets collection instead" >&2
+        exit 3
+        ;;
+    esac
+    printf '%s\n' "$STUB_RELEASE_ID"
+    ;;
+  */releases/*/assets*)
+    if [ "$paginate" -ne 1 ]; then
+      echo "stub gh: assets listed without --paginate" >&2
+      exit 4
+    fi
+    cat "$STUB_ASSETS_FILE"
+    ;;
+  *)
+    echo "stub gh: unexpected api path: $path" >&2
+    exit 5
+    ;;
+esac
+STUB
+
+    cat > "${bindir}/curl" <<'STUB'
+#!/usr/bin/env bash
+set -u
+url=""
+dest=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) dest="${2:-}"; shift 2 ;;
+    --retry) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf 'curl %s -> %s\n' "$url" "$dest" >> "$STUB_LOG"
+case "$url" in
+  *.zip) cp "$STUB_ZIP" "$dest" ;;
+  *.tar.gz) cp "$STUB_TGZ" "$dest" ;;
+  *) echo "stub curl: unexpected url: $url" >&2; exit 22 ;;
+esac
+STUB
+
+    chmod +x "${bindir}/gh" "${bindir}/curl"
+}
+
+make_stub_archives() {  # dir
+    mkdir -p "$1/payload"
+    printf 'stub binary\n' > "$1/payload/all-smi"
+    (cd "$1/payload" && zip -qr "$1/stub.zip" all-smi)
+    (cd "$1/payload" && tar -czf "$1/stub.tar.gz" all-smi)
+}
+
+# ASSET_LINES: names the stubbed release publishes, one per line.
+run_download_step() {  # sandbox asset-lines logfile -> status
+    local box="$1" asset_lines="$2" log="$3"
+    local script="${box}/download.sh"
+    step_script 'Download release artifacts and calculate SHA256' "$script" || return 127
+    printf '%s\n' "$asset_lines" > "${box}/assets.txt"
+    (
+        cd "$box" || exit 127
+        export PATH="${box}/bin:$PATH"
+        export GITHUB_ENV="${box}/github_env"
+        export RUNNER_TEMP="${box}/runner_temp"
+        export GITHUB_REPOSITORY="lablup/all-smi"
+        export VERSION="v${NEW_VERSION}"
+        export STUB_LOG="${box}/stub.log"
+        export STUB_RELEASE_ID="362933399"
+        export STUB_ASSETS_FILE="${box}/assets.txt"
+        export STUB_ZIP="${box}/stub.zip"
+        export STUB_TGZ="${box}/stub.tar.gz"
+        bash "$script"
+    ) > "$log" 2>&1
+}
+
+new_download_sandbox() {
+    local dir
+    dir=$(mktemp -d "${TMPDIR:-/tmp}/all-smi-hbw-dl.XXXXXX")
+    make_tap "$dir" "${FIXTURES}/one-stanza.rb"
+    : > "$dir/github_env"
+    : > "$dir/stub.log"
+    mkdir -p "$dir/runner_temp"
+    write_download_stubs "$dir/bin"
+    make_stub_archives "$dir"
+    printf '%s' "$dir"
+}
+
+THREE_ASSETS='all-smi-macos-aarch64.zip
+all-smi-macos-aarch64.zip.sha256
+all-smi-linux-aarch64.tar.gz
+all-smi-linux-x86_64.tar.gz'
+
+case_download_keeps_tap_clean() {
+    begin_case "download step: artifacts land outside the tap clone"
+    local box status dirty artifacts assets
+    box=$(new_download_sandbox)
+
+    # The Intel zip is deliberately the last name in a long list, so a listing
+    # that stopped early would report it absent.
+    assets="$THREE_ASSETS"
+    local i=0
+    while [ "$i" -lt 200 ]; do
+        assets="${assets}
+filler-asset-${i}.txt"
+        i=$((i + 1))
+    done
+    assets="${assets}
+all-smi-macos-x86_64.zip"
+
+    run_download_step "$box" "$assets" "$box/download.log"
+    status=$?
+    assert_status "download step succeeds" 0 "$status" "$box/download.log"
+
+    artifacts="${box}/runner_temp/all-smi-artifacts"
+    for name in mac.zip linux-arm.tar.gz linux-x86.tar.gz mac-x86.zip; do
+        if [ -s "${artifacts}/${name}" ]; then
+            ok "downloaded ${name} into RUNNER_TEMP"
+        else
+            bad "downloaded ${name} into RUNNER_TEMP" "missing: ${artifacts}/${name}"
+        fi
+    done
+
+    dirty=$(git -C "${box}/homebrew-tap" status --porcelain)
+    assert_eq "tap working tree is untouched" "" "$dirty"
+    if [ -e "${box}/homebrew-tap/tmp" ]; then
+        bad "no tmp directory inside the tap clone" "${box}/homebrew-tap/tmp exists"
+    else
+        ok "no tmp directory inside the tap clone"
+    fi
+
+    assert_file_has "the Intel zip at the end of the list is still seen" \
+        "$box/github_env" "mac_x86_present=true"
+    assert_file_has "asset list came from the paginated assets collection" \
+        "$box/stub.log" "/assets?per_page=100"
+    assert_file_has "asset list was requested with --paginate" \
+        "$box/stub.log" "--paginate"
+    assert_file_has "checksum was recorded for the macOS zip" "$box/github_env" "mac_sha="
+}
+
+case_download_absent_intel_asset() {
+    begin_case "download step: release without the Intel zip"
+    local box status
+    box=$(new_download_sandbox)
+
+    run_download_step "$box" "$THREE_ASSETS" "$box/download.log"
+    status=$?
+    assert_status "download step succeeds" 0 "$status" "$box/download.log"
+    assert_file_has "records mac_x86_present=false" "$box/github_env" "mac_x86_present=false"
+    assert_file_has "emits a notice" "$box/download.log" "::notice::"
+    if [ -e "${box}/runner_temp/all-smi-artifacts/mac-x86.zip" ]; then
+        bad "no Intel zip is downloaded" "mac-x86.zip should not exist"
+    else
+        ok "no Intel zip is downloaded"
+    fi
+}
+
+case_download_rejects_bad_version() {
+    begin_case "download step: a tag that is not a plain version is refused"
+    local box status script
+    box=$(new_download_sandbox)
+    script="${box}/download.sh"
+    step_script 'Download release artifacts and calculate SHA256' "$script"
+    printf '%s\n' "$THREE_ASSETS" > "${box}/assets.txt"
+    (
+        cd "$box" || exit 127
+        export PATH="${box}/bin:$PATH"
+        export GITHUB_ENV="${box}/github_env"
+        export RUNNER_TEMP="${box}/runner_temp"
+        export GITHUB_REPOSITORY="lablup/all-smi"
+        export VERSION="v0.0.0/../../../attacker/repo/releases/download/v1"
+        export STUB_LOG="${box}/stub.log"
+        export STUB_RELEASE_ID="1"
+        export STUB_ASSETS_FILE="${box}/assets.txt"
+        export STUB_ZIP="${box}/stub.zip"
+        export STUB_TGZ="${box}/stub.tar.gz"
+        bash "$script"
+    ) > "$box/download.log" 2>&1
+    status=$?
+    assert_status "download step refuses the traversal" 1 "$status" "$box/download.log"
+    assert_file_has "explains why" "$box/download.log" "Refusing to run for tag"
+    assert_eq "nothing was downloaded" "" "$(cat "$box/stub.log")"
+}
+
+run_download_cases() {
+    case_download_keeps_tap_clean
+    case_download_absent_intel_asset
+    case_download_rejects_bad_version
+}

--- a/tests/homebrew-formula-workflow/cases-formula.sh
+++ b/tests/homebrew-formula-workflow/cases-formula.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# The `Update formula` and `Validate updated formula` steps, executed against
+# fixture formulas. Covers the four asset/stanza states that PR #313 established
+# and the url/sha256 pairing guard added for issue #316.
+#
+# Sourced by run-workflow-steps.sh.
+
+# SC2154: mac_url and friends are exported by export_artifact_env in lib.sh,
+# which shellcheck does not follow across a source in a sibling file.
+# SC2030/SC2031: step bodies run in a subshell on purpose, so their environment
+# cannot leak between cases.
+# shellcheck disable=SC2154,SC2030,SC2031
+
+# The sha256 that follows the url stanza naming ARTIFACT. Deliberately a second,
+# independent implementation of the pairing the validate step performs, so the
+# two have to agree about what the file says.
+sha_after() {  # file artifact
+    awk -v a="$2" '
+      !seen && /^[[:space:]]*url / && index($0, a) { seen = 1; next }
+      seen && /^[[:space:]]*sha256 "/ {
+        s = $0
+        sub(/^[[:space:]]*sha256 "/, "", s)
+        sub(/".*$/, "", s)
+        print s
+        exit
+      }
+    ' "$1"
+}
+
+url_of() {  # file artifact
+    awk -v a="$2" '
+      /^[[:space:]]*url / && index($0, a) {
+        u = $0
+        sub(/^[[:space:]]*url "/, "", u)
+        sub(/".*$/, "", u)
+        print u
+        exit
+      }
+    ' "$1"
+}
+
+count_sha_stanzas() {  # file
+    grep -c '^[[:space:]]*sha256 ' "$1" || true
+}
+
+# One sandbox per case: a tap working tree, a GITHUB_ENV file, a RUNNER_TEMP.
+new_sandbox() {  # fixture -> echoes dir
+    local dir
+    dir=$(mktemp -d "${TMPDIR:-/tmp}/all-smi-hbw.XXXXXX")
+    make_tap "$dir" "$1"
+    : > "$dir/github_env"
+    mkdir -p "$dir/runner_temp"
+    printf '%s' "$dir"
+}
+
+run_formula_step() {  # step-name sandbox logfile -> status
+    local script="$2/step.sh"
+    step_script "$1" "$script" || return 127
+    (
+        cd "$2" || exit 127
+        export GITHUB_ENV="$2/github_env"
+        export RUNNER_TEMP="$2/runner_temp"
+        bash "$script"
+    ) > "$3" 2>&1
+}
+
+case_state1_asset_and_stanza() {
+    begin_case "state 1: release publishes the Intel zip, formula has the stanza"
+    local box status formula
+    box=$(new_sandbox "${FIXTURES}/two-stanza.rb")
+    export_artifact_env true
+
+    run_formula_step 'Update formula' "$box" "$box/update.log"
+    status=$?
+    assert_status "update step succeeds" 0 "$status" "$box/update.log"
+    assert_file_has "records mac_x86_state=updated" "$box/github_env" "mac_x86_state=updated"
+
+    apply_github_env "$box/github_env"
+    run_formula_step 'Validate updated formula' "$box" "$box/validate.log"
+    status=$?
+    assert_status "validate step succeeds" 0 "$status" "$box/validate.log"
+
+    formula="$box/homebrew-tap/Formula/all-smi.rb"
+    assert_file_has "version bumped" "$formula" "version \"${NEW_VERSION}\""
+    assert_eq "four sha256 stanzas" 4 "$(count_sha_stanzas "$formula")"
+    assert_eq "aarch64 macOS url rewritten" "$mac_url" "$(url_of "$formula" all-smi-macos-aarch64.zip)"
+    assert_eq "aarch64 macOS checksum is its own" "$SHA_MAC" "$(sha_after "$formula" all-smi-macos-aarch64.zip)"
+    assert_eq "x86_64 macOS url rewritten" "$mac_x86_url" "$(url_of "$formula" all-smi-macos-x86_64.zip)"
+    assert_eq "x86_64 macOS checksum is its own" "$SHA_MAC_X86" "$(sha_after "$formula" all-smi-macos-x86_64.zip)"
+    assert_eq "linux aarch64 checksum is its own" "$SHA_LINUX_ARM" "$(sha_after "$formula" all-smi-linux-aarch64.tar.gz)"
+    assert_eq "linux x86_64 checksum is its own" "$SHA_LINUX_X86" "$(sha_after "$formula" all-smi-linux-x86_64.tar.gz)"
+
+    SANDBOX_STATE1="$box"
+}
+
+case_state2_neither() {
+    begin_case "state 2: no Intel zip in the release, no stanza in the formula"
+    local box status formula before after
+    box=$(new_sandbox "${FIXTURES}/one-stanza.rb")
+    export_artifact_env false
+
+    before=$(sed -n '/on_macos do/,/^  end$/p' "$box/homebrew-tap/Formula/all-smi.rb" | grep -c 'sha256' || true)
+
+    run_formula_step 'Update formula' "$box" "$box/update.log"
+    status=$?
+    assert_status "update step succeeds" 0 "$status" "$box/update.log"
+    assert_file_has "records mac_x86_state=skipped" "$box/github_env" "mac_x86_state=skipped"
+    assert_file_has "emits a notice, not a warning" "$box/update.log" "::notice::"
+
+    apply_github_env "$box/github_env"
+    run_formula_step 'Validate updated formula' "$box" "$box/validate.log"
+    status=$?
+    assert_status "validate step succeeds" 0 "$status" "$box/validate.log"
+
+    formula="$box/homebrew-tap/Formula/all-smi.rb"
+    assert_eq "three sha256 stanzas" 3 "$(count_sha_stanzas "$formula")"
+    after=$(sed -n '/on_macos do/,/^  end$/p' "$formula" | grep -c 'sha256' || true)
+    assert_eq "macOS section gains no stanza" "$before" "$after"
+
+    SANDBOX_STATE2="$box"
+}
+
+case_state3_asset_without_stanza() {
+    begin_case "state 3: release publishes the Intel zip, formula has no stanza"
+    local box status formula
+    box=$(new_sandbox "${FIXTURES}/one-stanza.rb")
+    export_artifact_env true
+
+    run_formula_step 'Update formula' "$box" "$box/update.log"
+    status=$?
+    assert_status "update step succeeds so the other three still ship" 0 "$status" "$box/update.log"
+    assert_file_has "records mac_x86_state=stanza-missing" "$box/github_env" "mac_x86_state=stanza-missing"
+    assert_file_has "emits a warning" "$box/update.log" "::warning::"
+
+    apply_github_env "$box/github_env"
+    run_formula_step 'Validate updated formula' "$box" "$box/validate.log"
+    status=$?
+    assert_status "validate step succeeds at three artifacts" 0 "$status" "$box/validate.log"
+
+    formula="$box/homebrew-tap/Formula/all-smi.rb"
+    assert_eq "three sha256 stanzas" 3 "$(count_sha_stanzas "$formula")"
+
+    # The push happens, and only then does the job go red, which is the whole
+    # point of this state. That final gate lives in a step-level `if`, not in a
+    # step body, so it is asserted against the YAML.
+    if grep -q "if: env.mac_x86_state == 'stanza-missing'" "$WORKFLOW"; then
+        ok "a later step is gated on stanza-missing so the job ends red"
+    else
+        bad "a later step is gated on stanza-missing so the job ends red"
+    fi
+}
+
+case_state4_stanza_without_asset() {
+    begin_case "state 4: no Intel zip in the release, but the formula has a stanza"
+    local box status
+    box=$(new_sandbox "${FIXTURES}/two-stanza.rb")
+    export_artifact_env false
+
+    run_formula_step 'Update formula' "$box" "$box/update.log"
+    status=$?
+    assert_status "update step refuses" 1 "$status" "$box/update.log"
+    assert_file_has "refuses over version skew" "$box/update.log" \
+        "Refusing to bump the version while the Intel url still points at another release"
+    assert_file_lacks "no state is recorded for a refused run" "$box/github_env" "mac_x86_state="
+}
+
+case_malformed_duplicate_stanza() {
+    begin_case "malformed tap: two Intel stanzas"
+    local box status
+    box=$(new_sandbox "${FIXTURES}/two-intel-stanzas.rb")
+    export_artifact_env true
+
+    run_formula_step 'Update formula' "$box" "$box/update.log"
+    status=$?
+    assert_status "update step refuses" 1 "$status" "$box/update.log"
+    assert_file_has "names the ambiguous artifact" "$box/update.log" \
+        "expected exactly one url stanza for all-smi-macos-x86_64.zip, found 2"
+}
+
+# The regression this issue's pairing guard exists for. Every checksum in the
+# file is one the run computed, every url names the right release, and the
+# counts are right; only the pairing is wrong. Everything the validate step
+# checked before #316 passes on it.
+case_swapped_checksums() {
+    begin_case "swapped checksums: url and sha256 correct apart, wrong together"
+    local box status formula independent_checks_pass sha
+    box="$SANDBOX_STATE1"
+    if [ -z "${box:-}" ]; then
+        bad "state 1 sandbox available" "state 1 must run first"
+        return
+    fi
+    formula="$box/homebrew-tap/Formula/all-smi.rb"
+    export_artifact_env true
+    export mac_x86_state=updated
+
+    # Exchange the macOS aarch64 checksum with the Linux x86_64 one.
+    gsed -i "s|sha256 \"${SHA_MAC}\"|sha256 \"__SWAP__\"|" "$formula"
+    gsed -i "s|sha256 \"${SHA_LINUX_X86}\"|sha256 \"${SHA_MAC}\"|" "$formula"
+    gsed -i "s|sha256 \"__SWAP__\"|sha256 \"${SHA_LINUX_X86}\"|" "$formula"
+
+    assert_eq "the swap took" "$SHA_LINUX_X86" "$(sha_after "$formula" all-smi-macos-aarch64.zip)"
+
+    # Control: the pre-#316 checks, reimplemented here, all accept this file.
+    independent_checks_pass=yes
+    [ "$(count_sha_stanzas "$formula")" = 4 ] || independent_checks_pass=no
+    for sha in "$SHA_MAC" "$SHA_MAC_X86" "$SHA_LINUX_ARM" "$SHA_LINUX_X86"; do
+        grep -q "^[[:space:]]*sha256 \"${sha}\"$" "$formula" || independent_checks_pass=no
+    done
+    if [ "$(grep -c '^[[:space:]]*url ".*/releases/download/' "$formula")" \
+         != "$(grep -c "^[[:space:]]*url \".*/releases/download/v0\\.26\\.0/" "$formula")" ]; then
+        independent_checks_pass=no
+    fi
+    assert_eq "checking url and sha independently would accept it" yes "$independent_checks_pass"
+
+    run_formula_step 'Validate updated formula' "$box" "$box/validate-swapped.log"
+    status=$?
+    assert_status "validate step rejects it" 1 "$status" "$box/validate-swapped.log"
+    assert_file_has "names the pair that does not exist" "$box/validate-swapped.log" \
+        "no url stanza for ${mac_url} is followed by sha256 ${SHA_MAC}"
+}
+
+# A stanza the update step never touched keeps its old url. PR #313 added this
+# guard; it has to keep firing.
+case_stale_url() {
+    begin_case "stale url: one stanza left behind at the previous release"
+    local box status formula
+    box="$SANDBOX_STATE2"
+    if [ -z "${box:-}" ]; then
+        bad "state 2 sandbox available" "state 2 must run first"
+        return
+    fi
+    formula="$box/homebrew-tap/Formula/all-smi.rb"
+    export_artifact_env false
+    export mac_x86_state=skipped
+
+    gsed -i "s|download/v${NEW_VERSION}/all-smi-linux-x86_64.tar.gz|download/v0.25.0/all-smi-linux-x86_64.tar.gz|" "$formula"
+
+    run_formula_step 'Validate updated formula' "$box" "$box/validate-stale.log"
+    status=$?
+    assert_status "validate step rejects it" 1 "$status" "$box/validate-stale.log"
+    assert_file_has "names the artifact left behind" "$box/validate-stale.log" \
+        "all-smi-linux-x86_64.tar.gz"
+}
+
+run_formula_cases() {
+    case_state1_asset_and_stanza
+    case_state2_neither
+    case_state3_asset_without_stanza
+    case_state4_stanza_without_asset
+    case_malformed_duplicate_stanza
+    case_swapped_checksums
+    case_stale_url
+}

--- a/tests/homebrew-formula-workflow/cases-token.sh
+++ b/tests/homebrew-formula-workflow/cases-token.sh
@@ -21,7 +21,7 @@ start_git_server() {  # sandbox -> echoes port
         export AUTH_LOG="${box}/auth.log"
         exec python3 "${HARNESS_DIR}/git-http-server.py"
     ) > "${box}/port" 2>"${box}/server.log" &
-    GIT_SERVER_PID=$!
+    printf '%s\n' "$!" >> "$SERVER_PIDFILE"
 
     local waited=0
     while [ "$waited" -lt 100 ]; do
@@ -36,12 +36,17 @@ start_git_server() {  # sandbox -> echoes port
     return 1
 }
 
+# Kills every server this run started. `wait` is deliberately not used: the
+# servers were spawned inside a command substitution, so they are not children
+# of the shell that ends up calling this.
 stop_git_server() {
-    if [ -n "${GIT_SERVER_PID:-}" ]; then
-        kill "$GIT_SERVER_PID" 2>/dev/null
-        wait "$GIT_SERVER_PID" 2>/dev/null
-        GIT_SERVER_PID=""
-    fi
+    [ -s "${SERVER_PIDFILE:-/nonexistent}" ] || return 0
+    local pid
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        kill "$pid" 2>/dev/null
+    done < "$SERVER_PIDFILE"
+    : > "$SERVER_PIDFILE"
 }
 
 # A bare tap on the server side, a working clone on the client side whose

--- a/tests/homebrew-formula-workflow/cases-token.sh
+++ b/tests/homebrew-formula-workflow/cases-token.sh
@@ -58,8 +58,12 @@ new_push_sandbox() {
     make_tap "$box" "${FIXTURES}/one-stanza.rb"
     git -C "${box}/homebrew-tap" push --quiet "${box}/remote/tap.git" main
 
-    mkdir -p "${box}/home"
-    HOME="${box}/home" git config --global credential.helper store
+    # XDG_CONFIG_HOME is overridden alongside HOME because `git config --global`
+    # writes to $XDG_CONFIG_HOME/git/config when that file exists, and the point
+    # of the next line is to plant a global credential helper in the sandbox,
+    # not in whatever config the person running these tests actually uses.
+    mkdir -p "${box}/home" "${box}/xdg"
+    HOME="${box}/home" XDG_CONFIG_HOME="${box}/xdg" git config --global credential.helper store
     printf 'https://someone:leftover@127.0.0.1\n' > "${box}/home/.git-credentials"
 
     port=$(start_git_server "$box") || return 1
@@ -75,6 +79,7 @@ run_push_step() {  # sandbox logfile -> status
     (
         cd "$box" || exit 127
         export HOME="${box}/home"
+        export XDG_CONFIG_HOME="${box}/xdg"
         export HOMEBREW_TAP_TOKEN="$FAKE_TOKEN"
         export VERSION_NO_V="$NEW_VERSION"
         # -x on purpose: the trace is one of the things being asserted about.

--- a/tests/homebrew-formula-workflow/cases-token.sh
+++ b/tests/homebrew-formula-workflow/cases-token.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# The `Commit and push changes to tap` step, executed for real against a local
+# authenticating Git smart-HTTP server, plus the structural checks on the
+# workflow that no step body can make.
+#
+# The claim under test is that the tap credential exists in exactly one place,
+# the environment of one command, for the length of that command. Proving it
+# takes a server that records what arrived on the wire and a sandbox that can be
+# searched afterwards for anything left behind.
+#
+# Sourced by run-workflow-steps.sh.
+
+FAKE_TOKEN="ghs_notARealToken000000000000000000000000"
+
+start_git_server() {  # sandbox -> echoes port
+    local box="$1" port
+    (
+        export GIT_PROJECT_ROOT="${box}/remote"
+        export EXPECT_USER="x-access-token"
+        export EXPECT_PASS="$FAKE_TOKEN"
+        export AUTH_LOG="${box}/auth.log"
+        exec python3 "${HARNESS_DIR}/git-http-server.py"
+    ) > "${box}/port" 2>"${box}/server.log" &
+    GIT_SERVER_PID=$!
+
+    local waited=0
+    while [ "$waited" -lt 100 ]; do
+        port=$(cat "${box}/port" 2>/dev/null)
+        if [ -n "$port" ]; then
+            printf '%s' "$port"
+            return 0
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    return 1
+}
+
+stop_git_server() {
+    if [ -n "${GIT_SERVER_PID:-}" ]; then
+        kill "$GIT_SERVER_PID" 2>/dev/null
+        wait "$GIT_SERVER_PID" 2>/dev/null
+        GIT_SERVER_PID=""
+    fi
+}
+
+# A bare tap on the server side, a working clone on the client side whose
+# `origin` is the http url, and a HOME configured the way a runner's is: with a
+# global credential helper that would happily store anything git hands it.
+new_push_sandbox() {
+    local box port
+    box=$(mktemp -d "${TMPDIR:-/tmp}/all-smi-hbw-push.XXXXXX")
+
+    mkdir -p "${box}/remote"
+    git init --quiet --bare --initial-branch=main "${box}/remote/tap.git"
+    git -C "${box}/remote/tap.git" config http.receivepack true
+
+    make_tap "$box" "${FIXTURES}/one-stanza.rb"
+    git -C "${box}/homebrew-tap" push --quiet "${box}/remote/tap.git" main
+
+    mkdir -p "${box}/home"
+    HOME="${box}/home" git config --global credential.helper store
+    printf 'https://someone:leftover@127.0.0.1\n' > "${box}/home/.git-credentials"
+
+    port=$(start_git_server "$box") || return 1
+    git -C "${box}/homebrew-tap" remote add origin "http://127.0.0.1:${port}/tap.git"
+
+    printf '%s' "$box"
+}
+
+run_push_step() {  # sandbox logfile -> status
+    local box="$1" log="$2"
+    local script="${box}/push.sh"
+    step_script 'Commit and push changes to tap' "$script" || return 127
+    (
+        cd "$box" || exit 127
+        export HOME="${box}/home"
+        export HOMEBREW_TAP_TOKEN="$FAKE_TOKEN"
+        export VERSION_NO_V="$NEW_VERSION"
+        # -x on purpose: the trace is one of the things being asserted about.
+        bash -x "$script"
+    ) > "$log" 2>&1
+}
+
+case_push_sends_scoped_credential() {
+    begin_case "push step: the credential reaches the wire and nothing else"
+    local box status expected_basic pushed leftovers
+    box=$(new_push_sandbox)
+    if [ -z "$box" ]; then
+        bad "local git server started"
+        return
+    fi
+
+    gsed -i 's|version "0.25.0"|version "0.26.0"|' "${box}/homebrew-tap/Formula/all-smi.rb"
+
+    run_push_step "$box" "${box}/push.log"
+    status=$?
+    assert_status "push step succeeds" 0 "$status" "${box}/push.log"
+
+    pushed=$(git -C "${box}/remote/tap.git" log -1 --format=%s main 2>/dev/null)
+    assert_eq "the tap received the commit" "bump: all-smi to v${NEW_VERSION}" "$pushed"
+
+    expected_basic="Basic $(printf 'x-access-token:%s' "$FAKE_TOKEN" | base64)"
+    assert_file_has "the server was given the tap credential" "${box}/auth.log" "$expected_basic"
+
+    # Everything the step did, traced. If the token were built into the command
+    # line, `set -x` would have printed it here, which is the failure mode the
+    # http.extraheader alternative has.
+    assert_file_lacks "the execution trace does not contain the token" "${box}/push.log" "$FAKE_TOKEN"
+    # shellcheck disable=SC2016  # the unexpanded name is exactly what is asserted
+    assert_file_has "the trace shows the variable name instead" "${box}/push.log" '$HOMEBREW_TAP_TOKEN'
+
+    assert_file_lacks "the clone's git config does not contain the token" \
+        "${box}/homebrew-tap/.git/config" "$FAKE_TOKEN"
+    assert_file_lacks "the global credential store did not gain the token" \
+        "${box}/home/.git-credentials" "$FAKE_TOKEN"
+    assert_file_has "the poisoned global store was left alone, not consulted" \
+        "${box}/home/.git-credentials" "leftover"
+
+    # The whole sandbox, which stands in for the runner's disk. auth.log holds
+    # the base64 of the credential and is the server's record, not the client's.
+    leftovers=$(grep -rl -- "$FAKE_TOKEN" "$box" 2>/dev/null | grep -v '/auth.log$' | grep -v '/push.sh$')
+    assert_eq "no file under the workspace contains the token" "" "$leftovers"
+
+    stop_git_server
+}
+
+case_push_is_a_noop_when_unchanged() {
+    begin_case "push step: re-running for a version already in the tap"
+    local box status
+    box=$(new_push_sandbox)
+    if [ -z "$box" ]; then
+        bad "local git server started"
+        return
+    fi
+
+    run_push_step "$box" "${box}/push.log"
+    status=$?
+    assert_status "push step succeeds without pushing" 0 "$status" "${box}/push.log"
+    assert_file_has "says so" "${box}/push.log" "nothing to push"
+    assert_eq "the server was never contacted" "" "$(cat "${box}/auth.log" 2>/dev/null)"
+
+    stop_git_server
+}
+
+case_workflow_shape() {
+    begin_case "workflow shape: permissions, concurrency, and where the secret is named"
+    local output
+    output=$(python3 "${HARNESS_DIR}/check-workflow-shape.py" "$WORKFLOW" 2>&1)
+    printf '%s\n' "$output"
+    PASS_COUNT=$((PASS_COUNT + $(printf '%s\n' "$output" | grep -c '^  ok    ')))
+    FAIL_COUNT=$((FAIL_COUNT + $(printf '%s\n' "$output" | grep -c '^  FAIL  ')))
+}
+
+run_token_cases() {
+    case_workflow_shape
+    case_push_sends_scoped_credential
+    case_push_is_a_noop_when_unchanged
+}

--- a/tests/homebrew-formula-workflow/check-workflow-shape.py
+++ b/tests/homebrew-formula-workflow/check-workflow-shape.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Structural checks on update_homebrew_formula.yml that no step body can make.
+
+Three things this file has to keep true are properties of the YAML rather than
+of any script inside it: nothing interpolates a workflow expression into a
+shell, the job asks for no more permission than it uses, and the tap secret is
+named in exactly one place. Each prints one `ok`/`FAIL` line, in the same shape
+the shell cases use.
+
+Usage: check-workflow-shape.py WORKFLOW.yml
+"""
+
+import sys
+
+import yaml
+
+TAP_SECRET = "HOMEBREW_TAP_TOKEN"
+
+
+def steps_of(workflow: dict):
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        for step in job.get("steps") or []:
+            yield job_name, step
+
+
+def report(results: list[tuple[bool, str, str]]) -> int:
+    failures = 0
+    for good, label, detail in results:
+        if good:
+            print(f"  ok    {label}")
+        else:
+            failures += 1
+            print(f"  FAIL  {label}")
+            if detail:
+                print(f"        {detail}")
+    return failures
+
+
+def check(workflow: dict, raw: str) -> list[tuple[bool, str, str]]:
+    results = []
+
+    # A workflow expression in a `run:` body is substituted textually before
+    # bash parses the line, so a value carrying shell metacharacters runs as
+    # code. Every value this workflow needs is passed through `env:` instead.
+    offenders = [
+        f"{job}/{step.get('name')}"
+        for job, step in steps_of(workflow)
+        if step.get("run") and "${{" in step["run"]
+    ]
+    results.append(
+        (
+            not offenders,
+            "no step body interpolates a workflow expression",
+            "offending steps: " + ", ".join(offenders),
+        )
+    )
+
+    permissions = workflow.get("permissions")
+    results.append(
+        (
+            permissions == {"contents": "read"},
+            "workflow permissions are contents: read and nothing else",
+            f"found: {permissions!r}",
+        )
+    )
+
+    concurrency = workflow.get("concurrency") or {}
+    results.append(
+        (
+            bool(concurrency.get("group")),
+            "a concurrency group serializes formula updates",
+            f"found: {concurrency!r}",
+        )
+    )
+
+    # The tap token must reach exactly one step, through that step's `env:`,
+    # and it must be read there and nowhere else. One `secrets.` reference in
+    # the whole file is that shape; a second one is a second exposure.
+    references = raw.count(f"secrets.{TAP_SECRET}")
+    carriers = [
+        f"{job}/{step.get('name')}"
+        for job, step in steps_of(workflow)
+        if TAP_SECRET in (step.get("env") or {})
+    ]
+    results.append(
+        (
+            references == 1 and len(carriers) == 1,
+            f"{TAP_SECRET} is read once, into one step's env:",
+            f"{references} secrets.{TAP_SECRET} references, carried by: {carriers}",
+        )
+    )
+
+    # Comments in this workflow describe the credential-in-url shape at length
+    # in order to explain why it is not used, so the check is against the code
+    # the shell actually runs. `username=x-access-token` in the credential
+    # helper is the intended form and carries no colon after the name.
+    code = "\n".join(
+        line
+        for _, step in steps_of(workflow)
+        for line in (step.get("run") or "").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    results.append(
+        (
+            "x-access-token:" not in code,
+            "no credential is embedded in a git url",
+            "a shell line builds an x-access-token: url",
+        )
+    )
+
+    return results
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write("usage: check-workflow-shape.py WORKFLOW.yml\n")
+        return 2
+    with open(argv[1], encoding="utf-8") as handle:
+        raw = handle.read()
+    workflow = yaml.safe_load(raw)
+    return 1 if report(check(workflow, raw)) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/homebrew-formula-workflow/extract-step.py
+++ b/tests/homebrew-formula-workflow/extract-step.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Print the `run:` body of a named step from a GitHub Actions workflow file.
+
+The whole point of the tests around update_homebrew_formula.yml is that they
+execute the committed YAML rather than a copy of it that drifts. Extracting the
+step body by name keeps the thing under test and the thing that ships identical,
+so an edit to the workflow that breaks a documented behaviour fails a test even
+when nobody thought to update the test alongside it.
+
+Usage: extract-step.py WORKFLOW.yml 'Step name'
+"""
+
+import sys
+
+import yaml
+
+
+def find_step(workflow: dict, name: str):
+    for job in (workflow.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if step.get("name") == name:
+                return step
+    return None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        sys.stderr.write("usage: extract-step.py WORKFLOW.yml 'Step name'\n")
+        return 2
+
+    path, name = argv[1], argv[2]
+    with open(path, encoding="utf-8") as handle:
+        workflow = yaml.safe_load(handle)
+
+    step = find_step(workflow, name)
+    if step is None:
+        sys.stderr.write(f"step {name!r} not found in {path}\n")
+        return 1
+
+    body = step.get("run")
+    if body is None:
+        sys.stderr.write(f"step {name!r} has no run: body\n")
+        return 1
+
+    sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/homebrew-formula-workflow/fixtures/one-stanza.rb
+++ b/tests/homebrew-formula-workflow/fixtures/one-stanza.rb
@@ -1,0 +1,34 @@
+class AllSmi < Formula
+  desc      "GPU ‘top’ for NVIDIA/Jetson/Apple Silicon/Tenstorrent"
+  homepage  "https://github.com/lablup/all-smi"
+  version "0.25.0"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-macos-aarch64.zip"
+      sha256 "d090d6abbda5ac0c2fc06c0924b70845b32fd02ce6d1fca8f3ddf6fce1cad814"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-linux-aarch64.tar.gz"
+      sha256 "3bd2a8859df3edfc17c08b365f510d5531bfee5c3a182199ba697d44992c7df9"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-linux-x86_64.tar.gz"
+      sha256 "59c3742ab4de9f6de3c5b3830a3c517ae59e14bc1a6c64f521f4687d1f41a051"
+    end
+  end
+
+  def install
+    bin.install "all-smi"
+    man1.install "all-smi.1"
+  end
+
+  test do
+    output = shell_output("#{bin}/all-smi --version")
+    assert_match(/all-smi\s+#{version}/, output)
+  end
+end

--- a/tests/homebrew-formula-workflow/fixtures/two-intel-stanzas.rb
+++ b/tests/homebrew-formula-workflow/fixtures/two-intel-stanzas.rb
@@ -1,0 +1,42 @@
+class AllSmi < Formula
+  desc      "GPU ‘top’ for NVIDIA/Jetson/Apple Silicon/Tenstorrent"
+  homepage  "https://github.com/lablup/all-smi"
+  version "0.25.0"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-macos-aarch64.zip"
+      sha256 "d090d6abbda5ac0c2fc06c0924b70845b32fd02ce6d1fca8f3ddf6fce1cad814"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-macos-x86_64.zip"
+      sha256 "1111111111111111111111111111111111111111111111111111111111111111"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-macos-x86_64.zip"
+      sha256 "2222222222222222222222222222222222222222222222222222222222222222"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-linux-aarch64.tar.gz"
+      sha256 "3bd2a8859df3edfc17c08b365f510d5531bfee5c3a182199ba697d44992c7df9"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-linux-x86_64.tar.gz"
+      sha256 "59c3742ab4de9f6de3c5b3830a3c517ae59e14bc1a6c64f521f4687d1f41a051"
+    end
+  end
+
+  def install
+    bin.install "all-smi"
+    man1.install "all-smi.1"
+  end
+
+  test do
+    output = shell_output("#{bin}/all-smi --version")
+    assert_match(/all-smi\s+#{version}/, output)
+  end
+end

--- a/tests/homebrew-formula-workflow/fixtures/two-stanza.rb
+++ b/tests/homebrew-formula-workflow/fixtures/two-stanza.rb
@@ -1,0 +1,38 @@
+class AllSmi < Formula
+  desc      "GPU ‘top’ for NVIDIA/Jetson/Apple Silicon/Tenstorrent"
+  homepage  "https://github.com/lablup/all-smi"
+  version "0.25.0"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-macos-aarch64.zip"
+      sha256 "d090d6abbda5ac0c2fc06c0924b70845b32fd02ce6d1fca8f3ddf6fce1cad814"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-macos-x86_64.zip"
+      sha256 "1111111111111111111111111111111111111111111111111111111111111111"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-linux-aarch64.tar.gz"
+      sha256 "3bd2a8859df3edfc17c08b365f510d5531bfee5c3a182199ba697d44992c7df9"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/lablup/all-smi/releases/download/v0.25.0/all-smi-linux-x86_64.tar.gz"
+      sha256 "59c3742ab4de9f6de3c5b3830a3c517ae59e14bc1a6c64f521f4687d1f41a051"
+    end
+  end
+
+  def install
+    bin.install "all-smi"
+    man1.install "all-smi.1"
+  end
+
+  test do
+    output = shell_output("#{bin}/all-smi --version")
+    assert_match(/all-smi\s+#{version}/, output)
+  end
+end

--- a/tests/homebrew-formula-workflow/git-http-server.py
+++ b/tests/homebrew-formula-workflow/git-http-server.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""A single-repository, authenticating Git smart-HTTP server.
+
+It exists so the push step of update_homebrew_formula.yml can be executed for
+real. That step's entire claim is about where the tap credential goes: onto the
+wire for one command, and nowhere else. Neither half is observable without a
+server on the other end that records exactly what it was sent, so this one
+demands HTTP Basic auth for every request and appends every Authorization
+header it sees to a file before deciding anything.
+
+Configuration comes from the environment:
+  GIT_PROJECT_ROOT  directory holding the bare repository
+  EXPECT_USER       username the push has to present
+  EXPECT_PASS       password the push has to present
+  AUTH_LOG          file to append every Authorization header to
+
+Binds to an ephemeral port on the loopback interface, prints that port on
+stdout, then serves until killed.
+"""
+
+import base64
+import os
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PROJECT_ROOT = os.environ["GIT_PROJECT_ROOT"]
+EXPECT_USER = os.environ["EXPECT_USER"]
+EXPECT_PASS = os.environ["EXPECT_PASS"]
+AUTH_LOG = os.environ["AUTH_LOG"]
+
+
+class GitHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_args):
+        """Silence the default stderr access log; the harness has its own."""
+
+    def _record_and_check_auth(self) -> bool:
+        header = self.headers.get("Authorization", "")
+        with open(AUTH_LOG, "a", encoding="utf-8") as handle:
+            handle.write(f"{self.command} {self.path} {header}\n")
+        if not header.startswith("Basic "):
+            return False
+        try:
+            decoded = base64.b64decode(header[len("Basic "):]).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            return False
+        user, _, password = decoded.partition(":")
+        return user == EXPECT_USER and password == EXPECT_PASS
+
+    def _send(self, status: int, headers, body: bytes) -> None:
+        self.send_response(status)
+        for key, value in headers:
+            self.send_header(key, value)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_body(self) -> bytes:
+        if self.headers.get("Transfer-Encoding", "").lower() == "chunked":
+            chunks = []
+            while True:
+                size = int(self.rfile.readline().split(b";")[0], 16)
+                if size == 0:
+                    self.rfile.readline()
+                    break
+                chunks.append(self.rfile.read(size))
+                self.rfile.readline()
+            return b"".join(chunks)
+        length = int(self.headers.get("Content-Length", "0") or 0)
+        return self.rfile.read(length) if length else b""
+
+    def _serve(self) -> None:
+        body = self._read_body()
+        if not self._record_and_check_auth():
+            self._send(401, [("WWW-Authenticate", 'Basic realm="git"')], b"")
+            return
+
+        path, _, query = self.path.partition("?")
+        env = {
+            "GIT_PROJECT_ROOT": PROJECT_ROOT,
+            "GIT_HTTP_EXPORT_ALL": "1",
+            "REQUEST_METHOD": self.command,
+            "PATH_INFO": path,
+            "QUERY_STRING": query,
+            "REMOTE_USER": EXPECT_USER,
+            "REMOTE_ADDR": self.client_address[0],
+            "CONTENT_TYPE": self.headers.get("Content-Type", ""),
+            "CONTENT_LENGTH": str(len(body)),
+            "HTTP_CONTENT_ENCODING": self.headers.get("Content-Encoding", ""),
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+        }
+        result = subprocess.run(
+            ["git", "http-backend"], input=body, env=env, capture_output=True, check=False
+        )
+        if result.returncode != 0:
+            self._send(500, [("Content-Type", "text/plain")], result.stderr)
+            return
+
+        raw = result.stdout
+        head, separator, payload = raw.partition(b"\r\n\r\n")
+        if not separator:
+            head, separator, payload = raw.partition(b"\n\n")
+        if not separator:
+            head, payload = b"", raw
+
+        status = 200
+        headers = []
+        for line in head.replace(b"\r\n", b"\n").split(b"\n"):
+            if not line.strip():
+                continue
+            key, _, value = line.partition(b":")
+            key_text = key.strip().decode("utf-8", "replace")
+            value_text = value.strip().decode("utf-8", "replace")
+            if key_text.lower() == "status":
+                status = int(value_text.split()[0])
+            else:
+                headers.append((key_text, value_text))
+        self._send(status, headers, payload)
+
+    do_GET = _serve
+    do_POST = _serve
+
+
+def main() -> int:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), GitHandler)
+    print(server.server_address[1], flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/homebrew-formula-workflow/lib.sh
+++ b/tests/homebrew-formula-workflow/lib.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Shared helpers for the update_homebrew_formula.yml step tests. Sourced by
+# run-workflow-steps.sh, never executed on its own.
+#
+# SC2034: everything defined here is consumed by the sibling case files, which
+# are analysed separately.
+# shellcheck disable=SC2034
+
+HARNESS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${HARNESS_DIR}/../.." && pwd)
+# Overridable so the harness can be pointed at a deliberately broken copy, which
+# is how you check that a test would actually fail if the workflow regressed.
+WORKFLOW="${ALL_SMI_WORKFLOW:-${REPO_ROOT}/.github/workflows/update_homebrew_formula.yml}"
+FIXTURES="${HARNESS_DIR}/fixtures"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+CURRENT_CASE="(none)"
+
+# Synthetic values for the release being written. Distinct enough per artifact
+# that a rewrite landing on the wrong stanza is visible in the output rather
+# than merely wrong.
+NEW_VERSION="0.26.0"
+NEW_BASE="https://github.com/lablup/all-smi/releases/download/v${NEW_VERSION}"
+SHA_MAC="aaaaaaaa11111111aaaaaaaa11111111aaaaaaaa11111111aaaaaaaa11111111"
+SHA_MAC_X86="bbbbbbbb22222222bbbbbbbb22222222bbbbbbbb22222222bbbbbbbb22222222"
+SHA_LINUX_ARM="cccccccc33333333cccccccc33333333cccccccc33333333cccccccc33333333"
+SHA_LINUX_X86="dddddddd44444444dddddddd44444444dddddddd44444444dddddddd44444444"
+
+begin_case() {
+    CURRENT_CASE="$1"
+    printf '\n--- %s\n' "$CURRENT_CASE"
+}
+
+ok() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    printf '  ok    %s\n' "$1"
+}
+
+bad() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    printf '  FAIL  %s\n' "$1"
+    if [ -n "${2:-}" ]; then
+        printf '        %s\n' "$2"
+    fi
+}
+
+assert_eq() {  # label expected actual
+    if [ "$2" = "$3" ]; then
+        ok "$1"
+    else
+        bad "$1" "expected [$2], got [$3]"
+    fi
+}
+
+assert_status() {  # label expected_status actual_status logfile
+    if [ "$2" = "$3" ]; then
+        ok "$1"
+    else
+        bad "$1" "expected exit $2, got $3; log: ${4:-none}"
+    fi
+}
+
+assert_file_has() {  # label file pattern
+    if grep -qF -- "$3" "$2"; then
+        ok "$1"
+    else
+        bad "$1" "pattern not found in $2: $3"
+    fi
+}
+
+assert_file_lacks() {  # label file pattern
+    if grep -qF -- "$3" "$2"; then
+        bad "$1" "pattern unexpectedly found in $2: $3"
+    else
+        ok "$1"
+    fi
+}
+
+require_tools() {
+    local missing=""
+    local tool
+    for tool in "$@"; do
+        command -v "$tool" > /dev/null 2>&1 || missing="${missing} ${tool}"
+    done
+    if [ -n "$missing" ]; then
+        printf 'missing required tools:%s\n' "$missing" >&2
+        printf 'these tests run the workflow step bodies verbatim, so they need\n' >&2
+        printf 'the same tools macos-latest provides.\n' >&2
+        return 1
+    fi
+}
+
+# Writes the named step's run: body to a file and echoes the path. The body is
+# taken from the committed workflow, which is the entire point: the tests run
+# what ships.
+step_script() {  # step-name dest
+    python3 "${HARNESS_DIR}/extract-step.py" "$WORKFLOW" "$1" > "$2"
+}
+
+# Mirrors what the Actions runner does between steps: everything a step appended
+# to $GITHUB_ENV becomes an environment variable for the steps after it.
+apply_github_env() {  # env-file
+    local line key value
+    while IFS= read -r line; do
+        case "$line" in
+            *=*) ;;
+            *) continue ;;
+        esac
+        key="${line%%=*}"
+        value="${line#*=}"
+        export "$key=$value"
+    done < "$1"
+}
+
+# A tap working tree holding FIXTURE, committed on `main`, so the update and
+# commit steps see the same shape they see in CI.
+make_tap() {  # dir fixture
+    mkdir -p "$1/homebrew-tap/Formula"
+    cp "$2" "$1/homebrew-tap/Formula/all-smi.rb"
+    git -C "$1/homebrew-tap" init --quiet --initial-branch=main
+    git -C "$1/homebrew-tap" config user.name "GitHub Action"
+    git -C "$1/homebrew-tap" config user.email "actions@github.com"
+    git -C "$1/homebrew-tap" add Formula/all-smi.rb
+    git -C "$1/homebrew-tap" commit --quiet -m "fixture"
+}
+
+# The environment the download step would have left behind for the update and
+# validate steps. mac_x86_present is the caller's choice, because it is exactly
+# the axis the four asset/stanza states turn on.
+export_artifact_env() {  # mac_x86_present
+    export VERSION_NO_V="$NEW_VERSION"
+    export mac_url="${NEW_BASE}/all-smi-macos-aarch64.zip"
+    export mac_sha="$SHA_MAC"
+    export linux_arm_url="${NEW_BASE}/all-smi-linux-aarch64.tar.gz"
+    export linux_arm_sha="$SHA_LINUX_ARM"
+    export linux_x86_url="${NEW_BASE}/all-smi-linux-x86_64.tar.gz"
+    export linux_x86_sha="$SHA_LINUX_X86"
+    export mac_x86_present="$1"
+    if [ "$1" = "true" ]; then
+        export mac_x86_url="${NEW_BASE}/all-smi-macos-x86_64.zip"
+        export mac_x86_sha="$SHA_MAC_X86"
+    else
+        unset mac_x86_url mac_x86_sha
+    fi
+}

--- a/tests/homebrew-formula-workflow/lib.sh
+++ b/tests/homebrew-formula-workflow/lib.sh
@@ -17,6 +17,11 @@ PASS_COUNT=0
 FAIL_COUNT=0
 CURRENT_CASE="(none)"
 
+# Background servers are recorded here rather than in a variable, because the
+# sandbox builders that start them run inside `$(...)` and a variable set in a
+# command substitution never reaches the caller. A file crosses that boundary.
+SERVER_PIDFILE=$(mktemp "${TMPDIR:-/tmp}/all-smi-hbw-servers.XXXXXX")
+
 # Synthetic values for the release being written. Distinct enough per artifact
 # that a rewrite landing on the wrong stanza is visible in the output rather
 # than merely wrong.

--- a/tests/homebrew-formula-workflow/run-workflow-steps.sh
+++ b/tests/homebrew-formula-workflow/run-workflow-steps.sh
@@ -59,6 +59,15 @@ if [ "${#groups[@]}" -eq 0 ]; then
     groups=(formula download token)
 fi
 
+# The token cases start a local git server in the background. Each case stops
+# its own, but an interrupted or failed run would otherwise leave one bound to a
+# loopback port for the rest of the session.
+cleanup() {
+    stop_git_server
+    rm -f "$SERVER_PIDFILE"
+}
+trap cleanup EXIT INT TERM
+
 printf 'workflow: %s\n' "$WORKFLOW"
 
 for group in "${groups[@]}"; do

--- a/tests/homebrew-formula-workflow/run-workflow-steps.sh
+++ b/tests/homebrew-formula-workflow/run-workflow-steps.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Executes the step bodies of .github/workflows/update_homebrew_formula.yml
+# against fixtures, offline.
+#
+# The workflow pushes to lablup/homebrew-tap, a production Homebrew tap, so it
+# cannot be exercised by running it. What can be exercised is every step body it
+# contains, and that is what this does: the bodies are read out of the committed
+# YAML by name, so the thing under test is the file that ships rather than a
+# copy that drifts away from it.
+#
+# What is covered:
+#   - the four release-asset / formula-stanza states, plus a malformed tap
+#     (cases-formula.sh)
+#   - the url/sha256 pairing guard, including a control showing that checking
+#     them independently accepts a formula with the pairs exchanged
+#     (cases-formula.sh)
+#   - artifacts landing outside the tap clone, and the release asset list being
+#     read from the paginated assets collection (cases-download.sh)
+#   - the push credential reaching git without touching disk, argv or the trace
+#     (cases-token.sh)
+#
+# What is not covered, and cannot be from here: a real push to the tap, and
+# `brew install` from the result.
+#
+# Usage:  tests/homebrew-formula-workflow/run-workflow-steps.sh [case-group ...]
+#         case groups: formula download token   (default: all three)
+#
+# Runs on macOS, matching the workflow's `runs-on: macos-latest`, because the
+# step bodies call gsed, brew style and BSD awk.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck source=lib.sh
+. "${HERE}/lib.sh"
+# shellcheck source=cases-formula.sh
+. "${HERE}/cases-formula.sh"
+# shellcheck source=cases-download.sh
+. "${HERE}/cases-download.sh"
+# shellcheck source=cases-token.sh
+. "${HERE}/cases-token.sh"
+
+require_tools python3 git awk gsed ruby brew shasum unzip zip tar base64 || exit 1
+
+if ! python3 -c 'import yaml' > /dev/null 2>&1; then
+    printf 'python3 needs PyYAML to read the workflow file (pip install pyyaml)\n' >&2
+    exit 1
+fi
+
+if [ ! -f "$WORKFLOW" ]; then
+    printf 'workflow not found: %s\n' "$WORKFLOW" >&2
+    exit 1
+fi
+
+groups=("$@")
+if [ "${#groups[@]}" -eq 0 ]; then
+    groups=(formula download token)
+fi
+
+printf 'workflow: %s\n' "$WORKFLOW"
+
+for group in "${groups[@]}"; do
+    case "$group" in
+        formula) run_formula_cases ;;
+        download) run_download_cases ;;
+        token) run_token_cases ;;
+        *)
+            printf 'unknown case group: %s\n' "$group" >&2
+            exit 2
+            ;;
+    esac
+done
+
+printf '\n%d passed, %d failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary

All seven findings from the #313 security review, addressed in `update_homebrew_formula.yml`, with the behavior PR #313 verified left intact. The four release-asset / formula-stanza states still behave exactly as that PR documented, re-verified by executing the committed step bodies.

## How the tap token was scoped

The job cloned the tap from `https://x-access-token:<token>@github.com/lablup/homebrew-tap.git`. Git records that url verbatim as `origin` in `homebrew-tap/.git/config`, so the push token sat in the workspace for the rest of the job, readable by every later step and by anything those steps ran, third-party actions included.

`lablup/homebrew-tap` is public, and has to be for `brew tap lablup/tap` to work, so the clone needs no credential at all and is now anonymous. Only the push carries one:

```
git \
  -c credential.helper= \
  -c 'credential.helper=!f() { if [ "$1" = get ]; then printf "username=x-access-token\npassword=%s\n" "$HOMEBREW_TAP_TOKEN"; fi; }; f' \
  push origin main
```

The token lives in exactly one place: the environment of that one command, declared in the step's `env:`.

**Not disk.** No remote url carries it, and nothing writes it to a config file.

**Not argv,** which is what rules out `-c http.extraheader="Authorization: Basic $(...)"`, the usual replacement. Command lines are readable through `ps`, and a step that turns on `set -x` prints the expanded line into the workflow log. Here the helper string is single-quoted, so bash hands git the name `$HOMEBREW_TAP_TOKEN` and expands nothing. `set -x` prints the same name, and xtrace does not propagate into the shell git spawns for the helper (bash does not export `SHELLOPTS`), so the helper's own `printf` is not traced either. Both halves are asserted by the tests, and the `http.extraheader` variant fails them: it authenticates fine and leaks the raw token into the trace.

**Not the keychain.** The empty `-c credential.helper=` first resets the helper list, dropping the runner image's global helper (osxkeychain on macOS). Without it, git hands the credential to that helper for storage after a successful authentication, which is disk by another route. The helper here answers `get` only, so git's post-authentication `store` call is a no-op, and the `if` makes it exit 0 so git does not treat the silence as a failed helper.

## The seven findings

| # | Finding | Change |
|---|---|---|
| 1 | Token persists in `homebrew-tap/.git/config` | Anonymous clone; credential scoped to the single `git push` through an env-reading `credential.helper`, as above |
| 2 | `permissions: contents: write` is broader than needed | `contents: read`, which is what the `gh api` reads need and which zeroes every other scope |
| 3 | No `concurrency:` group | `group: update-homebrew-formula`, a constant because the contended resource is the tap, `cancel-in-progress: false` so an interrupted run cannot land between `git commit` and `git push` |
| 4 | Release asset list read without pagination | Resolve the release id, then list through the paginated `/releases/{id}/assets` collection with `--paginate` and `per_page=100` |
| 5 | Artifacts downloaded into the tap working tree | Downloaded to `$RUNNER_TEMP/all-smi-artifacts` |
| 6 | Checksums and urls validated independently | Validated as `(url, sha256)` pairs, read out of the formula the same way `set_artifact` writes them |
| 7 | `packaging` environment gates nothing | **Deferred to a human decision, deliberately.** See below |

One drive-by: `actions/checkout` now runs with `persist-credentials: false`. By default it writes `GITHUB_TOKEN` into `.git/config` as an `http.extraheader`, which is the same shape of problem as finding 1. No step performs a git operation in that checkout, so nothing needs it.

### On finding 4, precisely

I could not reproduce truncation of the embedded `assets` array: `electron/electron` returns all 76 of its assets inline, `denoland/deno` all 56. So the array is not visibly capped at any count this repo will reach soon, and our releases currently publish 18 assets, not the 28 the issue cites.

The change still stands on its own terms. The embedded array carries no pagination controls and no `Link` header, so its completeness is not something the API documents, whereas `/releases/{id}/assets` is a documented paginated collection. This workflow reads absence from that list as a decision rather than as missing data: a truncated list is a silent "the release publishes no Intel zip", which either skips an artifact that exists or trips the version-skew refusal in the next step. Depending on undocumented completeness for that is the part worth removing.

### On finding 6, precisely

Checking url and checksum independently accepts a formula in which two artifacts have exchanged checksums. Every checksum is one the run computed, every url names the right release, and the counts are right, so nothing before `brew install` notices; `brew install` then fetches one artifact and verifies it against another's checksum. Swapped is exactly what a rewrite that matched one stanza and wrote into another produces, which is the failure the whole update step is built around avoiding. The test suite includes a control that runs the pre-#316 checks over a swapped formula and confirms they accept it.

### On finding 7, the recorded decision

**The `packaging` environment was not configured, on purpose, and this was not an oversight.** It still has `protection_rules: []` and `deployment_branch_policy: null`, so naming it scopes `HOMEBREW_TAP_TOKEN` to this job but gates nothing.

Adding required reviewers or a deployment branch policy is a repository administration change rather than a workflow change, and it decides who is able to ship a release. That is a call for a maintainer to make and apply, not something to do quietly inside a hardening PR. The issue's acceptance criterion accepts either configuring it or recording an explicit decision not to; this is the recording. The reasoning is also written into a comment on the job, next to `environment: packaging`, so it stays with the thing it describes.

Until someone decides otherwise, the environment is bookkeeping, and what actually limits the token's reach is everything else in this PR.

## Tests

`tests/homebrew-formula-workflow/` is the #313 harness, committed this time so it is repeatable. Step bodies are read out of the committed YAML by step name, so the thing under test is the file that ships rather than a copy that drifts.

```bash
./tests/homebrew-formula-workflow/run-workflow-steps.sh
```

69 assertions, all passing, entirely offline. Nothing in it contacts GitHub or the real tap.

- [x] **state 1** (asset present, stanza present): both macOS stanzas rewritten, each with its own checksum, 4 sha256 stanzas, validation green
- [x] **state 2** (asset absent, stanza absent): `::notice::`, macOS section gains nothing, 3 sha256 stanzas, validation green
- [x] **state 3** (asset present, stanza absent): `::warning::`, the other three still update, validation green at 3, and the final gate is present in the YAML so the job ends red after the push
- [x] **state 4** (asset absent, stanza present): refused in the update step over version skew, before anything could be pushed, and no state recorded
- [x] malformed tap with two Intel stanzas: refused by `set_artifact`'s unchanged uniqueness assertion
- [x] **swapped checksums**: rejected by the new pairing guard, naming the pair that does not exist, with a control assertion confirming the pre-#316 independent checks accept the same file
- [x] stale url left at v0.25.0: rejected
- [x] traversal-shaped tag (`v0.0.0/../../../attacker/repo/...`): refused before any download, #313's guard intact
- [x] artifacts land in `$RUNNER_TEMP`; the tap working tree is `git status --porcelain`-clean afterwards and has no `tmp/`
- [x] asset listing reaches `/releases/{id}/assets` with `--paginate`; an Intel zip sitting last in a 205-name list is still found. The `gh` stub refuses an assets listing without `--paginate` and refuses to serve the embedded array at all, so reverting either fails here
- [x] **the push, executed for real** against a local authenticating Git smart-HTTP server backed by `git http-backend`: the push succeeds, the bare repo receives `bump: all-smi to v0.26.0`, and the server records `Authorization: Basic base64(x-access-token:<token>)`
- [x] after that push: the token appears in no file anywhere under the workspace, not in the clone's `.git/config`, and not in the `set -x` trace, which shows `$HOMEBREW_TAP_TOKEN` unexpanded instead. A pre-poisoned global `credential.helper=store` is neither consulted nor written to
- [x] re-running the push step with no formula change: "nothing to push", exit 0, server never contacted
- [x] structural checks: no step body interpolates a `${{ }}` expression, `permissions` is `contents: read` and nothing else, a `concurrency` group exists, `secrets.HOMEBREW_TAP_TOKEN` is read exactly once into exactly one step's `env:`, and no shell line builds an `x-access-token:` url
- [x] **negative controls**: three deliberately broken copies of the workflow were run through the harness. Reverting the pagination fails 8 assertions, restoring the token-in-clone-url fails the shape check, and swapping the credential scoping for `-c http.extraheader` fails 4, including the trace leak. The tests are not vacuous
- [x] `actionlint` on the workflow: clean, exit 0. `main` currently reports one `SC2086` info, which this PR fixes in passing (`>> $GITHUB_ENV` is now quoted). The one `SC2016` the credential helper attracts is suppressed inline, with the reason, because the unexpanded variable is the point
- [x] `shellcheck -x` on the harness scripts: clean. `python3 -m py_compile` on the Python: clean
- [x] `cargo metadata`: the new `tests/` subdirectory adds no cargo test target (no `.rs` files), so `cargo test` is unaffected
- [x] `make homebrew-formula-workflow` from `tests/`: the new target runs the suite and appears in `make help`
- [x] the harness leaves no background process behind, on a full run and on a SIGINT partway through. It did at first: the server pid was assigned inside a `$(...)`, so it never reached the caller and `stop_git_server` killed nothing
- [x] CI on this PR: Test Suite pass, license/cla pass, Docker Build Check skipped

## Not verified in this environment

- [ ] **A dry run against a real tag.** Not reachable autonomously: it means publishing a release or dispatching the real workflow, and the push target is a production tap. The push path is covered against a local git server instead, which proves the credential mechanics but not GitHub's acceptance of this particular token.
- [ ] **Nothing was pushed to `lablup/homebrew-tap`.** No release, tag, or workflow dispatch was created either.
- [ ] **No GitHub repository settings were changed.** The `packaging` environment is untouched; see finding 7.
- [ ] **`brew install` on a real Intel and Apple Silicon Mac.** Unchanged from #313, which also left this open.
- [ ] **Real GitHub API pagination.** The `--paginate` behavior is exercised against a stub. Live calls confirmed the endpoint and filter shape return the same 18 asset names as the embedded array for `v0.25.0`, but no release exists with enough assets to force a second page.
- [ ] **`concurrency` under an actual overlapping release.** The group is declared and parses; two genuinely concurrent releases were not staged.

Closes #316


