### PR TITLE
fix(api): always emit a metrics baseline and add /-/ready

### DIFF
--- a/API.md
+++ b/API.md
@@ -51,6 +51,48 @@ r = session.get('http+unix://%2Ftmp%2Fall-smi.sock/metrics')
 
 **Security**: Socket permissions are set to `0600` (owner-only access).
 
+## Readiness and the Startup Window
+
+`/metrics` answers `200 OK` from the moment the listener binds, which is before the first collection cycle has run. That is deliberate and unchanged: an existing scraper never sees a non-200 from this endpoint. What is guaranteed on top of it is that the body is never empty. Two families are emitted unconditionally on every response, ahead of all device metrics:
+
+| Metric | Type | Value | Labels |
+|--------|------|-------|--------|
+| `all_smi_up` | gauge | `0` until the first collection cycle populates the exporter, `1` afterwards | `instance`, `hostname` |
+| `all_smi_build_info` | gauge | always `1` | `instance`, `hostname`, `version`, `os`, `arch` |
+
+Without these, a scrape landing in the startup window recorded a *successful* scrape with zero samples, which reads as a silent gap in the series rather than a failed target and therefore does not alert.
+
+### `GET /-/ready`
+
+The dedicated readiness gate, for consumers that need a yes/no answer rather than an in-band sample.
+
+| Condition | Status | Headers | Body |
+|-----------|--------|---------|------|
+| No collection cycle completed yet | `503 Service Unavailable` | `Retry-After: 1`, `Cache-Control: no-store` | `all-smi is not ready: no collection cycle has completed yet.` |
+| At least one cycle completed | `200 OK` | `Cache-Control: no-store` | `all-smi is ready.` |
+
+```bash
+# Wait for real data before scraping.
+until curl -sf --max-time 5 localhost:9090/-/ready >/dev/null; do sleep 1; done
+```
+
+Use `/-/ready` for Kubernetes `readinessProbe`s, load-balancer health checks, and service-startup gates. A probe pointed at `/metrics` passes immediately, before there is anything to serve. The path follows the Prometheus-ecosystem convention (`/-/ready` on Prometheus, Alertmanager, and the Pushgateway).
+
+`all_smi_up` and `/-/ready` are two views of one predicate and cannot disagree.
+
+### Useful queries
+
+```promql
+# Exporters that are up but have not produced a collection cycle.
+all_smi_up == 0
+
+# Attach the running version to any series.
+all_smi_gpu_utilization * on (instance) group_left(version) all_smi_build_info
+
+# Version skew across the fleet.
+count by (version) (all_smi_build_info)
+```
+
 ## JSON Endpoints (Streaming + One-Shot)
 
 Alongside `/metrics`, API mode exposes two JSON endpoints that share the

--- a/README.md
+++ b/README.md
@@ -1117,6 +1117,31 @@ Metrics are available at `http://localhost:9090/metrics` (TCP) or via Unix socke
 
 For a complete list of all available metrics, see [API.md](API.md).
 
+#### Startup window and readiness
+
+`/metrics` answers `200 OK` for the entire lifetime of the process, including the window between the listener binding and the first collection cycle completing. It never returns an empty body: every response carries two baseline families, so a scrape that lands during startup is distinguishable from a scrape of a host that genuinely has nothing to report.
+
+| Metric | Meaning |
+|--------|---------|
+| `all_smi_up{instance,hostname}` | `0` until the first collection cycle has populated the exporter, `1` afterwards. |
+| `all_smi_build_info{instance,hostname,version,os,arch}` | Always `1`. The content is in the labels; join with `* on (instance) group_left(version)`. |
+
+For a yes/no gate, use the dedicated readiness endpoint instead of inferring it from `/metrics`:
+
+| Endpoint | Before the first collection | After |
+|----------|-----------------------------|-------|
+| `GET /-/ready` | `503 Service Unavailable` with `Retry-After: 1` | `200 OK` |
+
+```bash
+# Block until the exporter has real data, then scrape.
+until curl -sf --max-time 5 localhost:9090/-/ready >/dev/null; do sleep 1; done
+curl -s localhost:9090/metrics
+```
+
+Point Kubernetes `readinessProbe`s, load-balancer health checks, and service-startup gates at `/-/ready`. Pointing them at `/metrics` will pass immediately, before there is anything to serve. The `/-/` prefix follows the Prometheus-ecosystem convention used by Prometheus itself, Alertmanager, and the Pushgateway.
+
+`all-smi`'s own service integrations report "running" once the listener is bound, not once the first collection completes, so that a slow or wedged hardware probe cannot turn into a supervisor restart loop. Readiness is reported separately through the two surfaces above.
+
 #### Streaming (SSE)
 
 Alongside `/metrics`, API mode exposes two JSON endpoints that share the

--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -505,10 +505,39 @@ Intel and AMD CPU monitoring on Linux systems
 .SH API ENDPOINTS (API MODE)
 .TP
 .B /metrics
-Prometheus-compatible metrics endpoint with hardware statistics
+Prometheus-compatible metrics endpoint with hardware statistics. Always answers
+.BR "200 OK" ,
+including before the first collection cycle has completed. The body is never
+empty: every response carries
+.B all_smi_up
+(0 until the first collection cycle lands, 1 afterwards) and
+.BR all_smi_build_info ,
+so a scrape taken during startup is distinguishable from a scrape of a host
+with no devices.
 .TP
-.B /health
-Health check endpoint returning "OK"
+.B /-/ready
+Readiness probe. Returns
+.B 503 Service Unavailable
+with
+.B Retry-After: 1
+until the first collection cycle has populated the exporter, and
+.B 200 OK
+afterwards. Use this, not
+.BR /metrics ,
+for a Kubernetes
+.BR readinessProbe ,
+a load-balancer health check, or a startup gate. The
+.B /-/
+prefix follows the Prometheus-ecosystem convention.
+.TP
+.B /snapshot
+One-shot JSON dump of the latest collection cycle. Accepts
+.B ?include=
+and
+.BR ?pretty= .
+.TP
+.B /events
+Server-Sent Events stream, one JSON frame per collection cycle.
 .SH EXAMPLES
 .TP
 Monitor local hardware in interactive TUI:

--- a/src/api/handlers/metrics_render.rs
+++ b/src/api/handlers/metrics_render.rs
@@ -18,11 +18,22 @@
 //! exposition writer in [`crate::api::metrics::render`]. Kept separate from
 //! the SSE / snapshot handlers (issue #193) so adding new routes does not
 //! force a rebuild of this unchanged hot path.
+//!
+//! Status-code contract (issue #324): this endpoint answers `200` for its
+//! entire lifetime, including the window between the listener binding and
+//! the first collection cycle landing. It is deliberately *not* a
+//! readiness probe, because turning it into one would break every scraper
+//! that already treats a non-200 as a failed target. What changed in #324
+//! is that the body is no longer empty in that window: the exposition
+//! carries `all_smi_up 0` plus build info until the first cycle completes,
+//! then `all_smi_up 1` plus the full metric set. Consumers that need a
+//! yes/no gate use `/-/ready` (see [`crate::api::handlers::ready`]).
 
 use axum::extract::State;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::api::handlers::ready::is_ready;
 use crate::api::metrics::render::{MetricsRenderInputs, render_prometheus_exposition};
 use crate::app_state::AppState;
 
@@ -45,6 +56,11 @@ pub async fn metrics_handler(State(state): State<SharedState>) -> String {
         // counter's HELP/TYPE header lines are only emitted when there
         // is at least one device with recorded samples.
         energy_integrator: Some(state.energy.integrator()),
+        // Same predicate `/-/ready` answers with, read under the same
+        // lock acquisition as the data itself so the gauge cannot
+        // disagree with the samples it is rendered alongside (issue
+        // #324).
+        ready: is_ready(&state),
     };
     render_prometheus_exposition(&inputs)
 }

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -19,9 +19,12 @@
 //! * [`metrics_render`] — legacy Prometheus `/metrics` endpoint.
 //! * [`events`] — Server-Sent Events `/events` stream (issue #193).
 //! * [`snapshot`] — one-shot `/snapshot` JSON endpoint (issue #193).
+//! * [`ready`] — `/-/ready` readiness endpoint (issue #324).
 
 pub mod events;
 pub mod metrics_render;
+pub mod ready;
 pub mod snapshot;
 
 pub use metrics_render::{SharedState, metrics_handler};
+pub use ready::ready_handler;

--- a/src/api/handlers/ready.rs
+++ b/src/api/handlers/ready.rs
@@ -1,0 +1,150 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Readiness endpoint `/-/ready` (issue #324).
+//!
+//! `/metrics` answers `200` from the moment axum binds the listener, and
+//! after #324 it always carries a baseline (`all_smi_up`,
+//! `all_smi_build_info`) so a scrape in the pre-first-collection window is
+//! no longer an indistinguishable zero bytes. That keeps every existing
+//! scraper working, but it deliberately does *not* give an orchestrator a
+//! yes/no signal it can gate on: a Kubernetes `readinessProbe` pointed at
+//! `/metrics` passes immediately, before there is anything to serve.
+//!
+//! This module is that yes/no signal. `/-/ready` returns `503` until the
+//! first collection cycle has populated `AppState`, and `200` afterwards.
+//!
+//! The path follows the Prometheus-ecosystem convention (`/-/ready` on
+//! Prometheus itself, Alertmanager, and the Pushgateway) rather than
+//! inventing `/ready` or `/healthz`. The `/-/` prefix is the ecosystem's
+//! way of keeping operational endpoints out of the namespace a scrape
+//! target might otherwise want, so an operator who already knows one
+//! Prometheus component knows this one.
+
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+use crate::app_state::AppState;
+
+use super::SharedState;
+
+/// Body returned once the first collection cycle has completed.
+const READY_BODY: &str = "all-smi is ready.\n";
+
+/// Body returned during the pre-first-collection window.
+const NOT_READY_BODY: &str = "all-smi is not ready: no collection cycle has completed yet.\n";
+
+/// Whether the exporter has completed at least one collection cycle.
+///
+/// This is the single source of truth behind *both* halves of the #324
+/// contract: the `all_smi_up` gauge in the exposition and the `/-/ready`
+/// status code. Keeping one predicate is the point. If the two were
+/// computed independently they could disagree, and a consumer that gates
+/// on `/-/ready` but alerts on `all_smi_up` would see a contradiction it
+/// has no way to resolve.
+///
+/// [`AppState::loading`] starts `true` and is cleared by
+/// [`crate::api::collection_loop::run_collection_loop`] at the end of its
+/// first iteration, which is exactly the transition being described. It is
+/// never set back to `true` on the API path.
+pub fn is_ready(state: &AppState) -> bool {
+    !state.loading
+}
+
+pub async fn ready_handler(State(state): State<SharedState>) -> Response {
+    let ready = is_ready(&*state.read().await);
+    readiness_response(ready)
+}
+
+/// Build the response for a given readiness verdict. Split out from the
+/// handler so the status/header/body contract is unit-testable without an
+/// axum `State` extractor or a live `AppState`.
+fn readiness_response(ready: bool) -> Response {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    // A readiness verdict is the last thing that should be cached. Without
+    // this, a reverse proxy in front of the exporter can keep serving the
+    // startup `503` long after the process became ready, which turns a
+    // two-second window into an outage. The `/snapshot` handler takes the
+    // same posture for the same reason.
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+
+    if ready {
+        (StatusCode::OK, headers, READY_BODY).into_response()
+    } else {
+        // RFC 9110 says a 503 SHOULD carry Retry-After when the server
+        // knows roughly how long the condition lasts, and here it does:
+        // readiness arrives within one collection interval. One second is
+        // the honest floor for "poll again shortly" and matches what the
+        // CI gates do anyway.
+        headers.insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+        (StatusCode::SERVICE_UNAVAILABLE, headers, NOT_READY_BODY).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loading_state_is_not_ready() {
+        // `AppState::default()` is the state the server serves from
+        // between bind and the first collection cycle.
+        let state = AppState::default();
+        assert!(state.loading, "precondition: a fresh AppState is loading");
+        assert!(!is_ready(&state));
+    }
+
+    #[test]
+    fn cleared_loading_flag_is_ready() {
+        // Mirrors what `run_collection_loop` does at the end of its first
+        // iteration.
+        let state = AppState {
+            loading: false,
+            ..Default::default()
+        };
+        assert!(is_ready(&state));
+    }
+
+    #[test]
+    fn not_ready_is_503_with_retry_after_and_no_store() {
+        let response = readiness_response(false);
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let headers = response.headers();
+        assert_eq!(headers.get(header::RETRY_AFTER).unwrap(), "1");
+        assert_eq!(headers.get(header::CACHE_CONTROL).unwrap(), "no-store");
+        assert_eq!(
+            headers.get(header::CONTENT_TYPE).unwrap(),
+            "text/plain; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn ready_is_200_without_retry_after() {
+        let response = readiness_response(true);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response.headers().get(header::RETRY_AFTER).is_none(),
+            "Retry-After is meaningless on a 200 and would confuse a proxy"
+        );
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
+    }
+}

--- a/src/api/latch.rs
+++ b/src/api/latch.rs
@@ -23,6 +23,12 @@
 //! answers the mirror question of when the service may report
 //! `SERVICE_RUNNING`, which is "once a listener is bound".
 //!
+//! That boundary was revisited in issue #324, which added a real
+//! readiness signal, and deliberately left unchanged. See
+//! [`crate::api::shutdown::mark_serving`] for the reasoning; the short
+//! version is that this latch answers "is it serving", `/-/ready` answers
+//! "is it ready", and the SCM only has a question of the first kind.
+//!
 //! Both are one-way transitions: `false` once, `true` forever after.
 //! [`Latch`](crate::api::latch::Latch) is that primitive, and it is a
 //! plain value rather than a process global so its semantics can be unit

--- a/src/api/metrics/exporter_status.rs
+++ b/src/api/metrics/exporter_status.rs
@@ -1,0 +1,190 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Exporter self-description: the baseline every scrape carries
+//! (issue #324).
+//!
+//! Every other exporter in [`crate::api::metrics`] self-filters, so a host
+//! with no devices, or a process whose first collection cycle has not
+//! landed yet, used to render a byte-empty `/metrics` body with a
+//! `200 OK`. A scrape that lands in that window is recorded by Prometheus
+//! as a *successful* scrape with zero samples, which is a silent hole in
+//! the series rather than a failed target: it does not alert.
+//!
+//! This exporter is the one that never self-filters. It emits two
+//! families unconditionally, from the very first request:
+//!
+//! * `all_smi_up` — `0` until the first collection cycle has written into
+//!   `AppState`, `1` afterwards. This is what lets a consumer tell
+//!   "up but not ready" apart from "up with nothing to report", which
+//!   previously were the same zero bytes.
+//! * `all_smi_build_info` — the constant-`1` build-info idiom used by
+//!   `node_exporter` (`node_exporter_build_info`) and Prometheus itself
+//!   (`prometheus_build_info`): the interesting content is in the labels,
+//!   and `version` is joinable onto any other series with
+//!   `* on (instance) group_left(version)`.
+//!
+//! `/metrics` keeps answering `200` throughout. Readiness is a separate,
+//! explicitly queryable signal at `/-/ready`
+//! (see [`crate::api::handlers::ready`]); this exporter is the in-band
+//! half of the same contract, for consumers that only ever see a scrape.
+
+use crate::utils::get_hostname;
+
+use super::{MetricBuilder, MetricExporter};
+
+/// Liveness/readiness gauge. `0` before the first collection cycle.
+pub const UP_METRIC: &str = "all_smi_up";
+
+/// Constant-`1` build-info gauge. All the content is in the labels.
+pub const BUILD_INFO_METRIC: &str = "all_smi_build_info";
+
+/// Emits [`UP_METRIC`] and [`BUILD_INFO_METRIC`].
+pub struct ExporterStatusMetricExporter {
+    /// Whether at least one collection cycle has populated `AppState`.
+    ready: bool,
+}
+
+impl ExporterStatusMetricExporter {
+    pub fn new(ready: bool) -> Self {
+        Self { ready }
+    }
+}
+
+impl MetricExporter for ExporterStatusMetricExporter {
+    fn export_metrics(&self) -> String {
+        // `get_hostname` reads a process-wide `Lazy<String>`, so this is a
+        // clone rather than a syscall per scrape. It is also the exact
+        // source every device reader uses for its own `instance` /
+        // `hostname` labels (e.g. `MemoryInfo.instance`), so these two
+        // families join cleanly onto the rest of the exposition instead
+        // of introducing a second spelling of the same host.
+        let hostname = get_hostname();
+
+        // Label ordering and naming follow the house convention every
+        // other exporter in this module uses: `instance` first, then
+        // `hostname`. Prometheus supplies its own `instance` target
+        // label, but `all-smi view --hosts` scrapes these endpoints
+        // directly with no Prometheus in the middle and keys on the
+        // exporter-provided one, so omitting it here would make the
+        // baseline the only unattributable family in the body.
+        let up_labels = [
+            ("instance", hostname.as_str()),
+            ("hostname", hostname.as_str()),
+        ];
+
+        let mut builder = MetricBuilder::new();
+        builder
+            .help(
+                UP_METRIC,
+                "1 once the exporter has completed a collection cycle, 0 before that",
+            )
+            .type_(UP_METRIC, "gauge")
+            .metric(UP_METRIC, &up_labels, u8::from(self.ready));
+
+        // `version` is the label operators actually alert on. `os` and
+        // `arch` are compile-time constants and cost nothing, and this
+        // is a fleet tool whose whole point is heterogeneous clusters,
+        // so "which build is on which kind of box" is a question the
+        // exposition should be able to answer on its own. Deliberately
+        // no git revision: the crate has no build script that stamps
+        // one, and adding one would make otherwise identical builds
+        // differ.
+        let build_labels = [
+            ("instance", hostname.as_str()),
+            ("hostname", hostname.as_str()),
+            ("version", env!("CARGO_PKG_VERSION")),
+            ("os", std::env::consts::OS),
+            ("arch", std::env::consts::ARCH),
+        ];
+        builder
+            .help(
+                BUILD_INFO_METRIC,
+                "Build information for the running all-smi binary; always 1",
+            )
+            .type_(BUILD_INFO_METRIC, "gauge")
+            .metric(BUILD_INFO_METRIC, &build_labels, 1);
+
+        builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_ready_emits_up_zero() {
+        let rendered = ExporterStatusMetricExporter::new(false).export_metrics();
+        assert!(
+            rendered.contains("} 0\n"),
+            "all_smi_up must be 0 before the first collection cycle: {rendered}"
+        );
+        assert!(rendered.contains("# TYPE all_smi_up gauge\n"));
+        assert!(rendered.contains("all_smi_up{instance="));
+    }
+
+    #[test]
+    fn ready_emits_up_one() {
+        let rendered = ExporterStatusMetricExporter::new(true).export_metrics();
+        let up_line = rendered
+            .lines()
+            .find(|l| l.starts_with("all_smi_up{"))
+            .expect("all_smi_up sample line");
+        assert!(up_line.ends_with(" 1"), "expected up=1, got {up_line}");
+    }
+
+    /// The whole point of this exporter: it never self-filters, so the
+    /// exposition can never be byte-empty again.
+    #[test]
+    fn always_emits_something_in_both_states() {
+        for ready in [false, true] {
+            let rendered = ExporterStatusMetricExporter::new(ready).export_metrics();
+            assert!(!rendered.is_empty());
+            assert!(rendered.contains("all_smi_build_info{"));
+        }
+    }
+
+    #[test]
+    fn build_info_carries_version_os_and_arch() {
+        let rendered = ExporterStatusMetricExporter::new(true).export_metrics();
+        let line = rendered
+            .lines()
+            .find(|l| l.starts_with("all_smi_build_info{"))
+            .expect("build info sample line");
+        assert!(
+            line.contains(&format!("version=\"{}\"", env!("CARGO_PKG_VERSION"))),
+            "missing version label: {line}"
+        );
+        assert!(line.contains(&format!("os=\"{}\"", std::env::consts::OS)));
+        assert!(line.contains(&format!("arch=\"{}\"", std::env::consts::ARCH)));
+        assert!(line.ends_with(" 1"), "build info must always be 1: {line}");
+    }
+
+    /// Both families must carry the same host identity the device
+    /// exporters use, or a dashboard cannot join them.
+    #[test]
+    fn both_families_share_one_host_identity() {
+        let hostname = get_hostname();
+        let rendered = ExporterStatusMetricExporter::new(true).export_metrics();
+        for family in ["all_smi_up{", "all_smi_build_info{"] {
+            let line = rendered
+                .lines()
+                .find(|l| l.starts_with(family))
+                .unwrap_or_else(|| panic!("missing {family}"));
+            assert!(line.contains(&format!("instance=\"{hostname}\"")), "{line}");
+            assert!(line.contains(&format!("hostname=\"{hostname}\"")), "{line}");
+        }
+    }
+}

--- a/src/api/metrics/mod.rs
+++ b/src/api/metrics/mod.rs
@@ -16,6 +16,8 @@ pub mod chassis;
 pub mod cpu;
 pub mod disk;
 pub mod energy;
+/// Baseline `all_smi_up` / `all_smi_build_info` families (issue #324).
+pub mod exporter_status;
 pub mod gpu;
 pub mod hardware;
 pub mod memory;

--- a/src/api/metrics/render.rs
+++ b/src/api/metrics/render.rs
@@ -37,7 +37,8 @@ use crate::utils::RuntimeEnvironment;
 
 use super::{
     MetricExporter, chassis::ChassisMetricExporter, cpu::CpuMetricExporter,
-    disk::DiskMetricExporter, energy::EnergyMetricExporter, gpu::GpuMetricExporter,
+    disk::DiskMetricExporter, energy::EnergyMetricExporter,
+    exporter_status::ExporterStatusMetricExporter, gpu::GpuMetricExporter,
     hardware::HardwareMetricExporter, memory::MemoryMetricExporter, mig::MigMetricExporter,
     npu::NpuMetricExporter, process::ProcessMetricExporter, runtime::RuntimeMetricExporter,
     vgpu::VgpuMetricExporter,
@@ -65,15 +66,33 @@ pub struct MetricsRenderInputs<'a> {
     /// `snapshot --format prometheus` runs without a live integrator);
     /// the exporter then omits the metric family entirely.
     pub energy_integrator: Option<&'a PowerIntegrator>,
+    /// Whether at least one collection cycle has populated the source of
+    /// these inputs (issue #324). Drives the `all_smi_up` gauge.
+    ///
+    /// The live `/metrics` handler passes `!AppState::loading`; the
+    /// one-shot `snapshot --format prometheus` path passes `true`
+    /// because it collects synchronously before rendering. Byte-identical
+    /// parity between the two paths therefore still holds for the same
+    /// data *and* the same readiness.
+    pub ready: bool,
 }
 
 /// Render the Prometheus exposition string for the given inputs.
 ///
-/// Output is empty when no exporter writes anything. Every exporter in the
-/// chain self-filters so non-applicable hosts (e.g. non-NVIDIA for
-/// NVLink/MIG/vGPU) stay silent.
+/// The output is never empty: [`ExporterStatusMetricExporter`] emits
+/// `all_smi_up` and `all_smi_build_info` unconditionally (issue #324).
+/// Every *device* exporter in the chain still self-filters, so
+/// non-applicable hosts (e.g. non-NVIDIA for NVLink/MIG/vGPU) contribute
+/// nothing beyond that baseline.
 pub fn render_prometheus_exposition(inputs: &MetricsRenderInputs<'_>) -> String {
     let mut all_metrics = String::new();
+
+    // Baseline first (issue #324), so a consumer that reads only the head
+    // of the response, or scrapes before the first collection cycle has
+    // landed, still learns whether this exporter is up and which build it
+    // is. Everything below this line self-filters; this block does not.
+    let status_exporter = ExporterStatusMetricExporter::new(inputs.ready);
+    all_metrics.push_str(&status_exporter.export_metrics());
 
     // Export GPU/NPU metrics
     if !inputs.gpu_info.is_empty() {
@@ -159,22 +178,70 @@ pub fn render_prometheus_exposition(inputs: &MetricsRenderInputs<'_>) -> String 
 mod tests {
     use super::*;
 
-    #[test]
-    fn empty_inputs_render_empty_string() {
-        let env = RuntimeEnvironment::default();
-        let inputs = MetricsRenderInputs {
+    fn empty_inputs(env: &RuntimeEnvironment, ready: bool) -> MetricsRenderInputs<'_> {
+        MetricsRenderInputs {
             gpu_info: &[],
             process_info: &[],
             cpu_info: &[],
             memory_info: &[],
             storage_info: &[],
-            runtime_environment: &env,
+            runtime_environment: env,
             chassis_info: &[],
             vgpu_info: &[],
             mig_info: &[],
             energy_integrator: None,
-        };
-        let rendered = render_prometheus_exposition(&inputs);
-        assert_eq!(rendered, "");
+            ready,
+        }
+    }
+
+    /// Supersedes the former `empty_inputs_render_empty_string`, which
+    /// asserted the exact behaviour issue #324 removed: an all-empty
+    /// input set used to render zero bytes, so a scrape landing before
+    /// the first collection cycle was indistinguishable from a scrape of
+    /// a host with no devices. The baseline families are now the floor.
+    #[test]
+    fn empty_inputs_still_render_the_baseline() {
+        let env = RuntimeEnvironment::default();
+        let rendered = render_prometheus_exposition(&empty_inputs(&env, false));
+        assert!(
+            !rendered.is_empty(),
+            "the exposition must never be byte-empty (issue #324)"
+        );
+        assert!(rendered.contains("all_smi_up{"), "{rendered}");
+        assert!(rendered.contains("all_smi_build_info{"), "{rendered}");
+    }
+
+    /// Nothing but the baseline: with every device slice empty, the
+    /// self-filtering exporters must still contribute nothing, so the
+    /// added floor cannot be hiding a regression that made some other
+    /// family unconditional.
+    #[test]
+    fn empty_inputs_render_only_the_baseline_families() {
+        let env = RuntimeEnvironment::default();
+        let rendered = render_prometheus_exposition(&empty_inputs(&env, false));
+        for line in rendered.lines().filter(|l| !l.starts_with('#')) {
+            assert!(
+                line.starts_with("all_smi_up{") || line.starts_with("all_smi_build_info{"),
+                "unexpected sample from an empty input set: {line}"
+            );
+        }
+    }
+
+    /// The pre-first-collection window is observable in-band, without
+    /// timing the scrape.
+    #[test]
+    fn ready_flag_drives_the_up_gauge() {
+        let env = RuntimeEnvironment::default();
+        for (ready, expected) in [(false, " 0"), (true, " 1")] {
+            let rendered = render_prometheus_exposition(&empty_inputs(&env, ready));
+            let up_line = rendered
+                .lines()
+                .find(|l| l.starts_with("all_smi_up{"))
+                .expect("all_smi_up sample line");
+            assert!(
+                up_line.ends_with(expected),
+                "ready={ready} should render all_smi_up{expected}, got {up_line}"
+            );
+        }
     }
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -32,7 +32,7 @@ use crate::api::FrameBus;
 use crate::api::collection_loop::run_collection_loop;
 use crate::api::handlers::events::events_handler;
 use crate::api::handlers::snapshot::snapshot_handler;
-use crate::api::handlers::{SharedState, metrics_handler};
+use crate::api::handlers::{SharedState, metrics_handler, ready_handler};
 use crate::api::server_state::ApiState;
 use crate::app_state::AppState;
 use crate::cli::ApiArgs;
@@ -232,9 +232,16 @@ pub async fn run_api_mode(args: &ApiArgs, settings: &Settings) {
     // sub-state it needs (see `server_state::ApiState`).
     let api_state = ApiState::new(state, bus);
 
-    // Create the router with shared state
+    // Create the router with shared state.
+    //
+    // `/-/ready` (issue #324) is the readiness gate: 503 until the
+    // collection loop spawned above has written its first cycle into
+    // `AppState`, 200 after. `/metrics` never joins that gate, it answers
+    // 200 throughout and reports the same transition in-band through
+    // `all_smi_up`, so existing scrapers are unaffected.
     let app = Router::new()
         .route("/metrics", get(metrics_handler))
+        .route("/-/ready", get(ready_handler))
         .route("/events", get(events_handler))
         .route("/snapshot", get(snapshot_handler))
         .with_state(api_state)

--- a/src/api/shutdown.rs
+++ b/src/api/shutdown.rs
@@ -27,9 +27,15 @@
 //! flush, breaking Prometheus counter monotonicity across a restart.
 //!
 //! The mirror question, when the service may report `SERVICE_RUNNING`,
-//! is answered by the readiness latch: each listener raises it after a
+//! is answered by the serving latch: each listener raises it after a
 //! successful bind, so the SCM never sees a running service whose port
 //! refuses connections.
+//!
+//! Note the deliberate narrowing of vocabulary since #311: this latch is
+//! the *serving* signal, not the *readiness* signal. Issue #324 added the
+//! latter as `/-/ready` and as the `all_smi_up` gauge, and considered
+//! moving this latch behind it. It did not. [`mark_serving`] carries the
+//! reasoning.
 
 use std::sync::OnceLock;
 
@@ -85,6 +91,11 @@ pub fn shutdown_requested() -> bool {
 /// The Windows service host awaits this before reporting
 /// `SERVICE_RUNNING`, so the SCM never sees a running service whose port
 /// is not yet accepting connections.
+///
+/// This resolves at bind, which is *before* the first collection cycle.
+/// It is a serving signal, not a readiness one: see [`mark_serving`] for
+/// why the two are kept apart, and use `/-/ready` when the question is
+/// whether there is data to serve.
 #[cfg_attr(not(windows), allow(dead_code))]
 pub async fn wait_until_serving() {
     serving_latch().wait().await
@@ -96,8 +107,48 @@ pub fn is_serving() -> bool {
     serving_latch().is_triggered()
 }
 
-/// Raise the readiness latch. Called by each listener immediately after
-/// a successful bind.
+/// Raise the serving latch. Called by each listener immediately after a
+/// successful bind.
+///
+/// # Why this stays at bind rather than moving behind the first
+/// collection cycle (issue #324)
+///
+/// #324 gave the exporter a real readiness signal (`/-/ready`, and the
+/// `all_smi_up` gauge) and asked whether this latch should move with it,
+/// since #311 documented it as opening before there was anything to
+/// serve. It should not, for three reasons.
+///
+/// First, the two are different questions. The SCM has no readiness
+/// concept: its state machine offers `SERVICE_START_PENDING` and
+/// `SERVICE_RUNNING`, and `SERVICE_RUNNING` is a liveness verdict. The
+/// natural liveness boundary for a network exporter is "the listener
+/// answers". Readiness is now separately queryable at any time by anyone
+/// who actually needs it, which is exactly the liveness/readiness split
+/// Kubernetes and the Prometheus ecosystem already use.
+///
+/// Second, the inconsistency #324 was worried about is resolved at the
+/// other end. Before #324 this latch opened onto an endpoint that served
+/// zero bytes, so `SERVICE_RUNNING` really did promise nothing. Now
+/// `/metrics` carries `all_smi_up 0` plus build info from the first
+/// request onward, so the instant this latch opens there is a defined,
+/// non-empty response. Giving `/metrics` a floor fixed the mismatch;
+/// delaying the latch is not needed to fix it a second time.
+///
+/// Third, moving it has a concrete failure mode that is worse than the
+/// one it would prevent. `crate::service_cmd::scm_host` reports
+/// `StartPending` exactly once, with `wait_hint =
+/// TRANSITION_WAIT_HINT_SECS` (10 s) and `checkpoint: 0`. Because the
+/// checkpoint never increments, that single report is the entire start
+/// budget the SCM grants. A first collection cycle on Windows means cold
+/// COM/WMI initialization plus NVML enumeration, which on a
+/// many-GPU host or a wedged driver can exceed 10 s. The SCM would then
+/// fail the start and apply the configured recovery actions, restarting
+/// the process into the same slow path: a boot loop on precisely the
+/// hosts where the telemetry matters most. Reporting `SERVICE_RUNNING`
+/// for a process that is up and honestly publishing `all_smi_up 0` is
+/// the better trade. The same argument applies to any dependent service
+/// that waits on this one, which would otherwise block on hardware
+/// enumeration.
 pub(crate) fn mark_serving() {
     serving_latch().trigger();
 }

--- a/src/snapshot/serializers/prometheus.rs
+++ b/src/snapshot/serializers/prometheus.rs
@@ -138,8 +138,15 @@ mod tests {
         }
     }
 
+    /// Supersedes the former `empty_snapshot_renders_empty_string`, the
+    /// snapshot-side twin of `empty_inputs_render_empty_string`. Both
+    /// asserted the behaviour issue #324 removed. A snapshot that
+    /// collected no sections still renders the baseline, and must keep
+    /// reporting `all_smi_up 1`: the collection ran, it simply had
+    /// nothing to report, which is precisely the case that used to be
+    /// indistinguishable from "the exporter has not started yet".
     #[test]
-    fn empty_snapshot_renders_empty_string() {
+    fn empty_snapshot_still_renders_the_baseline() {
         let snap = Snapshot {
             schema: 1,
             timestamp: "2026-04-20T00:00:00Z".to_string(),
@@ -153,7 +160,26 @@ mod tests {
             errors: Vec::new(),
         };
         let rendered = render(&[snap]).unwrap();
-        assert_eq!(rendered, "");
+        assert!(!rendered.is_empty());
+
+        let up = rendered
+            .lines()
+            .find(|l| l.starts_with("all_smi_up{"))
+            .expect("all_smi_up sample line");
+        assert!(
+            up.ends_with(" 1"),
+            "a completed one-shot collection is up, even with no sections: {up}"
+        );
+        assert!(rendered.contains("all_smi_build_info{"));
+
+        // Nothing beyond the baseline: the device exporters must still
+        // self-filter on a snapshot that collected nothing.
+        for line in rendered.lines().filter(|l| !l.starts_with('#')) {
+            assert!(
+                line.starts_with("all_smi_up{") || line.starts_with("all_smi_build_info{"),
+                "unexpected sample from an empty snapshot: {line}"
+            );
+        }
     }
 
     #[test]

--- a/src/snapshot/serializers/prometheus.rs
+++ b/src/snapshot/serializers/prometheus.rs
@@ -71,6 +71,16 @@ pub fn render(snapshots: &[Snapshot]) -> Result<String> {
         // prometheus` byte-for-byte identical to a single `api`
         // scrape taken before any energy samples have been recorded.
         energy_integrator: None,
+        // The snapshot path collects synchronously and only reaches this
+        // serializer once that collection has returned, so by the time
+        // `all_smi_up` is rendered the cycle this output describes has
+        // completed. Reporting 0 here would be false (issue #324).
+        //
+        // `snap.errors` being non-empty does not change this: a partial
+        // collection is still a completed cycle, and per-reader failures
+        // are reported on stderr below rather than by pretending the
+        // exporter never ran.
+        ready: true,
     };
 
     let out = render_prometheus_exposition(&inputs);

--- a/tests/api_readiness_test.rs
+++ b/tests/api_readiness_test.rs
@@ -1,0 +1,280 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//! Integration tests for the pre-first-collection contract (issue #324).
+//!
+//! The acceptance criterion these exist for is specifically that the
+//! behaviour is pinned *behind the live route with an empty `AppState`*,
+//! not just at the renderer in isolation. The renderer-level tests live in
+//! `src/api/metrics/render.rs`; a passing renderer test would not have
+//! caught a handler that forgot to pass `ready`, nor a router that never
+//! mounted `/-/ready`.
+//!
+//! No hardware readers are involved: the collection loop is simulated by
+//! flipping `AppState::loading`, which is exactly the transition
+//! `run_collection_loop` performs at the end of its first iteration.
+
+#![cfg(feature = "cli")]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use all_smi::api::FrameBus;
+use all_smi::api::handlers::{metrics_handler, ready_handler};
+use all_smi::api::server_state::ApiState;
+use all_smi::app_state::AppState;
+use axum::{Router, routing::get};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::RwLock;
+use tokio::time::timeout;
+
+/// Hard ceiling on any single request in this suite. Everything here is
+/// in-process against a loopback listener, so a request that takes longer
+/// than this is hung, not slow.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+type Shared = Arc<RwLock<AppState>>;
+
+/// Build the router with the same two routes `server.rs` mounts for this
+/// contract, and hand back the shared state so a test can simulate the
+/// first collection cycle completing.
+fn build_router() -> (Router, Shared) {
+    let shared: Shared = Arc::new(RwLock::new(AppState::default()));
+    let bus = FrameBus::new(Duration::from_secs(3));
+    let state = ApiState::new(shared.clone(), bus);
+    let router = Router::new()
+        .route("/metrics", get(metrics_handler))
+        .route("/-/ready", get(ready_handler))
+        .with_state(state);
+    (router, shared)
+}
+
+async fn spawn_server(router: Router) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+/// Issue one HTTP/1.1 GET and return the whole raw response. `Connection:
+/// close` means the read terminates at EOF, so there is no framing logic
+/// here and no way for the read to hang past `REQUEST_TIMEOUT`.
+async fn http_get(addr: SocketAddr, path: &str) -> String {
+    let fut = async {
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        let request =
+            format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+        stream
+            .write_all(request.as_bytes())
+            .await
+            .expect("write request");
+        let mut buf = String::new();
+        stream
+            .read_to_string(&mut buf)
+            .await
+            .expect("read response");
+        buf
+    };
+    timeout(REQUEST_TIMEOUT, fut)
+        .await
+        .unwrap_or_else(|_| panic!("GET {path} did not complete within {REQUEST_TIMEOUT:?}"))
+}
+
+/// Split a raw HTTP response into (status line + headers, body).
+fn split_response(raw: &str) -> (&str, &str) {
+    raw.split_once("\r\n\r\n")
+        .unwrap_or_else(|| panic!("malformed HTTP response:\n{raw}"))
+}
+
+/// Simulate the collection loop finishing its first iteration.
+async fn complete_first_collection(shared: &Shared) {
+    shared.write().await.loading = false;
+}
+
+// ---------------------------------------------------------------------
+// /metrics: 200 throughout, never byte-empty.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn metrics_is_200_and_non_empty_before_the_first_collection() {
+    let (router, _shared) = build_router();
+    let addr = spawn_server(router).await;
+
+    let raw = http_get(addr, "/metrics").await;
+    let (head, body) = split_response(&raw);
+
+    assert!(
+        head.starts_with("HTTP/1.1 200 OK"),
+        "/metrics must stay 200 in the pre-first-collection window, got:\n{head}"
+    );
+    assert!(
+        !body.is_empty(),
+        "/metrics must never answer 200 with a byte-empty body (issue #324)"
+    );
+    assert!(
+        body.lines().any(|l| l.starts_with("all_smi_up{")),
+        "missing all_smi_up baseline:\n{body}"
+    );
+    assert!(
+        body.lines().any(|l| l.starts_with("all_smi_build_info{")),
+        "missing all_smi_build_info baseline:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn metrics_reports_up_zero_then_one_across_the_transition() {
+    let (router, shared) = build_router();
+    let addr = spawn_server(router).await;
+
+    let before = http_get(addr, "/metrics").await;
+    let (_, body) = split_response(&before);
+    let up = body
+        .lines()
+        .find(|l| l.starts_with("all_smi_up{"))
+        .expect("all_smi_up before collection");
+    assert!(
+        up.ends_with(" 0"),
+        "expected all_smi_up 0 before the first cycle, got: {up}"
+    );
+
+    complete_first_collection(&shared).await;
+
+    let after = http_get(addr, "/metrics").await;
+    let (_, body) = split_response(&after);
+    let up = body
+        .lines()
+        .find(|l| l.starts_with("all_smi_up{"))
+        .expect("all_smi_up after collection");
+    assert!(
+        up.ends_with(" 1"),
+        "expected all_smi_up 1 after the first cycle, got: {up}"
+    );
+}
+
+/// The exact regression that motivated the CI workaround in PR #323: a
+/// gate matching `^all_smi_` used to race the collection loop. With the
+/// baseline in place the pattern matches from the very first request.
+#[tokio::test]
+async fn an_all_smi_prefixed_line_exists_from_the_first_request() {
+    let (router, _shared) = build_router();
+    let addr = spawn_server(router).await;
+
+    let raw = http_get(addr, "/metrics").await;
+    let (_, body) = split_response(&raw);
+    assert!(
+        body.lines().any(|l| l.starts_with("all_smi_")),
+        "no ^all_smi_ line in the pre-first-collection body:\n{body}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// /-/ready: 503 before, 200 after.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn ready_is_503_before_the_first_collection() {
+    let (router, _shared) = build_router();
+    let addr = spawn_server(router).await;
+
+    let raw = http_get(addr, "/-/ready").await;
+    let (head, body) = split_response(&raw);
+
+    assert!(
+        head.starts_with("HTTP/1.1 503 Service Unavailable"),
+        "/-/ready must be 503 before the first collection cycle, got:\n{head}"
+    );
+    assert!(
+        head.to_ascii_lowercase().contains("retry-after: 1"),
+        "503 should advertise Retry-After, got:\n{head}"
+    );
+    assert!(
+        head.to_ascii_lowercase()
+            .contains("cache-control: no-store"),
+        "a readiness verdict must not be cacheable, got:\n{head}"
+    );
+    assert!(body.contains("not ready"), "unhelpful 503 body: {body:?}");
+}
+
+#[tokio::test]
+async fn ready_is_200_after_the_first_collection() {
+    let (router, shared) = build_router();
+    let addr = spawn_server(router).await;
+
+    complete_first_collection(&shared).await;
+
+    let raw = http_get(addr, "/-/ready").await;
+    let (head, body) = split_response(&raw);
+
+    assert!(
+        head.starts_with("HTTP/1.1 200 OK"),
+        "/-/ready must be 200 once a cycle has completed, got:\n{head}"
+    );
+    assert!(body.contains("ready"), "unhelpful 200 body: {body:?}");
+}
+
+/// `/-/ready` and `all_smi_up` are two views of one predicate. A consumer
+/// that gates on one and alerts on the other must never see them
+/// disagree, so assert them against each other on both sides of the
+/// transition rather than only in isolation.
+#[tokio::test]
+async fn ready_endpoint_and_up_gauge_never_disagree() {
+    let (router, shared) = build_router();
+    let addr = spawn_server(router).await;
+
+    for expect_ready in [false, true] {
+        if expect_ready {
+            complete_first_collection(&shared).await;
+        }
+
+        let ready_raw = http_get(addr, "/-/ready").await;
+        let (ready_head, _) = split_response(&ready_raw);
+        let endpoint_says_ready = ready_head.starts_with("HTTP/1.1 200 OK");
+
+        let metrics_raw = http_get(addr, "/metrics").await;
+        let (_, metrics_body) = split_response(&metrics_raw);
+        let gauge_says_ready = metrics_body
+            .lines()
+            .find(|l| l.starts_with("all_smi_up{"))
+            .expect("all_smi_up sample")
+            .ends_with(" 1");
+
+        assert_eq!(
+            endpoint_says_ready, gauge_says_ready,
+            "/-/ready and all_smi_up disagreed (expected ready={expect_ready})"
+        );
+        assert_eq!(endpoint_says_ready, expect_ready);
+    }
+}
+
+/// An unmounted neighbour of the readiness path must still 404. This
+/// guards against someone "fixing" the unusual `/-/` prefix by mounting a
+/// wildcard, which would silently answer 200 for typos.
+#[tokio::test]
+async fn unrelated_paths_are_not_captured_by_the_readiness_route() {
+    let (router, _shared) = build_router();
+    let addr = spawn_server(router).await;
+
+    let raw = http_get(addr, "/-/healthy").await;
+    let (head, _) = split_response(&raw);
+    assert!(
+        head.starts_with("HTTP/1.1 404"),
+        "only /-/ready is mounted; got:\n{head}"
+    );
+}

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -441,6 +441,11 @@ async fn prometheus_output_is_byte_identical_to_api_exporter_for_same_data() {
         // Snapshot mode has no live integrator — aligns with the
         // Prometheus serializer path.
         energy_integrator: None,
+        // The serializer under test hard-codes `ready: true` because it
+        // only runs after a synchronous collection (issue #324); match it
+        // so this stays a parity assertion rather than accidentally
+        // asserting the readiness flag has no effect on the output.
+        ready: true,
     };
     let expected = render_prometheus_exposition(&inputs);
 


### PR DESCRIPTION
## Summary

`/metrics` answered `200 OK` with a byte-empty body from the moment axum bound the listener until the first collection cycle landed, because the exposition renders straight from `AppState` and every exporter in the chain self-filters. A Prometheus scrape in that window is recorded as a *successful* scrape with zero samples: a silent gap in the series, not a failed target, so it does not alert. This gives the window a defined contract in two halves, without changing the status code `/metrics` returns.

## The contract shipped

**In band.** A new exporter, `src/api/metrics/exporter_status.rs`, is the one exporter that never self-filters. It emits two families ahead of every device family, on every response including the very first:

| Metric | Type | Value | Labels |
|--------|------|-------|--------|
| `all_smi_up` | gauge | `0` until the first collection cycle populates `AppState`, `1` afterwards | `instance`, `hostname` |
| `all_smi_build_info` | gauge | always `1` | `instance`, `hostname`, `version`, `os`, `arch` |

`/metrics` keeps answering `200` for its entire lifetime. Nothing about the existing scrape path changes; what changes is that "up but not ready" and "up with nothing to report" are now distinguishable without timing the scrape.

**Out of band.** `GET /-/ready`:

| Condition | Status | Headers |
|-----------|--------|---------|
| No collection cycle completed | `503 Service Unavailable` | `Retry-After: 1`, `Cache-Control: no-store` |
| At least one completed | `200 OK` | `Cache-Control: no-store` |

Both halves read one predicate, `api::handlers::ready::is_ready`, so the endpoint and the gauge cannot disagree. A test asserts exactly that on both sides of the transition.

### Why these details

**Build-info label set.** `version`, `os`, `arch`, plus the house `instance`/`hostname`. This mirrors the constant-`1` build-info idiom that `node_exporter` (`node_exporter_build_info`) and Prometheus itself (`prometheus_build_info`) use, where the content lives in the labels and `version` joins onto any other series with `* on (instance) group_left(version)`. `os`/`arch` are compile-time constants and this is a fleet tool whose premise is heterogeneous clusters, so "which build is on which kind of box" is worth answering. Deliberately **no git revision**: the crate has no build script that stamps one, and adding one would make otherwise identical builds differ. The repo exposed version only through `--version`, the TUI header, `doctor`, and `record` metadata, never through the Prometheus surface.

**`all_smi_up` labels.** It carries `instance` and `hostname`, matching the convention every other family here already uses. Prometheus supplies its own `instance` target label, but `all-smi view --hosts` scrapes these endpoints directly with no Prometheus in the middle and keys on the exporter-provided one, so omitting it would make the baseline the only unattributable family in the body. Both labels come from the same cached `get_hostname()` that `MemoryInfo.instance` and friends use, so there is no risk of a second spelling of the host breaking a join.

**`/-/ready` body.** `text/plain`, `all-smi is ready.` / `all-smi is not ready: no collection cycle has completed yet.`, mirroring Prometheus's own `/-/ready`. `Cache-Control: no-store` on both branches because a reverse proxy that caches the startup `503` turns a two-second window into an outage. `Retry-After: 1` on the `503` per RFC 9110, honest because readiness arrives within one collection interval.

## Decision: `mark_serving()` stays at bind

**It does not move behind the first collection cycle.** Reasoning, now recorded in the `mark_serving` doc comment and cross-referenced from `latch.rs`:

1. **They are different questions.** The SCM has no readiness concept; its state machine offers `SERVICE_START_PENDING` and `SERVICE_RUNNING`, and `SERVICE_RUNNING` is a liveness verdict. The natural liveness boundary for a network exporter is "the listener answers". This is the same liveness/readiness split Kubernetes and the Prometheus ecosystem already use, and readiness is now separately queryable by anyone who needs it.
2. **The inconsistency is fixed at the other end.** Before this PR the latch opened onto an endpoint serving zero bytes, so `SERVICE_RUNNING` genuinely promised nothing. Now the instant the latch opens there is a defined, non-empty response carrying `all_smi_up 0`. Giving `/metrics` a floor resolves the mismatch; delaying the latch is not needed to resolve it twice.
3. **Moving it has a worse failure mode than the one it prevents.** `src/service_cmd/scm_host.rs` reports `StartPending` exactly once, with `wait_hint = TRANSITION_WAIT_HINT_SECS` (10 s) and `checkpoint: 0`. Because the checkpoint never increments, that single report is the entire start budget the SCM grants. A first collection cycle on Windows means cold COM/WMI initialization plus NVML enumeration, which on a many-GPU host or behind a wedged driver can exceed 10 s. The SCM would fail the start and apply the configured recovery actions, restarting into the same slow path: a boot loop on exactly the hosts where the telemetry matters most. The same argument applies to any service that `depends_on` this one, which would otherwise block on hardware enumeration. Reporting RUNNING for a process that is up and honestly publishing `all_smi_up 0` is the better trade.

## What changed

- `src/api/metrics/exporter_status.rs` (new): the non-self-filtering baseline exporter, plus unit tests.
- `src/api/metrics/render.rs`: `MetricsRenderInputs` gains `ready: bool`; the baseline is prepended to the chain. Module doc corrected, it no longer claims the output can be empty.
- `src/api/handlers/ready.rs` (new): `/-/ready`, the shared `is_ready` predicate, and response-contract unit tests.
- `src/api/handlers/metrics_render.rs`: passes `ready` from the same lock acquisition as the data, so the gauge cannot disagree with the samples beside it. Status-code contract documented at the handler.
- `src/api/server.rs`: mounts `/-/ready`.
- `src/api/shutdown.rs`, `src/api/latch.rs`: `mark_serving` reasoning; vocabulary narrowed from "readiness latch" to "serving latch" so the two signals are not conflated again.
- `src/snapshot/serializers/prometheus.rs`: passes `ready: true`, since it only runs after a synchronous collection. Byte-identical parity with a live scrape is preserved and still asserted.
- `README.md`, `API.md`, `docs/man/all-smi.1`: the new endpoint, the two baseline families, PromQL examples, and guidance to point probes at `/-/ready` rather than `/metrics`.

### Drive-by correction

The man page's `API ENDPOINTS` section documented a `/health` endpoint "returning OK" that **has never existed** in the router (only `/metrics`, `/events`, `/snapshot` were ever mounted). The section now lists the real surface including `/-/ready`. This removes a documented-but-nonexistent endpoint rather than removing a feature.

## Test plan

- [x] `cargo test --test api_readiness_test` — 7 tests, all pass. Pins the contract behind the live route with an empty `AppState`: `/metrics` is 200 and non-empty pre-collection, `up` goes 0 then 1 across the transition, `^all_smi_` matches from the first request, `/-/ready` is 503 then 200 with the right headers, endpoint and gauge never disagree, and `/-/healthy` still 404s so nobody "fixes" the `/-/` prefix with a wildcard.
- [x] `cargo test --lib api::` — 113 pass.
- [x] `cargo test --test snapshot_test` — 13 pass, including `prometheus_output_is_byte_identical_to_api_exporter_for_same_data`.
- [x] `cargo clippy --lib --tests -- -D warnings` and `cargo clippy --bin all-smi -- -D warnings` — both clean. Checked separately because this crate compiles its module tree twice and #309/#310/#311 were each bitten by a `pub` item that was live in the library target and dead in the binary target.
- [x] `cargo fmt --check` — clean.
- [x] **Live binary, pre-first-collection window raced deliberately.** `/metrics` returned `HTTP 200` with **399 bytes instead of zero**, containing `all_smi_up{instance="...",hostname="..."} 0` and `all_smi_build_info{...,version="0.25.0",os="macos",arch="aarch64"} 1`. `/-/ready` in the same window returned `503 Service Unavailable` with `retry-after: 1` and `cache-control: no-store`. After the cycle landed, `/-/ready` returned `200 OK` with `all-smi is ready.` and `/metrics` reported `all_smi_up ... 1`.

### Not verified here

- Behavior under the Windows SCM. The `mark_serving()` reasoning above is derived from reading `scm_host.rs` (the single `StartPending` report, `wait_hint = 10 s`, `checkpoint: 0`) rather than from a live SCM run; the Windows smoke job is opt-in and needs a self-hosted elevated runner. No code on that path changed, so this is unchanged behavior with newly documented rationale, not a new claim.
- The launchd/systemd smoke jobs still gate on metric content. Migrating them onto `/-/ready` is #329's scope and lands next.

Closes #324
