### PR TITLE
feat(service): run API mode as a launchd service on macOS (#310)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,224 @@ jobs:
           sudo rm -f "$UNIT"
           sudo systemctl daemon-reload
 
+  # ═══════════════════════════════════════════════════════════════
+  # Job: launchd service smoke test (issue #310)
+  # ═══════════════════════════════════════════════════════════════
+  # Runs on Apple Silicon so the native readers (IOReport, SMC,
+  # thermalState) are actually exercised from a launchd context, not
+  # just the plist renderer.
+  #
+  # Split into two tiers because a hosted runner may have no
+  # bootstrappable GUI domain:
+  #
+  #  1. Render tier. `install --user` without `--now` writes the plist
+  #     and touches launchd not at all, so plist validity, the managed
+  #     marker, the user-scope key drops, and both refusal paths are
+  #     checkable anywhere. Always runs.
+  #  2. Lifecycle tier. Gated on `launchctl print gui/$UID` succeeding.
+  #     Skips with a notice rather than failing where the domain is
+  #     absent.
+  #
+  # The system domain is deliberately never touched: no
+  # /Library/LaunchDaemons, no `sudo launchctl bootstrap system`.
+  # ───────────────────────────────────────────────────────────────
+  launchd-service:
+    name: launchd Service Smoke Test
+    runs-on: macos-14
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup protoc
+        uses: ./.github/actions/setup-protoc
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          platform: osx-aarch_64
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build all-smi
+        run: cargo build --bin all-smi
+
+      - name: Probe for a bootstrappable GUI domain
+        id: probe
+        run: |
+          if launchctl print "gui/$(id -u)" >/dev/null 2>&1; then
+            echo "gui_domain=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "gui_domain=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::no gui/\$UID domain on this runner; running the render tier only"
+          fi
+
+      # ── Render tier: no launchd domain required ──
+      #
+      # launchd accepts a LaunchAgent carrying UserName/GroupName and
+      # silently ignores them, so a regression that leaves those keys in
+      # a user-scope plist cannot be caught by bootstrapping it. It has
+      # to be caught here, on the rendered file.
+      - name: Rendered plist is valid and correctly scoped
+        run: |
+          set -eEux
+          BIN="$PWD/target/debug/all-smi"
+          PLIST="$HOME/Library/LaunchAgents/com.lablup.all-smi.plist"
+
+          diagnose() {
+            set +x
+            echo "::group::diagnostics: rendered LaunchAgent plist"
+            echo "--- $PLIST ---"
+            cat "$PLIST" 2>&1 || echo "(absent)"
+            echo "--- plutil ---"
+            plutil -lint "$PLIST" 2>&1 || true
+            echo "::endgroup::"
+          }
+          trap diagnose ERR
+
+          "$BIN" service status --user && rc=0 || rc=$?
+          test "$rc" -eq 3
+
+          "$BIN" service install --user
+          test -f "$PLIST"
+
+          # launchd parses this with CFPropertyList; a stray `--` inside
+          # the marker comment would make the whole job unloadable.
+          plutil -lint "$PLIST"
+          grep -qF "<!-- Managed by 'all-smi service' -->" "$PLIST"
+          grep -qF "<string>api</string>" "$PLIST"
+          grep -qF "$HOME/Library/Logs/all-smi/all-smi.log" "$PLIST"
+
+          # Keys a gui/$UID domain cannot honour must be absent.
+          for key in UserName GroupName InitGroups; do
+            if grep -qF "<key>${key}</key>" "$PLIST"; then
+              echo "::error::${key} must not survive into a user-scope plist"
+              exit 1
+            fi
+          done
+
+          # Installed but not bootstrapped is the documented state here.
+          "$BIN" service status --user && rc=0 || rc=$?
+          test "$rc" -eq 3
+          "$BIN" service status --user --json | grep -q '"installed": true'
+
+          "$BIN" service uninstall --user
+          test ! -f "$PLIST"
+
+      - name: Refuse an unelevated system install and a foreign plist
+        run: |
+          set -eEux
+          BIN="$PWD/target/debug/all-smi"
+          PLIST="$HOME/Library/LaunchAgents/com.lablup.all-smi.plist"
+
+          # System scope must refuse before writing anything at all.
+          "$BIN" service install && rc=0 || rc=$?
+          test "$rc" -eq 1
+          "$BIN" service install 2>&1 | grep -q "requires root"
+          test ! -f /Library/LaunchDaemons/com.lablup.all-smi.plist
+
+          printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' \
+            '<plist version="1.0"><dict><key>Label</key><string>hand written</string></dict></plist>' \
+            > "$PLIST"
+          "$BIN" service install --user && rc=0 || rc=$?
+          test "$rc" -eq 1
+          "$BIN" service uninstall --user && rc=0 || rc=$?
+          test "$rc" -eq 1
+          grep -q "hand written" "$PLIST"
+
+          "$BIN" service uninstall --user --force
+          test ! -f "$PLIST"
+
+      # ── Lifecycle tier: needs a real gui/$UID domain ──
+      - name: User-scope lifecycle
+        if: steps.probe.outputs.gui_domain == 'true'
+        run: |
+          set -eEux
+          BIN="$PWD/target/debug/all-smi"
+          PLIST="$HOME/Library/LaunchAgents/com.lablup.all-smi.plist"
+          LOG="$HOME/Library/Logs/all-smi/all-smi.log"
+          TARGET="gui/$(id -u)/com.lablup.all-smi"
+
+          # A job that fails to spawn under launchd reports almost
+          # nothing through the exit code alone, so dump the three
+          # places the reason can be before giving up.
+          diagnose() {
+            set +x
+            echo "::group::diagnostics: launchd user-scope service"
+            echo "--- $PLIST ---"
+            cat "$PLIST" 2>&1 || echo "(absent)"
+            echo "--- launchctl print $TARGET ---"
+            launchctl print "$TARGET" 2>&1 || true
+            echo "--- launchctl print-disabled gui/$(id -u) ---"
+            launchctl print-disabled "gui/$(id -u)" 2>&1 | grep -i all-smi || true
+            echo "--- $LOG ---"
+            cat "$LOG" 2>&1 || echo "(absent)"
+            echo "--- service status ---"
+            "$BIN" service status --user 2>&1 || true
+            echo "::endgroup::"
+          }
+          trap diagnose ERR
+
+          # `service status` reports running the moment launchd spawns
+          # the program, which is well before it has finished coming up:
+          # enumerating the IOReport channel list dominates startup and
+          # ProcessType=Background runs it at background QoS. Every
+          # readiness wait below therefore polls the metrics endpoint,
+          # not the process state. Polling status instead races, and the
+          # race is invisible until an assertion downstream fails for an
+          # unrelated-looking reason.
+          ready() {
+            for _ in $(seq 1 60); do
+              curl -sf --max-time 5 localhost:9090/metrics >/dev/null && return 0
+              sleep 2
+            done
+            echo "::error::the exporter never served /metrics"
+            return 1
+          }
+
+          "$BIN" service install --user --now
+          ready
+          "$BIN" service status --user
+          "$BIN" service status --user --json | grep -q '"running": true'
+          "$BIN" service status --user --json | grep -q '"enabled": true'
+          curl -sf --max-time 10 localhost:9090/metrics | grep -q '^all_smi_'
+          grep -q "API server listening" "$LOG"
+
+          "$BIN" service restart --user
+          ready
+
+          # `stop` boots the job out, which is a SIGTERM. The final
+          # energy-WAL flush has to be reached before launchd's
+          # ExitTimeOut turns it into a SIGKILL (issues #191, #310).
+          "$BIN" service stop --user
+          sleep 3
+          grep -q "energy WAL: shutdown requested" "$LOG"
+          "$BIN" service status --user && rc=0 || rc=$?
+          test "$rc" -eq 3
+          "$BIN" service status --user --json | grep -q '"installed": true'
+
+          # A persistent disable override outlives the plist and a
+          # reboot, so `install` has to clear it and `status` has to see
+          # it.
+          launchctl disable "$TARGET"
+          "$BIN" service status --user --json | grep -q '"enabled": false'
+          "$BIN" service install --user
+          "$BIN" service status --user --json | grep -q '"enabled": true'
+
+          "$BIN" service uninstall --user
+          test ! -f "$PLIST"
+          launchctl print "$TARGET" >/dev/null 2>&1 && rc=0 || rc=$?
+          test "$rc" -ne 0
+          # `uninstall` keeps the log deliberately.
+          test -f "$LOG"
+
   build-check:
     name: Build Check
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ http://gpu-node3:9090
 | Platform | Canonical path | Also searched |
 |----------|----------------|---------------|
 | Linux    | `$XDG_CONFIG_HOME/all-smi/config.toml` (fallback `~/.config/all-smi/config.toml`) | `/etc/all-smi/config.toml` |
-| macOS    | `~/Library/Application Support/all-smi/config.toml` | `~/.config/all-smi/config.toml` |
+| macOS    | `~/Library/Application Support/all-smi/config.toml` | `~/.config/all-smi/config.toml`, then `/Library/Application Support/all-smi/config.toml` |
 | Windows  | `%APPDATA%\all-smi\config.toml` | — |
 
-Candidates are probed in order and the first existing file wins, so a per-user file always beats the machine-wide one. `/etc/all-smi/config.toml` exists for daemons: a service running as a dedicated account has no home directory, so no per-user candidate ever resolves for it (see [Running as a service](#running-as-a-service)). `all-smi config init` only ever writes the per-user path; creating `/etc/all-smi/config.toml` is an administrator's decision.
+Candidates are probed in order and the first existing file wins, so a per-user file always beats the machine-wide one. The machine-wide paths exist for daemons. On Linux a service running as a dedicated account has no home directory, so no per-user candidate ever resolves for it; on macOS a launchd LaunchDaemon runs outside any login session, so `~/Library/Application Support` resolves to root's home rather than the administrator's, and launchd has no environment-file mechanism to work around it (see [Running as a service](#running-as-a-service)). `all-smi config init` only ever writes the per-user path; creating `/etc/all-smi/config.toml` or `/Library/Application Support/all-smi/config.toml` is an administrator's decision.
 
 Pass `--config <PATH>` to any subcommand to override the discovery and force a specific file. A missing or malformed `--config` target is a hard error (exit 2); implicit discovery silently falls back to defaults when no candidate file exists. To print the active path for the current user without writing any file, run `all-smi config path` (also surfaced in `all-smi --help` under the "Configuration file" section).
 
@@ -377,6 +377,53 @@ A user-scope unit keeps only the hardening that needs no privilege, `NoNewPrivil
 **Unix socket.** `PrivateTmp=true` namespaces `/tmp`, so the default `/tmp/all-smi.sock` fallback would not be reachable from outside the service. The unit provides `/run/all-smi` through `RuntimeDirectory=`; set `ALL_SMI_API_SOCKET=/run/all-smi/all-smi.sock` in the environment file to expose the socket there.
 
 **Other init systems.** OpenRC, runit, and sysvinit are not supported by the subcommand; it detects the absence of systemd and points at the canonical unit for manual adaptation.
+
+### macOS (launchd)
+
+The canonical job definition is [`packaging/launchd/com.lablup.all-smi.plist`](packaging/launchd/com.lablup.all-smi.plist), a self-contained system LaunchDaemon you can also copy into `/Library/LaunchDaemons` by hand. `all-smi service install` embeds the same file and rewrites `ProgramArguments`, the log paths, and the account keys for the scope you asked for. The launchd label is `com.lablup.all-smi` in both scopes; they live in different domains, so the name never collides.
+
+**From Homebrew.** The formula ships a service block, so `brew services` is the supported path and the subcommand refuses to install alongside it:
+
+```bash
+brew install lablup/tap/all-smi
+
+# Per-user. Bootstraps into gui/$UID, so it stops at logout.
+brew services start all-smi
+
+# Boot-time. Bootstraps into the system domain and survives a reboot
+# with nobody logged in. This is the one a headless node wants.
+sudo brew services start all-smi
+
+curl -s localhost:9090/metrics | head
+tail -f "$(brew --prefix)/var/log/all-smi.log"
+```
+
+The two invocations are not interchangeable. Without `sudo`, `brew services` targets your GUI login session; a rack-mounted Mac mini or Studio that reboots unattended will come back with no exporter running. With `sudo` it targets the system domain and starts at boot.
+
+**From a zip, `cargo install`, or a local build.** Use the subcommand:
+
+```bash
+# System-wide LaunchDaemon at /Library/LaunchDaemons, started immediately.
+sudo all-smi service install --now
+all-smi service status
+sudo all-smi service uninstall
+
+# Per-user LaunchAgent at ~/Library/LaunchAgents, no root.
+all-smi service install --user --now
+all-smi service status --user
+```
+
+Logs go to `/var/log/all-smi/all-smi.log` for the daemon and `~/Library/Logs/all-smi/all-smi.log` for the agent, through `StandardOutPath` and `StandardErrorPath`. `uninstall` boots the job out and removes the plist but leaves the log behind, so you can still read why you removed it.
+
+**launchd has no separate "enabled" state.** A plist sitting in `LaunchDaemons` or `LaunchAgents` is bootstrapped automatically at boot or login, and `RunAtLoad` starts it from there. So `install` without `--now` writes the plist and stops, which is precisely "enabled at boot, not running yet"; `install --now` additionally boots the job out and back in, because launchd caches a loaded job's definition and bootstrapping over it fails rather than replacing it. `stop` boots the job out of its domain and leaves the plist, so the service returns at the next boot, matching `systemctl stop`. `install` also runs `launchctl enable` to clear a persistent disable override, which otherwise outlives both the plist and a reboot; `uninstall` deliberately does not `disable`, for the same reason.
+
+**Configuration.** launchd has no `EnvironmentFile=` equivalent, so unlike the Linux service there is no `/etc/default/all-smi` analogue: the TOML config is the whole story. A system LaunchDaemon runs outside any login session, so `~/Library/Application Support` resolves to root's home rather than yours. `/Library/Application Support/all-smi/config.toml` is a discovery candidate exactly for that case, ordered after every per-user candidate so your own file still wins when both exist. `all-smi config path` lists the full search order.
+
+**Which plist keys a LaunchAgent gets.** A user-scope render drops `UserName`, `GroupName`, and `InitGroups`, all of which need root. On macOS 26.6 launchd does not reject them the way systemd rejects an unprivileged user unit: bootstrapping a LaunchAgent that carries `UserName root` succeeds and the job still runs as you, with the key silently ignored. They are dropped because keeping them would ship a plist that reads, to anyone auditing what runs privileged on the machine, as a root job when it is not, and because Apple documents the keys as requiring root without documenting the fallback. Everything else is kept in both scopes, including `SoftResourceLimits`, since raising a soft rlimit up to the inherited hard limit needs no privilege.
+
+`--service-user` sets `UserName` in system scope and drops `GroupName` rather than mirroring the account name the way the Linux renderer does. macOS has no convention that an account owns an eponymous group, so omitting the key makes launchd use the account's primary group straight from the password database. Give such an account a writable home directory, or point `[energy] wal_path` somewhere it can write, or the energy WAL degrades to in-memory with a warning in the log.
+
+**Apple Silicon metrics under launchd.** The native readers (IOReport, the SMC, and `NSProcessInfo.thermalState`) need no GUI session and no sudo, and a LaunchAgent exports the same metric set a foreground `all-smi api` does: GPU utilization and power, SMC GPU and CPU temperatures, ANE power, thermal pressure, and P/E cluster frequencies. The plist sets `ProcessType` to `Background` so the exporter runs at background QoS on the efficiency cores and does not compete with the workload it is watching. That costs a few seconds of extra startup, because enumerating the IOReport channel list is the expensive part of coming up; it is a one-time cost per launch.
 
 ## Platform-Specific Requirements
 

--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -255,6 +255,91 @@ instead; \fBRuntimeDirectory=\fR provides \fI/run/all\-smi\fR.
 .PP
 OpenRC, runit, and sysvinit are not supported by the subcommand. It detects the
 absence of systemd and points at the canonical unit for manual adaptation.
+.SS macOS (launchd)
+The canonical job definition is
+\fIpackaging/launchd/com.lablup.all\-smi.plist\fR in the source tree, a
+self\-contained system LaunchDaemon.
+.B all\-smi service install
+embeds the same file and rewrites \fBProgramArguments\fR, the log paths, and
+the account keys for the requested scope. The launchd label is
+\fBcom.lablup.all\-smi\fR in both scopes; they occupy different domains, so it
+never collides.
+.PP
+Homebrew installs ship a service block, and the subcommand refuses to install
+alongside it. The two \fBbrew services\fR invocations are not interchangeable:
+.RS
+.nf
+brew services start all\-smi        # gui/$UID, stops at logout
+sudo brew services start all\-smi   # system domain, starts at boot
+.fi
+.RE
+A rack\-mounted Mac that reboots unattended needs the elevated form; the
+unelevated one leaves it with no exporter after a power cycle.
+.PP
+For a zip archive, \fBcargo install\fR, or a local build, use the subcommand:
+.RS
+.nf
+sudo all\-smi service install \-\-now   # /Library/LaunchDaemons
+all\-smi service status
+sudo all\-smi service uninstall
+
+all\-smi service install \-\-user \-\-now  # ~/Library/LaunchAgents
+.fi
+.RE
+.PP
+launchd has no separate enabled state. A plist in \fILaunchDaemons\fR or
+\fILaunchAgents\fR is bootstrapped automatically at boot or login, and
+\fBRunAtLoad\fR starts it from there, so
+.B install
+without \fB\-\-now\fR writes the plist and stops, which is exactly "enabled at
+boot, not running yet".
+.B install \-\-now
+additionally boots the job out and back in, because launchd caches a loaded
+job's definition and bootstrapping over it fails rather than replacing it.
+.B stop
+boots the job out and leaves the plist, so the service returns at the next
+boot.
+.B install
+also runs \fBlaunchctl enable\fR to clear a persistent disable override, which
+outlives both the plist and a reboot;
+.B uninstall
+deliberately does not disable, for the same reason, and leaves the log file in
+place.
+.PP
+launchd has no \fBEnvironmentFile=\fR equivalent, so there is no
+\fI/etc/default/all\-smi\fR analogue on macOS: the TOML config is the only
+settings surface. A LaunchDaemon runs outside any login session, which makes
+\fI~/Library/Application Support\fR resolve to root's home rather than the
+administrator's;
+\fI/Library/Application Support/all\-smi/config.toml\fR is a discovery
+candidate for exactly that case, ordered after every per\-user candidate.
+.PP
+A user\-scope render drops \fBUserName\fR, \fBGroupName\fR, and
+\fBInitGroups\fR, all of which need root. launchd does not reject them the way
+systemd rejects an unprivileged user unit: on macOS 26.6, bootstrapping a
+LaunchAgent carrying \fBUserName root\fR succeeds and the job still runs as the
+invoking user, with the key silently ignored. They are dropped because keeping
+them would ship a plist that reads as a root job to anyone auditing the
+machine when it is not one, and because Apple documents the keys as requiring
+root without documenting that fallback. \fBSoftResourceLimits\fR is kept in
+both scopes, since raising a soft rlimit up to the inherited hard limit needs
+no privilege.
+.PP
+\fB\-\-service\-user\fR sets \fBUserName\fR in system scope and drops
+\fBGroupName\fR rather than mirroring the account name the way the systemd
+renderer does, because macOS has no convention that an account owns an
+eponymous group; omitting the key makes launchd use the account's primary
+group from the password database. Such an account needs a writable home
+directory, or an explicit \fB[energy] wal_path\fR, or the energy WAL degrades
+to in\-memory with a warning.
+.PP
+The Apple Silicon native readers (IOReport, the SMC,
+\fBNSProcessInfo.thermalState\fR) need neither sudo nor a GUI session, and a
+LaunchAgent exports the same metric set a foreground \fBall\-smi api\fR does.
+The plist sets \fBProcessType\fR to \fBBackground\fR so the exporter runs at
+background QoS on the efficiency cores rather than competing with the workload
+it monitors, which costs a few seconds of extra startup while the IOReport
+channel list is enumerated.
 .SH INTERACTIVE CONTROLS (LOCAL/VIEW MODE)
 .TP
 .B Tab / Shift+Tab
@@ -401,16 +486,19 @@ Optional TOML configuration file. Per-platform canonical paths:
 .IP \(bu 3
 Linux: \fI$XDG_CONFIG_HOME/all-smi/config.toml\fR (fallback \fI~/.config/all-smi/config.toml\fR), then \fI/etc/all-smi/config.toml\fR
 .IP \(bu 3
-macOS: \fI~/Library/Application Support/all-smi/config.toml\fR (also accepts \fI~/.config/all-smi/config.toml\fR)
+macOS: \fI~/Library/Application Support/all-smi/config.toml\fR (also accepts \fI~/.config/all-smi/config.toml\fR, then \fI/Library/Application Support/all-smi/config.toml\fR)
 .IP \(bu 3
 Windows: \fI%APPDATA%\\all-smi\\config.toml\fR
 .RE
 .RS
 Candidates are probed in order and the first existing file wins, so a
-per-user file always beats the machine-wide one. \fI/etc/all-smi/config.toml\fR
-exists for daemons: a service running as a dedicated account has no home
-directory, and the shipped unit sets \fBProtectHome=true\fR, so no per-user
-candidate resolves for it. \fBall-smi config init\fR only ever writes the
+per-user file always beats the machine-wide one. The machine-wide paths exist
+for daemons. On Linux, a service running as a dedicated account has no home
+directory and the shipped unit sets \fBProtectHome=true\fR, so no per-user
+candidate resolves for it. On macOS, a launchd LaunchDaemon runs outside any
+login session, so \fI~/Library/Application Support\fR resolves to root's home
+rather than the administrator's, and launchd offers no environment-file
+mechanism to work around it. \fBall-smi config init\fR only ever writes the
 per-user path.
 .RE
 .RS
@@ -455,6 +543,22 @@ carry \fB# Managed by 'all-smi service'\fR as their first line; the subcommand
 refuses to overwrite or remove a unit without it unless \fB--force\fR is
 passed. The canonical source is \fIpackaging/systemd/all-smi.service\fR in the
 all-smi source tree.
+.TP
+.I com.lablup.all-smi.plist
+launchd job definition for API mode on macOS. The system-scope LaunchDaemon
+lives at \fI/Library/LaunchDaemons/com.lablup.all-smi.plist\fR; a user-scope
+LaunchAgent lives at \fI~/Library/LaunchAgents/com.lablup.all-smi.plist\fR.
+Both are written by
+.B all-smi service install
+and carry \fB<!-- Managed by 'all-smi service' -->\fR after the DOCTYPE (an XML
+declaration has to stay on line 1, so unlike a systemd unit the marker cannot
+be the first line); the subcommand refuses to overwrite or remove a plist
+without it unless \fB--force\fR is passed. The canonical source is
+\fIpackaging/launchd/com.lablup.all-smi.plist\fR in the all-smi source tree.
+Logs go to \fI/var/log/all-smi/all-smi.log\fR and
+\fI~/Library/Logs/all-smi/all-smi.log\fR respectively;
+.B uninstall
+leaves them in place.
 .TP
 .I /etc/default/all-smi
 Environment file read by the systemd unit through

--- a/packaging/launchd/com.lablup.all-smi.plist
+++ b/packaging/launchd/com.lablup.all-smi.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.lablup.all-smi</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/all-smi</string>
+		<string>api</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>ThrottleInterval</key>
+	<integer>5</integer>
+	<key>ExitTimeOut</key>
+	<integer>30</integer>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>WorkingDirectory</key>
+	<string>/</string>
+	<key>UserName</key>
+	<string>root</string>
+	<key>GroupName</key>
+	<string>wheel</string>
+	<key>InitGroups</key>
+	<true/>
+	<key>SoftResourceLimits</key>
+	<dict>
+		<key>NumberOfFiles</key>
+		<integer>4096</integer>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>/var/log/all-smi/all-smi.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/all-smi/all-smi.log</string>
+</dict>
+</plist>

--- a/src/common/paths.rs
+++ b/src/common/paths.rs
@@ -50,6 +50,19 @@ pub const APP_DIR_NAME: &str = "all-smi";
 #[cfg(target_os = "linux")]
 pub const LINUX_SYSTEM_CONFIG_PATH: &str = "/etc/all-smi/config.toml";
 
+/// System-wide configuration file on macOS (issue #310).
+///
+/// The macOS counterpart of [`LINUX_SYSTEM_CONFIG_PATH`], and the only
+/// settings surface a launchd daemon has: launchd offers no
+/// `EnvironmentFile=` equivalent, so `/etc/default/all-smi` has no
+/// analogue here. A system LaunchDaemon runs outside any login session,
+/// so `~/Library/Application Support` resolves to root's own home (or to
+/// a `--service-user` account's) rather than to the administrator's.
+/// Like the Linux path this is a discovery candidate only: `all-smi
+/// config init` still writes the per-user file.
+#[cfg(target_os = "macos")]
+pub const MACOS_SYSTEM_CONFIG_PATH: &str = "/Library/Application Support/all-smi/config.toml";
+
 /// Expand a leading `~` or `~/` in a path-like string to the user's
 /// home directory. Returns the input unchanged when no home directory is
 /// available (e.g. `$HOME` unset on Linux, no `UserProfile` on Windows).
@@ -158,15 +171,18 @@ fn push_unique(out: &mut Vec<PathBuf>, path: PathBuf) {
 ///    [`default_config_path`], plus any per-platform parity fallback.
 /// 2. **System-wide candidates** (issue #309). A daemon runs as a
 ///    dedicated account with no home directory, so it needs a
-///    machine-wide file. Linux contributes `/etc/all-smi/config.toml`;
-///    the macOS (#310) and Windows (#311) counterparts are added as
-///    sibling branches in the same tier.
+///    machine-wide file. Linux contributes `/etc/all-smi/config.toml`
+///    and macOS contributes
+///    `/Library/Application Support/all-smi/config.toml` (#310); the
+///    Windows counterpart (#311) is added as a sibling branch in the
+///    same tier.
 ///
 /// Current resolution per platform:
 ///
 /// * Linux: the XDG path, then `/etc/all-smi/config.toml`.
 /// * macOS: the canonical Apple path, then `~/.config/all-smi/config.toml`
-///   as a parity fallback for operators migrating from Linux.
+///   as a parity fallback for operators migrating from Linux, then
+///   `/Library/Application Support/all-smi/config.toml`.
 /// * Windows: only the canonical `%APPDATA%` path.
 pub fn candidate_config_paths() -> Vec<PathBuf> {
     let mut out = Vec::new();
@@ -195,6 +211,11 @@ pub fn candidate_config_paths() -> Vec<PathBuf> {
     #[cfg(target_os = "linux")]
     {
         push_unique(&mut out, PathBuf::from(LINUX_SYSTEM_CONFIG_PATH));
+    }
+    // macOS system LaunchDaemon (issue #310).
+    #[cfg(target_os = "macos")]
+    {
+        push_unique(&mut out, PathBuf::from(MACOS_SYSTEM_CONFIG_PATH));
     }
 
     out
@@ -376,6 +397,46 @@ mod tests {
     fn default_config_path_is_never_the_system_wide_path() {
         if let Some(p) = default_config_path() {
             assert_ne!(p, PathBuf::from(LINUX_SYSTEM_CONFIG_PATH));
+        }
+    }
+
+    /// Issue #310: a launchd LaunchDaemon runs outside any login
+    /// session, so `~/Library/Application Support` resolves to root's
+    /// home rather than the administrator's. The machine-wide file has
+    /// to be discoverable for the daemon to be configurable at all.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_candidates_include_the_system_wide_path() {
+        let paths = candidate_config_paths();
+        let system = PathBuf::from(MACOS_SYSTEM_CONFIG_PATH);
+        assert!(
+            paths.contains(&system),
+            "/Library/Application Support/all-smi/config.toml must be a discovery candidate on \
+             macOS: {paths:?}"
+        );
+    }
+
+    /// The operator's own files, both the Apple-canonical path and the
+    /// `~/.config` parity fallback, must win over the machine-wide one.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_system_candidate_is_ordered_last() {
+        let paths = candidate_config_paths();
+        let system = PathBuf::from(MACOS_SYSTEM_CONFIG_PATH);
+        assert_eq!(
+            paths.iter().position(|p| p == &system),
+            Some(paths.len() - 1),
+            "the machine-wide candidate must be probed after every per-user one: {paths:?}"
+        );
+    }
+
+    /// `config init` must never target `/Library/Application Support`
+    /// for the same reason it must never target `/etc`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_default_config_path_is_never_the_system_wide_path() {
+        if let Some(p) = default_config_path() {
+            assert_ne!(p, PathBuf::from(MACOS_SYSTEM_CONFIG_PATH));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,11 +210,27 @@ async fn run_command(cli: Cli, settings: Settings) {
     //   cleanly with a complete final JSON line"). Skip them for
     //   `Record` so the cooperative path wins.
     //
+    // * `Api` owns its shutdown for the same reason. `run_api_mode`
+    //   waits for axum's graceful shutdown, then performs the final
+    //   energy-WAL flush and fsync and removes the Unix socket file.
+    //   The unconditional exit below won that race, so every SIGTERM
+    //   dropped the last batch of accumulated Joules and left a stale
+    //   socket behind. That is not an edge case for a service: SIGTERM
+    //   is exactly how `launchctl bootout` and `systemctl stop` end it,
+    //   so it happened on every restart (issues #191, #309, #310).
+    //
     // * Every other subcommand keeps the original behaviour — no device
     //   manager does partial-state flushing, so an immediate exit on
     //   signal is the desired shutdown semantics.
-    let is_record = matches!(cli.command, Some(Commands::Record(_)));
-    if !is_record {
+    let owns_shutdown = match &cli.command {
+        Some(Commands::Record(_) | Commands::Api(_)) => true,
+        // `None` redispatches through `[general].default_mode` further
+        // down, and the recursive call cannot uninstall a handler this
+        // call already spawned. Resolve the effective mode here.
+        None => settings.general.default_mode == "api",
+        _ => false,
+    };
+    if !owns_shutdown {
         // Set up signal handler for clean shutdown
         tokio::spawn(async {
             signal::ctrl_c().await.expect("Failed to listen for Ctrl+C");
@@ -331,6 +347,19 @@ async fn run_command(cli: Cli, settings: Settings) {
             }
 
             run_api_mode(&args, &settings).await;
+
+            // Reached once the graceful shutdown above has finished, so
+            // the collectors are torn down in the same deterministic
+            // order `view` uses. Previously the signal handler exited
+            // the process before this point could be reached at all.
+            #[cfg(target_os = "macos")]
+            {
+                shutdown_native_metrics_manager();
+            }
+            #[cfg(target_os = "linux")]
+            {
+                shutdown_hlsmi_manager();
+            }
         }
         Some(Commands::Local(mut args)) => {
             // On non-macOS platforms, require sudo

--- a/src/service_cmd/detect.rs
+++ b/src/service_cmd/detect.rs
@@ -105,13 +105,25 @@ pub fn guard(force: bool) -> Result<(), ServiceError> {
              all-smi' instead"
                 .to_string(),
         )),
-        PackageOwner::Homebrew => Err(ServiceError::PackageManaged(
+        PackageOwner::Homebrew => Err(ServiceError::PackageManaged(format!(
             "The Homebrew formula already ships a service definition; use 'brew services start \
-             all-smi' instead"
-                .to_string(),
-        )),
+             all-smi' instead{HOMEBREW_BOOT_HINT}"
+        ))),
     }
 }
+
+/// Extra guidance appended to the Homebrew refusal.
+///
+/// `brew services` bootstraps into `gui/$UID` without sudo and into the
+/// system domain with it, and only the latter survives a reboot on a
+/// headless node. That distinction is macOS-specific: on Linuxbrew
+/// `brew services` drives `systemctl --user`, where running it under
+/// sudo is not a supported mode.
+#[cfg(target_os = "macos")]
+const HOMEBREW_BOOT_HINT: &str =
+    " (or 'sudo brew services start all-smi' for a boot-time system daemon)";
+#[cfg(not(target_os = "macos"))]
+const HOMEBREW_BOOT_HINT: &str = "";
 
 #[cfg(test)]
 mod tests {
@@ -192,6 +204,24 @@ mod tests {
         // `--force` short-circuits before any filesystem probing, so
         // this holds on every host regardless of what is installed.
         assert!(guard(true).is_ok());
+    }
+
+    /// Issue #310: on macOS the two `brew services` invocations land in
+    /// different launchd domains and only the elevated one survives a
+    /// reboot, so a headless operator who follows the unelevated hint
+    /// gets a monitoring node that goes dark at the next power cycle.
+    /// The refusal has to name both.
+    #[test]
+    fn the_homebrew_refusal_distinguishes_the_two_brew_services_domains() {
+        #[cfg(target_os = "macos")]
+        {
+            assert!(HOMEBREW_BOOT_HINT.contains("sudo brew services start all-smi"));
+            assert!(HOMEBREW_BOOT_HINT.contains("boot-time"));
+        }
+        // Linuxbrew drives `systemctl --user`, where running the whole
+        // thing under sudo is not a supported mode, so no hint there.
+        #[cfg(not(target_os = "macos"))]
+        assert!(HOMEBREW_BOOT_HINT.is_empty());
     }
 
     #[test]

--- a/src/service_cmd/launchctl.rs
+++ b/src/service_cmd/launchctl.rs
@@ -1,0 +1,349 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The `launchctl(1)` interface used by the launchd backend (issue
+//! #310): how launchd objects are named, how the tool is invoked, and
+//! how its output is parsed.
+//!
+//! Split out of [`super::launchd`] so the backend file stays under the
+//! 500-line limit, and so the half that is pure (layout resolution and
+//! output parsing) sits together and can be unit tested on any host.
+//!
+//! Nothing here knows what a plist contains; that is [`super::plist`].
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use super::plist::LABEL;
+use super::{Scope, ServiceError};
+use crate::utils::command::new_command;
+
+/// Plist file name, identical in both scopes.
+pub const PLIST_FILE_NAME: &str = "com.lablup.all-smi.plist";
+
+/// Where an administrator's system-wide daemons belong. Apple reserves
+/// `/System/Library/LaunchDaemons` for itself.
+const SYSTEM_PLIST_DIR: &str = "/Library/LaunchDaemons";
+
+/// Log file for the system daemon. The parent directory is created at
+/// install time and left behind by `uninstall`, so an operator can still
+/// read why the service died after removing it.
+const SYSTEM_LOG_PATH: &str = "/var/log/all-smi/all-smi.log";
+
+/// Per-user plist directory, relative to the home directory.
+const USER_AGENT_SUBDIR: &str = "Library/LaunchAgents";
+
+/// Per-user log file, relative to the home directory. `~/Library/Logs`
+/// is the Apple-sanctioned location and is what Console.app shows.
+const USER_LOG_SUBPATH: &str = "Library/Logs/all-smi/all-smi.log";
+
+/// `launchctl bootout` returns before launchd has finished tearing the
+/// job down, so an immediately following `bootstrap` can lose the race
+/// and fail with "Operation already in progress". Retry a few times
+/// before giving up.
+const BOOTSTRAP_ATTEMPTS: u32 = 5;
+const BOOTSTRAP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+/// Everything one scope resolves to: where its plist and log live, and
+/// how launchctl names its domain and its job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Layout {
+    pub plist: PathBuf,
+    pub log: PathBuf,
+    /// Domain argument for `launchctl bootstrap`, e.g. `gui/501`.
+    pub domain: String,
+    /// Service target for every other launchctl verb, e.g.
+    /// `gui/501/com.lablup.all-smi`.
+    pub target: String,
+}
+
+/// Pure half of layout resolution, kept separate so both scopes are
+/// testable on any host without a real home directory or uid.
+pub fn layout_from(scope: Scope, home: &Path, uid: u32) -> Layout {
+    match scope {
+        Scope::System => Layout {
+            plist: Path::new(SYSTEM_PLIST_DIR).join(PLIST_FILE_NAME),
+            log: PathBuf::from(SYSTEM_LOG_PATH),
+            domain: "system".to_string(),
+            target: format!("system/{LABEL}"),
+        },
+        Scope::User => Layout {
+            plist: home.join(USER_AGENT_SUBDIR).join(PLIST_FILE_NAME),
+            log: home.join(USER_LOG_SUBPATH),
+            domain: format!("gui/{uid}"),
+            target: format!("gui/{uid}/{LABEL}"),
+        },
+    }
+}
+
+/// Resolve the layout for `scope` against this process's environment.
+pub fn layout(scope: Scope) -> Result<Layout, ServiceError> {
+    if scope == Scope::System {
+        // The system domain needs neither a home directory nor a uid.
+        return Ok(layout_from(scope, Path::new("/"), 0));
+    }
+    let uid = gui_uid()?;
+    let home = dirs::home_dir().ok_or_else(|| {
+        ServiceError::NotSupported(
+            "cannot locate a home directory for the LaunchAgent; set $HOME, or drop --user to \
+             install the system LaunchDaemon with sudo"
+                .to_string(),
+        )
+    })?;
+    Ok(layout_from(scope, &home, uid))
+}
+
+/// The uid whose `gui` domain a user-scope action targets.
+///
+/// Refuses uid 0 rather than producing `gui/0`. That domain does not
+/// exist: root has no GUI login session, so `launchctl bootstrap gui/0`
+/// fails with an error that says nothing about the real mistake, which
+/// is almost always a reflexive `sudo` in front of an otherwise correct
+/// `--user` command.
+#[cfg(unix)]
+fn gui_uid() -> Result<u32, ServiceError> {
+    // SAFETY: `getuid` takes no arguments, reads no caller-provided
+    // memory, and is documented as always succeeding.
+    let uid = unsafe { libc::getuid() };
+    if uid == 0 {
+        return Err(ServiceError::NotSupported(
+            "--user targets the gui/0 launchd domain, which does not exist because root has no \
+             login session. Drop sudo to manage your own LaunchAgent, or drop --user to install \
+             the system LaunchDaemon."
+                .to_string(),
+        ));
+    }
+    Ok(uid)
+}
+
+/// Non-Unix stand-in so the pure logic in this module still compiles
+/// under `cfg(test)` on Windows. launchd exists only on macOS, so this
+/// arm is never reachable from a dispatched backend.
+#[cfg(not(unix))]
+fn gui_uid() -> Result<u32, ServiceError> {
+    Err(ServiceError::NotSupported(
+        "launchd is macOS-only".to_string(),
+    ))
+}
+
+// ── launchctl plumbing ────────────────────────────────────────────────
+
+pub(super) fn describe(args: &[&str]) -> String {
+    format!("launchctl {}", args.join(" "))
+}
+
+fn command(args: &[&str]) -> Command {
+    let mut cmd = new_command("launchctl");
+    cmd.args(args);
+    cmd
+}
+
+pub(super) fn output(args: &[&str]) -> Result<Output, ServiceError> {
+    Ok(command(args).output()?)
+}
+
+/// Run `launchctl` and return stdout, mapping a non-zero exit onto
+/// [`ServiceError::CommandFailed`].
+pub(super) fn run(args: &[&str]) -> Result<String, ServiceError> {
+    let output = output(args)?;
+    if !output.status.success() {
+        return Err(ServiceError::CommandFailed {
+            cmd: describe(args),
+            stderr: failure_text(&output),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Run `launchctl` for its side effect, tolerating failure.
+///
+/// Used where the desired end state is already satisfied by the failure:
+/// booting out a job that is not loaded, or enabling one that was never
+/// disabled.
+pub(super) fn run_best_effort(args: &[&str]) {
+    let _ = output(args);
+}
+
+/// Human-readable reason a launchctl invocation failed. launchctl prints
+/// its diagnostics to stderr, but falls back to stdout for some verbs.
+pub(super) fn failure_text(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return stdout;
+    }
+    format!("exited with {}", output.status)
+}
+
+/// `launchctl print <target>` stdout, or `None` when the job is not
+/// loaded in that domain.
+///
+/// `launchctl print` exits 113 for an unknown service, so a non-zero
+/// exit is the normal "not loaded" answer rather than an error.
+pub(super) fn print_job(target: &str) -> Result<Option<String>, ServiceError> {
+    let output = output(&["print", target])?;
+    if output.status.success() {
+        Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Bootstrap the job, retrying past the teardown race described on
+/// [`BOOTSTRAP_ATTEMPTS`].
+pub(super) fn bootstrap(layout: &Layout) -> Result<(), ServiceError> {
+    let plist_arg = path_arg(&layout.plist)?;
+    let args = ["bootstrap", layout.domain.as_str(), plist_arg];
+    let mut last = None;
+    for attempt in 0..BOOTSTRAP_ATTEMPTS {
+        match run(&args) {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                last = Some(e);
+                if attempt + 1 < BOOTSTRAP_ATTEMPTS {
+                    std::thread::sleep(BOOTSTRAP_RETRY_DELAY);
+                }
+            }
+        }
+    }
+    Err(last.unwrap_or_else(|| ServiceError::CommandFailed {
+        cmd: describe(&args),
+        stderr: "bootstrap did not run".to_string(),
+    }))
+}
+
+/// Borrow a path as a launchctl argument, refusing one that is not UTF-8.
+pub(super) fn path_arg(path: &Path) -> Result<&str, ServiceError> {
+    path.to_str().ok_or_else(|| {
+        ServiceError::Conflict(format!(
+            "path `{}` is not valid UTF-8 and cannot be passed to launchctl",
+            path.display()
+        ))
+    })
+}
+
+// ── parsing ───────────────────────────────────────────────────────────
+
+/// The subset of `launchctl print <service-target>` this backend needs.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PrintInfo {
+    /// The job's top-level `state` value, e.g. `running`, `not running`.
+    pub state: String,
+    /// The job's pid when it has one.
+    pub pid: Option<u32>,
+}
+
+impl PrintInfo {
+    /// launchd reports `state = running` only while the program is
+    /// actually executing; `waiting`, `not running`, and `spawn
+    /// scheduled` all mean it is not.
+    pub fn running(&self) -> bool {
+        self.state == "running"
+    }
+}
+
+/// Parse `launchctl print <service-target>` output.
+///
+/// `launchctl print` nests dictionaries (endpoints, semaphores) that
+/// repeat the `state` key with unrelated values such as `active`, so
+/// only the first occurrence of each key, which is the job's own, is
+/// taken. Keys are matched on the whole trimmed name so neighbours like
+/// `jetsam priority` and `last exit code` cannot be mistaken for them.
+pub fn parse_print_output(raw: &str) -> PrintInfo {
+    let mut state: Option<String> = None;
+    let mut pid: Option<u32> = None;
+
+    for line in raw.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let value = value.trim();
+        match key.trim() {
+            "state" if state.is_none() => state = Some(value.to_string()),
+            "pid" if pid.is_none() => pid = value.parse::<u32>().ok().filter(|p| *p != 0),
+            _ => {}
+        }
+    }
+
+    PrintInfo {
+        state: state.unwrap_or_default(),
+        pid,
+    }
+}
+
+/// Find `label` in `launchctl print-disabled <domain>` output.
+///
+/// Returns `Some(true)` when the label carries a persistent disable
+/// override, `Some(false)` when it is explicitly enabled, and `None`
+/// when the domain does not mention it at all. Both spellings launchctl
+/// has used are accepted: `=> true` / `=> false` on older releases,
+/// `=> disabled` / `=> enabled` since Sonoma.
+pub fn parse_disabled(raw: &str, label: &str) -> Option<bool> {
+    let needle = format!("\"{label}\"");
+    for line in raw.lines() {
+        let Some(rest) = line.trim().strip_prefix(needle.as_str()) else {
+            continue;
+        };
+        let Some(value) = rest.split("=>").nth(1) else {
+            continue;
+        };
+        return match value.trim() {
+            "true" | "disabled" => Some(true),
+            "false" | "enabled" => Some(false),
+            _ => None,
+        };
+    }
+    None
+}
+
+/// Whether the domain carries a persistent disable override for our
+/// label. `None` when launchctl could not answer.
+pub(super) fn query_disabled(domain: &str) -> Option<bool> {
+    let output = output(&["print-disabled", domain]).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    Some(parse_disabled(&raw, LABEL).unwrap_or(false))
+}
+/// Detail line for a job launchctl could not print.
+///
+/// The usual reason is that the plist is on disk but nothing has
+/// bootstrapped it yet, which is exactly the state `install` without
+/// `--now` leaves behind. Anything else (most often a system-domain
+/// query from an unprivileged shell) is surfaced verbatim, because
+/// silently reporting "not loaded" for a permission failure would be a
+/// lie.
+pub(super) fn not_loaded_detail(installed: bool, stderr: &str) -> String {
+    if !installed {
+        return "not installed".to_string();
+    }
+    if stderr.contains("Could not find service") {
+        return "not loaded".to_string();
+    }
+    let first = stderr.lines().next().unwrap_or("").trim();
+    if first.is_empty() {
+        "not loaded".to_string()
+    } else {
+        format!("loaded state unknown: {first}")
+    }
+}
+
+// Test module lives in `launchctl_tests.rs` to keep this file under the
+// 500-line soft limit.
+#[cfg(test)]
+#[path = "launchctl_tests.rs"]
+mod tests;

--- a/src/service_cmd/launchctl_tests.rs
+++ b/src/service_cmd/launchctl_tests.rs
@@ -1,0 +1,326 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the `launchctl(1)` interface: layout resolution,
+//! `launchctl print` and `print-disabled` parsing, the status detail
+//! line, and command description. Kept in a sibling file so the
+//! implementation stays under the 500-line soft limit.
+//!
+//! Every fixture below is verbatim `launchctl` output captured on macOS
+//! 26.6 (Darwin 25.6), trimmed to the keys the parser reads plus the
+//! neighbours that have historically confused key matching.
+
+use std::path::PathBuf;
+
+use super::*;
+
+fn home() -> PathBuf {
+    PathBuf::from("/Users/dev")
+}
+
+// ── layout ────────────────────────────────────────────────────────────
+
+#[test]
+fn system_layout_targets_the_administrator_daemon_directory() {
+    let l = layout_from(Scope::System, &home(), 501);
+    // /System/Library/LaunchDaemons is Apple's; third-party daemons
+    // belong in /Library/LaunchDaemons and only there.
+    assert_eq!(
+        l.plist,
+        PathBuf::from("/Library/LaunchDaemons/com.lablup.all-smi.plist")
+    );
+    assert_eq!(l.log, PathBuf::from("/var/log/all-smi/all-smi.log"));
+    assert_eq!(l.domain, "system");
+    assert_eq!(l.target, "system/com.lablup.all-smi");
+}
+
+#[test]
+fn user_layout_targets_the_gui_domain_of_the_invoking_uid() {
+    let l = layout_from(Scope::User, &home(), 501);
+    assert_eq!(
+        l.plist,
+        PathBuf::from("/Users/dev/Library/LaunchAgents/com.lablup.all-smi.plist")
+    );
+    assert_eq!(
+        l.log,
+        PathBuf::from("/Users/dev/Library/Logs/all-smi/all-smi.log")
+    );
+    assert_eq!(l.domain, "gui/501");
+    assert_eq!(l.target, "gui/501/com.lablup.all-smi");
+}
+
+#[test]
+fn the_uid_is_not_hardcoded() {
+    let l = layout_from(Scope::User, &home(), 1234);
+    assert_eq!(l.domain, "gui/1234");
+    assert_eq!(l.target, "gui/1234/com.lablup.all-smi");
+}
+
+#[test]
+fn the_bootstrap_domain_is_a_prefix_of_the_service_target() {
+    // `launchctl bootstrap` takes the domain, every other verb takes
+    // the service target. Getting one of them wrong produces a
+    // "Bootstrap failed" that says nothing about which.
+    for scope in [Scope::System, Scope::User] {
+        let l = layout_from(scope, &home(), 501);
+        assert_eq!(l.target, format!("{}/{LABEL}", l.domain));
+    }
+}
+
+#[test]
+fn both_scopes_share_the_label_and_the_file_name() {
+    let system = layout_from(Scope::System, &home(), 501);
+    let user = layout_from(Scope::User, &home(), 501);
+    // Different domains, so the same label never collides, and an
+    // operator sees one name everywhere.
+    assert_eq!(system.plist.file_name(), user.plist.file_name());
+    assert_eq!(
+        system.plist.file_name().unwrap().to_str().unwrap(),
+        PLIST_FILE_NAME
+    );
+    assert!(PLIST_FILE_NAME.starts_with(LABEL));
+}
+
+#[test]
+fn a_user_layout_never_escapes_the_home_directory() {
+    let l = layout_from(Scope::User, &home(), 501);
+    assert!(l.plist.starts_with(home()));
+    assert!(l.log.starts_with(home()));
+}
+
+// ── `launchctl print` parsing ─────────────────────────────────────────
+
+const PRINT_RUNNING: &str = r#"gui/501/com.lablup.all-smi = {
+	active count = 1
+	path = /Users/dev/Library/LaunchAgents/com.lablup.all-smi.plist
+	type = LaunchAgent
+	state = running
+
+	program = /opt/all-smi/bin/all-smi
+	default environment = {
+		PATH => /usr/bin:/bin:/usr/sbin:/sbin
+	}
+
+	domain = gui/501 [100019]
+	asid = 100019
+	minimum runtime = 10
+	exit timeout = 30
+	runs = 1
+	pid = 4242
+	immediate reason = speculative
+	forks = 0
+	execs = 1
+	last exit code = (never exited)
+
+	endpoints = {
+		"com.lablup.all-smi.peer" = {
+			port = 0x1234
+			active = 1
+			state = active
+		}
+	}
+	jetsam priority = 4
+}
+"#;
+
+const PRINT_NOT_RUNNING: &str = r#"gui/501/com.lablup.all-smi = {
+	active count = 0
+	path = /Users/dev/Library/LaunchAgents/com.lablup.all-smi.plist
+	type = LaunchAgent
+	state = not running
+
+	program = /opt/all-smi/bin/all-smi
+	runs = 3
+	last exit code = 0
+}
+"#;
+
+const PRINT_NOT_FOUND: &str = "Bad request.\nCould not find service \
+                               \"com.lablup.all-smi\" in domain for user gui: 501\n";
+
+#[test]
+fn a_running_job_yields_its_state_and_pid() {
+    let info = parse_print_output(PRINT_RUNNING);
+    assert_eq!(info.state, "running");
+    assert_eq!(info.pid, Some(4242));
+    assert!(info.running());
+}
+
+#[test]
+fn nested_dictionaries_do_not_shadow_the_jobs_own_state() {
+    // `launchctl print` repeats `state` inside every endpoint
+    // dictionary with the unrelated value `active`. A last-wins parser
+    // reports a running job as `active` and a stopped one as running.
+    assert!(PRINT_RUNNING.contains("state = active"));
+    assert_eq!(parse_print_output(PRINT_RUNNING).state, "running");
+}
+
+#[test]
+fn a_loaded_but_stopped_job_is_not_running() {
+    let info = parse_print_output(PRINT_NOT_RUNNING);
+    assert_eq!(info.state, "not running");
+    assert_eq!(info.pid, None);
+    assert!(!info.running());
+}
+
+#[test]
+fn neighbouring_keys_are_not_mistaken_for_pid_or_state() {
+    // `last exit code`, `exit timeout`, and `jetsam priority` all sit
+    // next to the keys we want and all contain integers.
+    let info = parse_print_output(PRINT_RUNNING);
+    assert_eq!(info.pid, Some(4242));
+    assert_ne!(info.pid, Some(0));
+    assert_ne!(info.pid, Some(30));
+    assert_ne!(info.pid, Some(4));
+}
+
+#[test]
+fn a_zero_pid_is_treated_as_absent() {
+    let info = parse_print_output("\tstate = not running\n\tpid = 0\n");
+    assert_eq!(info.pid, None);
+}
+
+#[test]
+fn garbage_never_panics_and_never_claims_a_running_job() {
+    for raw in [
+        "",
+        PRINT_NOT_FOUND,
+        "= = =\n",
+        "state\npid\n",
+        "pid = abc\n",
+    ] {
+        let info = parse_print_output(raw);
+        assert!(!info.running(), "must not claim running for: {raw:?}");
+    }
+}
+
+#[test]
+fn only_the_exact_running_state_counts_as_running() {
+    // launchd also reports `waiting` and `spawn scheduled`; neither
+    // means the program is executing.
+    for state in ["not running", "waiting", "spawn scheduled", ""] {
+        let info = parse_print_output(&format!("\tstate = {state}\n"));
+        assert!(!info.running(), "{state:?} must not count as running");
+    }
+    assert!(parse_print_output("\tstate = running\n").running());
+}
+
+// ── `launchctl print-disabled` parsing ────────────────────────────────
+
+const DISABLED_MODERN: &str = "\tdisabled services = {\n\
+                               \t\t\"com.apple.Siri.agent\" => enabled\n\
+                               \t\t\"com.lablup.all-smi\" => disabled\n\
+                               \t\t\"com.apple.ScriptMenuApp\" => disabled\n\
+                               \t}\n";
+
+const ENABLED_MODERN: &str = "\tdisabled services = {\n\
+                              \t\t\"com.lablup.all-smi\" => enabled\n\
+                              \t}\n";
+
+const DISABLED_LEGACY: &str = "\tdisabled services = {\n\
+                               \t\t\"com.lablup.all-smi\" => true\n\
+                               \t}\n";
+
+#[test]
+fn a_persistent_disable_override_is_detected() {
+    assert_eq!(parse_disabled(DISABLED_MODERN, LABEL), Some(true));
+    assert_eq!(parse_disabled(ENABLED_MODERN, LABEL), Some(false));
+}
+
+#[test]
+fn the_legacy_boolean_spelling_is_still_understood() {
+    // launchctl printed `=> true` / `=> false` before Sonoma; an
+    // operator on an older machine must not silently read as enabled.
+    assert_eq!(parse_disabled(DISABLED_LEGACY, LABEL), Some(true));
+    assert_eq!(
+        parse_disabled("\t\t\"com.lablup.all-smi\" => false\n", LABEL),
+        Some(false)
+    );
+}
+
+#[test]
+fn an_unlisted_label_is_not_an_override() {
+    assert_eq!(parse_disabled(DISABLED_MODERN, "com.lablup.other"), None);
+    assert_eq!(parse_disabled("", LABEL), None);
+}
+
+#[test]
+fn a_label_that_is_a_prefix_of_ours_is_not_confused_for_it() {
+    // The quotes in the fixture are what make this exact rather than a
+    // substring match.
+    let raw = "\t\t\"com.lablup.all-smi-exporter\" => disabled\n";
+    assert_eq!(parse_disabled(raw, LABEL), None);
+}
+// ── status detail ─────────────────────────────────────────────────────
+
+#[test]
+fn a_plist_on_disk_that_is_not_loaded_reads_as_not_loaded() {
+    // This is exactly the state `install` without `--now` leaves
+    // behind, so it must read as a normal condition, not as a fault.
+    assert_eq!(
+        not_loaded_detail(
+            true,
+            "Could not find service \"com.lablup.all-smi\" in domain"
+        ),
+        "not loaded"
+    );
+    assert_eq!(
+        not_loaded_detail(false, "Could not find service"),
+        "not installed"
+    );
+}
+
+#[test]
+fn an_unexpected_launchctl_failure_is_surfaced_rather_than_hidden() {
+    // Reporting "not loaded" for a permission failure would be a lie,
+    // and the usual cause is querying the system domain from an
+    // unprivileged shell.
+    let detail = not_loaded_detail(true, "Operation not permitted\nsecond line");
+    assert!(detail.starts_with("loaded state unknown:"));
+    assert!(detail.contains("Operation not permitted"));
+    assert!(!detail.contains("second line"), "one line is enough");
+}
+
+#[test]
+fn an_empty_failure_still_produces_a_usable_detail() {
+    assert_eq!(not_loaded_detail(true, ""), "not loaded");
+}
+
+// ── command construction ──────────────────────────────────────────────
+
+#[test]
+fn launchctl_invocations_are_described_verbatim_for_diagnostics() {
+    // The description is what an operator sees in a CommandFailed
+    // error, so it must be a command they can paste back into a shell.
+    assert_eq!(
+        describe(&["bootstrap", "gui/501", "/Users/dev/x.plist"]),
+        "launchctl bootstrap gui/501 /Users/dev/x.plist"
+    );
+    assert_eq!(
+        describe(&["kickstart", "-k", "system/com.lablup.all-smi"]),
+        "launchctl kickstart -k system/com.lablup.all-smi"
+    );
+}
+
+#[test]
+fn a_non_utf8_plist_path_is_refused_before_it_reaches_launchctl() {
+    #[cfg(unix)]
+    {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        let bad = PathBuf::from(OsString::from_vec(vec![0x2f, 0xff]));
+        let err = path_arg(&bad).expect_err("launchctl arguments must be UTF-8");
+        assert!(matches!(err, ServiceError::Conflict(_)));
+    }
+}

--- a/src/service_cmd/launchd.rs
+++ b/src/service_cmd/launchd.rs
@@ -1,0 +1,319 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! launchd backend for `all-smi service` (issue #310).
+//!
+//! System scope writes `/Library/LaunchDaemons/com.lablup.all-smi.plist`
+//! and drives the `system` launchd domain; user scope writes
+//! `~/Library/LaunchAgents/com.lablup.all-smi.plist` and drives
+//! `gui/$UID`.
+//!
+//! # Where launchd differs from systemd
+//!
+//! systemd separates "enabled at boot" from "loaded right now"; launchd
+//! does not. A plist sitting in `LaunchDaemons` / `LaunchAgents` is
+//! bootstrapped automatically at boot or login, and `RunAtLoad` then
+//! starts it. So:
+//!
+//! * `install` without `--now` writes the plist and clears any
+//!   `launchctl disable` override, but deliberately does **not**
+//!   bootstrap. That is the exact launchd spelling of "enabled at boot,
+//!   not running yet".
+//! * `install --now` additionally boots the job out and back in, because
+//!   launchd caches a loaded job's definition and bootstrapping over it
+//!   fails instead of replacing it.
+//! * `stop` boots the job out of its domain. The plist stays on disk, so
+//!   the service returns at the next boot, matching `systemctl stop`.
+//! * `status` reads plist presence from disk for `installed`, because
+//!   `launchctl print` only knows about jobs that are currently loaded.
+//!
+//! This file owns the policy: what each verb means, and the on-disk
+//! side of an install. Naming launchd objects, invoking `launchctl`,
+//! and parsing its output all live in [`super::launchctl`]; what goes
+//! inside a plist lives in [`super::plist`].
+//!
+//! The module compiles on non-macOS hosts under `cfg(test)` only, so
+//! its pure logic (the managed-marker guard, the atomic plist write)
+//! stays covered on Linux and Windows developer machines and in CI. It
+//! is never dispatched off macOS.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use super::launchctl::{
+    self, Layout, PLIST_FILE_NAME, layout, not_loaded_detail, parse_print_output,
+};
+use super::plist::{self, RenderParams};
+use super::{
+    Scope, ServiceBackend, ServiceError, ServiceStatus, current_exe_canonical, require_elevation,
+};
+
+/// `all-smi service` backed by launchd.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LaunchdBackend;
+
+impl LaunchdBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+// ── filesystem ────────────────────────────────────────────────────────
+
+fn read_existing_plist(path: &Path) -> Result<Option<String>, ServiceError> {
+    match fs::read_to_string(path) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(ServiceError::Io(e)),
+    }
+}
+
+/// Refuse to overwrite or remove a plist this tool did not write.
+fn guard_managed(path: &Path, force: bool, verb: &str) -> Result<(), ServiceError> {
+    if force {
+        return Ok(());
+    }
+    let Some(existing) = read_existing_plist(path)? else {
+        return Ok(());
+    };
+    if plist::is_managed(&existing) {
+        return Ok(());
+    }
+    Err(ServiceError::Conflict(format!(
+        "{} was not written by `all-smi service` (it lacks the `{}` marker); refusing to {verb} \
+         it. Pass --force to proceed, or remove the file yourself first.",
+        path.display(),
+        plist::MANAGED_MARKER
+    )))
+}
+
+/// Create the log file's parent directory.
+///
+/// `0755` matters for the system daemon: launchd refuses nothing here,
+/// but `/var/log/all-smi` has to stay readable by operators who are not
+/// root, and must not be writable by anyone else.
+fn create_log_dir(log_path: &Path) -> Result<(), ServiceError> {
+    let Some(dir) = log_path.parent() else {
+        return Ok(());
+    };
+    fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(dir, fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
+}
+
+/// Write the plist atomically with `0644`.
+///
+/// launchd validates ownership and permissions before loading a
+/// LaunchDaemon and refuses a plist that is writable by group or other,
+/// so the mode is not cosmetic. Creating the file as root (which system
+/// scope always is) gives it `root:wheel`. The temporary file is
+/// dot-prefixed and does not end in `.plist`, so a directory scan never
+/// sees a half-written job definition.
+fn write_plist(path: &Path, contents: &str) -> Result<(), ServiceError> {
+    let parent = path.parent().ok_or_else(|| {
+        ServiceError::Io(std::io::Error::other(format!(
+            "plist path {} has no parent directory",
+            path.display()
+        )))
+    })?;
+    fs::create_dir_all(parent)?;
+
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(PLIST_FILE_NAME);
+    let tmp = parent.join(format!(".{file_name}.tmp"));
+
+    {
+        let mut opts = fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o644);
+        }
+        let mut f = opts.open(&tmp)?;
+        f.write_all(contents.as_bytes())?;
+        f.sync_all()?;
+    }
+
+    // `OpenOptions::mode` only applies to a freshly created file, so a
+    // leftover temporary from an interrupted run could carry the wrong
+    // mode. Set it explicitly.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(0o644))?;
+    }
+
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(ServiceError::Io(e));
+    }
+    Ok(())
+}
+
+// ── backend ───────────────────────────────────────────────────────────
+
+impl ServiceBackend for LaunchdBackend {
+    fn install(&self, spec: &super::InstallSpec) -> Result<(), ServiceError> {
+        if spec.scope == Scope::System {
+            require_elevation("install")?;
+        }
+        let layout = layout(spec.scope)?;
+        guard_managed(&layout.plist, spec.force, "overwrite")?;
+
+        let exec = current_exe_canonical()?;
+        let rendered = plist::render_plist(&RenderParams {
+            scope: spec.scope,
+            exec_path: &exec,
+            log_path: &layout.log,
+            service_user: spec.service_user.as_deref(),
+        })
+        .map_err(|e| ServiceError::Conflict(e.to_string()))?;
+
+        create_log_dir(&layout.log)?;
+        write_plist(&layout.plist, &rendered)?;
+
+        // Clear a persistent disable override, which survives both
+        // uninstall and reboot once anything has run `launchctl
+        // disable` (or `brew services stop`) against this label.
+        launchctl::run_best_effort(&["enable", &layout.target]);
+
+        if spec.start_now {
+            launchctl::run_best_effort(&["bootout", &layout.target]);
+            launchctl::bootstrap(&layout)?;
+        }
+        Ok(())
+    }
+
+    fn uninstall(&self, scope: Scope) -> Result<(), ServiceError> {
+        self.remove(scope, false)
+    }
+
+    fn uninstall_forced(&self, scope: Scope) -> Result<(), ServiceError> {
+        self.remove(scope, true)
+    }
+
+    fn start(&self, scope: Scope) -> Result<(), ServiceError> {
+        let layout = self.prepare(scope, "start")?;
+        if launchctl::print_job(&layout.target)?.is_some() {
+            launchctl::run(&["kickstart", &layout.target])?;
+        } else {
+            launchctl::bootstrap(&layout)?;
+        }
+        Ok(())
+    }
+
+    fn stop(&self, scope: Scope) -> Result<(), ServiceError> {
+        let layout = self.prepare(scope, "stop")?;
+        // Booting out an already-unloaded job is an error in launchctl
+        // but a no-op in intent, so ask first and keep `stop`
+        // idempotent.
+        if launchctl::print_job(&layout.target)?.is_some() {
+            launchctl::run(&["bootout", &layout.target])?;
+        }
+        Ok(())
+    }
+
+    fn restart(&self, scope: Scope) -> Result<(), ServiceError> {
+        let layout = self.prepare(scope, "restart")?;
+        if launchctl::print_job(&layout.target)?.is_some() {
+            launchctl::run(&["kickstart", "-k", &layout.target])?;
+        } else {
+            launchctl::bootstrap(&layout)?;
+        }
+        Ok(())
+    }
+
+    fn status(&self, scope: Scope) -> Result<ServiceStatus, ServiceError> {
+        let layout = layout(scope)?;
+        let installed = layout.plist.exists();
+        let enabled =
+            launchctl::query_disabled(&layout.domain).map(|disabled| installed && !disabled);
+
+        let output = launchctl::output(&["print", layout.target.as_str()])?;
+        if !output.status.success() {
+            return Ok(ServiceStatus {
+                installed,
+                enabled,
+                running: false,
+                pid: None,
+                detail: not_loaded_detail(installed, &launchctl::failure_text(&output)),
+            });
+        }
+
+        let info = parse_print_output(&String::from_utf8_lossy(&output.stdout));
+        let running = info.running();
+        Ok(ServiceStatus {
+            installed,
+            enabled,
+            running,
+            // launchd keeps reporting the last pid briefly after exit;
+            // never claim one for a job we do not consider running.
+            pid: if running { info.pid } else { None },
+            detail: if info.state.is_empty() {
+                "loaded".to_string()
+            } else {
+                info.state
+            },
+        })
+    }
+}
+
+impl LaunchdBackend {
+    /// Shared preamble for the lifecycle verbs: elevate when needed,
+    /// resolve the layout, and refuse when nothing is installed.
+    fn prepare(&self, scope: Scope, verb: &'static str) -> Result<Layout, ServiceError> {
+        if scope == Scope::System {
+            require_elevation(verb)?;
+        }
+        let layout = layout(scope)?;
+        if !layout.plist.exists() {
+            return Err(ServiceError::NotInstalled);
+        }
+        Ok(layout)
+    }
+
+    fn remove(&self, scope: Scope, force: bool) -> Result<(), ServiceError> {
+        if scope == Scope::System {
+            require_elevation("uninstall")?;
+        }
+        let layout = layout(scope)?;
+        if !layout.plist.exists() {
+            return Err(ServiceError::NotInstalled);
+        }
+        guard_managed(&layout.plist, force, "remove")?;
+
+        // A job that is already unloaded must not block removal.
+        launchctl::run_best_effort(&["bootout", &layout.target]);
+        fs::remove_file(&layout.plist)?;
+        // Deliberately no `launchctl disable`: a disable override
+        // outlives the plist and would silently defeat the next
+        // install. The log directory is left in place so the operator
+        // can still read why the service was removed.
+        Ok(())
+    }
+}
+
+// Test module lives in `launchd_tests.rs` to keep this file under the
+// 500-line soft limit.
+#[cfg(test)]
+#[path = "launchd_tests.rs"]
+mod tests;

--- a/src/service_cmd/launchd_tests.rs
+++ b/src/service_cmd/launchd_tests.rs
@@ -1,0 +1,118 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the launchd backend's on-disk half: the managed
+//! marker guard, the atomic plist write, and log-directory creation.
+//! Kept in a sibling file so the implementation stays under the
+//! 500-line soft limit.
+
+use std::path::Path;
+
+use super::*;
+
+// ── the managed marker guard ──────────────────────────────────────────
+
+#[test]
+fn an_absent_plist_never_blocks_an_install() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(PLIST_FILE_NAME);
+    assert!(guard_managed(&path, false, "overwrite").is_ok());
+}
+
+#[test]
+fn a_plist_we_wrote_may_be_overwritten_and_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(PLIST_FILE_NAME);
+    let rendered = plist::render_plist(&RenderParams {
+        scope: Scope::System,
+        exec_path: Path::new("/opt/all-smi/bin/all-smi"),
+        log_path: Path::new("/var/log/all-smi/all-smi.log"),
+        service_user: None,
+    })
+    .unwrap();
+    fs::write(&path, &rendered).unwrap();
+    assert!(guard_managed(&path, false, "overwrite").is_ok());
+    assert!(guard_managed(&path, false, "remove").is_ok());
+}
+
+#[test]
+fn a_foreign_plist_is_refused_and_the_message_says_how_to_proceed() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(PLIST_FILE_NAME);
+    fs::write(&path, "<plist version=\"1.0\"><dict/></plist>\n").unwrap();
+
+    let err = guard_managed(&path, false, "remove").expect_err("a foreign plist must be refused");
+    assert!(matches!(err, ServiceError::Conflict(_)));
+    let msg = err.to_string();
+    assert!(msg.contains("--force"), "must name the override: {msg}");
+    assert!(msg.contains(plist::MANAGED_MARKER), "must quote the marker");
+
+    // `--force` is the documented escape hatch and must actually work.
+    assert!(guard_managed(&path, true, "remove").is_ok());
+}
+
+// ── plist writing ─────────────────────────────────────────────────────
+
+#[test]
+fn a_written_plist_is_not_group_or_world_writable() {
+    // launchd validates permissions before loading a LaunchDaemon and
+    // refuses one anybody but its owner can rewrite, which would
+    // otherwise be a local root escalation.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(PLIST_FILE_NAME);
+    write_plist(&path, "<plist/>\n").unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "<plist/>\n");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o644, "expected 0644, got {mode:o}");
+    }
+}
+
+#[test]
+fn writing_leaves_no_temporary_behind_and_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(PLIST_FILE_NAME);
+    write_plist(&path, "<plist>first</plist>\n").unwrap();
+    write_plist(&path, "<plist>second</plist>\n").unwrap();
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        "<plist>second</plist>\n"
+    );
+
+    let entries: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(entries, vec![PLIST_FILE_NAME.to_string()]);
+}
+
+#[test]
+fn the_log_directory_is_created_readable() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("all-smi").join("all-smi.log");
+    create_log_dir(&log).unwrap();
+    let parent = log.parent().unwrap();
+    assert!(parent.is_dir());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "expected 0755, got {mode:o}");
+    }
+    // Idempotent: a reinstall must not fail on an existing directory.
+    create_log_dir(&log).unwrap();
+}

--- a/src/service_cmd/mod.rs
+++ b/src/service_cmd/mod.rs
@@ -29,11 +29,12 @@
 //! # Adding a platform
 //!
 //! [`backend`] already carries a `cfg` arm for Linux, macOS, and
-//! Windows. The macOS launchd backend (issue #310) and the Windows SCM
-//! backend (issue #311) each replace their own arm and add a sibling
-//! module; nothing else in this file needs to change. Keep the
-//! [`ServiceBackend`] method signatures and the exit codes below
-//! untouched: they are the cross-platform contract the CLI documents.
+//! Windows. The Windows SCM backend (issue #311) replaces its own arm
+//! and adds a sibling module; nothing else in this file needs to
+//! change. Keep the [`ServiceBackend`] method signatures and the exit
+//! codes below untouched: they are the cross-platform contract the CLI
+//! documents. macOS (issue #310) landed exactly that way: it replaced
+//! one arm and added [`launchd`] plus [`plist`].
 //!
 //! # Exit codes
 //!
@@ -43,12 +44,11 @@
 //! * `3` — `status` only: the service is installed but stopped, or not
 //!   installed at all. Mirrors `systemctl is-active`.
 
-// Only the Linux arm of `backend()` is live today, so on macOS and
-// Windows the shared plumbing the backends consume (the error variants,
-// the elevation probe, `SERVICE_NAME`) has no caller until #310 and #311
-// land. Dead-code detection stays fully active on Linux, which is where
-// CI runs `cargo clippy -- -D warnings`.
-#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+// Windows has no live `backend()` arm yet, so there the shared plumbing
+// the backends consume (the error variants, the elevation probe) has no
+// caller until #311 lands. Dead-code detection stays fully active on
+// Linux and macOS, which both dispatch a real backend.
+#![cfg_attr(not(any(target_os = "linux", target_os = "macos")), allow(dead_code))]
 
 use std::path::PathBuf;
 
@@ -56,17 +56,44 @@ use crate::cli::ServiceAction;
 
 pub mod detect;
 
-// The systemd backend and its unit renderer compile on Linux, and under
-// `cfg(test)` everywhere else so their pure logic (template rendering,
-// `systemctl show` parsing) stays covered on macOS and Windows
-// developer machines. They are never dispatched off Linux.
+// Each backend compiles on its own platform, and under `cfg(test)`
+// everywhere else so its pure logic (definition rendering, supervisor
+// output parsing, path layout) stays covered on every developer machine
+// and in CI. Neither is ever dispatched off its own platform.
+//
+// The `allow(dead_code)` companions are the per-target blindness guard:
+// this crate compiles the module tree twice, and in the binary target a
+// `pub` item is live only if it is reachable. A backend that the local
+// `backend()` arm does not return therefore looks dead there even
+// though it is exercised by the library target's tests.
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub mod systemd;
 #[cfg(any(target_os = "linux", test))]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub mod template;
 
-/// The service identifier used by every backend: the systemd unit name
-/// minus its suffix, the launchd label suffix, the SCM service name.
+#[cfg(any(target_os = "macos", test))]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub mod launchctl;
+#[cfg(any(target_os = "macos", test))]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub mod launchd;
+#[cfg(any(target_os = "macos", test))]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub mod plist;
+
+/// The service identifier every backend is named after: the systemd
+/// unit name minus its suffix, the trailing component of the launchd
+/// label, the SCM service name.
+///
+/// Only the systemd backend passes it to its supervisor as a runtime
+/// argument; launchd needs a reverse-DNS label, so [`plist::LABEL`]
+/// spells the whole thing out. That makes this constant genuinely
+/// uncalled in a non-Linux **binary** build, where reachability rather
+/// than `pub` decides liveness, even though the library target and the
+/// tests both use it.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub const SERVICE_NAME: &str = "all-smi";
 
 /// Exit code for a successful action, and for `status` when running.
@@ -213,13 +240,7 @@ pub fn backend() -> Result<Box<dyn ServiceBackend>, ServiceError> {
 
     #[cfg(target_os = "macos")]
     {
-        Err(ServiceError::NotSupported(
-            "`all-smi service` has no macOS backend yet; launchd support is tracked in \
-             https://github.com/lablup/all-smi/issues/310. Until then, run \
-             `brew services start all-smi` on a Homebrew install, or write a launchd \
-             plist that execs `all-smi api`."
-                .to_string(),
-        ))
+        Ok(Box::new(launchd::LaunchdBackend::new()))
     }
 
     #[cfg(target_os = "windows")]
@@ -372,16 +393,40 @@ fn report_install_success(spec: &InstallSpec) {
         println!("It is not running yet. Start it with: all-smi service start{flag}");
     }
     if scope == Scope::User {
-        let user = whoami::username().unwrap_or_else(|_| "<user>".to_string());
-        println!(
-            "Note: a user service only runs while you are logged in. Run \
-             `loginctl enable-linger {user}` for boot persistence."
-        );
+        println!("{}", user_scope_persistence_note());
     }
     println!(
-        "Runtime settings live in the environment file and the TOML config, not in the \
-         service definition. Run `all-smi config path` to see the active TOML path."
+        "Runtime settings live in {SETTINGS_SOURCES}, not in the service definition. Run \
+         `all-smi config path` to see the active TOML path."
     );
+}
+
+/// Where an operator changes a running service's settings. launchd has
+/// no `EnvironmentFile=` equivalent, so on macOS the TOML config is the
+/// whole story.
+#[cfg(target_os = "macos")]
+const SETTINGS_SOURCES: &str = "the TOML config";
+#[cfg(not(target_os = "macos"))]
+const SETTINGS_SOURCES: &str = "the environment file and the TOML config";
+
+/// Platform-specific caveat printed after a user-scope install. Every
+/// platform bounds a per-user service to a login session, but each one
+/// spells the escape hatch differently.
+#[cfg(target_os = "macos")]
+fn user_scope_persistence_note() -> String {
+    "Note: a LaunchAgent runs only while you are logged in to a desktop session and stops at \
+     logout. launchd has no per-user lingering, so boot persistence on a headless node means the \
+     system LaunchDaemon: `sudo all-smi service install --now`."
+        .to_string()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn user_scope_persistence_note() -> String {
+    let user = whoami::username().unwrap_or_else(|_| "<user>".to_string());
+    format!(
+        "Note: a user service only runs while you are logged in. Run \
+         `loginctl enable-linger {user}` for boot persistence."
+    )
 }
 
 fn print_status_text(status: &ServiceStatus, scope: Scope) {

--- a/src/service_cmd/mod_tests.rs
+++ b/src/service_cmd/mod_tests.rs
@@ -72,25 +72,20 @@ fn default_status_is_not_installed() {
     assert_eq!(s.pid, None);
 }
 
-/// Non-Linux platforms must fail with a message that names the
-/// follow-up issue, so an operator who hits it knows where to look.
-#[cfg(not(target_os = "linux"))]
+/// Platforms with no backend yet must fail with a message that names
+/// the follow-up issue, so an operator who hits it knows where to look.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 #[test]
-fn non_linux_backend_points_at_the_follow_up_issue() {
-    let err = backend().err().expect("no backend outside Linux yet");
+fn unimplemented_backend_points_at_the_follow_up_issue() {
+    let err = backend().err().expect("no backend on this platform yet");
     let msg = err.to_string();
     assert!(matches!(err, ServiceError::NotSupported(_)));
-    #[cfg(target_os = "macos")]
-    assert!(
-        msg.contains("issues/310"),
-        "macOS arm must name issue #310, got: {msg}"
-    );
     #[cfg(target_os = "windows")]
     assert!(
         msg.contains("issues/311"),
         "Windows arm must name issue #311, got: {msg}"
     );
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(not(target_os = "windows"))]
     assert!(msg.contains("packaging/systemd/all-smi.service"));
 }
 
@@ -98,4 +93,30 @@ fn non_linux_backend_points_at_the_follow_up_issue() {
 #[test]
 fn linux_backend_resolves() {
     assert!(backend().is_ok(), "Linux must always resolve a backend");
+}
+
+/// Issue #310: the macOS arm dispatches launchd rather than refusing.
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_backend_resolves() {
+    assert!(backend().is_ok(), "macOS must resolve the launchd backend");
+}
+
+/// A user-scope install has to warn about the session boundary, and the
+/// escape hatch it names has to be the one that platform actually has.
+/// Getting this wrong sends an operator chasing a command that does not
+/// exist on their machine.
+#[test]
+fn user_scope_note_names_a_real_escape_hatch() {
+    let note = user_scope_persistence_note();
+    #[cfg(target_os = "macos")]
+    assert!(
+        note.contains("LaunchAgent") && note.contains("sudo all-smi service install"),
+        "macOS note must point at the system LaunchDaemon, got: {note}"
+    );
+    #[cfg(not(target_os = "macos"))]
+    assert!(
+        note.contains("enable-linger"),
+        "the systemd note must point at lingering, got: {note}"
+    );
 }

--- a/src/service_cmd/plist.rs
+++ b/src/service_cmd/plist.rs
@@ -1,0 +1,370 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! launchd property-list rendering for `all-smi service install` on
+//! macOS (issue #310).
+//!
+//! There is exactly one plist definition in this repository:
+//! `packaging/launchd/com.lablup.all-smi.plist`. It is a valid system
+//! LaunchDaemon on its own, so an operator can copy it into
+//! `/Library/LaunchDaemons` by hand. This module embeds the same file
+//! with `include_str!` and rewrites the handful of keys that depend on
+//! how the operator is installing it, mirroring what
+//! [`super::template`] does for the systemd unit.
+//!
+//! Rewrites applied:
+//!
+//! | Key | System scope | User scope |
+//! |---|---|---|
+//! | `ProgramArguments` | canonicalized `current_exe()` plus `api` | same |
+//! | `StandardOutPath` / `StandardErrorPath` | `/var/log/all-smi/all-smi.log` | `~/Library/Logs/all-smi/all-smi.log` |
+//! | `UserName` | `--service-user` value, else `root` | dropped |
+//! | `GroupName` | dropped when `--service-user` is given, else `wheel` | dropped |
+//! | everything in [`USER_SCOPE_DROPPED_KEYS`] | kept | dropped |
+//!
+//! Everything else is passed through verbatim so the shipped plist
+//! stays the single source of truth.
+//!
+//! `GroupName` is dropped rather than mirrored when `--service-user`
+//! names an account, which is where this diverges from the systemd
+//! renderer. systemd can assume a group named after the account exists,
+//! because that is how `systemd-sysusers` creates one. macOS has no such
+//! convention: a regular account's primary group is `staff`, and a
+//! service account created with `dscl` may have any group at all.
+//! Omitting `GroupName` makes launchd use the account's primary group
+//! straight out of the password database, which is always right.
+
+use std::path::Path;
+
+use super::Scope;
+
+/// Marker comment stamped into every plist this tool writes.
+/// `install` and `uninstall` both refuse to touch a plist that lacks it
+/// unless `--force` is passed, which keeps a hand-written or
+/// vendor-shipped plist from being silently clobbered.
+///
+/// XML comments are legal anywhere after the prolog and are discarded by
+/// `CFPropertyList`, so launchd never sees this line: `plutil -lint`
+/// accepts the rendered file unchanged.
+pub const MANAGED_MARKER: &str = "<!-- Managed by 'all-smi service' -->";
+
+/// The canonical launchd job label, shared by both scopes. They live in
+/// different launchd domains, so the same label never collides.
+pub const LABEL: &str = "com.lablup.all-smi";
+
+/// The canonical plist, embedded verbatim at compile time.
+pub const PLIST_TEMPLATE: &str = include_str!("../../packaging/launchd/com.lablup.all-smi.plist");
+
+/// Keys stripped when rendering a user-scope LaunchAgent.
+///
+/// # The rule, and how launchd differs from systemd here
+///
+/// This is the launchd counterpart of
+/// [`super::template::USER_SCOPE_DROPPED_PREFIXES`], but the failure
+/// mode is the opposite one, so the reason to drop these is different
+/// and worth stating precisely.
+///
+/// A `gui/$UID` domain is owned by an unprivileged user and cannot
+/// `setuid` to another account. systemd answers that by refusing the
+/// unit outright: a user-scope unit carrying `SupplementaryGroups=` dies
+/// at `216/GROUP` before `ExecStart`. launchd does not. Bootstrapping a
+/// LaunchAgent that carries `UserName`, `GroupName`, or `InitGroups`
+/// succeeds, the job runs, and the keys are **silently ignored**.
+///
+/// Measured on macOS 26.6 (Darwin 25.6) by bootstrapping a probe agent
+/// into `gui/501` whose program printed `id`:
+///
+/// | Plist keys | `launchctl bootstrap` | Effective uid/gid |
+/// |---|---|---|
+/// | none | succeeds | `501` / `20` |
+/// | `UserName root`, `GroupName wheel` | succeeds | `501` / `20` |
+///
+/// So these are dropped not to avoid a crash but because keeping them
+/// would ship a plist that lies. A file in `~/Library/LaunchAgents`
+/// declaring `UserName root` reads, to an operator auditing what runs
+/// privileged on the machine, as a root job; it is not one. Two further
+/// reasons make the silent-ignore behaviour a bad thing to lean on:
+/// `launchd.plist(5)` documents these as requiring root and says nothing
+/// about ignoring them, so the fallback is unspecified and free to
+/// become fatal in a later release; and `InitGroups` is explicitly
+/// documented as ignored whenever `UserName` is unset, which in user
+/// scope it now always is.
+///
+/// Keys that need no privilege stay in both scopes, notably
+/// `SoftResourceLimits`: raising a *soft* rlimit up to the inherited
+/// hard limit is allowed for any process, so the file-descriptor bump
+/// applies to a LaunchAgent too. `HardResourceLimits` is deliberately
+/// absent from the canonical plist for the mirror-image reason: only
+/// root can raise a hard limit, and lowering one buys nothing here.
+pub const USER_SCOPE_DROPPED_KEYS: &[&str] = &["UserName", "GroupName", "InitGroups"];
+
+/// Inputs for [`render_plist`].
+#[derive(Debug, Clone)]
+pub struct RenderParams<'a> {
+    pub scope: Scope,
+    /// Absolute path to the binary the job should exec. Callers pass
+    /// the canonicalized `current_exe()`.
+    pub exec_path: &'a Path,
+    /// Absolute path for `StandardOutPath` and `StandardErrorPath`.
+    pub log_path: &'a Path,
+    /// Account for `UserName`. `None` keeps the canonical `root` /
+    /// `wheel` pair. Ignored in user scope.
+    pub service_user: Option<&'a str>,
+}
+
+/// Reasons a path cannot be embedded in a plist.
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error(
+        "path `{0}` is not valid UTF-8; property lists are XML, so the binary and its log have to \
+         live at UTF-8 paths to be installed as a service"
+    )]
+    NonUtf8Path(String),
+    #[error(
+        "path `{0}` contains a control character that XML 1.0 cannot represent; move the file to a \
+         plainer path"
+    )]
+    UnsafePath(String),
+    #[error(
+        "account name `{0}` contains a character that is not allowed in a launchd UserName (only \
+         letters, digits, `_`, `-`, and `.`)"
+    )]
+    UnsafeAccount(String),
+}
+
+/// Render the plist for one install.
+///
+/// The template is walked as a sequence of `<key>` / value pairs rather
+/// than line by line, because a plist value can be a multi-line
+/// `<array>` or `<dict>` and dropping a key means dropping its whole
+/// value with it.
+pub fn render_plist(params: &RenderParams<'_>) -> Result<String, RenderError> {
+    let exec = xml_text(params.exec_path)?;
+    let log = xml_text(params.log_path)?;
+    let user_scope = params.scope == Scope::User;
+    if let Some(account) = params.service_user
+        && !user_scope
+    {
+        validate_account(account)?;
+    }
+
+    let lines: Vec<&str> = PLIST_TEMPLATE.lines().collect();
+    let mut out = String::with_capacity(PLIST_TEMPLATE.len() + 512);
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim();
+
+        // The marker and the provenance note go directly after the
+        // DOCTYPE: the XML declaration has to stay on line 1, so a
+        // plist cannot carry a first-line marker the way a unit file
+        // does.
+        if trimmed.starts_with("<!DOCTYPE") {
+            out.push_str(line);
+            out.push('\n');
+            out.push_str(MANAGED_MARKER);
+            out.push('\n');
+            out.push_str(PROVENANCE_COMMENT);
+            i += 1;
+            continue;
+        }
+
+        let Some(key) = parse_key(trimmed) else {
+            out.push_str(line);
+            out.push('\n');
+            i += 1;
+            continue;
+        };
+
+        let value_end = value_end_index(&lines, i + 1);
+        let indent = leading_whitespace(line);
+
+        match key {
+            "ProgramArguments" => {
+                out.push_str(line);
+                out.push('\n');
+                out.push_str(&format!("{indent}<array>\n"));
+                out.push_str(&format!("{indent}\t<string>{exec}</string>\n"));
+                out.push_str(&format!("{indent}\t<string>api</string>\n"));
+                out.push_str(&format!("{indent}</array>\n"));
+            }
+            "StandardOutPath" | "StandardErrorPath" => {
+                out.push_str(line);
+                out.push('\n');
+                out.push_str(&format!("{indent}<string>{log}</string>\n"));
+            }
+            "UserName" => {
+                if !user_scope {
+                    out.push_str(line);
+                    out.push('\n');
+                    let account = params.service_user.unwrap_or("root");
+                    out.push_str(&format!("{indent}<string>{account}</string>\n"));
+                }
+            }
+            "GroupName" => {
+                // Kept only for the default root daemon; see the module
+                // docs for why an explicit account drops it instead of
+                // mirroring the name.
+                if !user_scope && params.service_user.is_none() {
+                    for l in &lines[i..value_end] {
+                        out.push_str(l);
+                        out.push('\n');
+                    }
+                }
+            }
+            k if user_scope && USER_SCOPE_DROPPED_KEYS.contains(&k) => {}
+            _ => {
+                for l in &lines[i..value_end] {
+                    out.push_str(l);
+                    out.push('\n');
+                }
+            }
+        }
+
+        i = value_end;
+    }
+
+    Ok(out)
+}
+
+/// Whether `contents` was written by this tool.
+pub fn is_managed(contents: &str) -> bool {
+    contents.lines().any(|l| l.trim() == MANAGED_MARKER)
+}
+
+/// Provenance note emitted right below [`MANAGED_MARKER`].
+///
+/// XML forbids `--` inside a comment, so this text must never grow a
+/// double hyphen: no `--force`, no em-dash-like runs.
+const PROVENANCE_COMMENT: &str = "<!-- Written by `all-smi service install`. Manual edits are lost \
+                                  on the next install.\n     Put runtime settings in the TOML \
+                                  config instead; run `all-smi config path`\n     to print the \
+                                  active TOML path. -->\n";
+
+/// Extract `X` from a `<key>X</key>` line, or `None` for anything else.
+fn parse_key(trimmed: &str) -> Option<&str> {
+    trimmed
+        .strip_prefix("<key>")
+        .and_then(|r| r.strip_suffix("</key>"))
+}
+
+/// Index just past the value element that starts at `start`.
+///
+/// A value is either a single self-contained line (`<string>…</string>`,
+/// `<true/>`, `<integer>…</integer>`) or a container that runs until its
+/// matching close tag. Container nesting is counted so a `<dict>` inside
+/// a `<dict>` does not terminate the outer one early.
+fn value_end_index(lines: &[&str], start: usize) -> usize {
+    let mut i = start;
+    // Skip blank lines between the key and its value.
+    while i < lines.len() && lines[i].trim().is_empty() {
+        i += 1;
+    }
+    if i >= lines.len() {
+        return lines.len();
+    }
+
+    let opener = lines[i].trim();
+    let tag = if opener.starts_with("<array>") {
+        Some(("<array>", "</array>"))
+    } else if opener.starts_with("<dict>") {
+        Some(("<dict>", "</dict>"))
+    } else {
+        None
+    };
+
+    let Some((open, close)) = tag else {
+        return i + 1;
+    };
+
+    let mut depth = 0usize;
+    while i < lines.len() {
+        let t = lines[i].trim();
+        if t.starts_with(open) {
+            depth += 1;
+        }
+        if t.starts_with(close) || t.ends_with(close) {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                return i + 1;
+            }
+        }
+        i += 1;
+    }
+    lines.len()
+}
+
+/// Leading whitespace of `line`, reused so a rewritten value keeps the
+/// template's indentation.
+fn leading_whitespace(line: &str) -> &str {
+    let end = line
+        .find(|c: char| !c.is_whitespace())
+        .unwrap_or(line.len());
+    &line[..end]
+}
+
+/// Turn a path into XML character data for a `<string>` element.
+///
+/// `&` and `<` have to be escaped or the plist stops parsing; `>` is
+/// escaped too because it is only conditionally legal as raw text.
+/// Control characters (including a newline embedded in a filename) are
+/// rejected: XML 1.0 cannot represent them at all, not even as numeric
+/// references.
+fn xml_text(path: &Path) -> Result<String, RenderError> {
+    let raw = path
+        .to_str()
+        .ok_or_else(|| RenderError::NonUtf8Path(path.display().to_string()))?;
+    if raw.chars().any(|c| c.is_control()) {
+        return Err(RenderError::UnsafePath(raw.escape_debug().to_string()));
+    }
+    Ok(xml_escape(raw))
+}
+
+fn xml_escape(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Reject an account name that could not be a real macOS short name.
+///
+/// This is not cosmetic. The name is written into the plist unescaped
+/// and then handed to `getpwnam` by launchd, so restricting it to the
+/// POSIX portable set keeps XML injection and shell-looking names out of
+/// a root-owned LaunchDaemon.
+fn validate_account(name: &str) -> Result<(), RenderError> {
+    let ok = !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'));
+    if ok {
+        Ok(())
+    } else {
+        Err(RenderError::UnsafeAccount(name.escape_debug().to_string()))
+    }
+}
+
+// Test module lives in `plist_tests.rs` to keep this file under the
+// 500-line soft limit.
+#[cfg(test)]
+#[path = "plist_tests.rs"]
+mod tests;

--- a/src/service_cmd/plist_tests.rs
+++ b/src/service_cmd/plist_tests.rs
@@ -1,0 +1,442 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for launchd plist rendering. Kept in a sibling file so the
+//! implementation stays under the 500-line soft limit.
+
+use std::path::{Path, PathBuf};
+
+use super::*;
+
+const EXEC: &str = "/opt/all-smi/bin/all-smi";
+const SYSTEM_LOG: &str = "/var/log/all-smi/all-smi.log";
+const USER_LOG: &str = "/Users/dev/Library/Logs/all-smi/all-smi.log";
+
+/// Keys a `gui/$UID` LaunchAgent applies without any privilege. The
+/// complement of [`USER_SCOPE_DROPPED_KEYS`], asserted here as a test
+/// contract rather than declared in `plist.rs`, because the renderer
+/// never consults it and a `pub` item nothing reads is dead code in the
+/// binary target.
+const USER_SCOPE_KEPT_KEYS: &[&str] = &[
+    "Label",
+    "ProgramArguments",
+    "RunAtLoad",
+    "KeepAlive",
+    "ThrottleInterval",
+    "ExitTimeOut",
+    "ProcessType",
+    "WorkingDirectory",
+    "SoftResourceLimits",
+    "StandardOutPath",
+    "StandardErrorPath",
+];
+
+fn render(scope: Scope, service_user: Option<&str>) -> String {
+    let log = if scope == Scope::User {
+        USER_LOG
+    } else {
+        SYSTEM_LOG
+    };
+    render_plist(&RenderParams {
+        scope,
+        exec_path: Path::new(EXEC),
+        log_path: Path::new(log),
+        service_user,
+    })
+    .expect("canonical inputs must render")
+}
+
+fn has_key(rendered: &str, key: &str) -> bool {
+    rendered
+        .lines()
+        .any(|l| l.trim() == format!("<key>{key}</key>"))
+}
+
+// ── template invariants ───────────────────────────────────────────────
+
+#[test]
+fn template_is_the_shipped_daemon_plist() {
+    // The embedded copy is the packaging artifact, not a second
+    // definition: it must stay a valid, self-contained LaunchDaemon.
+    assert!(PLIST_TEMPLATE.starts_with("<?xml version=\"1.0\""));
+    assert!(PLIST_TEMPLATE.contains("<!DOCTYPE plist"));
+    assert!(PLIST_TEMPLATE.contains(&format!("<string>{LABEL}</string>")));
+    assert!(PLIST_TEMPLATE.trim_end().ends_with("</plist>"));
+}
+
+#[test]
+fn template_carries_no_marker_of_its_own() {
+    // The packaged file is not "managed by all-smi service"; only the
+    // rendered copy is. Otherwise `uninstall` would happily delete a
+    // plist an operator installed by hand from the source tree.
+    assert!(!is_managed(PLIST_TEMPLATE));
+}
+
+#[test]
+fn template_omits_hard_resource_limits() {
+    // Only root can raise a hard rlimit, and lowering one buys nothing
+    // here. Keeping it out means the user scope has one less key to
+    // drop and one less way to fail at spawn time.
+    assert!(!has_key(PLIST_TEMPLATE, "HardResourceLimits"));
+}
+
+// ── marker and provenance ─────────────────────────────────────────────
+
+#[test]
+fn rendered_plist_carries_the_marker() {
+    for scope in [Scope::System, Scope::User] {
+        let out = render(scope, None);
+        assert!(is_managed(&out), "{scope} render must carry the marker");
+    }
+}
+
+#[test]
+fn marker_follows_the_xml_declaration() {
+    // XML forbids anything before `<?xml ... ?>`, so unlike a systemd
+    // unit the marker cannot be the first line. It has to land after
+    // the DOCTYPE and before `<plist>`.
+    let out = render(Scope::System, None);
+    let lines: Vec<&str> = out.lines().collect();
+    assert!(lines[0].starts_with("<?xml"));
+    assert!(lines[1].starts_with("<!DOCTYPE"));
+    assert_eq!(lines[2], MANAGED_MARKER);
+    let marker_at = out.find(MANAGED_MARKER).unwrap();
+    let plist_at = out.find("<plist").unwrap();
+    assert!(marker_at < plist_at);
+}
+
+#[test]
+fn comments_never_contain_a_double_hyphen() {
+    // `--` inside an XML comment is a hard parse error, so a stray one
+    // makes launchd reject the whole job. It is an easy thing to
+    // reintroduce: the marker and the provenance note are the only
+    // free-form prose in the file, and `--force` reads perfectly
+    // naturally in either of them.
+    let out = render(Scope::System, None);
+    let mut inside = false;
+    for line in out.lines() {
+        let mut body = line;
+        if !inside {
+            let Some(rest) = line.trim_start().strip_prefix("<!--") else {
+                continue;
+            };
+            inside = true;
+            body = rest;
+        }
+        if let Some(rest) = body.strip_suffix("-->") {
+            inside = false;
+            body = rest;
+        }
+        assert!(
+            !body.contains("--"),
+            "comment body must not contain a double hyphen: {line}"
+        );
+    }
+    assert!(!inside, "an XML comment was opened and never closed");
+}
+
+// ── substitutions ─────────────────────────────────────────────────────
+
+#[test]
+fn program_arguments_use_the_running_binary_and_api() {
+    let out = render(Scope::System, None);
+    assert!(out.contains(&format!("<string>{EXEC}</string>")));
+    assert!(out.contains("<string>api</string>"));
+    // The packaged placeholder must be gone, not merely accompanied.
+    assert!(!out.contains("/usr/local/bin/all-smi"));
+}
+
+#[test]
+fn log_paths_follow_the_scope() {
+    let system = render(Scope::System, None);
+    assert_eq!(system.matches(SYSTEM_LOG).count(), 2, "stdout and stderr");
+
+    let user = render(Scope::User, None);
+    assert_eq!(user.matches(USER_LOG).count(), 2);
+    assert!(!user.contains(SYSTEM_LOG));
+}
+
+#[test]
+fn system_scope_defaults_to_root_and_wheel() {
+    let out = render(Scope::System, None);
+    assert!(has_key(&out, "UserName"));
+    assert!(has_key(&out, "GroupName"));
+    assert!(out.contains("<string>root</string>"));
+    assert!(out.contains("<string>wheel</string>"));
+}
+
+#[test]
+fn service_user_replaces_username_and_drops_groupname() {
+    // macOS has no convention that an account owns an eponymous group,
+    // so mirroring the name the way the systemd renderer does would
+    // produce a GroupName that often does not resolve. Omitting the key
+    // makes launchd use the account's primary group from the password
+    // database.
+    let out = render(Scope::System, Some("_all-smi"));
+    assert!(out.contains("<string>_all-smi</string>"));
+    assert!(has_key(&out, "UserName"));
+    assert!(!has_key(&out, "GroupName"));
+    assert!(!out.contains("<string>wheel</string>"));
+}
+
+// ── the user-scope drop list ──────────────────────────────────────────
+
+#[test]
+fn user_scope_drops_every_privileged_key() {
+    // This has to fail here, at render time, rather than on an
+    // operator's machine. It cannot fail at bootstrap time: launchd
+    // accepts these keys in a LaunchAgent and silently ignores them
+    // (measured on macOS 26.6, see USER_SCOPE_DROPPED_KEYS), so a
+    // regression would ship a plist that claims to run as root while
+    // running as the operator, with nothing anywhere reporting it.
+    let out = render(Scope::User, None);
+    for key in USER_SCOPE_DROPPED_KEYS {
+        assert!(
+            !has_key(&out, key),
+            "{key} cannot take effect in a gui/$UID domain and must not survive into a LaunchAgent"
+        );
+    }
+    // The values have to go with their keys, or the plist is malformed.
+    assert!(!out.contains("<string>root</string>"));
+    assert!(!out.contains("<string>wheel</string>"));
+}
+
+#[test]
+fn user_scope_ignores_service_user() {
+    // `run()` already warns that --service-user is meaningless in user
+    // scope; the renderer must not smuggle it in anyway.
+    let out = render(Scope::User, Some("_all-smi"));
+    assert!(!out.contains("_all-smi"));
+    assert!(!has_key(&out, "UserName"));
+}
+
+#[test]
+fn user_scope_keeps_every_unprivileged_key() {
+    let out = render(Scope::User, None);
+    for key in USER_SCOPE_KEPT_KEYS {
+        assert!(
+            has_key(&out, key),
+            "{key} needs no privilege and must survive into a LaunchAgent"
+        );
+    }
+}
+
+#[test]
+fn the_two_key_lists_partition_the_template() {
+    // Every key in the shipped plist must be classified, so adding one
+    // without deciding whether a LaunchAgent can honour it fails here
+    // rather than at bootstrap time on an operator's machine.
+    let top_level: Vec<&str> = PLIST_TEMPLATE
+        .lines()
+        .filter(|l| l.starts_with("\t<key>"))
+        .filter_map(|l| {
+            l.trim()
+                .strip_prefix("<key>")
+                .and_then(|r| r.strip_suffix("</key>"))
+        })
+        .collect();
+    assert!(!top_level.is_empty());
+    for key in top_level {
+        assert!(
+            USER_SCOPE_DROPPED_KEYS.contains(&key) || USER_SCOPE_KEPT_KEYS.contains(&key),
+            "{key} is in the plist but classified by neither list; decide whether a gui/$UID \
+             LaunchAgent can apply it"
+        );
+    }
+}
+
+// ── structural soundness ──────────────────────────────────────────────
+
+/// Every `<key>` must be immediately followed by a value element, and
+/// every container must close. A renderer that drops a key but keeps its
+/// value (or the reverse) produces a plist launchd rejects wholesale,
+/// and the operator only finds out at bootstrap time.
+fn assert_structurally_sound(rendered: &str, label: &str) {
+    const VALUE_OPENERS: &[&str] = &[
+        "<string>",
+        "<integer>",
+        "<real>",
+        "<data>",
+        "<date>",
+        "<true/>",
+        "<false/>",
+        "<array>",
+        "<dict>",
+    ];
+
+    let mut depth: i32 = 0;
+    let mut expect_value = false;
+    for line in rendered.lines() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with("<?") || t.starts_with("<!") {
+            continue;
+        }
+        if expect_value {
+            assert!(
+                VALUE_OPENERS.iter().any(|o| t.starts_with(o)),
+                "{label}: <key> is not followed by a value, found: {t}"
+            );
+            expect_value = false;
+            if !t.starts_with("<array>") && !t.starts_with("<dict>") {
+                continue;
+            }
+        }
+        if t.starts_with("<key>") {
+            assert!(
+                t.ends_with("</key>"),
+                "{label}: key element spans lines: {t}"
+            );
+            expect_value = true;
+            continue;
+        }
+        if t.starts_with("<dict>") || t.starts_with("<array>") {
+            depth += 1;
+        }
+        if t.starts_with("</dict>") || t.starts_with("</array>") {
+            depth -= 1;
+            assert!(depth >= 0, "{label}: container closed too many times");
+        }
+    }
+    assert!(!expect_value, "{label}: trailing <key> with no value");
+    assert_eq!(depth, 0, "{label}: unbalanced containers");
+}
+
+#[test]
+fn every_render_stays_structurally_sound() {
+    for (scope, user) in [
+        (Scope::System, None),
+        (Scope::System, Some("_all-smi")),
+        (Scope::User, None),
+        (Scope::User, Some("_all-smi")),
+    ] {
+        let out = render(scope, user);
+        assert_structurally_sound(&out, &format!("{scope} scope, service_user={user:?}"));
+    }
+    assert_structurally_sound(PLIST_TEMPLATE, "packaged template");
+}
+
+#[test]
+fn keepalive_survives_as_a_whole_dict() {
+    // KeepAlive is the only nested container in the template; a value
+    // walker that mishandles nesting truncates the job definition
+    // exactly here.
+    for scope in [Scope::System, Scope::User] {
+        let out = render(scope, None);
+        assert!(out.contains("<key>KeepAlive</key>"));
+        assert!(out.contains("<key>SuccessfulExit</key>"));
+        assert!(out.contains("<false/>"));
+    }
+}
+
+// ── escaping and rejection ────────────────────────────────────────────
+
+#[test]
+fn xml_metacharacters_in_paths_are_escaped() {
+    let out = render_plist(&RenderParams {
+        scope: Scope::System,
+        exec_path: Path::new("/opt/a&b/all-smi"),
+        log_path: Path::new("/var/log/<x>/all-smi.log"),
+        service_user: None,
+    })
+    .expect("metacharacters are escapable, not fatal");
+    assert!(out.contains("/opt/a&amp;b/all-smi"));
+    assert!(out.contains("/var/log/&lt;x&gt;/all-smi.log"));
+    assert!(!out.contains("/opt/a&b/"));
+}
+
+#[test]
+fn spaces_in_paths_need_no_quoting() {
+    // Unlike a systemd ExecStart=, ProgramArguments is a real array, so
+    // a space is just a character.
+    let out = render_plist(&RenderParams {
+        scope: Scope::System,
+        exec_path: Path::new("/Applications/All SMI.app/Contents/MacOS/all-smi"),
+        log_path: Path::new(SYSTEM_LOG),
+        service_user: None,
+    })
+    .expect("a path with a space must render");
+    assert!(out.contains("<string>/Applications/All SMI.app/Contents/MacOS/all-smi</string>"));
+}
+
+#[test]
+fn control_characters_in_paths_are_rejected() {
+    let err = render_plist(&RenderParams {
+        scope: Scope::System,
+        exec_path: Path::new("/opt/all\nsmi"),
+        log_path: Path::new(SYSTEM_LOG),
+        service_user: None,
+    })
+    .expect_err("XML 1.0 cannot represent a control character at all");
+    assert!(matches!(err, RenderError::UnsafePath(_)));
+}
+
+#[test]
+fn a_hostile_account_name_is_rejected() {
+    for name in ["", "root</string><key>X</key><string>y", "a b", "root;id"] {
+        let err = render_plist(&RenderParams {
+            scope: Scope::System,
+            exec_path: Path::new(EXEC),
+            log_path: Path::new(SYSTEM_LOG),
+            service_user: Some(name),
+        })
+        .expect_err("only POSIX-portable account names may reach a root-owned plist");
+        assert!(matches!(err, RenderError::UnsafeAccount(_)), "name: {name}");
+    }
+}
+
+#[test]
+fn ordinary_account_names_are_accepted() {
+    for name in ["_all-smi", "allsmi", "all.smi", "svc_1"] {
+        render_plist(&RenderParams {
+            scope: Scope::System,
+            exec_path: Path::new(EXEC),
+            log_path: Path::new(SYSTEM_LOG),
+            service_user: Some(name),
+        })
+        .unwrap_or_else(|e| panic!("{name} must be accepted: {e}"));
+    }
+}
+
+#[test]
+fn non_utf8_paths_are_rejected() {
+    // Only constructible on Unix; on Windows every OsStr is WTF-16 and
+    // `to_str` failure cannot be forced this way.
+    #[cfg(unix)]
+    {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        let bad = PathBuf::from(OsString::from_vec(vec![0x2f, 0xff, 0xfe]));
+        let err = render_plist(&RenderParams {
+            scope: Scope::System,
+            exec_path: &bad,
+            log_path: Path::new(SYSTEM_LOG),
+            service_user: None,
+        })
+        .expect_err("a non-UTF-8 path cannot be written into XML");
+        assert!(matches!(err, RenderError::NonUtf8Path(_)));
+    }
+    #[cfg(not(unix))]
+    let _ = PathBuf::new();
+}
+
+// ── marker detection ──────────────────────────────────────────────────
+
+#[test]
+fn is_managed_tolerates_indentation_but_not_a_near_miss() {
+    assert!(is_managed(&format!(
+        "<plist>\n  {MANAGED_MARKER}\n</plist>"
+    )));
+    assert!(!is_managed("<!-- Managed by homebrew -->"));
+    assert!(!is_managed("<plist version=\"1.0\"><dict/></plist>"));
+}


### PR DESCRIPTION
## Summary

Replaces the macOS arm of `service_cmd::backend()`, which until now returned `NotSupported` pointing at #310, with a real launchd backend, and adds `/Library/Application Support/all-smi/config.toml` as the macOS system-wide config candidate. The #309 contract is untouched: same `ServiceBackend` methods, same scope semantics, same exit codes, same error variants.

Along the way this fixes a pre-existing bug that made API mode's graceful shutdown unreachable on SIGTERM, which is exactly how `launchctl bootout` and `systemctl stop` end a service.

## What changed

- **`packaging/launchd/com.lablup.all-smi.plist`** (new). The canonical job definition, a self-contained system LaunchDaemon an operator can also copy into `/Library/LaunchDaemons` by hand. Same role `packaging/systemd/all-smi.service` plays on Linux.
- **`src/service_cmd/plist.rs`** (new, 370 lines) + `plist_tests.rs`. Embeds that file with `include_str!` and rewrites `ProgramArguments`, the log paths, and the account keys per scope. Walks key/value pairs rather than lines, because a plist value can be a multi-line `<array>`/`<dict>` and dropping a key has to drop its whole value with it. XML-escapes paths and rejects control characters and non-POSIX account names.
- **`src/service_cmd/launchctl.rs`** (new, 349 lines) + `launchctl_tests.rs`. Layout resolution (plist path, log path, launchd domain, service target), `launchctl` invocation, and parsing of `launchctl print` and `launchctl print-disabled`.
- **`src/service_cmd/launchd.rs`** (new, 319 lines) + `launchd_tests.rs`. Verb policy and the on-disk half: the managed-marker guard, the atomic `0644` plist write, log-directory creation.
- **`src/service_cmd/mod.rs`**. The macOS `backend()` arm now returns `LaunchdBackend`. The user-scope persistence note and the "where settings live" line are now per-platform, because `loginctl enable-linger` and "the environment file" do not exist on macOS.
- **`src/service_cmd/detect.rs`**. The Homebrew refusal gains a macOS-only hint naming `sudo brew services start all-smi`.
- **`src/common/paths.rs`**. `/Library/Application Support/all-smi/config.toml` added as a Tier 2 candidate, ordered after every per-user one.
- **`src/main.rs`**. The API-mode shutdown fix, below.
- **`README.md`**, **`docs/man/all-smi.1`**. macOS subsections appended into the slots #309 left, plus the config-candidate tables.
- **`.github/workflows/ci.yml`**. New gated `launchd-service` job on `macos-14`.

## How launchd differs from systemd, and how the verbs map

launchd has no separate "enabled at boot" state. A plist in `LaunchDaemons`/`LaunchAgents` is bootstrapped automatically at boot or login and `RunAtLoad` starts it from there. So:

- `install` without `--now` writes the plist and stops. That *is* "enabled at boot, not running yet".
- `install --now` boots the job out and back in, because launchd caches a loaded job's definition and bootstrapping over it fails rather than replacing it.
- `stop` boots the job out and leaves the plist, so the service returns at the next boot, matching `systemctl stop`.
- `status` reads plist presence from disk for `installed`, since `launchctl print` only knows about loaded jobs, and reads `launchctl print-disabled` for `enabled`.
- `install` runs `launchctl enable` to clear a persistent disable override, which outlives both the plist and a reboot. `uninstall` deliberately does not `disable`, for the same reason.

## The user-scope trap, measured rather than assumed

The user-scope render drops `UserName`, `GroupName`, and `InitGroups`. This is the launchd analogue of #309's `ProtectKernelModules=` problem, but **the failure mode is the opposite one**, and I want to be precise about it rather than repeat the systemd rationale by analogy.

systemd refuses a user unit it cannot apply: `ProtectKernelModules=` dies at `218/CAPABILITIES` before `ExecStart`. launchd does not refuse. Probe agent bootstrapped into `gui/501` on macOS 26.6 (Darwin 25.6), program printed `id`:

| Plist keys | `launchctl bootstrap` | Effective uid/gid |
|---|---|---|
| none | succeeds | `501` / `20` |
| `UserName root`, `GroupName wheel` | succeeds | `501` / `20` |
| `InitGroups` + `UserName root` | succeeds | `501` / `20` |

They are silently ignored. So they are dropped **not** to avoid a crash, but because keeping them would ship a plist that reads, to anyone auditing what runs privileged on the machine, as a root job when it is not one; and because `launchd.plist(5)` documents them as requiring root without documenting the fallback, so it is unspecified behaviour that is free to become fatal later. Since no bootstrap will ever catch a regression here, a render-time test asserts their absence, and a second test asserts every top-level key in the shipped plist is classified by one of the two lists so adding one without deciding fails in CI.

`HardResourceLimits` is deliberately absent from the template for the mirror-image reason (only root can raise a hard limit, lowering one buys nothing). `SoftResourceLimits` is kept in both scopes, since raising a soft rlimit up to the inherited hard limit needs no privilege.

`--service-user` sets `UserName` and drops `GroupName` rather than mirroring the account name the way the systemd renderer does: macOS has no convention that an account owns an eponymous group, so omitting the key makes launchd use the primary group straight from the password database.

## Bug fix: API mode never took its graceful shutdown path

`run_command` installed a SIGTERM handler calling `std::process::exit(0)`. It won the race against `run_api_mode`'s post-serve cleanup, so **every** SIGTERM dropped the last batch of accumulated Joules and left a stale Unix socket behind. Not an edge case for a service: SIGTERM is how both `launchctl bootout` and `systemctl stop` end one, so it happened on every restart.

`Api` now owns its shutdown the way `Record` already did, including through the `[general].default_mode` redispatch (the recursive call cannot uninstall a handler the outer call already spawned), and the collectors are torn down after `run_api_mode` returns like `view` already does.

Before: SIGTERM produced no `energy WAL: shutdown requested` line. After: it appears, and the process exits in 0.45 s.

## Test plan

Scoped commands only (the orchestrator runs the full suite):

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo clippy --bin all-smi -- -D warnings` (run separately on purpose. The library target caught nothing, but the binary target flagged `SERVICE_NAME` as dead: it is reachable only from the systemd backend, which is not compiled in a non-Linux non-test build. Per-target dead-code blindness is real here and the scoped library check does not see it.)
- [x] `cargo test --lib service_cmd::`: 110 passed
- [x] `cargo test --lib common::paths`: 17 passed
- [x] `plutil -lint` on the rendered plist, and `man ./docs/man/all-smi.1` renders clean

Live on an M1 Ultra, macOS 26.6, **user scope only** (see below):

- [x] `status` before install exits 3 and reports "not installed"
- [x] `install --user` writes the plist, creates `~/Library/Logs/all-smi`, and leaves the job unloaded; `status` reports `installed, enabled, stopped` / `not loaded`, exit 3
- [x] `start` bootstraps it; `status` reports running with a pid
- [x] `install --user --now`, `restart`, `stop`, `uninstall`, and a second `install` over our own plist (idempotent)
- [x] `curl localhost:9090/metrics` serves 72 `all_smi_*` lines from the LaunchAgent
- [x] `stop` (i.e. `launchctl bootout`) reaches the final energy-WAL flush, visible in the log
- [x] A hand-written plist is refused by both `install` and `uninstall`, the file is left untouched, and `--force` lifts the refusal
- [x] `launchctl disable` is reported as `"enabled": false` by `status` and cleared by `install`
- [x] System scope without root refuses with "requires root" and writes nothing to `/Library/LaunchDaemons`
- [x] `all-smi config path` lists `/Library/Application Support/all-smi/config.toml` as candidate 3, ordered last

### Apple Silicon metrics under launchd

The LaunchAgent's metric **name set is byte-identical** to a foreground `all-smi api` (`diff` of the sorted metric names: no difference). Values sampled from the agent:

```
all_smi_gpu_utilization             17.19
all_smi_gpu_power_consumption_watts  0.56
all_smi_gpu_temperature_celsius     52
all_smi_cpu_temperature_celsius      65
all_smi_ane_power_watts               0
all_smi_thermal_pressure_info         1
all_smi_cpu_p_cluster_frequency_mhz 3223
all_smi_cpu_e_cluster_frequency_mhz 1978
all_smi_chassis_power_watts         48.12
```

IOReport, the SMC, and `NSProcessInfo.thermalState` all resolve from a launchd context with no TTY and no sudo prompt. Cluster frequencies are non-zero thanks to #317.

Two environment notes worth recording:

1. **`ProcessType Background` costs startup time.** Foreground bind: 0.6 s. Under `taskpolicy -b`: 2.9 s. As a LaunchAgent: 6.3 s. Enumerating the IOReport channel list is the expensive part and background QoS runs it on the E-cores. Kept anyway: a GPU monitor should not steal P-cores from the job it is watching. This is why every readiness wait in CI polls `/metrics` rather than `service status`, which reports running the moment launchd spawns the program.
2. **A binary on an external volume hangs under launchd.** The first attempt pointed the plist at `target/debug/all-smi` on an external volume; the job spawned and blocked indefinitely in `dyld` `open()` on its own binary (TCC gate for launchd-spawned processes on removable volumes). Not a code issue; re-verified from an internal-disk path. Worth knowing if anyone installs from a mounted volume.

## Not verified in this environment

These were explicitly out of scope for this run and their acceptance boxes are left unchecked on the issue.

- **System-domain LaunchDaemon.** No `/Library/LaunchDaemons` write and no `sudo launchctl bootstrap system`. The system-scope code path is therefore exercised only by unit tests plus the live "refuses without root, writes nothing" check.
- **Reboot persistence**, in either the subcommand or the `sudo brew services` form. Not reachable without the system domain.
- **`sudo brew services start all-smi`** and the tap formula end to end. Nothing was pushed to `lablup/homebrew-tap`; see the checklist below.
- **The Homebrew refusal live.** `detect::classify` is unit-tested for all three Homebrew prefixes and a new test asserts the macOS hint text, but no binary was placed under `/opt/homebrew` to trigger it for real.
- **`/Library/Application Support/all-smi/config.toml` being loaded.** Listing is verified live; creating the file needs root. The load path itself is the same `discover_existing_config()` used by the Linux `/etc` candidate, and is covered by unit tests for presence, ordering, and never being the `config init` target.
- **Full `cargo test`.** Only the two scoped filters above were run here.
- **Issue item 4 (daemon context with no GUI session) is only partly reached.** A `gui/$UID` LaunchAgent still belongs to a login session. What is genuinely demonstrated is that the native readers need neither a controlling terminal nor sudo and work at background QoS. Whether they behave identically from a boot-time LaunchDaemon with nobody logged in needs a real headless daemon. **No degradation was found in the part that was reachable**, so no follow-up issue is filed; if the system-domain test later shows one, that is the moment to file it.

## Checklist for a human: the tap `service do` block

**Nothing was pushed to `lablup/homebrew-tap`.** Apply this by hand, the way PR #313 handled the Intel formula stanza. Against `Formula/all-smi.rb` at its current HEAD:

```diff
@@ -27,6 +27,13 @@
     man1.install "all-smi.1"
   end
 
+  service do
+    run [opt_bin/"all-smi", "api"]
+    keep_alive true
+    log_path var/"log/all-smi.log"
+    error_log_path var/"log/all-smi.log"
+    process_type :background
+  end
+
   test do
     output = shell_output("#{bin}/all-smi --version")
     assert_match(/all-smi\s+#{version}/, output)
```

Verified locally against a scratch copy, never the tap: `ruby -c` passes, and `brew style` reports exactly the same 4 offenses on the patched file as on the unpatched upstream file (all four are artifacts of linting a bare `.rb` outside a tap directory: Sorbet sigils, frozen-string-literal, class documentation). The service block itself adds none.

Two notes on the block versus the version proposed in the issue:

- `process_type :background` is added so a brew-managed service and a subcommand-installed one get the same CPU scheduling. Without it, which install method you used silently changes the QoS class, which is an unpleasant thing to debug. `Homebrew::Service#process_type` accepts `:background`.
- No hardcoded port or interval, and no `require_root`, so both `brew services start all-smi` and `sudo brew services start all-smi` keep working. The update workflow rewrites only the version/url/sha256 stanzas by name, so this block does not disturb it.

Closes #310
