### PR TITLE
fix(tui): survive a terminal that reports no size (#326)

### DIFF
--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -31,6 +31,17 @@ pub fn print_loading_indicator<W: Write>(
     frame_counter: u64,
     startup_status_lines: &[String],
 ) {
+    // A terminal with no cells has nowhere to put any of this, and every
+    // `MoveTo` below would address a position outside the window. Bail out
+    // rather than emit cursor motion into nothing (issue #326).
+    //
+    // This is only the panic-safety floor. The policy question of what to
+    // show on a terminal that is real but too small to be useful belongs to
+    // `ui::viewport`, which gates this function's callers well above 1x1.
+    if cols == 0 || rows == 0 {
+        return;
+    }
+
     // Center the loading message
     let message = "Loading...";
     let x = (cols.saturating_sub(message.len() as u16)) / 2;
@@ -39,36 +50,42 @@ pub fn print_loading_indicator<W: Write>(
     queue!(stdout, cursor::MoveTo(x, y)).unwrap();
     print_colored_text(stdout, message, Color::Yellow, None, None);
 
-    // Progress bar parameters
-    let bar_width = 40.min(cols as usize - SCREEN_MARGIN); // Ensure it fits on screen
+    // Progress bar parameters. A terminal narrower than SCREEN_MARGIN leaves
+    // no room at all, which `saturating_sub` reports as a zero-width bar.
+    let bar_width = 40.min((cols as usize).saturating_sub(SCREEN_MARGIN));
     let bar_x = (cols.saturating_sub(bar_width as u16)) / 2;
     let bar_y = y + 2; // 2 lines below "Loading..."
 
-    // Create animated progress bar
-    // Lower ANIMATION_SPEED = faster
-    let position = ((frame_counter / ANIMATION_SPEED) % (bar_width as u64 * 2)) as usize;
+    // Skip the bar when it has no width (the modulo below would divide by
+    // zero) or when it would land past the last row.
+    if bar_width > 0 && bar_y < rows {
+        // Create animated progress bar
+        // Lower ANIMATION_SPEED = faster
+        let position = ((frame_counter / ANIMATION_SPEED) % (bar_width as u64 * 2)) as usize;
 
-    // Calculate the sliding block position (ping-pong effect)
-    let block_size = BLOCK_SIZE_MAX.min(bar_width / BLOCK_SIZE_DIVISOR); // Calculate block size relative to bar width
-    let actual_pos = if position < bar_width {
-        position
-    } else {
-        bar_width * 2 - position - 1
-    };
-
-    // Ensure the block doesn't go out of bounds
-    let block_start = actual_pos.min(bar_width.saturating_sub(block_size));
-    let block_end = (block_start + block_size).min(bar_width);
-
-    // Move to progress bar position
-    queue!(stdout, cursor::MoveTo(bar_x, bar_y)).unwrap();
-
-    // Draw the progress bar with thinner characters
-    for i in 0..bar_width {
-        if i >= block_start && i < block_end {
-            print_colored_text(stdout, "━", Color::Cyan, None, None);
+        // Calculate the sliding block position (ping-pong effect)
+        let block_size = BLOCK_SIZE_MAX.min(bar_width / BLOCK_SIZE_DIVISOR); // Calculate block size relative to bar width
+        let actual_pos = if position < bar_width {
+            position
         } else {
-            print_colored_text(stdout, "─", Color::DarkGrey, None, None);
+            // `position` is a modulo of `bar_width * 2`, so this stays >= 0.
+            bar_width * 2 - position - 1
+        };
+
+        // Ensure the block doesn't go out of bounds
+        let block_start = actual_pos.min(bar_width.saturating_sub(block_size));
+        let block_end = (block_start + block_size).min(bar_width);
+
+        // Move to progress bar position
+        queue!(stdout, cursor::MoveTo(bar_x, bar_y)).unwrap();
+
+        // Draw the progress bar with thinner characters
+        for i in 0..bar_width {
+            if i >= block_start && i < block_end {
+                print_colored_text(stdout, "━", Color::Cyan, None, None);
+            } else {
+                print_colored_text(stdout, "─", Color::DarkGrey, None, None);
+            }
         }
     }
 
@@ -76,8 +93,13 @@ pub fn print_loading_indicator<W: Write>(
     if !startup_status_lines.is_empty() {
         let status_start_y = bar_y + 2; // 2 lines below the progress bar
 
-        // Calculate starting position to show last N lines that fit on screen
-        let max_lines = ((rows - status_start_y) - 1).min(10) as usize; // Show max 10 lines
+        // Calculate starting position to show last N lines that fit on screen.
+        // Saturating: on a short terminal `status_start_y` can already be at
+        // or past the last row, which means zero lines fit.
+        let max_lines = rows
+            .saturating_sub(status_start_y)
+            .saturating_sub(1)
+            .min(10) as usize; // Show max 10 lines
         let lines_to_show = startup_status_lines.len().min(max_lines);
         let start_idx = startup_status_lines.len().saturating_sub(lines_to_show);
 
@@ -109,8 +131,19 @@ pub fn print_function_keys<W: Write>(
     state: &AppState,
     is_remote: bool,
 ) {
+    // The status bar occupies the last row. A terminal reporting zero rows
+    // has no last row to occupy, and `rows - 1` used to underflow here and
+    // abort the process (issue #326). Emit nothing instead.
+    //
+    // This is the panic-safety floor only. Deciding that a real-but-tiny
+    // terminal should show a notice rather than a cramped frame is
+    // `ui::viewport`'s job, not this function's.
+    if rows == 0 {
+        return;
+    }
+
     // Move to bottom of screen
-    queue!(stdout, cursor::MoveTo(0, rows - 1)).unwrap();
+    queue!(stdout, cursor::MoveTo(0, rows.saturating_sub(1))).unwrap();
 
     // Precedence on the status bar:
     //
@@ -392,8 +425,26 @@ fn print_filter_bar<W: Write>(stdout: &mut W, cols: u16, state: &AppState) {
 
 #[cfg(test)]
 mod tests {
-    use super::print_function_keys;
+    use super::{print_function_keys, print_loading_indicator};
     use crate::app_state::{AppState, SortCriteria};
+    use crate::ui::viewport::{MIN_COLS, MIN_ROWS};
+
+    /// Every degenerate geometry the chrome has to survive. Zero and one in
+    /// both axes, plus the mixed cases: the panic in issue #326 was on rows,
+    /// not columns, so a width-only sweep would have missed it entirely.
+    const DEGENERATE_SIZES: &[(u16, u16)] = &[
+        (0, 0),
+        (1, 1),
+        (0, 1),
+        (1, 0),
+        (0, 24),
+        (80, 0),
+        (1, 24),
+        (80, 1),
+        (10, 24), // cols == SCREEN_MARGIN: zero-width progress bar
+        (11, 2),
+        (MIN_COLS, MIN_ROWS),
+    ];
 
     #[test]
     fn local_status_bar_advertises_cpu_sort_shortcut_and_indicator() {
@@ -426,5 +477,130 @@ mod tests {
             !rendered.contains("c:CPU"),
             "remote status bar must not advertise the local-only CPU shortcut.\n--- status ---\n{rendered}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Degenerate terminal geometry (issue #326).
+    //
+    // `script -q /dev/null all-smi local` hands the process a pty with no
+    // window size, so crossterm reports 0x0 and `rows - 1` in
+    // `print_function_keys` aborted the process. These drive the real
+    // rendering functions, not a copy of their arithmetic.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn function_keys_survive_every_degenerate_size() {
+        let state = AppState::new();
+        for &(cols, rows) in DEGENERATE_SIZES {
+            for is_remote in [false, true] {
+                let mut output = Vec::new();
+                print_function_keys(&mut output, cols, rows, &state, is_remote);
+                // Reaching here without unwinding is the assertion; before the
+                // fix this underflowed at every `rows == 0` entry.
+                if rows == 0 {
+                    assert!(
+                        output.is_empty(),
+                        "no row exists to draw the status bar on at {cols}x{rows}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn loading_indicator_survives_every_degenerate_size() {
+        // Non-empty status lines are required to reach the `rows -
+        // status_start_y - 1` subtraction, which is the second underflow the
+        // issue names.
+        let status_lines = [
+            "Detecting GPUs...".to_string(),
+            "\u{2713} Found 8 devices".to_string(),
+            "Connecting...".to_string(),
+        ];
+        for &(cols, rows) in DEGENERATE_SIZES {
+            for lines in [&[][..], &status_lines[..]] {
+                let mut output = Vec::new();
+                print_loading_indicator(&mut output, cols, rows, 0, lines);
+                if cols == 0 || rows == 0 {
+                    assert!(
+                        output.is_empty(),
+                        "nothing can be drawn into a {cols}x{rows} terminal"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn loading_indicator_animation_survives_a_zero_width_progress_bar() {
+        // At `cols == SCREEN_MARGIN` the bar has zero width. The frame
+        // counter feeds a `% (bar_width * 2)`, which is a division by zero
+        // unless the bar is skipped. Sweep several counters so the ping-pong
+        // branch is taken too.
+        for frame_counter in [0u64, 1, 7, 40, 4096] {
+            let mut output = Vec::new();
+            print_loading_indicator(&mut output, 10, 24, frame_counter, &[]);
+            assert!(
+                String::from_utf8(output)
+                    .expect("loading screen should be valid UTF-8")
+                    .contains("Loading"),
+                "the message still renders even when the bar does not"
+            );
+        }
+    }
+
+    #[test]
+    fn function_keys_still_render_at_the_minimum_supported_size() {
+        // The floor `ui::viewport` enforces must actually produce a status
+        // bar, otherwise the minimum is set below what the chrome can draw.
+        let state = AppState::new();
+        let mut output = Vec::new();
+        print_function_keys(&mut output, MIN_COLS, MIN_ROWS, &state, false);
+        let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
+        assert!(
+            rendered.contains("h:Help"),
+            "the minimum size must fit at least the first hotkey.\n--- status ---\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn function_keys_never_exceed_one_row_of_cells() {
+        // The status bar owns exactly one row, so it must never emit more
+        // printable cells than the terminal is wide. A regression here wraps
+        // the bar onto the row above and corrupts the frame.
+        let state = AppState::new();
+        for cols in [1u16, 2, 5, 13, MIN_COLS, 40, 200] {
+            let mut output = Vec::new();
+            print_function_keys(&mut output, cols, 24, &state, false);
+            let rendered = String::from_utf8(output).expect("status bar should be valid UTF-8");
+            let printable: String = strip_ansi(&rendered);
+            assert!(
+                crate::ui::text::display_width(&printable) <= cols as usize,
+                "status bar overflowed {cols} columns: {printable:?}"
+            );
+        }
+    }
+
+    /// Drop CSI escape sequences and the cursor-motion prefix so only the
+    /// cells that land on screen are measured.
+    fn strip_ansi(input: &str) -> String {
+        let mut out = String::with_capacity(input.len());
+        let mut chars = input.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c != '\u{1b}' {
+                out.push(c);
+                continue;
+            }
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                // A CSI sequence runs until a byte in the range 0x40..=0x7e.
+                for term in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&term) {
+                        break;
+                    }
+                }
+            }
+        }
+        out
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -35,4 +35,5 @@ pub mod scale;
 pub mod tabs;
 pub mod text;
 pub mod topology;
+pub mod viewport;
 pub mod widgets;

--- a/src/ui/viewport.rs
+++ b/src/ui/viewport.rs
@@ -1,0 +1,332 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Terminal geometry: how a reported size becomes a size we will render at.
+//!
+//! Every dimension the TUI uses enters through [`Viewport`], which separates
+//! two degenerate cases that look identical in the raw numbers but mean
+//! opposite things (issue #326).
+//!
+//! # Zero is "no geometry", not "a terminal of size zero"
+//!
+//! A pty allocated without a `TIOCSWINSZ` has no window size, so `TIOCGWINSZ`
+//! reports zero rows and zero columns and `crossterm::terminal::size` returns
+//! `Ok((0, 0))`. `script -q /dev/null all-smi local` produces exactly this, as
+//! do some CI harnesses and terminal multiplexer edge cases. Zero there means
+//! "nobody ever told the kernel how big this window is", and there is very
+//! likely a real terminal of ordinary size on the far end of the pty. Refusing
+//! to draw would be the wrong reading of the signal, so an absent dimension is
+//! replaced by `$COLUMNS` / `$LINES` when the environment supplies one and by
+//! the conventional 80x24 otherwise. This is the same fallback order ncurses
+//! uses, and it is what makes the TUI drivable under `script` at all.
+//!
+//! # A tiny terminal is real and must be believed
+//!
+//! 12x2 is not missing geometry, it is an operator who dragged the window
+//! that small. Substituting a size there would be a lie and would scribble
+//! outside the visible area. Below [`MIN_COLS`] x [`MIN_ROWS`] the TUI renders
+//! a single-line notice instead of a frame and recovers on the next resize.
+
+use crossterm::terminal;
+
+use crate::ui::text::{display_width, truncate_to_width};
+
+/// Narrowest terminal the TUI will compose a frame for.
+///
+/// This is not a taste judgement, it is the width above every unchecked
+/// width subtraction in the renderer set. The binding constraint is the
+/// three-gauge GPU row in `renderers/gpu_renderer.rs`, which computes
+/// `available_width - (num_gauges - 1) * 2` over `width.saturating_sub(10)`
+/// and therefore needs `width >= 14`; the Apple Silicon CPU row needs 12, and
+/// the chassis, storage and single-gauge CPU rows need 5. Twenty clears all of
+/// them with room to spare and is also the point where the shortest status bar
+/// text (`h:Help q:Exit`, 13 columns) stops being the whole line.
+pub const MIN_COLS: u16 = 20;
+
+/// Shortest terminal the TUI will compose a frame for: one header row, one
+/// row of actual content, and the status bar that always occupies the last
+/// row. Two rows would be pure chrome with nothing between it.
+pub const MIN_ROWS: u16 = 3;
+
+/// Column count assumed when the terminal reports none.
+pub const FALLBACK_COLS: u16 = 80;
+
+/// Row count assumed when the terminal reports none.
+pub const FALLBACK_ROWS: u16 = 24;
+
+/// A terminal geometry that has already been through [`Viewport::resolve`],
+/// so neither dimension is zero.
+///
+/// The fields are public and there is deliberately no bare constructor:
+/// building one literally is legal but visibly bypasses resolution, which is
+/// what the tests below want and what production code never wants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Viewport {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+impl Viewport {
+    /// Resolve a raw size as reported by the terminal, substituting a
+    /// fallback for any dimension the terminal could not supply.
+    ///
+    /// Substitution is per-dimension: a terminal that knows its width but not
+    /// its height keeps the width it reported.
+    #[must_use]
+    pub fn resolve(raw_cols: u16, raw_rows: u16) -> Self {
+        Self {
+            cols: resolve_dimension(raw_cols, "COLUMNS", FALLBACK_COLS),
+            rows: resolve_dimension(raw_rows, "LINES", FALLBACK_ROWS),
+        }
+    }
+
+    /// Read the current terminal geometry and resolve it.
+    ///
+    /// `terminal::size` failing outright is treated the same as it reporting
+    /// zeros: geometry is unavailable, so fall back rather than abandon the
+    /// frame. A monitoring TUI that quits because one `ioctl` blipped is
+    /// worse than one that keeps drawing at an assumed size.
+    #[must_use]
+    pub fn current() -> Self {
+        match terminal::size() {
+            Ok((cols, rows)) => Self::resolve(cols, rows),
+            Err(_) => Self::resolve(0, 0),
+        }
+    }
+
+    /// Whether a normal frame is worth composing at this size.
+    #[must_use]
+    pub fn is_renderable(self) -> bool {
+        self.cols >= MIN_COLS && self.rows >= MIN_ROWS
+    }
+
+    /// The single line shown in place of a frame when the terminal is below
+    /// the minimum. Always fits within `cols`, down to and including zero.
+    ///
+    /// Deliberately plain text with no color escapes: it has to survive being
+    /// squeezed into a handful of columns, and staying plain makes it
+    /// greppable in a captured session transcript.
+    #[must_use]
+    pub fn too_small_notice(self) -> String {
+        let Self { cols, rows } = self;
+        let width = cols as usize;
+
+        let long =
+            format!("all-smi needs at least {MIN_COLS}x{MIN_ROWS}, this terminal is {cols}x{rows}");
+        if display_width(&long) <= width {
+            return long;
+        }
+
+        let short = format!("{cols}x{rows} < {MIN_COLS}x{MIN_ROWS}");
+        if display_width(&short) <= width {
+            return short;
+        }
+
+        truncate_to_width(&short, width).into_owned()
+    }
+}
+
+/// Resolve one dimension: keep what the terminal reported when it reported
+/// anything, otherwise consult the environment, otherwise use the fallback.
+///
+/// The environment lookup only happens on the zero path, so the common case
+/// costs nothing.
+fn resolve_dimension(raw: u16, env_key: &str, fallback: u16) -> u16 {
+    if raw > 0 {
+        return raw;
+    }
+    dimension_from_env(std::env::var(env_key).ok().as_deref(), fallback)
+}
+
+/// The environment half of [`resolve_dimension`], split out so it can be
+/// tested without mutating the process environment (which would race against
+/// every other test in the binary).
+fn dimension_from_env(value: Option<&str>, fallback: u16) -> u16 {
+    value
+        .and_then(|value| value.trim().parse::<u16>().ok())
+        .filter(|&parsed| parsed > 0)
+        .unwrap_or(fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Zero means "geometry unavailable" and is replaced, not believed.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn zero_size_resolves_to_the_fallback_geometry() {
+        // The `script -q /dev/null all-smi local` case: the pty never had a
+        // window size set, so both dimensions come back as zero.
+        let viewport = Viewport::resolve(0, 0);
+        assert_eq!(viewport.cols, FALLBACK_COLS);
+        assert_eq!(viewport.rows, FALLBACK_ROWS);
+        assert!(
+            viewport.is_renderable(),
+            "a pty with no geometry must still render a normal frame"
+        );
+    }
+
+    #[test]
+    fn substitution_is_per_dimension() {
+        // A terminal that reported one real dimension keeps it; only the
+        // missing one is invented.
+        assert_eq!(
+            Viewport::resolve(0, 30),
+            Viewport {
+                cols: FALLBACK_COLS,
+                rows: 30
+            }
+        );
+        assert_eq!(
+            Viewport::resolve(100, 0),
+            Viewport {
+                cols: 100,
+                rows: FALLBACK_ROWS
+            }
+        );
+    }
+
+    #[test]
+    fn a_real_size_passes_through_untouched() {
+        assert_eq!(
+            Viewport::resolve(100, 30),
+            Viewport {
+                cols: 100,
+                rows: 30
+            }
+        );
+        // Including a real size below the minimum: resolve must not "fix" it,
+        // because believing the operator is the whole point of the split.
+        assert_eq!(Viewport::resolve(12, 2), Viewport { cols: 12, rows: 2 });
+    }
+
+    #[test]
+    fn environment_supplies_a_missing_dimension_when_it_is_usable() {
+        // `$COLUMNS` / `$LINES` are the operator's way to drive the TUI at a
+        // chosen size under a pty that has none, which is what makes an
+        // automated session capture reproducible.
+        assert_eq!(dimension_from_env(Some("120"), FALLBACK_COLS), 120);
+        assert_eq!(dimension_from_env(Some("  40  "), FALLBACK_COLS), 40);
+    }
+
+    #[test]
+    fn unusable_environment_values_fall_through_to_the_fallback() {
+        for value in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("abc"),
+            Some("-5"),
+            Some("99999"),
+        ] {
+            assert_eq!(
+                dimension_from_env(value, FALLBACK_COLS),
+                FALLBACK_COLS,
+                "{value:?} must not be trusted as a dimension"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The renderable floor.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn renderable_floor_is_inclusive_and_rejects_just_below() {
+        assert!(
+            Viewport {
+                cols: MIN_COLS,
+                rows: MIN_ROWS
+            }
+            .is_renderable()
+        );
+        assert!(
+            !Viewport {
+                cols: MIN_COLS - 1,
+                rows: MIN_ROWS
+            }
+            .is_renderable()
+        );
+        assert!(
+            !Viewport {
+                cols: MIN_COLS,
+                rows: MIN_ROWS - 1
+            }
+            .is_renderable()
+        );
+    }
+
+    #[test]
+    fn degenerate_and_tiny_sizes_are_not_renderable() {
+        // These never reach the renderers in production, because ui_loop
+        // gates on `is_renderable`. The test pins that contract.
+        for (cols, rows) in [
+            (0, 0),
+            (1, 1),
+            (0, 30),
+            (200, 0),
+            (200, 1),
+            (20, 2),
+            (19, 3),
+        ] {
+            assert!(
+                !Viewport { cols, rows }.is_renderable(),
+                "{cols}x{rows} must not be treated as renderable"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The notice always fits the width it is given.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn notice_never_exceeds_the_available_width() {
+        // Bounded sweep over every width the notice could face, including
+        // zero and one.
+        for cols in 0u16..=90 {
+            let notice = Viewport { cols, rows: 2 }.too_small_notice();
+            assert!(
+                display_width(&notice) <= cols as usize,
+                "notice {notice:?} overflows {cols} columns"
+            );
+        }
+    }
+
+    #[test]
+    fn notice_states_both_the_requirement_and_the_actual_size() {
+        let notice = Viewport { cols: 80, rows: 2 }.too_small_notice();
+        assert!(notice.contains("20x3"), "notice must state the minimum");
+        assert!(notice.contains("80x2"), "notice must state what it got");
+    }
+
+    #[test]
+    fn notice_degrades_to_a_short_form_when_the_long_one_will_not_fit() {
+        // 24 columns cannot hold the sentence but can hold "24x2 < 20x3".
+        let notice = Viewport { cols: 24, rows: 2 }.too_small_notice();
+        assert_eq!(notice, "24x2 < 20x3");
+    }
+
+    #[test]
+    fn notice_is_plain_text_with_no_escape_sequences() {
+        let notice = Viewport { cols: 80, rows: 2 }.too_small_notice();
+        assert!(
+            !notice.contains('\u{1b}'),
+            "notice must stay greppable in a captured transcript"
+        );
+    }
+}

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -14,10 +14,7 @@
 
 use std::time::Duration;
 
-use crossterm::{
-    event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind},
-    terminal::size,
-};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
 use crate::app_state::{AppState, FilterInputMode, SortCriteria};
 use crate::cli::ViewArgs;
@@ -26,6 +23,7 @@ use crate::ui::aggregation::user::{UserSortKey, sort_users};
 use crate::ui::filter_dsl::{apply as apply_filter, parse as parse_filter};
 use crate::ui::layout::LayoutCalculator;
 use crate::ui::tabs::{topology_tab_index, users_tab_index};
+use crate::ui::viewport::Viewport;
 
 /// Upper bound on the filter input buffer size (bytes).
 ///
@@ -42,7 +40,7 @@ fn get_visible_process_rows(state: &AppState) -> usize {
         state.visible_process_rows
     } else {
         // Fallback for the first frame before rendering has set the value
-        let (_cols, rows) = size().unwrap_or((80, 24));
+        let rows = Viewport::current().rows;
         (rows / 2).saturating_sub(1) as usize
     }
 }
@@ -935,7 +933,7 @@ fn handle_right_arrow(state: &mut AppState) {
 
             // If we're moving to a node tab (not "All" tab), check if we need to scroll
             if state.current_tab > 0 {
-                let (cols, _) = size().unwrap();
+                let cols = Viewport::current().cols;
                 let mut available_width = cols.saturating_sub(8); // Space for "Tabs: " prefix
 
                 // Reserve space for "All" tab (always visible)
@@ -1077,7 +1075,7 @@ fn handle_page_up(state: &mut AppState, args: &ViewArgs) {
     let is_remote = args.hosts.is_some() || args.hostfile.is_some() || args.replay.is_some();
     if is_remote {
         // Remote mode - page up through GPU list
-        let (_cols, rows) = size().unwrap();
+        let rows = Viewport::current().rows;
         let content_start_row = 19;
         let available_rows = rows.saturating_sub(content_start_row).saturating_sub(1) as usize;
 
@@ -1125,7 +1123,7 @@ fn handle_page_down(state: &mut AppState, args: &ViewArgs) {
     let is_remote = args.hosts.is_some() || args.hostfile.is_some() || args.replay.is_some();
     if is_remote {
         // Remote mode - page down through GPU list
-        let (_cols, rows) = size().unwrap();
+        let rows = Viewport::current().rows;
         let content_start_row = 19;
         let available_rows = rows.saturating_sub(content_start_row).saturating_sub(1) as usize;
 
@@ -1209,15 +1207,14 @@ fn handle_process_header_click(x: u16, y: u16, state: &mut AppState) {
     }
 
     // Get terminal size to calculate process list position
-    let (_cols, rows) = match size() {
-        Ok((c, r)) => (c, r),
-        Err(_) => return,
-    };
+    let rows = Viewport::current().rows;
 
     // Calculate where the process header should be
-    // The header is at half_rows - 1 based on testing
+    // The header is at half_rows - 1 based on testing.
+    // Saturating: a one-row terminal puts `half_rows` at zero, and this
+    // subtraction used to underflow on the mouse-click path (issue #326).
     let half_rows = rows / 2;
-    let process_header_row = half_rows - 1;
+    let process_header_row = half_rows.saturating_sub(1);
 
     // Check if click is on the process header row
     if y != process_header_row {

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -1180,4 +1180,157 @@ mod tests {
         let snapshot = make_remote_topology_snapshot(Some("ghost"));
         assert_eq!(topology_target_host(&snapshot), "host1");
     }
+
+    // -----------------------------------------------------------------------
+    // Degenerate and minimum terminal geometry (issue #326).
+    //
+    // `ui::viewport::MIN_COLS` claims to sit above every unchecked width
+    // subtraction in the renderer set. That claim is only worth anything if
+    // it is checked against a snapshot that actually reaches those
+    // renderers, so these drive real device rows rather than the empty
+    // snapshot the smoke tests above use.
+    // -----------------------------------------------------------------------
+
+    fn make_gpu(uuid: &str, name: &str) -> crate::device::GpuInfo {
+        crate::device::GpuInfo {
+            uuid: uuid.to_string(),
+            time: String::new(),
+            name: name.to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "localhost".to_string(),
+            hostname: "testhost".to_string(),
+            instance: "testhost".to_string(),
+            utilization: 42.0,
+            ane_utilization: 5.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 61,
+            used_memory: 8 * 1024 * 1024 * 1024,
+            total_memory: 24 * 1024 * 1024 * 1024,
+            frequency: 1400,
+            power_consumption: 120.0,
+            gpu_core_count: Some(38),
+            temperature_threshold_slowdown: Some(93),
+            temperature_threshold_shutdown: Some(98),
+            temperature_threshold_max_operating: Some(87),
+            temperature_threshold_acoustic: None,
+            performance_state: Some(2),
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
+            detail: HashMap::new(),
+        }
+    }
+
+    fn make_cpu() -> crate::device::CpuInfo {
+        use crate::device::{CoreType, CoreUtilization, CpuPlatformType};
+        crate::device::CpuInfo {
+            index: 0,
+            host_id: "localhost".to_string(),
+            hostname: "testhost".to_string(),
+            instance: "testhost".to_string(),
+            cpu_model: "Test CPU".to_string(),
+            architecture: "aarch64".to_string(),
+            platform_type: CpuPlatformType::AppleSilicon,
+            socket_count: 1,
+            total_cores: 4,
+            total_threads: 4,
+            base_frequency_mhz: 2400,
+            max_frequency_mhz: 3600,
+            cache_size_mb: 16,
+            utilization: 37.5,
+            temperature: Some(55),
+            power_consumption: Some(18.0),
+            per_socket_info: Vec::new(),
+            apple_silicon_info: None,
+            per_core_utilization: (0..4)
+                .map(|i| CoreUtilization {
+                    core_id: i,
+                    core_type: CoreType::Standard,
+                    utilization: f64::from(i) * 20.0,
+                })
+                .collect(),
+            time: String::new(),
+        }
+    }
+
+    /// A local-mode snapshot carrying device rows, so `render_main` walks the
+    /// GPU and CPU gauge renderers instead of short-circuiting on empty
+    /// vectors. The Apple-named GPU is deliberate: it selects the
+    /// three-gauge layout in `gpu_renderer`, which is the narrowest-tolerant
+    /// row in the whole renderer set.
+    fn make_populated_snapshot() -> RenderSnapshot {
+        let mut state = AppState::new();
+        state.is_local_mode = true;
+        state.gpu_info = vec![
+            make_gpu("gpu-0", "Apple M3 Max"),
+            make_gpu("gpu-1", "NVIDIA H100 80GB HBM3"),
+        ];
+        state.cpu_info = vec![make_cpu()];
+        RenderSnapshot::capture(&mut state)
+    }
+
+    #[test]
+    fn render_paths_survive_every_size_at_or_above_the_minimum() {
+        use crate::ui::viewport::{MIN_COLS, MIN_ROWS};
+
+        let snapshot = make_populated_snapshot();
+        let args = make_local_args();
+
+        // Bounded sweep across the interesting band just above the floor,
+        // plus a couple of ordinary sizes. Every width in this range crosses
+        // at least one gauge-layout branch.
+        for cols in MIN_COLS..=(MIN_COLS + 12) {
+            for rows in MIN_ROWS..=(MIN_ROWS + 6) {
+                let (main, _) = FrameRenderer::render_main(&snapshot, &args, cols, rows, None);
+                assert!(
+                    !main.is_empty(),
+                    "render_main produced nothing at {cols}x{rows}"
+                );
+                let _ = FrameRenderer::render_loading(&snapshot, false, cols, rows);
+                let _ = FrameRenderer::render_loading(&snapshot, true, cols, rows);
+                let _ = FrameRenderer::render_help(&snapshot, &args, cols, rows);
+                let _ = FrameRenderer::render_alert_panel(&snapshot, cols, rows);
+            }
+        }
+    }
+
+    #[test]
+    fn render_paths_survive_a_resolved_zero_size_pty() {
+        use crate::ui::viewport::Viewport;
+
+        // End to end for the reported reproduction: a pty with no window
+        // size reports 0x0, `Viewport` resolves it, and the frame composes
+        // normally. Before the fix this aborted in `print_function_keys`.
+        let viewport = Viewport::resolve(0, 0);
+        assert!(viewport.is_renderable());
+
+        let snapshot = make_populated_snapshot();
+        let args = make_local_args();
+        let (content, _) =
+            FrameRenderer::render_main(&snapshot, &args, viewport.cols, viewport.rows, None);
+        assert!(content.contains("all-smi"));
+        assert!(
+            content.contains("h:Help"),
+            "the status bar must render on a resolved zero-size pty"
+        );
+    }
+
+    #[test]
+    fn tall_help_popup_survives_a_one_column_terminal() {
+        use crate::ui::viewport::Viewport;
+
+        // The help popup only reaches its two-column shortcut layout once
+        // the terminal is tall enough, so a narrow-and-tall geometry is the
+        // one that exercises `help.rs`'s width arithmetic. Production gates
+        // this size out, which the assertion records.
+        assert!(!Viewport { cols: 1, rows: 40 }.is_renderable());
+
+        let snapshot = make_populated_snapshot();
+        let args = make_local_args();
+        let resolved = Viewport::resolve(0, 40);
+        let _ = FrameRenderer::render_help(&snapshot, &args, resolved.cols, resolved.rows);
+    }
 }

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -16,13 +16,14 @@ use std::collections::HashSet;
 use std::io::Write;
 use std::sync::Arc;
 
-use crossterm::{cursor, event::Event, queue, terminal::size};
+use crossterm::{cursor, event::Event, queue};
 use tokio::sync::{Mutex, Notify};
 
 use crate::app_state::AppState;
 use crate::cli::ViewArgs;
 use crate::common::config::AppConfig;
 use crate::ui::buffer::DifferentialRenderer;
+use crate::ui::viewport::Viewport;
 use crate::view::event_handler::handle_key_event;
 use crate::view::frame_renderer::FrameRenderer;
 use crate::view::render_snapshot::{RenderDecisions, RenderSnapshot};
@@ -48,6 +49,9 @@ pub struct UiLoop {
     previous_gpu_filter_enabled: bool,
     previous_alert_panel_open: bool,
     previous_filter_is_active: bool,
+    /// Whether the last iteration rendered the too-small notice instead of a
+    /// frame, so the transition back can repaint from scratch.
+    previous_too_small: bool,
     /// Cached derived view data (sorted GPU lists, filtered host subsets, etc.)
     view_cache: ViewCache,
     /// Event coordinator for event-driven wakeups
@@ -87,6 +91,7 @@ impl UiLoop {
             previous_gpu_filter_enabled: false,
             previous_alert_panel_open: false,
             previous_filter_is_active: false,
+            previous_too_small: false,
             view_cache: ViewCache::new(),
             event_coordinator,
             #[cfg(target_os = "linux")]
@@ -284,10 +289,44 @@ impl UiLoop {
             // ------------------------------------------------------------------
             // Frame composition: operates entirely on the snapshot, no lock held.
             // ------------------------------------------------------------------
-            let (cols, rows) = match size() {
-                Ok((c, r)) => (c, r),
-                Err(_) => return Err("Failed to get terminal size".into()),
-            };
+            let viewport = Viewport::current();
+            let (cols, rows) = (viewport.cols, viewport.rows);
+
+            // Terminals below the minimum cannot hold a frame: the header,
+            // one content row and the status bar do not fit, and the gauge
+            // renderers have no room to lay out. Show a one-line notice and
+            // skip composition entirely. `UiEvent::Resize` wakes the loop, so
+            // growing the window recovers on its own (issue #326).
+            //
+            // A pty reporting no geometry never lands here. `Viewport`
+            // resolved that to the fallback size above, because "the kernel
+            // does not know how big this window is" is a different statement
+            // from "this window is too small to draw in".
+            if !viewport.is_renderable() {
+                if !self.previous_too_small {
+                    self.previous_too_small = true;
+                    self.view_cache.invalidate_all();
+                    self.differential_renderer.force_clear().ok();
+                }
+                if self
+                    .differential_renderer
+                    .render_differential(&viewport.too_small_notice(), cols, rows)
+                    .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
+
+            // Coming back from the notice: the screen holds one stale line
+            // and the cache was dropped, so repaint from scratch.
+            if self.previous_too_small {
+                self.previous_too_small = false;
+                self.view_cache.invalidate_all();
+                if self.differential_renderer.force_clear().is_err() {
+                    break;
+                }
+            }
 
             if decisions.force_clear {
                 self.view_cache.invalidate_all();


### PR DESCRIPTION
## Summary

`all-smi local` aborted the moment it was handed a pty with no window size. `TIOCGWINSZ` reports zero on such a pty, `crossterm::terminal::size` faithfully returns `Ok((0, 0))`, and `rows - 1` in `print_function_keys` underflowed. The fix makes the arithmetic safe, but the substance of it is deciding what a zero size actually means and what the TUI should do at sizes where a frame is meaningless.

## The design decision

**Zero is "no geometry available", not "a terminal of size zero".** A pty allocated without a `TIOCSWINSZ` has never been told how big it is, and there is almost always an ordinary terminal on the far end. Rendering nothing there would be the wrong reading of the signal, and it would keep the TUI untestable, which is the reason PR #317 had to call `print_cpu_info` directly instead of driving a real session. So a missing dimension is replaced, per dimension, by `$COLUMNS` / `$LINES` when the environment supplies a usable value and by the conventional 80x24 otherwise. That is the fallback order ncurses uses.

**A tiny terminal is real and is believed.** 12x2 is not missing geometry, it is an operator who dragged the window that small. Substituting a size there would be a lie. Below the minimum the loop renders a single-line notice and skips composition; `UiEvent::Resize` already wakes the loop, so growing the window recovers on its own. Exiting was rejected because no TUI quits when you drag it narrow, and blocking is just this without a repaint.

**The minimum is 20x3, and the width half is measured rather than chosen by taste.** 20 sits above every unchecked width subtraction in the renderer set: the binding constraint is the three-gauge GPU row in `gpu_renderer.rs`, which needs 14, followed by the Apple Silicon CPU row at 12 and the chassis, storage and single-gauge CPU rows at 5. It is also where the shortest status bar text (`h:Help q:Exit`, 13 columns) stops being the entire line. 3 rows is a header row, one row of content, and the status bar that always owns the last row.

The gate and the saturating arithmetic are both required. A gate alone leaves the help, alert and replay paths underflowing and leaves a window between sampling the size and rendering; saturation alone closes the issue while drawing garbage into a one-row window.

## Sweep

`ast-grep` over `src/ui` and `src/view` for `$A - $B`, `$A / $B` and `$A % $B`, filtered to dimension operands. Beyond the two sites the issue named it found three more reachable faults and a set of already-safe matches.

Fixed:

| Site | Fault |
|---|---|
| `chrome.rs:113` | `rows - 1` underflows at 0 rows. The reported panic. |
| `chrome.rs:80` | `(rows - status_start_y) - 1` underflows whenever the status block starts at or past the last row. |
| `chrome.rs:43` | `cols as usize - SCREEN_MARGIN` underflows below 10 columns. Not in the issue. |
| `chrome.rs:49` | `% (bar_width * 2)` divides by zero at exactly 10 columns. Not in the issue. |
| `event_handler.rs:1220` | `half_rows - 1` underflows at 0 or 1 rows, on the mouse-click path. Not in the issue. |

Left alone, with reasons: `chrome.rs:56` (`position` is a modulo of `bar_width * 2`, so the result cannot go below zero, and it now sits inside the `bar_width > 0` guard); `chrome.rs:237` and `frame_renderer.rs:168` (subtrahend bounded by `.min()` / an `if`); `help.rs:37,47,119` (evaluated only inside `for row in 0..height`, so `height >= 1`); `help.rs:527`, `led_grid.rs:146`, `topology/graph_render.rs:274`, `topology/matrix_render.rs:174` (guarded by an early return on the narrow case); `braille.rs:225`, `activity_panel.rs:290`, `user_renderer.rs:513` (loop-bound indices, and `graph_row_color` already special-cases zero); `layout.rs:162,192` (guarded, and `#[allow(dead_code)]`); `process_renderer.rs:91,649` (both behind explicit width comparisons).

Not fixed and reported rather than silently widened: the gauge renderers (`gpu_renderer.rs:439,444`, `cpu_renderer.rs:444,449,504,687`, `chassis_renderer.rs:247`, `storage_renderer.rs:135`) and `help.rs:348` still use unchecked subtraction. They are unreachable below the 20-column floor, which the sweep test pins with a populated snapshot rather than by assertion. Hardening all eight would be a wide diff across files #325 is also touching, for no behavior change below the gate.

## What changed

- `src/ui/viewport.rs` (new): `Viewport` with `resolve`, `current`, `is_renderable`, `too_small_notice`, and the `MIN_COLS` / `MIN_ROWS` / `FALLBACK_*` constants, each carrying the reasoning for its value.
- `src/ui/chrome.rs`: guarded and saturating arithmetic in both functions, plus an early return when there are no cells to draw into. The policy question is explicitly delegated to `ui::viewport` in comments so the two layers do not drift.
- `src/view/ui_loop.rs`: geometry now comes from `Viewport::current`; the too-small branch renders the notice and forces a repaint on the way in and out.
- `src/view/event_handler.rs`: same geometry source, which also retires three `size().unwrap()` calls that would have aborted on a failed ioctl, and one saturating fix.

## Test plan

- [x] `cargo test --lib ui::` — 559 passed. Includes 7 new `ui::chrome` and 11 new `ui::viewport` tests.
- [x] `cargo test --bin all-smi view::` — 123 passed. `view` is only in the binary target, so `--lib` never compiles it; the 3 new `frame_renderer` tests live here.
- [x] `cargo clippy --lib --tests -- -D warnings` — clean.
- [x] `cargo clippy --bin all-smi --tests -- -D warnings` — clean. Run separately on purpose: the crate compiles its module tree twice and this caught a `pub` item that was live in the library and dead in the binary.
- [x] `cargo fmt --check` — clean.

Regression coverage is at 0 and 1 in **both** axes, not just width: the reported panic was on rows, so a width-only sweep would have missed it. `chrome.rs` drives the real `print_function_keys` and `print_loading_indicator` across eleven degenerate geometries including the mixed `(0, 24)` and `(80, 0)` cases and the `cols == SCREEN_MARGIN` zero-width-bar case. `frame_renderer.rs` sweeps every size from 20x3 to 32x9 through `render_main`, `render_loading`, `render_help` and `render_alert_panel` with a snapshot carrying two GPUs and a CPU, which is what actually proves the 20-column floor clears the gauge cliffs.

## End-to-end verification

`script` needs a controlling terminal, which the agent shell does not have, so verification used a `forkpty()` harness that leaves the window size unset. That produces the identical condition: `TIOCGWINSZ` returns zeros and `crossterm::terminal::size` returns `Ok((0, 0))`.

Before, on `1f540e1`:

```
[pty winsize: rows=0 cols=0]
thread 'main' (32556106) panicked at src/ui/chrome.rs:113:38:
attempt to subtract with overflow
[exit status: 25856]      # 101 << 8
```

After, same harness, screen reconstructed from the captured escape stream at the 80x24 fallback:

```
[pty winsize: rows=0 cols=0]
[captured 38927 bytes, child status None]
 0 |all-smi - 2026-08-06 21:21:08                                            v0.25.0
 1 |Host cube.local · Apple M1 Ultra · arch arm64 · up 7d 0h 24m    ● Live
 2 |CPU  10.9%↓      ⢸⣤⣄  GPU  31.1%↑      ⢀⣼⣾  RAM  42/128GB→      ⢰⣶⣶  Pwr   5.0W↘
 3 |NODE cube.loca Pwr:   5.0W Thermal: Nominal │ CPU:  4.4W GPU:  0.7W ANE:  0.0W
 4 |     Power: [▬▬───────────────────────────────────────────────────    5.0W]
 5 |     Energy session: 43.7 J  |  $0.00 (at $0.12/kWh)
 6 |GPU  a GPU   Apple M Util: 31.1% VRAM: 42.3/128GB Temp:  51°C Freq:638MHz Pwr:
 7 |     Util : [▬▬▬▬─   31.1%]  Mem  : [▬▬▬▬─  42.3GB]  ANE  : [─────    0.0W]
 8 |CPU  Apple M1 Ultra  Arch:arm64 Sockets: 1 Cores:16P+ 4E Freq: 1.30+1.58GHz Temp
 9 |     P-CPU: [▬────────────────    5.4%]  E-CPU: [▬▬▬▬▬▬▬▬─────────   33.2%]
10 |Host Memory          Total:   128GB Used:  42.3GB Avail: 120.1GB Util: 33.0%
...
20 |── Processes ───────────────────────────────────────────────────────────────────
21 |    PID USER         PRI  NI   VIRT    RES S  CPU%  MEM%  GPU%    VRAM      TIME
23 |Showing 1-0 of 500 processes (Use ↑↓ to navigate, PgUp/PgDn for pages)
```

A real 12x2 terminal takes the other branch and emits 82 bytes rather than a garbled frame:

```
[pty winsize: rows=2 cols=12]
[captured 82 bytes, child status None]
 0 |12x2 < 20x3
```

1x1 degrades the same way, to the one character that fits. `COLUMNS=100 LINES=12` over a zero-size pty renders a full 100x12 frame, which is the mechanism that makes an automated session capture reproducible at a chosen size.

## Not verified

Recovery from the notice back to a normal frame relies on `UiEvent::Resize`, which the loop already handles; the transition is covered by reading the code and by the `force_clear` on both edges, but it was not driven end to end, since resizing a pty mid-session was outside what the harness needed to do. The whole-suite `cargo test` was not run under the agent's time budget; the scoped runs above cover every module this PR touches and CI runs the rest.

Closes #326
