### PR TITLE
fix(ci): include packaging assets in the Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ COPY proto/ ./proto/
 # Copy the source code
 COPY src/ ./src/
 
+# Copy packaging assets embedded into the binary with include_str!
+# (service unit templates). Keep this in sync with the paths asserted by
+# tests/docker_build_context_test.rs.
+COPY packaging/ ./packaging/
+
 # Build the application in release mode
 RUN cargo build --release --bin all-smi
 

--- a/tests/docker_build_context_test.rs
+++ b/tests/docker_build_context_test.rs
@@ -1,0 +1,335 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cross-file contract: every asset the crate embeds with `include_str!`
+//! or `include_bytes!` must be reachable inside the Docker build context.
+//!
+//! `include_str!` resolves at compile time against the source tree, so a
+//! new embedded asset compiles fine on a developer machine and in the
+//! normal CI jobs, which all build from a full checkout. The Docker image
+//! builds from a narrowed context assembled by explicit `COPY` lines in
+//! the Dockerfile, so an asset outside that set fails the image build and
+//! nothing else.
+//!
+//! That failure is invisible until after merge: `docker-check` in
+//! `.github/workflows/ci.yml` is gated on `github.event_name == 'push' &&
+//! github.ref == 'refs/heads/main'`, so it never runs on a pull request.
+//! Issue #309 added `packaging/systemd/all-smi.service` as the first such
+//! asset, every PR check passed, and `main` went red on the merge commit
+//! with `couldn't read src/service_cmd/../../packaging/systemd/all-smi.service`.
+//!
+//! This test moves that class of break back onto the pull request, where
+//! it costs a few milliseconds instead of a red default branch.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Collect every `.rs` file under `dir`, recursively.
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Extract the literal argument of every `include_str!` / `include_bytes!`
+/// invocation in `haystack`.
+///
+/// Deliberately simple: the macros are always written with a plain string
+/// literal in this crate. A `concat!`-built path would not be matched, so
+/// if one is ever introduced this parser must grow with it. Doc comments
+/// mentioning the macro name are skipped by requiring the `(` and a quote.
+fn embedded_paths(haystack: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    for macro_name in ["include_str!", "include_bytes!"] {
+        let mut cursor = 0;
+        while let Some(hit) = haystack[cursor..].find(macro_name) {
+            let after = cursor + hit + macro_name.len();
+            cursor = after;
+            let rest = haystack[after..].trim_start();
+            let Some(inner) = rest.strip_prefix('(') else {
+                continue;
+            };
+            let inner = inner.trim_start();
+            let Some(inner) = inner.strip_prefix('"') else {
+                continue;
+            };
+            let Some(end) = inner.find('"') else {
+                continue;
+            };
+            found.push(inner[..end].to_string());
+        }
+    }
+    found
+}
+
+/// Resolve `..` and `.` lexically. The target may not exist yet on disk
+/// in a failure case, so `canonicalize` is not usable here.
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Source paths copied into the builder stage of the Dockerfile.
+///
+/// Only the first stage matters: the runtime stage copies the built
+/// binary out of the builder with `--from=`, never the source tree.
+fn builder_copy_sources(dockerfile: &str) -> Vec<String> {
+    let mut sources = Vec::new();
+    let mut stage = 0usize;
+    for line in dockerfile.lines() {
+        let line = line.trim();
+        if line.to_ascii_uppercase().starts_with("FROM ") {
+            stage += 1;
+            continue;
+        }
+        if stage != 1 {
+            continue;
+        }
+        let Some(rest) = line
+            .strip_prefix("COPY ")
+            .or_else(|| line.strip_prefix("copy "))
+        else {
+            continue;
+        };
+        let args: Vec<&str> = rest.split_whitespace().collect();
+        // `COPY --from=builder ...` pulls from another stage, not the context.
+        if args.iter().any(|a| a.starts_with("--from=")) {
+            continue;
+        }
+        let args: Vec<&str> = args.into_iter().filter(|a| !a.starts_with("--")).collect();
+        // The last argument is the destination inside the image.
+        if args.len() >= 2 {
+            sources.extend(args[..args.len() - 1].iter().map(|s| s.to_string()));
+        }
+    }
+    sources
+}
+
+/// True when `copied` (a Dockerfile COPY source) brings `target` in.
+fn copy_covers(copied: &str, target: &Path) -> bool {
+    let copied = copied.trim_end_matches('/');
+    if copied == "." {
+        return true;
+    }
+    let copied_path = PathBuf::from(copied);
+    target == copied_path.as_path() || target.starts_with(&copied_path)
+}
+
+/// Patterns in `.dockerignore` that would strip `target` back out of the
+/// context even though a `COPY` names it.
+///
+/// Supports the subset this repository uses: bare names, directory
+/// prefixes (`tests/`), and extension globs (`*.md`). Negations (`!`) are
+/// treated as "does not exclude", which is the conservative direction for
+/// a test whose failure blocks a merge.
+fn dockerignore_hit(patterns: &[String], target: &Path) -> Option<String> {
+    let target_str = target.to_string_lossy().replace('\\', "/");
+    for raw in patterns {
+        let pattern = raw.trim();
+        if pattern.is_empty() || pattern.starts_with('#') || pattern.starts_with('!') {
+            continue;
+        }
+        let stripped = pattern.trim_end_matches('/');
+        if let Some(ext) = stripped.strip_prefix("*.") {
+            if target_str.ends_with(&format!(".{ext}")) {
+                return Some(raw.clone());
+            }
+            continue;
+        }
+        if target_str == stripped || target_str.starts_with(&format!("{stripped}/")) {
+            return Some(raw.clone());
+        }
+    }
+    None
+}
+
+#[test]
+fn embedded_assets_are_inside_the_docker_build_context() {
+    let root = repo_root();
+
+    let mut sources = Vec::new();
+    rust_sources(&root.join("src"), &mut sources);
+    assert!(
+        !sources.is_empty(),
+        "found no Rust sources under src/, the walker is broken"
+    );
+
+    // Repo-relative asset path -> the source file that embeds it.
+    let mut assets: BTreeSet<(String, String)> = BTreeSet::new();
+    for source in &sources {
+        let text = fs::read_to_string(source).unwrap_or_default();
+        for literal in embedded_paths(&text) {
+            let parent = source.parent().expect("source file has a parent");
+            let resolved = normalize(&parent.join(&literal));
+            let relative = resolved
+                .strip_prefix(&root)
+                .unwrap_or(&resolved)
+                .to_path_buf();
+            let owner = source
+                .strip_prefix(&root)
+                .unwrap_or(source)
+                .to_string_lossy()
+                .into_owned();
+            assets.insert((relative.to_string_lossy().into_owned(), owner));
+        }
+    }
+
+    if assets.is_empty() {
+        // Nothing is embedded today. The contract is vacuously satisfied,
+        // and the test stays in place for the next asset that appears.
+        return;
+    }
+
+    let dockerfile = fs::read_to_string(root.join("Dockerfile")).expect("Dockerfile must exist");
+    let copies = builder_copy_sources(&dockerfile);
+    assert!(
+        !copies.is_empty(),
+        "parsed no COPY sources from the Dockerfile builder stage"
+    );
+
+    let ignore_patterns: Vec<String> = fs::read_to_string(root.join(".dockerignore"))
+        .map(|text| text.lines().map(|l| l.to_string()).collect())
+        .unwrap_or_default();
+
+    let mut failures = Vec::new();
+    for (asset, owner) in &assets {
+        let asset_path = Path::new(asset);
+
+        assert!(
+            root.join(asset_path).exists(),
+            "{owner} embeds {asset}, which does not exist on disk"
+        );
+
+        if !copies.iter().any(|c| copy_covers(c, asset_path)) {
+            let dir = asset_path
+                .parent()
+                .and_then(|p| p.components().next())
+                .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                .unwrap_or_else(|| asset.clone());
+            failures.push(format!(
+                "  {asset}\n    embedded by: {owner}\n    To fix: add `COPY {dir}/ ./{dir}/` to the builder stage of the Dockerfile."
+            ));
+            continue;
+        }
+
+        if let Some(pattern) = dockerignore_hit(&ignore_patterns, asset_path) {
+            failures.push(format!(
+                "  {asset}\n    embedded by: {owner}\n    A COPY covers it, but .dockerignore pattern `{pattern}` strips it back out.\n    To fix: narrow that pattern or add a `!` negation for this path."
+            ));
+        }
+    }
+
+    let detail = failures.join("\n");
+    assert!(
+        failures.is_empty(),
+        "These embedded assets are unreachable from the Docker build context, so \
+         `docker build` fails at compile time even though every other check passes.\n\
+         Note that the `docker-check` CI job only runs on pushes to main, so this \
+         would otherwise surface as a red default branch after merge.\n\n{detail}\n\n\
+         Dockerfile builder stage copies: {copies:?}"
+    );
+}
+
+#[test]
+fn copy_coverage_matches_directories_and_exact_files() {
+    assert!(copy_covers("src/", Path::new("src/main.rs")));
+    assert!(copy_covers("src", Path::new("src/service_cmd/mod.rs")));
+    assert!(copy_covers(
+        "packaging/",
+        Path::new("packaging/systemd/all-smi.service")
+    ));
+    assert!(copy_covers("Cargo.toml", Path::new("Cargo.toml")));
+    assert!(copy_covers(".", Path::new("anything/at/all")));
+
+    assert!(!copy_covers(
+        "src/",
+        Path::new("packaging/systemd/x.service")
+    ));
+    assert!(!copy_covers("proto/", Path::new("packaging/x")));
+    // A prefix match must respect path boundaries.
+    assert!(!copy_covers("pack", Path::new("packaging/x")));
+}
+
+#[test]
+fn dockerignore_patterns_are_recognised() {
+    let patterns: Vec<String> = ["target/", "*.md", "tests/", "!keep.md", "# comment"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    assert!(dockerignore_hit(&patterns, Path::new("target/release/x")).is_some());
+    assert!(dockerignore_hit(&patterns, Path::new("README.md")).is_some());
+    assert!(dockerignore_hit(&patterns, Path::new("tests/foo.rs")).is_some());
+
+    assert!(dockerignore_hit(&patterns, Path::new("packaging/systemd/all-smi.service")).is_none());
+    assert!(dockerignore_hit(&patterns, Path::new("src/main.rs")).is_none());
+    // `target/` must not swallow a path that merely starts with the same text.
+    assert!(dockerignore_hit(&patterns, Path::new("targets/x")).is_none());
+}
+
+#[test]
+fn embedded_path_extraction_finds_literals() {
+    let text = r#"
+        //! Some docs mentioning include_str! in prose.
+        pub const A: &str = include_str!("../../packaging/systemd/all-smi.service");
+        pub const B: &[u8] = include_bytes!("assets/logo.png");
+    "#;
+    let found = embedded_paths(text);
+    assert!(found.contains(&"../../packaging/systemd/all-smi.service".to_string()));
+    assert!(found.contains(&"assets/logo.png".to_string()));
+    assert_eq!(
+        found.len(),
+        2,
+        "prose mention must not be picked up: {found:?}"
+    );
+}
+
+#[test]
+fn builder_stage_copies_are_isolated_from_the_runtime_stage() {
+    let dockerfile = "\
+FROM rust:1.96-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src/ ./src/
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/target/release/all-smi /usr/local/bin/all-smi
+COPY runtime-only/ ./runtime-only/
+";
+    let copies = builder_copy_sources(dockerfile);
+    assert_eq!(copies, vec!["Cargo.toml", "Cargo.lock", "src/"]);
+}


### PR DESCRIPTION
## Summary

`main` has been red since #319 (issue #309) merged. The Docker image build fails to compile:

```
error: couldn't read src/service_cmd/../../packaging/systemd/all-smi.service
  --> src/service_cmd/template.rs:56:33
   |
56 | pub const UNIT_TEMPLATE: &str = include_str!("../../packaging/systemd/all-smi.service");
```

Run: https://github.com/lablup/all-smi/actions/runs/30997457472

## Cause

Issue #309 added the first asset embedded with `include_str!`. The Dockerfile builder stage copies only `Cargo.toml`, `Cargo.lock`, `build.rs`, `proto/` and `src/`, so the narrowed build context has no `packaging/` directory and the crate cannot compile inside the image.

Two files have to agree here and nothing enforced it: the set of paths reachable from `include_str!` in `src/`, and the set of paths the Dockerfile copies into the build context.

## Why no check caught it before merge

`docker-check` in `.github/workflows/ci.yml` is gated on:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

It never runs on a pull request. PR #319 was fully green, and the failure appeared only on the merge commit. Every other gate (`cargo test`, `cargo clippy`, `cargo build`) builds from a full checkout and cannot see a build-context problem.

## Changes

1. `Dockerfile`: add `COPY packaging/ ./packaging/` to the builder stage.
2. `tests/docker_build_context_test.rs`: a contract test that keeps the two files in agreement.

The test extracts every `include_str!` / `include_bytes!` string literal under `src/`, resolves each against the file that embeds it, and asserts the result is covered by a builder-stage `COPY` and is not stripped back out by `.dockerignore`. It runs in the normal test suite, so this class of break now fails on the pull request instead of on `main`. The failure message names the exact `COPY` line to add:

```
These embedded assets are unreachable from the Docker build context, so `docker build`
fails at compile time even though every other check passes.
  packaging/systemd/all-smi.service
    embedded by: src/service_cmd/template.rs
    To fix: add `COPY packaging/ ./packaging/` to the builder stage of the Dockerfile.
```

This also covers the launchd plist that #310 adds under `packaging/`, since the `COPY` takes the whole directory.

## Verification

- `cargo test --test docker_build_context_test`: 5 passed.
- Negative control on the test: removing the `COPY` line makes `embedded_assets_are_inside_the_docker_build_context` fail with the message above. The test is not vacuous.
- Negative control on the real build context: a Dockerfile built from this Dockerfile's exact builder-stage `COPY` set plus `RUN test -f packaging/systemd/all-smi.service` succeeds with the fix, and fails with `exit code: 1` on that same `RUN` without it. The unit template and the env-file example are both present in the resulting image.
- `cargo fmt --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.

## Not addressed here

`docker-check` still does not run on pull requests. The new test covers the embedded-asset class specifically, but a Docker build can also break for reasons it cannot see, for example a missing system dependency in the builder stage. Whether to run the image build on pull requests is a CI cost decision and is filed separately.
