### PR TITLE
fix: omit Apple Silicon GPU metrics instead of reporting 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,14 +641,19 @@ jobs:
           curl -sf --max-time 10 localhost:9090/metrics | grep -q '^all_smi_build_info'
           # Assert a specific device family rather than only "some line".
           # The runner is a VM with no IOReport, so the native metrics
-          # manager fails to initialize and the GPU and chassis readers
-          # degrade to zeros and to nothing respectively. The memory
-          # reader is pure sysinfo with no failure path at all
-          # (src/device/memory_macos.rs), which makes this the one line
-          # guaranteed to be present on any macOS host. Distinct from the
-          # baseline above: this one proves a collection cycle actually
+          # manager fails to initialize: the chassis reader emits nothing
+          # and the GPU reader omits every series it would have sourced
+          # from IOReport/SMC (issue #325 -- it used to publish those as
+          # zeros, which was indistinguishable from an idle GPU). The
+          # memory reader is pure sysinfo with no failure path at all
+          # (src/device/memory_macos.rs), which makes this the one device
+          # line guaranteed to be present on any macOS host. Distinct from
+          # the baseline above: this one proves a collection cycle actually
           # produced data, which is what `/-/ready` gated on.
           curl -sf --max-time 10 localhost:9090/metrics | grep -q '^all_smi_memory_total_bytes'
+          # And the degradation must stay honest: no fabricated GPU
+          # utilization on a host that cannot measure it.
+          ! curl -sf --max-time 10 localhost:9090/metrics | grep -q '^all_smi_gpu_utilization'
           grep -q "API server listening" "$LOG"
 
           "$BIN" service restart --user

--- a/src/api/collection_loop.rs
+++ b/src/api/collection_loop.rs
@@ -97,8 +97,8 @@ pub async fn run_collection_loop(
             .map(|mut ci| {
                 // Aggregate GPU power into chassis total if not already set.
                 if ci.total_power_watts.is_none() {
-                    let total_gpu_power: f64 =
-                        all_gpu_info.iter().map(|g| g.power_consumption).sum();
+                    let total_gpu_power =
+                        crate::metrics::gpu_readings::total_power_watts(&all_gpu_info);
                     if total_gpu_power > 0.0 {
                         ci.total_power_watts = Some(total_gpu_power);
                     }
@@ -178,11 +178,17 @@ pub(crate) fn integrate_power_samples(state: &mut AppState) {
     // `state.energy`.
     let mut samples: Vec<(EnergyKey, f64)> =
         Vec::with_capacity(state.gpu_info.len() + state.cpu_info.len() + state.chassis_info.len());
+    // Devices with no power reading contribute no sample: the integrator's
+    // "has this device ever been seen?" check is what drives the exporter's
+    // omit-on-no-data behavior, and feeding it the unavailable sentinel would
+    // accumulate negative joules (issue #325).
     for gpu in &state.gpu_info {
-        samples.push((
-            EnergyKey::gpu(gpu.hostname.clone(), gpu.uuid.clone()),
-            gpu.power_consumption,
-        ));
+        if let Some(watts) = gpu.power_consumption_reading() {
+            samples.push((
+                EnergyKey::gpu(gpu.hostname.clone(), gpu.uuid.clone()),
+                watts,
+            ));
+        }
     }
     for cpu in &state.cpu_info {
         if let Some(power) = cpu.power_consumption {

--- a/src/api/metrics/gpu.rs
+++ b/src/api/metrics/gpu.rs
@@ -34,11 +34,25 @@ impl<'a> GpuMetricExporter<'a> {
             ("gpu_index", row.index_str.as_str()),
         ];
 
-        // GPU utilization
-        builder
-            .help("all_smi_gpu_utilization", "GPU utilization percentage")
-            .type_("all_smi_gpu_utilization", "gauge")
-            .metric("all_smi_gpu_utilization", &base_labels, info.utilization);
+        // GPU utilization.
+        //
+        // Omitted when the reader had no source for it, following the same
+        // Prometheus "absence means no data" convention this exporter already
+        // applies to `all_smi_gpu_performance_state` and the thermal
+        // thresholds below. Emitting `0` instead would be indistinguishable
+        // from a genuinely idle GPU (issue #325); `all_smi_gpu_info` is still
+        // emitted for the device, so a consumer can tell "device present but
+        // not reporting" from "device gone" and, on Apple Silicon, read the
+        // reason off the `native_metrics` label.
+        if let Some(utilization) = info.utilization_reading() {
+            builder
+                .help(
+                    "all_smi_gpu_utilization",
+                    "GPU utilization percentage (omitted when the device reports no utilization)",
+                )
+                .type_("all_smi_gpu_utilization", "gauge")
+                .metric("all_smi_gpu_utilization", &base_labels, utilization);
+        }
 
         // Memory metrics
         builder
@@ -62,47 +76,57 @@ impl<'a> GpuMetricExporter<'a> {
                 info.total_memory,
             );
 
-        // Temperature
-        builder
-            .help(
-                "all_smi_gpu_temperature_celsius",
-                "GPU temperature in celsius",
-            )
-            .type_("all_smi_gpu_temperature_celsius", "gauge")
-            .metric(
-                "all_smi_gpu_temperature_celsius",
-                &base_labels,
-                info.temperature,
-            );
+        // Temperature. Omitted when no sensor answered — a powered die never
+        // reads 0 °C, so the old unconditional `0` made a missing SMC/NVML
+        // key look like a cryogenic GPU.
+        if let Some(temperature) = info.temperature_reading() {
+            builder
+                .help(
+                    "all_smi_gpu_temperature_celsius",
+                    "GPU temperature in celsius (omitted when no sensor reports one)",
+                )
+                .type_("all_smi_gpu_temperature_celsius", "gauge")
+                .metric("all_smi_gpu_temperature_celsius", &base_labels, temperature);
+        }
 
-        // Power consumption
-        builder
-            .help(
-                "all_smi_gpu_power_consumption_watts",
-                "GPU power consumption in watts",
-            )
-            .type_("all_smi_gpu_power_consumption_watts", "gauge")
-            .metric(
-                "all_smi_gpu_power_consumption_watts",
-                &base_labels,
-                info.power_consumption,
-            );
+        // Power consumption. Omitted when the device exposes no power rail.
+        if let Some(power) = info.power_consumption_reading() {
+            builder
+                .help(
+                    "all_smi_gpu_power_consumption_watts",
+                    "GPU power consumption in watts (omitted when the device reports no power)",
+                )
+                .type_("all_smi_gpu_power_consumption_watts", "gauge")
+                .metric("all_smi_gpu_power_consumption_watts", &base_labels, power);
+        }
 
-        // Frequency
-        builder
-            .help("all_smi_gpu_frequency_mhz", "GPU frequency in MHz")
-            .type_("all_smi_gpu_frequency_mhz", "gauge")
-            .metric("all_smi_gpu_frequency_mhz", &base_labels, info.frequency);
+        // Frequency. Omitted when the platform has no clock probe. This also
+        // covers the readers that have always reported a static `0` to mean
+        // "no probe" (Rebellions, Intel Gaudi, AMD via WMI), which the TUI
+        // already rendered as N/A; the exposition now agrees with it instead
+        // of publishing a flat 0 MHz line.
+        if let Some(frequency) = info.frequency_reading() {
+            builder
+                .help(
+                    "all_smi_gpu_frequency_mhz",
+                    "GPU frequency in MHz (omitted when the device exposes no clock probe)",
+                )
+                .type_("all_smi_gpu_frequency_mhz", "gauge")
+                .metric("all_smi_gpu_frequency_mhz", &base_labels, frequency);
+        }
 
-        // ANE utilization (Apple Silicon)
-        builder
-            .help("all_smi_ane_utilization", "ANE utilization in mW")
-            .type_("all_smi_ane_utilization", "gauge")
-            .metric(
-                "all_smi_ane_utilization",
-                &base_labels,
-                info.ane_utilization,
-            );
+        // ANE utilization (Apple Silicon). Non-Apple readers set this to a
+        // literal 0.0 meaning "not applicable" and keep emitting it, so this
+        // gate only fires for an Apple Silicon row with no live sample.
+        if let Some(ane) = info.ane_utilization_reading() {
+            builder
+                .help(
+                    "all_smi_ane_utilization",
+                    "ANE utilization in mW (omitted when the native metrics source is unavailable)",
+                )
+                .type_("all_smi_ane_utilization", "gauge")
+                .metric("all_smi_ane_utilization", &base_labels, ane);
+        }
 
         // DLA utilization (if available)
         if let Some(dla_util) = info.dla_utilization {
@@ -126,15 +150,17 @@ impl<'a> GpuMetricExporter<'a> {
             ("gpu_index", row.index_str.as_str()),
         ];
 
-        // ANE power in watts
-        builder
-            .help("all_smi_ane_power_watts", "ANE power consumption in watts")
-            .type_("all_smi_ane_power_watts", "gauge")
-            .metric(
-                "all_smi_ane_power_watts",
-                &base_labels,
-                info.ane_utilization / 1000.0,
-            );
+        // ANE power in watts. Same source as `all_smi_ane_utilization`, so
+        // the two families appear and disappear together.
+        if let Some(ane_mw) = info.ane_utilization_reading() {
+            builder
+                .help(
+                    "all_smi_ane_power_watts",
+                    "ANE power consumption in watts (omitted when the native metrics source is unavailable)",
+                )
+                .type_("all_smi_ane_power_watts", "gauge")
+                .metric("all_smi_ane_power_watts", &base_labels, ane_mw / 1000.0);
+        }
 
         // Thermal pressure level
         if let Some(thermal_level) = info.detail.get("thermal_pressure") {
@@ -586,6 +612,93 @@ mod tests {
         assert!(output.contains("all_smi_gpu_temperature_threshold_shutdown_celsius"));
         assert!(!output.contains("all_smi_gpu_temperature_threshold_max_operating_celsius"));
         assert!(!output.contains("all_smi_gpu_temperature_threshold_acoustic_celsius"));
+    }
+
+    /// Issue #325: an Apple Silicon row whose native metrics manager never
+    /// initialized must omit the value series rather than publish zeros.
+    #[test]
+    fn exporter_omits_series_with_no_reading() {
+        use crate::device::types::GPU_METRIC_UNAVAILABLE;
+
+        let mut gpu = make_nvidia_gpu();
+        gpu.name = "Apple M2 Max GPU".to_string();
+        gpu.utilization = GPU_METRIC_UNAVAILABLE;
+        gpu.power_consumption = GPU_METRIC_UNAVAILABLE;
+        gpu.ane_utilization = GPU_METRIC_UNAVAILABLE;
+        gpu.temperature = 0;
+        gpu.frequency = 0;
+        gpu.detail
+            .insert("native_metrics".to_string(), "unavailable".to_string());
+
+        let output = GpuMetricExporter::new(&[gpu]).export_metrics();
+
+        for family in [
+            "all_smi_gpu_utilization{",
+            "all_smi_gpu_power_consumption_watts{",
+            "all_smi_gpu_temperature_celsius{",
+            "all_smi_gpu_frequency_mhz{",
+            "all_smi_ane_utilization{",
+            "all_smi_ane_power_watts{",
+        ] {
+            assert!(
+                !output.contains(family),
+                "{family} must be omitted, not emitted as 0:\n{output}"
+            );
+        }
+
+        // The sentinel must never appear on the wire in any form.
+        assert!(
+            !output.contains(" -1"),
+            "the in-band unavailable encoding leaked into the exposition:\n{output}"
+        );
+
+        // The device must still be discoverable, and must say why.
+        let info_line = output
+            .lines()
+            .find(|l| l.starts_with("all_smi_gpu_info{"))
+            .expect("identity series must survive");
+        assert!(
+            info_line.contains("native_metrics=\"unavailable\""),
+            "{info_line}"
+        );
+        // Memory comes from sysinfo, not IOReport, so it keeps reporting.
+        assert!(output.contains("all_smi_gpu_memory_total_bytes{"));
+    }
+
+    /// The other half of the contract: a real zero is still published, so
+    /// omission unambiguously means "no data".
+    #[test]
+    fn exporter_emits_genuine_zero_readings() {
+        let mut gpu = make_nvidia_gpu();
+        gpu.utilization = 0.0;
+        gpu.power_consumption = 0.0;
+        gpu.temperature = 42;
+        gpu.frequency = 300;
+
+        let output = GpuMetricExporter::new(&[gpu]).export_metrics();
+
+        let util = output
+            .lines()
+            .find(|l| l.starts_with("all_smi_gpu_utilization{"))
+            .expect("idle GPU must still report 0% utilization");
+        assert!(util.ends_with(" 0"), "expected a zero reading, got {util}");
+
+        let power = output
+            .lines()
+            .find(|l| l.starts_with("all_smi_gpu_power_consumption_watts{"))
+            .expect("a 0 W rail is a reading");
+        assert!(power.ends_with(" 0"), "{power}");
+    }
+
+    /// Non-Apple readers set `ane_utilization` to a literal 0.0 meaning "not
+    /// applicable". That has always been published and must keep being
+    /// published, so this change does not silently alter NVIDIA scrapes.
+    #[test]
+    fn exporter_keeps_emitting_zero_ane_for_non_apple_gpus() {
+        let output = GpuMetricExporter::new(&[make_nvidia_gpu()]).export_metrics();
+        assert!(output.contains("all_smi_ane_utilization{"));
+        // `all_smi_ane_power_watts` stays Apple-only, as before.
+        assert!(!output.contains("all_smi_ane_power_watts{"));
     }
 
     #[test]

--- a/src/device/macos_native/manager.rs
+++ b/src/device/macos_native/manager.rs
@@ -36,6 +36,58 @@
 //!     println!("CPU Power: {:.2}W", data.cpu_power_mw / 1000.0);
 //! }
 //! ```
+//!
+//! ## Degradation policy when this manager is unavailable (issue #325)
+//!
+//! [`NativeMetricsManager::new`] fails whenever `IOReport::new()` fails,
+//! which is the normal state on a macOS host with no IOReport: a VM, a
+//! hardened sandbox, a hosted CI runner. When it does,
+//! [`initialize_native_metrics_manager`] leaves the singleton empty and
+//! [`get_native_metrics_manager`] returns `None` for the rest of the
+//! process's life. There is no retry and no partial mode.
+//!
+//! **Every reader that depends on this manager must signal absence rather
+//! than substitute a value.** Concretely, the four macOS readers:
+//!
+//! | Reader | Behavior with no manager |
+//! |---|---|
+//! | Memory (`device::memory_macos`) | Unaffected. Reads `sysinfo`, never touches this manager, has no failure path. |
+//! | CPU (`device::cpu_macos`) | Partial. `utilization` still comes from `sysinfo`; the fields this manager feeds (`temperature`, `power_consumption`, per-cluster frequencies) are `Option` and become `None`. Base/max frequency falls back to `sysctl`. |
+//! | Chassis (`device::readers::chassis::apple_silicon_native`) | Absent. `get_chassis_info` returns `None`, so no chassis series is emitted at all. Every field it reports comes from this manager, so there is nothing left to report. |
+//! | GPU (`device::readers::apple_silicon_native`) | Partial, like CPU. The row is still emitted, because identity (`sysctl`) and unified memory (`sysinfo`) remain valid. The live fields carry the "no reading" encoding described below. |
+//!
+//! The rule that unifies them: **a reader emits a row when it can still say
+//! something true about the device, and marks the individual fields it could
+//! not source as absent. It never substitutes `0`.** Zero is a legitimate
+//! reading for an idle GPU or a parked ANE, so a consumer that sees `0` must
+//! be able to trust it.
+//!
+//! `GpuInfo`'s live fields are not `Option`, so absence is encoded in-band
+//! and read back through the accessors on
+//! [`crate::device::GpuInfo`]: `utilization_reading`,
+//! `ane_utilization_reading`, `power_consumption_reading`,
+//! `temperature_reading`, `frequency_reading`. See
+//! [`crate::device::types::GPU_METRIC_UNAVAILABLE`] for why that encoding
+//! exists rather than `Option<f64>`.
+//!
+//! That in-band encoding is an internal detail and must never reach a
+//! consumer. It is translated at each boundary:
+//!
+//! * **Prometheus** (`api::metrics::gpu`): the series is omitted. This is
+//!   Prometheus' own convention for "no data" and the same thing this
+//!   exporter already does for `all_smi_gpu_performance_state` and the
+//!   thermal thresholds. `all_smi_gpu_info` is still emitted, carrying a
+//!   `native_metrics="unavailable"` label, so the device stays discoverable
+//!   and the reason is queryable. `all_smi_up` and `all_smi_build_info`
+//!   (issue #324) mean the body is never empty either way.
+//! * **TUI** (`ui::renderers::gpu_renderer`): the field renders `N/A` and
+//!   its gauge draws empty with an `N/A` label, never a 0%-filled bar.
+//! * **Remote scrape** (`network::metrics_parser`): a `GpuInfo` starts with
+//!   every live field absent and only the series present in the scrape
+//!   overwrite it, so omission survives the round trip instead of being
+//!   re-zeroed on the viewing side.
+//! * **Aggregation** (`metrics::gpu_readings`): absent fields are excluded
+//!   from means and sums rather than folded in as zero.
 
 use super::ioreport::{IOReport, IOReportMetrics};
 use super::metrics::NativeMetricsData;

--- a/src/device/readers/apple_silicon_native.rs
+++ b/src/device/readers/apple_silicon_native.rs
@@ -28,6 +28,7 @@ use crate::device::macos_native::{
     NativeMetricsManager, get_native_metrics_manager, initialize_native_metrics_manager,
 };
 use crate::device::readers::common_cache::{DetailBuilder, DeviceStaticInfo};
+use crate::device::types::GPU_METRIC_UNAVAILABLE;
 use crate::device::{GpuInfo, GpuReader, ProcessInfo};
 use crate::utils::get_hostname;
 use chrono::Local;
@@ -140,119 +141,39 @@ impl GpuReader for AppleSiliconNativeGpuReader {
         // Ensure GPU info is initialized (happens on first call)
         self.ensure_initialized();
 
-        // Try to get metrics from native manager
-        let (metrics, combined_power_mw, cpu_temp, gpu_temp) =
-            if let Some(manager) = self.native_manager.get() {
-                match manager.collect_once() {
-                    Ok(data) => {
-                        let combined_power = data.combined_power_mw;
-                        (
-                            GpuMetrics {
-                                utilization: Some(data.gpu_active_residency),
-                                ane_utilization: Some(data.ane_power_mw),
-                                frequency: Some(data.gpu_frequency),
-                                power_consumption: Some(data.gpu_power_mw / 1000.0),
-                                thermal_pressure_level: data.thermal_pressure_level,
-                            },
-                            Some(combined_power),
-                            data.cpu_temperature,
-                            data.gpu_temperature,
-                        )
-                    }
-                    Err(_) => (GpuMetrics::default(), None, None, None),
-                }
-            } else {
-                (GpuMetrics::default(), None, None, None)
-            };
+        // `None` is the degraded path. Either the native metrics manager
+        // never initialized (no IOReport on this host: a VM, a hardened
+        // sandbox, a hosted macOS runner) and the process-wide singleton is
+        // permanently empty, or a single collection failed. Both mean the
+        // same thing to everything downstream: this reader has no live
+        // numbers to report this cycle.
+        let sample = self
+            .native_manager
+            .get()
+            .and_then(|manager| manager.collect_once().ok())
+            .map(|data| NativeSample {
+                utilization: data.gpu_active_residency,
+                ane_power_mw: data.ane_power_mw,
+                frequency: data.gpu_frequency,
+                power_watts: data.gpu_power_mw / 1000.0,
+                thermal_pressure_level: data.thermal_pressure_level,
+                combined_power_mw: data.combined_power_mw,
+                cpu_temperature: data.cpu_temperature,
+                gpu_temperature: data.gpu_temperature,
+            });
 
-        // Get cached static info
-        let static_info = match self.static_info.get() {
-            Some(info) => info,
-            None => {
-                // Fallback if initialization failed
-                return vec![];
-            }
+        // Static identity comes from sysctl/system_profiler, not from
+        // IOReport, so it survives the degraded path. Only a failure to
+        // identify the GPU at all suppresses the row.
+        let Some(static_info) = self.static_info.get() else {
+            return vec![];
         };
-        let apple_info = self.apple_info.get();
 
-        let mut detail = static_info.detail.clone();
-        detail.insert("architecture".to_string(), "Apple Silicon".to_string());
-        detail.insert("api".to_string(), "Native (IOReport/SMC)".to_string());
-
-        if let Some(ref thermal_level) = metrics.thermal_pressure_level {
-            detail.insert("thermal_pressure".to_string(), thermal_level.clone());
-        }
-
-        // Add combined power (CPU + GPU + ANE) for metrics export
-        if let Some(combined_power) = combined_power_mw {
-            detail.insert("combined_power_mw".to_string(), combined_power.to_string());
-        }
-
-        // Add temperature metrics from SMC
-        if let Some(cpu_t) = cpu_temp {
-            detail.insert("cpu_temperature".to_string(), format!("{cpu_t:.1}"));
-        }
-        if let Some(gpu_t) = gpu_temp {
-            detail.insert("gpu_temperature".to_string(), format!("{gpu_t:.1}"));
-        }
-
-        // Add unified AI acceleration library labels
-        detail.insert("lib_name".to_string(), "Metal".to_string());
-        if let Some(driver_ver) = static_info.detail.get("driver_version")
-            && driver_ver != "Unknown"
-        {
-            let lib_ver = driver_ver
-                .strip_prefix("Metal ")
-                .unwrap_or(driver_ver)
-                .to_string();
-            detail.insert("lib_version".to_string(), lib_ver);
-        }
-
-        // GPU temperature: Apple Silicon's per-die GPU thermistor keys (Tg*) are
-        // not always exposed reliably across chip generations. When SMC didn't
-        // return a usable value, fall back to the CPU die temperature — CPU and
-        // GPU share the same SoC package so the readings are tightly correlated
-        // and this is far more meaningful than reporting 0 °C.
-        let temperature = gpu_temp.or(cpu_temp).map(|t| t.round() as u32).unwrap_or(0);
-
-        vec![GpuInfo {
-            uuid: static_info
-                .uuid
-                .clone()
-                .unwrap_or_else(|| "AppleSiliconGPU".to_string()),
-            time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
-            name: static_info.name.clone(),
-            device_type: "GPU".to_string(),
-            host_id: get_hostname(),
-            hostname: get_hostname(),
-            instance: get_hostname(),
-            utilization: metrics.utilization.unwrap_or(0.0),
-            ane_utilization: metrics.ane_utilization.unwrap_or(0.0),
-            dla_utilization: None,
-            tensorcore_utilization: None,
-            temperature,
-            used_memory: get_used_memory(),
-            total_memory: get_total_memory(),
-            frequency: metrics.frequency.unwrap_or(0),
-            power_consumption: metrics.power_consumption.unwrap_or(0.0),
-            gpu_core_count: apple_info.and_then(|i| i.gpu_core_count),
-            // Apple Silicon reports thermal pressure as a qualitative enum
-            // (Nominal / Fair / Serious / Critical) via the `detail` map, not
-            // as NVML-style numeric thresholds. Leave these fields empty.
-            // NVIDIA-specific hardware details (NUMA, GSP firmware, NvLink,
-            // GPM) do not apply to Apple Silicon either.
-            temperature_threshold_slowdown: None,
-            temperature_threshold_shutdown: None,
-            temperature_threshold_max_operating: None,
-            temperature_threshold_acoustic: None,
-            performance_state: None,
-            numa_node_id: None,
-            gsp_firmware_mode: None,
-            gsp_firmware_version: None,
-            nvlink_remote_devices: Vec::new(),
-            gpm_metrics: None,
-            detail,
-        }]
+        vec![build_gpu_info(
+            static_info,
+            self.apple_info.get(),
+            sample.as_ref(),
+        )]
     }
 
     fn get_process_info(&self) -> Vec<ProcessInfo> {
@@ -262,13 +183,140 @@ impl GpuReader for AppleSiliconNativeGpuReader {
     }
 }
 
-#[derive(Default)]
-struct GpuMetrics {
-    utilization: Option<f64>,
-    ane_utilization: Option<f64>,
-    frequency: Option<u32>,
-    power_consumption: Option<f64>,
+/// One successful collection from the native metrics manager.
+///
+/// Every field here is unconditionally present on `NativeMetricsData`, so an
+/// `Option<NativeSample>` carries exactly one bit of information: whether the
+/// native source produced anything at all. The two `Option` members below are
+/// SMC sensors that can individually be missing while IOReport is healthy.
+struct NativeSample {
+    utilization: f64,
+    ane_power_mw: f64,
+    frequency: u32,
+    power_watts: f64,
     thermal_pressure_level: Option<String>,
+    combined_power_mw: f64,
+    cpu_temperature: Option<f64>,
+    gpu_temperature: Option<f64>,
+}
+
+/// Assemble the `GpuInfo` row from cached static identity plus an optional
+/// live sample.
+///
+/// Split out of [`AppleSiliconNativeGpuReader::get_gpu_info`] so the
+/// manager-unavailable path is reachable from a test without needing a host
+/// that lacks IOReport: passing `sample: None` drives exactly the branch a
+/// macOS VM takes. See the `degraded_*` tests at the bottom of this file.
+///
+/// When `sample` is `None` the live fields are filled with this crate's
+/// "no reading" encodings ([`GPU_METRIC_UNAVAILABLE`] for the `f64` fields,
+/// `0` for the `u32` fields) rather than with `0.0`, so that neither the
+/// Prometheus exporter nor the TUI can mistake a dead IOReport subscription
+/// for an idle GPU. The policy is documented on
+/// `crate::device::macos_native::manager`.
+fn build_gpu_info(
+    static_info: &DeviceStaticInfo,
+    apple_info: Option<&AppleSiliconInfo>,
+    sample: Option<&NativeSample>,
+) -> GpuInfo {
+    let mut detail = static_info.detail.clone();
+    detail.insert("architecture".to_string(), "Apple Silicon".to_string());
+    detail.insert("api".to_string(), "Native (IOReport/SMC)".to_string());
+
+    // Explicit, queryable reason for the omitted series. The value series
+    // disappear (Prometheus' own convention for "no data"), but the identity
+    // series `all_smi_gpu_info` is still emitted and now carries why, so a
+    // consumer can tell "this Mac has no IOReport" apart from "all-smi is not
+    // running" without inspecting the absence pattern.
+    detail.insert(
+        "native_metrics".to_string(),
+        if sample.is_some() {
+            "available".to_string()
+        } else {
+            "unavailable".to_string()
+        },
+    );
+
+    if let Some(thermal_level) = sample.and_then(|s| s.thermal_pressure_level.as_ref()) {
+        detail.insert("thermal_pressure".to_string(), thermal_level.clone());
+    }
+
+    // Add combined power (CPU + GPU + ANE) for metrics export
+    if let Some(combined_power) = sample.map(|s| s.combined_power_mw) {
+        detail.insert("combined_power_mw".to_string(), combined_power.to_string());
+    }
+
+    // Add temperature metrics from SMC
+    let cpu_temp = sample.and_then(|s| s.cpu_temperature);
+    let gpu_temp = sample.and_then(|s| s.gpu_temperature);
+    if let Some(cpu_t) = cpu_temp {
+        detail.insert("cpu_temperature".to_string(), format!("{cpu_t:.1}"));
+    }
+    if let Some(gpu_t) = gpu_temp {
+        detail.insert("gpu_temperature".to_string(), format!("{gpu_t:.1}"));
+    }
+
+    // Add unified AI acceleration library labels
+    detail.insert("lib_name".to_string(), "Metal".to_string());
+    if let Some(driver_ver) = static_info.detail.get("driver_version")
+        && driver_ver != "Unknown"
+    {
+        let lib_ver = driver_ver
+            .strip_prefix("Metal ")
+            .unwrap_or(driver_ver)
+            .to_string();
+        detail.insert("lib_version".to_string(), lib_ver);
+    }
+
+    // GPU temperature: Apple Silicon's per-die GPU thermistor keys (Tg*) are
+    // not always exposed reliably across chip generations. When SMC didn't
+    // return a usable value, fall back to the CPU die temperature — CPU and
+    // GPU share the same SoC package so the readings are tightly correlated
+    // and this is far more meaningful than reporting 0 °C. When neither
+    // sensor answered, `0` is the struct's "unknown" encoding for
+    // `temperature` (see `GpuInfo::temperature_reading`), not a reading.
+    let temperature = gpu_temp.or(cpu_temp).map(|t| t.round() as u32).unwrap_or(0);
+
+    GpuInfo {
+        uuid: static_info
+            .uuid
+            .clone()
+            .unwrap_or_else(|| "AppleSiliconGPU".to_string()),
+        time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+        name: static_info.name.clone(),
+        device_type: "GPU".to_string(),
+        host_id: get_hostname(),
+        hostname: get_hostname(),
+        instance: get_hostname(),
+        utilization: sample.map_or(GPU_METRIC_UNAVAILABLE, |s| s.utilization),
+        ane_utilization: sample.map_or(GPU_METRIC_UNAVAILABLE, |s| s.ane_power_mw),
+        dla_utilization: None,
+        tensorcore_utilization: None,
+        temperature,
+        // Unified memory is read from sysinfo, not from IOReport, so these
+        // stay valid on the degraded path and the row keeps reporting them.
+        used_memory: get_used_memory(),
+        total_memory: get_total_memory(),
+        frequency: sample.map_or(0, |s| s.frequency),
+        power_consumption: sample.map_or(GPU_METRIC_UNAVAILABLE, |s| s.power_watts),
+        gpu_core_count: apple_info.and_then(|i| i.gpu_core_count),
+        // Apple Silicon reports thermal pressure as a qualitative enum
+        // (Nominal / Fair / Serious / Critical) via the `detail` map, not
+        // as NVML-style numeric thresholds. Leave these fields empty.
+        // NVIDIA-specific hardware details (NUMA, GSP firmware, NvLink,
+        // GPM) do not apply to Apple Silicon either.
+        temperature_threshold_slowdown: None,
+        temperature_threshold_shutdown: None,
+        temperature_threshold_max_operating: None,
+        temperature_threshold_acoustic: None,
+        performance_state: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
+        detail,
+    }
 }
 
 fn get_gpu_name_and_version() -> (String, Option<String>) {
@@ -412,6 +460,184 @@ fn get_used_memory() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    fn static_info() -> DeviceStaticInfo {
+        DeviceStaticInfo::with_details(
+            "Apple M2 Max GPU".to_string(),
+            None,
+            DetailBuilder::new()
+                .insert("gpu_type", "Integrated")
+                .insert("driver_version", "Metal 3")
+                .build(),
+        )
+    }
+
+    /// A live sample whose live values all happen to be zero: an idle GPU
+    /// with the ANE parked. This is the reading that must stay a reading.
+    fn idle_sample() -> NativeSample {
+        NativeSample {
+            utilization: 0.0,
+            ane_power_mw: 0.0,
+            frequency: 338,
+            power_watts: 0.0,
+            thermal_pressure_level: Some("Nominal".to_string()),
+            combined_power_mw: 1200.0,
+            cpu_temperature: Some(48.6),
+            gpu_temperature: Some(46.2),
+        }
+    }
+
+    /// The macOS-VM case from issue #325: `get_native_metrics_manager()`
+    /// returned `None`, so no sample exists. Every live field must read as
+    /// absent, not as zero.
+    #[test]
+    fn degraded_path_reports_absence_not_zero() {
+        let info = build_gpu_info(&static_info(), None, None);
+
+        assert_eq!(
+            info.utilization_reading(),
+            None,
+            "utilization must be absent"
+        );
+        assert_eq!(
+            info.power_consumption_reading(),
+            None,
+            "power must be absent"
+        );
+        assert_eq!(
+            info.temperature_reading(),
+            None,
+            "temperature must be absent"
+        );
+        assert_eq!(info.frequency_reading(), None, "frequency must be absent");
+        assert_eq!(info.ane_utilization_reading(), None, "ANE must be absent");
+    }
+
+    /// End-to-end across the seam this issue is actually about: a row built
+    /// by the real reader on the degraded path, rendered by the real
+    /// Prometheus exporter. This is what a scrape of a macOS host with no
+    /// IOReport now looks like.
+    #[test]
+    fn degraded_row_renders_no_gpu_value_series() {
+        use crate::api::metrics::{MetricExporter, gpu::GpuMetricExporter};
+
+        let rendered =
+            GpuMetricExporter::new(&[build_gpu_info(&static_info(), None, None)]).export_metrics();
+
+        for family in [
+            "all_smi_gpu_utilization{",
+            "all_smi_gpu_power_consumption_watts{",
+            "all_smi_gpu_temperature_celsius{",
+            "all_smi_gpu_frequency_mhz{",
+            "all_smi_ane_utilization{",
+            "all_smi_ane_power_watts{",
+        ] {
+            assert!(!rendered.contains(family), "{family} leaked:\n{rendered}");
+        }
+        assert!(rendered.contains("native_metrics=\"unavailable\""));
+        assert!(rendered.contains("all_smi_gpu_memory_total_bytes{"));
+    }
+
+    /// Same seam, healthy path: every family is back, including the zeros.
+    #[test]
+    fn healthy_row_renders_every_value_series() {
+        use crate::api::metrics::{MetricExporter, gpu::GpuMetricExporter};
+
+        let rendered =
+            GpuMetricExporter::new(&[build_gpu_info(&static_info(), None, Some(&idle_sample()))])
+                .export_metrics();
+
+        for family in [
+            "all_smi_gpu_utilization{",
+            "all_smi_gpu_power_consumption_watts{",
+            "all_smi_gpu_temperature_celsius{",
+            "all_smi_gpu_frequency_mhz{",
+            "all_smi_ane_utilization{",
+            "all_smi_ane_power_watts{",
+        ] {
+            assert!(rendered.contains(family), "{family} missing:\n{rendered}");
+        }
+        assert!(rendered.contains("native_metrics=\"available\""));
+    }
+
+    /// The row itself must survive: the device exists, its identity and its
+    /// unified-memory figures come from sysctl/sysinfo and are unaffected by
+    /// IOReport. Dropping the whole `GpuInfo` would hide a real GPU.
+    #[test]
+    fn degraded_path_keeps_identity_and_memory() {
+        let info = build_gpu_info(
+            &static_info(),
+            Some(&AppleSiliconInfo {
+                gpu_core_count: Some(38),
+            }),
+            None,
+        );
+
+        assert_eq!(info.name, "Apple M2 Max GPU");
+        assert_eq!(info.device_type, "GPU");
+        assert_eq!(info.gpu_core_count, Some(38));
+        assert!(info.total_memory > 0, "unified memory total must survive");
+        assert_eq!(
+            info.detail.get("native_metrics").map(String::as_str),
+            Some("unavailable"),
+            "the identity series must carry the reason for the omission"
+        );
+        // Values sourced from the dead subscription must not appear at all,
+        // not even as a zero-valued detail label.
+        assert!(!info.detail.contains_key("combined_power_mw"));
+        assert!(!info.detail.contains_key("thermal_pressure"));
+        assert!(!info.detail.contains_key("cpu_temperature"));
+    }
+
+    /// The other half of the contract: a genuine zero from a healthy
+    /// subscription stays a zero and is distinguishable from absence.
+    #[test]
+    fn idle_gpu_reports_zero_as_a_reading() {
+        let info = build_gpu_info(&static_info(), None, Some(&idle_sample()));
+
+        assert_eq!(info.utilization_reading(), Some(0.0));
+        assert_eq!(info.power_consumption_reading(), Some(0.0));
+        assert_eq!(info.ane_utilization_reading(), Some(0.0));
+        assert_eq!(info.frequency_reading(), Some(338));
+        assert_eq!(info.temperature_reading(), Some(46));
+        assert_eq!(
+            info.detail.get("native_metrics").map(String::as_str),
+            Some("available")
+        );
+    }
+
+    /// IOReport healthy but the SMC die sensors missing: temperature alone
+    /// degrades, everything else keeps reporting. Per-sensor, not per-source.
+    #[test]
+    fn missing_smc_sensors_degrade_only_temperature() {
+        let sample = NativeSample {
+            cpu_temperature: None,
+            gpu_temperature: None,
+            utilization: 42.5,
+            ..idle_sample()
+        };
+        let info = build_gpu_info(&static_info(), None, Some(&sample));
+
+        assert_eq!(info.temperature_reading(), None);
+        assert_eq!(info.utilization_reading(), Some(42.5));
+        assert_eq!(info.power_consumption_reading(), Some(0.0));
+    }
+
+    /// The GPU thermistor is preferred, the CPU die temperature is the
+    /// documented fallback. Locking this in so the absence work above cannot
+    /// quietly remove it.
+    #[test]
+    fn cpu_die_temperature_is_the_documented_fallback() {
+        let sample = NativeSample {
+            gpu_temperature: None,
+            cpu_temperature: Some(51.4),
+            ..idle_sample()
+        };
+        let info = build_gpu_info(&static_info(), None, Some(&sample));
+        assert_eq!(info.temperature_reading(), Some(51));
+    }
+
     #[test]
     fn test_gpu_core_count_parsing() {
         // Test known chip patterns

--- a/src/device/traits.rs
+++ b/src/device/traits.rs
@@ -18,6 +18,24 @@ use crate::device::{
 use std::collections::HashSet;
 
 pub trait GpuReader: Send + Sync {
+    /// Enumerate the GPUs/NPUs this reader can see.
+    ///
+    /// # Reporting absence (issue #325)
+    ///
+    /// An implementation MUST NOT substitute `0` for a value it could not
+    /// source. `0` is a legitimate reading (an idle GPU, a parked ANE, a
+    /// board drawing no measurable power), so a consumer has to be able to
+    /// trust it. Mark the field absent instead, using the encoding described
+    /// on [`crate::device::types::GPU_METRIC_UNAVAILABLE`], and read values
+    /// back through `GpuInfo::utilization_reading` and its siblings rather
+    /// than touching the raw fields.
+    ///
+    /// Emit the row whenever the reader can still say something true about
+    /// the device (its identity, its memory) and mark only the fields that
+    /// failed. Suppress the row entirely only when the device itself cannot
+    /// be identified. `crate::device::macos_native::manager` documents the
+    /// worked example: what each of the four macOS readers does when their
+    /// shared native source is unavailable.
     fn get_gpu_info(&self) -> Vec<GpuInfo>;
     fn get_process_info(&self) -> Vec<ProcessInfo>;
 

--- a/src/device/types.rs
+++ b/src/device/types.rs
@@ -231,7 +231,70 @@ impl Default for ThermalProximityConfig {
     }
 }
 
+/// Sentinel written into [`GpuInfo`]'s non-optional `f64` metric fields
+/// (`utilization`, `ane_utilization`, `power_consumption`) when the reader
+/// could not obtain a reading at all.
+///
+/// These three fields are plain `f64` rather than `Option<f64>` because they
+/// are consumed by roughly sixty call sites (gauges, sparklines, sort
+/// comparators, energy accumulation, three CLI shims) that all treat them as
+/// numbers. A negative value is outside the valid range of every one of them
+/// (a percentage is `0..=100`, a power rail draws `>= 0` watts), so it cannot
+/// collide with a real reading. Read them through
+/// [`GpuInfo::utilization_reading`], [`GpuInfo::ane_utilization_reading`] and
+/// [`GpuInfo::power_consumption_reading`] rather than comparing against this
+/// constant directly.
+///
+/// This value must never reach the Prometheus exposition: the exporter omits
+/// the series instead. See the module docs on
+/// `crate::device::macos_native::manager` for the full policy.
+pub const GPU_METRIC_UNAVAILABLE: f64 = -1.0;
+
 impl GpuInfo {
+    /// GPU utilization percentage, or `None` when the reader had no source
+    /// for it. A genuinely idle GPU returns `Some(0.0)`.
+    pub fn utilization_reading(&self) -> Option<f64> {
+        (self.utilization >= 0.0).then_some(self.utilization)
+    }
+
+    /// ANE power draw in milliwatts (Apple Silicon), or `None` when the
+    /// reader had no source for it. An idle ANE returns `Some(0.0)`.
+    ///
+    /// Non-Apple readers set this to `0.0` to mean "not applicable", which is
+    /// indistinguishable from an idle ANE and is preserved as `Some(0.0)` for
+    /// backward compatibility with existing scrapes.
+    pub fn ane_utilization_reading(&self) -> Option<f64> {
+        (self.ane_utilization >= 0.0).then_some(self.ane_utilization)
+    }
+
+    /// GPU power draw in watts, or `None` when the reader had no source for
+    /// it. A GPU parked at zero watts returns `Some(0.0)`.
+    pub fn power_consumption_reading(&self) -> Option<f64> {
+        (self.power_consumption >= 0.0).then_some(self.power_consumption)
+    }
+
+    /// GPU temperature in Celsius, or `None` when no sensor produced a value.
+    ///
+    /// `temperature` is a `u32` and therefore cannot carry a negative
+    /// sentinel, so `0` is the unavailable marker. That is the convention the
+    /// TUI renderer, the alert engine and the filter DSL already applied
+    /// before this accessor existed: a powered SoC or board never reads
+    /// 0 °C, and 0 is what a missing SMC/NVML key decodes to.
+    pub fn temperature_reading(&self) -> Option<u32> {
+        (self.temperature > 0).then_some(self.temperature)
+    }
+
+    /// GPU core clock in MHz, or `None` when the platform exposes no
+    /// frequency probe.
+    ///
+    /// As with [`GpuInfo::temperature_reading`], `0` is the unavailable
+    /// marker: Rebellions, Intel Gaudi and AMD-via-WMI already report a
+    /// static `0` to mean "no probe", and a clock-gated GPU still reports its
+    /// nominal clock rather than 0 MHz.
+    pub fn frequency_reading(&self) -> Option<u32> {
+        (self.frequency > 0).then_some(self.frequency)
+    }
+
     /// Classify the current temperature against the reported thresholds.
     ///
     /// Returns [`ThermalProximity::Normal`] when no threshold data is

--- a/src/metrics/aggregator.rs
+++ b/src/metrics/aggregator.rs
@@ -39,29 +39,20 @@ impl MetricsAggregator {
             .map(|gpu| gpu.used_memory as f64 / (1024.0 * 1024.0 * 1024.0))
             .sum();
 
-        let total_power_watts = gpu_info.iter().map(|gpu| gpu.power_consumption).sum();
+        // Every statistic below is computed over the GPUs that actually
+        // reported the field, not over `total_gpus`. Dividing a partial sum
+        // by the full device count silently halves the mean when one card
+        // stops reporting (issue #325).
+        let total_power_watts = super::gpu_readings::total_power_watts(gpu_info);
+        let avg_utilization = super::gpu_readings::mean_utilization(gpu_info);
+        let avg_temperature = super::gpu_readings::mean_temperature(gpu_info);
+        let temp_std_dev = super::gpu_readings::temperature_std_dev(gpu_info);
 
-        let avg_utilization =
-            gpu_info.iter().map(|gpu| gpu.utilization).sum::<f64>() / total_gpus as f64;
-
-        let avg_temperature = gpu_info
+        let reporting_power = gpu_info
             .iter()
-            .map(|gpu| gpu.temperature as f64)
-            .sum::<f64>()
-            / total_gpus as f64;
-
-        // Calculate temperature standard deviation
-        let temp_variance = gpu_info
-            .iter()
-            .map(|gpu| {
-                let diff = gpu.temperature as f64 - avg_temperature;
-                diff * diff
-            })
-            .sum::<f64>()
-            / (total_gpus - 1) as f64;
-        let temp_std_dev = temp_variance.sqrt();
-
-        let avg_power = total_power_watts / total_gpus as f64;
+            .filter(|gpu| gpu.power_consumption_reading().is_some())
+            .count();
+        let avg_power = (reporting_power > 0).then(|| total_power_watts / reporting_power as f64);
 
         GpuClusterMetrics {
             total_gpus,
@@ -236,10 +227,16 @@ pub struct GpuClusterMetrics {
     pub total_memory_gb: f64,
     pub used_memory_gb: f64,
     pub total_power_watts: f64,
-    pub avg_utilization: f64,
-    pub avg_temperature: f64,
-    pub temp_std_dev: f64,
-    pub avg_power: f64,
+    /// `None` when no GPU in the cluster reported a utilization reading.
+    /// Distinct from `Some(0.0)`, which is a cluster of genuinely idle GPUs.
+    pub avg_utilization: Option<f64>,
+    /// `None` when no GPU reported a temperature.
+    pub avg_temperature: Option<f64>,
+    /// `None` when fewer than two GPUs reported a temperature, where the
+    /// sample standard deviation is undefined.
+    pub temp_std_dev: Option<f64>,
+    /// Mean power over the GPUs that reported a rail, `None` when none did.
+    pub avg_power: Option<f64>,
 }
 
 /// Aggregated CPU metrics for the cluster
@@ -319,9 +316,9 @@ mod tests {
         assert_eq!(metrics.total_memory_gb, 32.0);
         assert_eq!(metrics.used_memory_gb, 16.0);
         assert_eq!(metrics.total_power_watts, 500.0);
-        assert_eq!(metrics.avg_utilization, 75.0);
-        assert_eq!(metrics.avg_temperature, 80.0);
-        assert_eq!(metrics.avg_power, 250.0);
+        assert_eq!(metrics.avg_utilization, Some(75.0));
+        assert_eq!(metrics.avg_temperature, Some(80.0));
+        assert_eq!(metrics.avg_power, Some(250.0));
     }
 
     #[test]

--- a/src/metrics/coordinator.rs
+++ b/src/metrics/coordinator.rs
@@ -123,16 +123,18 @@ impl MetricsCoordinator {
         gpu_metrics: &GpuClusterMetrics,
         memory_metrics: &MemoryClusterMetrics,
     ) {
-        // Add new data points
-        state
-            .utilization_history
-            .push_back(gpu_metrics.avg_utilization);
+        // Add new data points. A cycle where no GPU reported contributes no
+        // sample rather than a fabricated 0, which would draw a dip in the
+        // history graph that never happened (issue #325).
+        if let Some(util) = gpu_metrics.avg_utilization {
+            state.utilization_history.push_back(util);
+        }
         state
             .memory_history
             .push_back(memory_metrics.avg_utilization);
-        state
-            .temperature_history
-            .push_back(gpu_metrics.avg_temperature);
+        if let Some(temp) = gpu_metrics.avg_temperature {
+            state.temperature_history.push_back(temp);
+        }
 
         // Maintain history size limits
         self.trim_history(&mut state.utilization_history);
@@ -209,11 +211,11 @@ impl MetricsCoordinator {
     ) -> Vec<String> {
         let mut issues = Vec::new();
 
-        if gpu_metrics.avg_utilization > 95.0 {
+        if gpu_metrics.avg_utilization.is_some_and(|u| u > 95.0) {
             issues.push("GPU utilization critically high (>95%)".to_string());
         }
 
-        if gpu_metrics.avg_temperature > 90.0 {
+        if gpu_metrics.avg_temperature.is_some_and(|t| t > 90.0) {
             issues.push("GPU temperature critically high (>90°C)".to_string());
         }
 
@@ -232,11 +234,11 @@ impl MetricsCoordinator {
     ) -> Vec<String> {
         let mut issues = Vec::new();
 
-        if gpu_metrics.avg_utilization > 85.0 {
+        if gpu_metrics.avg_utilization.is_some_and(|u| u > 85.0) {
             issues.push("GPU utilization high (>85%)".to_string());
         }
 
-        if gpu_metrics.avg_temperature > 80.0 {
+        if gpu_metrics.avg_temperature.is_some_and(|t| t > 80.0) {
             issues.push("GPU temperature high (>80°C)".to_string());
         }
 
@@ -244,7 +246,7 @@ impl MetricsCoordinator {
             issues.push("Memory utilization high (>85%)".to_string());
         }
 
-        if gpu_metrics.temp_std_dev > 10.0 {
+        if gpu_metrics.temp_std_dev.is_some_and(|sd| sd > 10.0) {
             issues.push("High temperature variance across GPUs".to_string());
         }
 

--- a/src/metrics/gpu_readings.rs
+++ b/src/metrics/gpu_readings.rs
@@ -1,0 +1,198 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Aggregations over GPU fields that can be absent (issue #325).
+//!
+//! `GpuInfo`'s live metric fields are plain numbers carrying an
+//! out-of-range "no reading" encoding rather than `Option`, because roughly
+//! sixty call sites consume them as numbers (see
+//! [`crate::device::types::GPU_METRIC_UNAVAILABLE`]). The cost of that choice
+//! is that every *aggregation* has to skip the non-readings explicitly, or it
+//! averages a sentinel into a real number and produces a plausible-looking
+//! lie: a two-GPU host where one card stopped reporting would show half its
+//! real mean utilization, and summing a `-1.0` into an energy accumulator
+//! integrates negative joules.
+//!
+//! These helpers are the one place that skipping happens, so the TUI
+//! dashboard, the header, the sparkline panel, the snapshot writer and the
+//! Prometheus-side aggregator cannot each get it subtly different.
+//!
+//! Every function here treats "nobody reported" as `None` (or `0.0` for the
+//! sums, where an empty sum genuinely is zero) rather than inventing a value.
+
+use crate::device::GpuInfo;
+
+/// Sum of the GPU power readings that are actually present, in watts.
+///
+/// GPUs with no power rail reading contribute nothing instead of dragging
+/// the total negative. An empty input, or an input where nothing reported,
+/// sums to `0.0` — which is the correct total power of zero reporting rails
+/// and matches what callers previously did for an empty GPU list.
+pub fn total_power_watts(gpus: &[GpuInfo]) -> f64 {
+    gpus.iter()
+        .filter_map(GpuInfo::power_consumption_reading)
+        .sum()
+}
+
+/// Mean utilization across the GPUs that reported one, or `None` when none
+/// did.
+pub fn mean_utilization(gpus: &[GpuInfo]) -> Option<f64> {
+    mean(gpus.iter().filter_map(GpuInfo::utilization_reading))
+}
+
+/// Mean temperature in Celsius across the GPUs that reported one, or `None`
+/// when no sensor answered on any device.
+pub fn mean_temperature(gpus: &[GpuInfo]) -> Option<f64> {
+    mean(
+        gpus.iter()
+            .filter_map(GpuInfo::temperature_reading)
+            .map(f64::from),
+    )
+}
+
+/// Sample standard deviation of the reported temperatures.
+///
+/// Returns `None` when fewer than two devices reported, since the sample
+/// standard deviation is undefined there (the previous code divided by
+/// `n - 1` and relied on a `total_gpus > 1` guard at every call site).
+pub fn temperature_std_dev(gpus: &[GpuInfo]) -> Option<f64> {
+    let temps: Vec<f64> = gpus
+        .iter()
+        .filter_map(GpuInfo::temperature_reading)
+        .map(f64::from)
+        .collect();
+    if temps.len() < 2 {
+        return None;
+    }
+    let mean = temps.iter().sum::<f64>() / temps.len() as f64;
+    let variance = temps.iter().map(|t| (t - mean).powi(2)).sum::<f64>() / (temps.len() - 1) as f64;
+    Some(variance.sqrt())
+}
+
+/// ANE power in watts for the first Apple Silicon row that reported one.
+///
+/// There is exactly one GPU row per Apple Silicon host, so "first that
+/// reported" is "the one, if it reported".
+pub fn first_ane_power_watts(gpus: &[GpuInfo]) -> Option<f64> {
+    gpus.iter()
+        .find_map(GpuInfo::ane_utilization_reading)
+        .map(|mw| mw / 1000.0)
+}
+
+fn mean(values: impl Iterator<Item = f64>) -> Option<f64> {
+    let mut count = 0usize;
+    let mut sum = 0.0;
+    for value in values {
+        sum += value;
+        count += 1;
+    }
+    (count > 0).then(|| sum / count as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::types::GPU_METRIC_UNAVAILABLE;
+    use std::collections::HashMap;
+
+    fn gpu(utilization: f64, temperature: u32, power: f64) -> GpuInfo {
+        GpuInfo {
+            uuid: "GPU-1".to_string(),
+            time: String::new(),
+            name: "test".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "h".to_string(),
+            hostname: "h".to_string(),
+            instance: "h".to_string(),
+            utilization,
+            ane_utilization: GPU_METRIC_UNAVAILABLE,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: power,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
+            detail: HashMap::new(),
+        }
+    }
+
+    fn unavailable() -> GpuInfo {
+        gpu(GPU_METRIC_UNAVAILABLE, 0, GPU_METRIC_UNAVAILABLE)
+    }
+
+    #[test]
+    fn absent_rows_are_skipped_not_counted_as_zero() {
+        let gpus = vec![gpu(80.0, 70, 300.0), unavailable()];
+        // The mean is over the one device that reported, not 40.0.
+        assert_eq!(mean_utilization(&gpus), Some(80.0));
+        assert_eq!(mean_temperature(&gpus), Some(70.0));
+        assert_eq!(total_power_watts(&gpus), 300.0);
+    }
+
+    #[test]
+    fn a_genuine_zero_still_counts() {
+        let gpus = vec![gpu(0.0, 30, 0.0), gpu(100.0, 50, 200.0)];
+        assert_eq!(mean_utilization(&gpus), Some(50.0));
+        assert_eq!(mean_temperature(&gpus), Some(40.0));
+        assert_eq!(total_power_watts(&gpus), 200.0);
+    }
+
+    #[test]
+    fn nothing_reported_yields_none_rather_than_zero() {
+        let gpus = vec![unavailable(), unavailable()];
+        assert_eq!(mean_utilization(&gpus), None);
+        assert_eq!(mean_temperature(&gpus), None);
+        assert_eq!(temperature_std_dev(&gpus), None);
+        assert_eq!(first_ane_power_watts(&gpus), None);
+        // A sum over nothing is genuinely zero.
+        assert_eq!(total_power_watts(&gpus), 0.0);
+    }
+
+    #[test]
+    fn empty_input_is_handled() {
+        assert_eq!(mean_utilization(&[]), None);
+        assert_eq!(total_power_watts(&[]), 0.0);
+        assert_eq!(temperature_std_dev(&[]), None);
+    }
+
+    #[test]
+    fn std_dev_needs_two_reporting_devices() {
+        // Two devices present but only one reporting: undefined, not 0.
+        let gpus = vec![gpu(10.0, 60, 5.0), unavailable()];
+        assert_eq!(temperature_std_dev(&gpus), None);
+
+        let gpus = vec![gpu(10.0, 60, 5.0), gpu(10.0, 70, 5.0)];
+        let sd = temperature_std_dev(&gpus).expect("two readings");
+        assert!((sd - 7.0710678).abs() < 1e-6, "got {sd}");
+    }
+
+    #[test]
+    fn ane_power_converts_milliwatts_to_watts() {
+        let mut g = gpu(1.0, 40, 1.0);
+        g.ane_utilization = 2500.0;
+        assert_eq!(first_ane_power_watts(&[g]), Some(2.5));
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -16,3 +16,4 @@ pub mod aggregator;
 pub mod coordinator;
 pub mod energy;
 pub mod energy_wal;
+pub mod gpu_readings;

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -18,6 +18,7 @@ use crate::parsing::common::sanitize_label_value;
 use chrono::Local;
 use regex::Regex;
 
+use crate::device::types::GPU_METRIC_UNAVAILABLE;
 use crate::device::{
     AppleSiliconCpuInfo, CpuInfo, CpuPlatformType, GpmMetrics, GpuInfo, MemoryInfo, MigGpuInfo,
     MigInstanceInfo, NvLinkRemoteDevice, NvLinkRemoteType, VgpuHostInfo, VgpuInfo,
@@ -467,15 +468,23 @@ impl MetricsParser {
                 host_id: host.to_string(),      // Host identifier (e.g., "10.82.128.41:9090")
                 hostname: crate::get_label_or_default!(labels, "instance", host), // DNS hostname from instance label
                 instance: crate::get_label_or_default!(labels, "instance", host),
-                utilization: 0.0,
-                ane_utilization: 0.0,
+                // Start every live field at "no reading" rather than at
+                // zero. A scrape only overwrites the fields whose series it
+                // actually contains, so a zero default silently re-fabricated
+                // the exact value the exporter went out of its way to omit:
+                // a remote macOS node with no IOReport would render "0.0%" in
+                // the local TUI instead of N/A (issue #325). Exporters that
+                // do emit the series overwrite these below, so nothing
+                // changes for a node that reports normally.
+                utilization: GPU_METRIC_UNAVAILABLE,
+                ane_utilization: GPU_METRIC_UNAVAILABLE,
                 dla_utilization: None,
                 tensorcore_utilization: None,
                 temperature: 0,
                 used_memory: 0,
                 total_memory: 0,
                 frequency: 0,
-                power_consumption: 0.0,
+                power_consumption: GPU_METRIC_UNAVAILABLE,
                 gpu_core_count: None,
                 // Populated by the new threshold / pstate metric handlers
                 // below when the scraped exposition contains them. Remote
@@ -536,7 +545,11 @@ impl MetricsParser {
                         "firmware",
                         "serial_number",
                         "pci_address",
-                        "pci_device"
+                        "pci_device",
+                        // Apple Silicon: why the live series are missing.
+                        // Carried on the identity series so a remote viewer
+                        // sees the reason and not just the absence (#325).
+                        "native_metrics"
                     ]
                 );
             }
@@ -1592,6 +1605,60 @@ all_smi_ane_utilization{gpu="NVIDIA H200 141GB HBM3", instance="node-0058", uuid
         assert_eq!(gpu.temperature, 65);
         assert_eq!(gpu.power_consumption, 400.5);
         assert_eq!(gpu.ane_utilization, 15.2);
+    }
+
+    /// Issue #325: a remote macOS node with no IOReport omits its GPU value
+    /// series. The viewing side must keep them absent rather than defaulting
+    /// them to zero, or the fix only works locally.
+    #[test]
+    fn test_omitted_gpu_series_stay_absent_after_scrape() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10058";
+
+        // Exactly what the degraded exporter renders: identity plus memory,
+        // no utilization / temperature / power / frequency / ANE.
+        let test_data = r#"
+all_smi_gpu_memory_used_bytes{gpu="Apple M2 Max GPU", instance="mac-1", gpu_uuid="AppleSiliconGPU", gpu_index="0"} 8589934592
+all_smi_gpu_memory_total_bytes{gpu="Apple M2 Max GPU", instance="mac-1", gpu_uuid="AppleSiliconGPU", gpu_index="0"} 34359738368
+all_smi_gpu_info{gpu="Apple M2 Max GPU", instance="mac-1", gpu_uuid="AppleSiliconGPU", gpu_index="0", type="GPU", architecture="Apple Silicon", native_metrics="unavailable"} 1
+"#;
+
+        let parsed = parser.parse_metrics(test_data, host, &re);
+        assert_eq!(parsed.gpu_info.len(), 1);
+        let gpu = &parsed.gpu_info[0];
+
+        assert_eq!(gpu.utilization_reading(), None);
+        assert_eq!(gpu.power_consumption_reading(), None);
+        assert_eq!(gpu.temperature_reading(), None);
+        assert_eq!(gpu.frequency_reading(), None);
+        assert_eq!(gpu.ane_utilization_reading(), None);
+
+        // Memory and the reason label do survive.
+        assert_eq!(gpu.total_memory, 34359738368);
+        assert_eq!(
+            gpu.detail.get("native_metrics").map(String::as_str),
+            Some("unavailable")
+        );
+    }
+
+    /// A remote node that reports a genuine zero must still land as a zero on
+    /// the viewing side, so the two cases stay distinguishable end to end.
+    #[test]
+    fn test_zero_gpu_series_survives_scrape_as_a_reading() {
+        let parser = create_test_parser();
+        let re = create_test_regex();
+        let host = "127.0.0.1:10058";
+
+        let test_data = r#"
+all_smi_gpu_utilization{gpu="Apple M2 Max GPU", instance="mac-1", gpu_uuid="AppleSiliconGPU", gpu_index="0"} 0
+all_smi_gpu_power_consumption_watts{gpu="Apple M2 Max GPU", instance="mac-1", gpu_uuid="AppleSiliconGPU", gpu_index="0"} 0
+"#;
+
+        let parsed = parser.parse_metrics(test_data, host, &re);
+        let gpu = &parsed.gpu_info[0];
+        assert_eq!(gpu.utilization_reading(), Some(0.0));
+        assert_eq!(gpu.power_consumption_reading(), Some(0.0));
     }
 
     #[test]

--- a/src/snapshot/collector.rs
+++ b/src/snapshot/collector.rs
@@ -216,7 +216,7 @@ pub async fn collect_once<C: SnapshotCollector + 'static>(
     // specific to the Prometheus path on the server side, but it is
     // equally meaningful to JSON consumers.
     if let (Some(gpus), Some(chassis)) = (snap.gpus.as_ref(), snap.chassis.as_mut()) {
-        let total_gpu_power: f64 = gpus.iter().map(|g| g.power_consumption).sum();
+        let total_gpu_power = crate::metrics::gpu_readings::total_power_watts(gpus);
         if total_gpu_power > 0.0 {
             for ci in chassis.iter_mut() {
                 if ci.total_power_watts.is_none() {

--- a/src/ui/alerts.rs
+++ b/src/ui/alerts.rs
@@ -201,10 +201,10 @@ impl Alerter {
     }
 
     fn evaluate_temperature(&mut self, gpu: &GpuInfo, out: &mut Vec<AlertTransition>) {
-        let temp = gpu.temperature as f64;
-        if gpu.temperature == 0 {
-            return; // N/A — don't alert on missing data.
-        }
+        // N/A — don't alert on missing data.
+        let Some(temp) = gpu.temperature_reading().map(f64::from) else {
+            return;
+        };
         let warn_on = self.config.temp_warn_c as f64;
         let crit_on = self.config.temp_crit_c as f64;
         let warn_off = warn_on - self.config.hysteresis_c as f64;
@@ -296,10 +296,9 @@ impl Alerter {
         if self.config.util_idle_warn_mins == 0 {
             return;
         }
-        let util = gpu.utilization;
-        if util < 0.0 {
+        let Some(util) = gpu.utilization_reading() else {
             return;
-        }
+        };
         let threshold_pct = self.config.util_idle_pct as f64;
         let warn_after =
             std::time::Duration::from_secs(self.config.util_idle_warn_mins as u64 * 60);
@@ -383,7 +382,11 @@ impl Alerter {
         if limit <= 0.0 {
             return;
         }
-        let value = gpu.power_consumption;
+        // No power reading means no power alert: an absent rail must not
+        // read as a device sitting comfortably under the limit.
+        let Some(value) = gpu.power_consumption_reading() else {
+            return;
+        };
         // `hysteresis_c` is named after the °C unit used by the
         // temperature rule but is reused verbatim here as a watt delta.
         // The numeric value (default: 2) is appropriate for both rules;

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -17,6 +17,7 @@ use std::io::Write;
 use crossterm::{queue, style::Color, style::Print};
 
 use crate::app_state::AppState;
+use crate::metrics::gpu_readings;
 use crate::ui::buffer::BufferWriter;
 use crate::ui::led_grid;
 use crate::ui::remote_sparkline_panel;
@@ -112,18 +113,10 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
             .next() // Only one GPU entry for Apple Silicon
             .unwrap_or_else(|| {
                 // Fallback to GPU power if combined power not available
-                state
-                    .gpu_info
-                    .iter()
-                    .map(|gpu| gpu.power_consumption)
-                    .sum::<f64>()
+                gpu_readings::total_power_watts(&state.gpu_info)
             })
     } else {
-        state
-            .gpu_info
-            .iter()
-            .map(|gpu| gpu.power_consumption)
-            .sum::<f64>()
+        gpu_readings::total_power_watts(&state.gpu_info)
     };
 
     // Calculate total CPU cores
@@ -154,33 +147,20 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
         .sum::<u64>() as f64
         / (1024.0 * 1024.0 * 1024.0);
 
-    // Calculate averages
-    let avg_utilization = if total_gpus > 0 {
-        state
-            .gpu_info
-            .iter()
-            .map(|gpu| gpu.utilization)
-            .sum::<f64>()
-            / total_gpus as f64
-    } else {
-        0.0
-    };
+    // Calculate averages. These skip devices with no reading rather than
+    // folding a sentinel in, and render N/A when nothing reported at all —
+    // an average over zero reporting GPUs is not 0% (issue #325).
+    let avg_utilization = gpu_readings::mean_utilization(&state.gpu_info);
 
     // Average GPU temperature in °C — shown identically on every platform.
     // On Apple Silicon, gpu.temperature is sourced from the SMC CPU die sensor
     // (CPU/GPU share the same SoC die), so this is a real die temperature
     // rather than the qualitative thermal-pressure text we used to show.
-    let avg_temperature = if total_gpus > 0 {
-        state
-            .gpu_info
-            .iter()
-            .map(|gpu| gpu.temperature as f64)
-            .sum::<f64>()
-            / total_gpus as f64
-    } else {
-        0.0
+    let avg_temperature = gpu_readings::mean_temperature(&state.gpu_info);
+    let avg_temperature_display = match avg_temperature {
+        Some(temp) => format!("{temp:.0}°C"),
+        None => "N/A".to_string(),
     };
-    let avg_temperature_display = format!("{avg_temperature:.0}°C");
 
     // The second-row temperature cell is platform-dependent:
     // - On Apple Silicon (single SoC die) standard deviation is meaningless,
@@ -196,21 +176,15 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
             .unwrap_or_else(|| "Unknown".to_string());
         ("Thermal", thermal_pressure)
     } else {
-        let temp_std_dev = if total_gpus > 1 {
-            let temp_variance = state
-                .gpu_info
-                .iter()
-                .map(|gpu| {
-                    let diff = gpu.temperature as f64 - avg_temperature;
-                    diff * diff
-                })
-                .sum::<f64>()
-                / (total_gpus - 1) as f64;
-            temp_variance.sqrt()
-        } else {
-            0.0
+        let display = match gpu_readings::temperature_std_dev(&state.gpu_info) {
+            Some(sd) => format!("±{sd:.1}°C"),
+            // Fewer than two devices reported a temperature, so the spread
+            // is undefined. Preserves the previous "±0.0°C" for the
+            // single-GPU case, which callers read as "no spread".
+            None if total_gpus <= 1 => "±0.0°C".to_string(),
+            None => "N/A".to_string(),
         };
-        ("Temp. Stdev", format!("±{temp_std_dev:.1}°C"))
+        ("Temp. Stdev", display)
     };
 
     let avg_power = if total_gpus > 0 {
@@ -279,7 +253,14 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
                     format_ram_value(used_system_memory_gb),
                     Color::Green,
                 ),
-                ("GPU Util", format!("{avg_utilization:.1}%"), Color::Blue),
+                (
+                    "GPU Util",
+                    match avg_utilization {
+                        Some(util) => format!("{util:.1}%"),
+                        None => "N/A".to_string(),
+                    },
+                    Color::Blue,
+                ),
                 (
                     "Used VRAM",
                     format_ram_value(used_gpu_memory_gb),

--- a/src/ui/filter_dsl/eval.rs
+++ b/src/ui/filter_dsl/eval.rs
@@ -210,18 +210,10 @@ use crate::device::types::{CpuInfo, GpuInfo, ProcessInfo};
 
 impl DeviceRowView for GpuInfo {
     fn temp_field(&self) -> Option<f64> {
-        if self.temperature == 0 {
-            None
-        } else {
-            Some(self.temperature as f64)
-        }
+        self.temperature_reading().map(|t| t as f64)
     }
     fn util_field(&self) -> Option<f64> {
-        if self.utilization < 0.0 {
-            None
-        } else {
-            Some(self.utilization)
-        }
+        self.utilization_reading()
     }
     fn mem_pct_field(&self) -> Option<f64> {
         if self.total_memory == 0 {
@@ -240,7 +232,7 @@ impl DeviceRowView for GpuInfo {
         }
     }
     fn power_field(&self) -> Option<f64> {
-        Some(self.power_consumption)
+        self.power_consumption_reading()
     }
     fn host_field(&self) -> Option<&str> {
         if self.hostname.is_empty() {

--- a/src/ui/gpu_sparkline_panel.rs
+++ b/src/ui/gpu_sparkline_panel.rs
@@ -338,11 +338,7 @@ fn build_rows(state: &AppState, is_apple: bool, has_ane: bool, has_npu: bool) ->
     // 4. ANE (Apple Silicon -- always shown regardless of current power)
     if has_ane {
         let ane_w = state.ane_power_history.back().copied().unwrap_or_else(|| {
-            state
-                .gpu_info
-                .first()
-                .map(|g| g.ane_utilization / 1000.0)
-                .unwrap_or(0.0)
+            crate::metrics::gpu_readings::first_ane_power_watts(&state.gpu_info).unwrap_or(0.0)
         });
         let ane_history: Vec<f64> = if state.ane_power_history.is_empty() {
             vec![ane_w]
@@ -649,7 +645,7 @@ fn package_power(state: &AppState, is_apple: bool) -> f64 {
         power_mw / 1000.0
     } else {
         // NVIDIA / other: sum GPU board power
-        state.gpu_info.iter().map(|g| g.power_consumption).sum()
+        crate::metrics::gpu_readings::total_power_watts(&state.gpu_info)
     }
 }
 

--- a/src/ui/led_grid.rs
+++ b/src/ui/led_grid.rs
@@ -158,15 +158,21 @@ pub fn render_led_grid_lines(state: &AppState, grid_width: usize, max_rows: usiz
 ///
 /// Uses a single O(G) pass over all GPUs instead of O(N*G) nested filtering.
 fn compute_node_utils(state: &AppState, _nodes: &[&String]) -> HashMap<String, f64> {
-    // Accumulate (sum, count) per host_id in one pass over gpu_info.
+    // Accumulate (sum, count) per host_id in one pass over gpu_info. GPUs
+    // with no utilization reading are left out of both the sum and the
+    // count, so a node whose GPUs stopped reporting shows as unlit rather
+    // than as a node that is genuinely idle (issue #325).
     let mut accum: HashMap<&str, (f64, usize)> = HashMap::with_capacity(state.gpu_info.len());
     for gpu in &state.gpu_info {
-        let entry = accum.entry(gpu.host_id.as_str()).or_insert((0.0, 0));
-        entry.0 += gpu.utilization;
-        entry.1 += 1;
+        if let Some(util) = gpu.utilization_reading() {
+            let entry = accum.entry(gpu.host_id.as_str()).or_insert((0.0, 0));
+            entry.0 += util;
+            entry.1 += 1;
+        }
     }
     accum
         .into_iter()
+        .filter(|(_, (_, count))| *count > 0)
         .map(|(host, (sum, count))| (host.to_string(), sum / count as f64))
         .collect()
 }

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -335,10 +335,10 @@ fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
                     .map(|mw| mw / 1000.0)
             })
             .next()
-            .unwrap_or_else(|| state.gpu_info.iter().map(|g| g.power_consumption).sum())
+            .unwrap_or_else(|| crate::metrics::gpu_readings::total_power_watts(&state.gpu_info))
     } else {
         // Linux/NVIDIA: aggregate GPU power
-        state.gpu_info.iter().map(|g| g.power_consumption).sum()
+        crate::metrics::gpu_readings::total_power_watts(&state.gpu_info)
     };
 
     let value_str = format!("{power_watts:>5.1}W");

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -263,10 +263,9 @@ pub fn print_gpu_info<W: Write>(
         print_colored_text(stdout, &hostname_display, Color::White, None, None);
     }
     print_colored_text(stdout, " Util:", Color::Yellow, None, None);
-    let util_display = if info.utilization < 0.0 {
-        format!("{:>6}", "N/A")
-    } else {
-        format!("{:>5.1}%", info.utilization)
+    let util_display = match info.utilization_reading() {
+        Some(util) => format!("{util:>5.1}%"),
+        None => format!("{:>6}", "N/A"),
     };
     print_colored_text(stdout, &util_display, Color::White, None, None);
     print_colored_text(stdout, " VRAM:", Color::Blue, None, None);
@@ -292,9 +291,9 @@ pub fn print_gpu_info<W: Write>(
     let (temp_display, temp_color) =
         if info.detail.get("metrics_available") == Some(&"false".to_string()) {
             (format!("{:>7}", "N/A"), Color::White)
-        } else if info.temperature == 0 {
-            // SMC didn't yield a usable reading and we have no fallback — show N/A
-            // rather than a misleading "0 °C".
+        } else if info.temperature_reading().is_none() {
+            // No sensor yielded a usable reading and we have no fallback —
+            // show N/A rather than a misleading "0 °C".
             (format!("{:>7}", "N/A"), Color::White)
         } else {
             // Highlight the current temperature when it is within the
@@ -319,24 +318,16 @@ pub fn print_gpu_info<W: Write>(
     // ` Freq:     N/A` instead of letting the field — and every field after
     // it — vanish for the duration of that sample.
     print_colored_text(stdout, " Freq:", Color::Magenta, None, None);
-    if info.frequency == 0 {
-        print_colored_text(stdout, &format!("{:>7}", "N/A"), Color::White, None, None);
-    } else if info.frequency >= 1000 {
-        print_colored_text(
+    match info.frequency_reading() {
+        None => print_colored_text(stdout, &format!("{:>7}", "N/A"), Color::White, None, None),
+        Some(mhz) if mhz >= 1000 => print_colored_text(
             stdout,
-            &format!("{:.2}GHz", info.frequency as f64 / 1000.0),
+            &format!("{:.2}GHz", mhz as f64 / 1000.0),
             Color::White,
             None,
             None,
-        );
-    } else {
-        print_colored_text(
-            stdout,
-            &format!("{}MHz", info.frequency),
-            Color::White,
-            None,
-            None,
-        );
+        ),
+        Some(mhz) => print_colored_text(stdout, &format!("{mhz}MHz"), Color::White, None, None),
     }
 
     print_colored_text(stdout, " Pwr:", Color::Red, None, None);
@@ -344,20 +335,21 @@ pub fn print_gpu_info<W: Write>(
     // Check if power_limit_max is available and display as current/max
     // For Apple Silicon, info.power_consumption contains GPU power only
     let is_apple_silicon = info.name.contains("Apple") || info.name.contains("Metal");
-    let power_display = if info.power_consumption < 0.0 {
-        "N/A".to_string()
-    } else if is_apple_silicon {
-        // Apple Silicon GPU uses very little power, show 2 decimal places
-        // Use fixed width formatting to prevent trailing characters
-        format!("{:5.2}W", info.power_consumption)
-    } else if let Some(power_max_str) = info.detail.get("power_limit_max") {
-        if let Ok(power_max) = power_max_str.parse::<f64>() {
-            format!("{:.0}/{power_max:.0}W", info.power_consumption)
-        } else {
-            format!("{:.0}W", info.power_consumption)
+    let power_display = match info.power_consumption_reading() {
+        None => "N/A".to_string(),
+        Some(power) if is_apple_silicon => {
+            // Apple Silicon GPU uses very little power, show 2 decimal places
+            // Use fixed width formatting to prevent trailing characters
+            format!("{power:5.2}W")
         }
-    } else {
-        format!("{:.0}W", info.power_consumption)
+        Some(power) => match info
+            .detail
+            .get("power_limit_max")
+            .and_then(|s| s.parse::<f64>().ok())
+        {
+            Some(power_max) => format!("{power:.0}/{power_max:.0}W"),
+            None => format!("{power:.0}W"),
+        },
     };
 
     // Dynamically adjust width based on content, with minimum of 8 chars
@@ -446,14 +438,21 @@ pub fn print_gpu_info<W: Write>(
     // Print gauges on one line with proper spacing
     print_colored_text(stdout, "     ", Color::White, None, None); // 5 char left padding
 
-    // Util gauge
+    // Util gauge. An absent reading draws an empty bar labelled N/A rather
+    // than a full-looking zero bar: the row above already says N/A, and a
+    // 0%-filled gauge reads as "idle", which is the confusion this whole
+    // path exists to remove (issue #325).
+    let (util_fill, util_label) = match info.utilization_reading() {
+        Some(util) => (util, format!("{util:.1}%")),
+        None => (0.0, "N/A".to_string()),
+    };
     draw_bar(
         stdout,
         "Util",
-        info.utilization,
+        util_fill,
         100.0,
         gauge_width,
-        Some(format!("{:.1}%", info.utilization)),
+        Some(util_label),
     );
     print_colored_text(stdout, "  ", Color::White, None, None); // 2 space separator
 
@@ -475,9 +474,18 @@ pub fn print_gpu_info<W: Write>(
         let is_ultra = info.name.contains("Ultra");
         let max_ane_power = if is_ultra { 12.0 } else { 6.0 };
 
-        // Convert mW to W and cap at max
-        let ane_power_w = (info.ane_utilization / 1000.0).min(max_ane_power);
-        let ane_percent = (ane_power_w / max_ane_power) * 100.0;
+        // Convert mW to W and cap at max. Absent reading draws empty + N/A,
+        // matching the Util gauge above.
+        let (ane_percent, ane_label) = match info.ane_utilization_reading() {
+            Some(ane_mw) => {
+                let ane_power_w = (ane_mw / 1000.0).min(max_ane_power);
+                (
+                    (ane_power_w / max_ane_power) * 100.0,
+                    format!("{ane_power_w:.1}W"),
+                )
+            }
+            None => (0.0, "N/A".to_string()),
+        };
 
         draw_bar(
             stdout,
@@ -485,7 +493,7 @@ pub fn print_gpu_info<W: Write>(
             ane_percent,
             100.0,
             gauge_width,
-            Some(format!("{ane_power_w:.1}W")),
+            Some(ane_label),
         );
     }
 
@@ -802,6 +810,81 @@ mod tests {
         let renderer = GpuRenderer::new();
         // Just verify it can be created
         let _ = renderer;
+    }
+
+    /// Render a row and return the plain text, stripped of the ANSI colour
+    /// sequences `print_colored_text` emits, so assertions can look at what
+    /// an operator actually reads on screen.
+    fn render_row(info: &GpuInfo) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        print_gpu_info(&mut buf, 0, info, 120, 0, 0, false);
+        let raw = String::from_utf8_lossy(&buf).into_owned();
+        let mut out = String::with_capacity(raw.len());
+        let mut chars = raw.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                // Skip a CSI sequence: ESC '[' ... final byte in @..~
+                if chars.peek() == Some(&'[') {
+                    chars.next();
+                    for c in chars.by_ref() {
+                        if ('@'..='~').contains(&c) {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
+            out.push(c);
+        }
+        out
+    }
+
+    /// Issue #325: with no reading, every live field reads N/A, and the Util
+    /// gauge is labelled N/A rather than drawn as a 0%-filled "idle" bar.
+    #[test]
+    fn absent_readings_render_as_na_not_zero() {
+        let mut gpu = make_gpu(0);
+        gpu.name = "Apple M2 Max GPU".to_string();
+        gpu.utilization = crate::device::types::GPU_METRIC_UNAVAILABLE;
+        gpu.power_consumption = crate::device::types::GPU_METRIC_UNAVAILABLE;
+        gpu.ane_utilization = crate::device::types::GPU_METRIC_UNAVAILABLE;
+        gpu.frequency = 0;
+
+        let rendered = render_row(&gpu);
+
+        assert!(rendered.contains("Util:   N/A"), "{rendered}");
+        assert!(rendered.contains("Temp:    N/A"), "{rendered}");
+        assert!(rendered.contains("Freq:    N/A"), "{rendered}");
+        assert!(rendered.contains("Pwr:     N/A"), "{rendered}");
+        // Neither gauge may claim a value.
+        assert!(
+            !rendered.contains("0.0%"),
+            "util gauge shows 0%: {rendered}"
+        );
+        assert!(!rendered.contains("0.0W"), "ANE gauge shows 0W: {rendered}");
+    }
+
+    /// The complement: a genuine zero reading renders as a zero, so N/A
+    /// unambiguously means "no data" on screen too.
+    #[test]
+    fn zero_readings_render_as_zero() {
+        let mut gpu = make_gpu(45);
+        gpu.name = "Apple M2 Max GPU".to_string();
+        gpu.utilization = 0.0;
+        gpu.power_consumption = 0.0;
+        gpu.ane_utilization = 0.0;
+        gpu.frequency = 338;
+
+        let rendered = render_row(&gpu);
+
+        assert!(rendered.contains("Util:  0.0%"), "{rendered}");
+        assert!(rendered.contains("45°C"), "{rendered}");
+        assert!(rendered.contains("338MHz"), "{rendered}");
+        assert!(rendered.contains("0.00W"), "{rendered}");
+        assert!(
+            !rendered.contains("N/A"),
+            "nothing should be N/A: {rendered}"
+        );
     }
 
     // --- thermal proximity classification ---

--- a/src/view/data_collection/aggregator.rs
+++ b/src/view/data_collection/aggregator.rs
@@ -63,9 +63,15 @@ impl DataAggregator {
         // up on the Prometheus metric and the TUI top-consumer view,
         // so we use it as the host component of the key (same as
         // other per-GPU exporters).
+        // A GPU with no power reading contributes no sample at all. Feeding
+        // the "unavailable" sentinel into the integrator would accumulate
+        // negative joules and corrupt the running energy total (issue #325);
+        // feeding a 0.0 would silently claim the device drew no energy.
         for gpu in &state.gpu_info {
-            let key = EnergyKey::gpu(gpu.hostname.clone(), gpu.uuid.clone());
-            samples.push((key, gpu.power_consumption));
+            if let Some(watts) = gpu.power_consumption_reading() {
+                let key = EnergyKey::gpu(gpu.hostname.clone(), gpu.uuid.clone());
+                samples.push((key, watts));
+            }
         }
 
         // Per-CPU samples (Apple Silicon, some Intel/AMD chipsets).
@@ -167,12 +173,9 @@ impl DataAggregator {
         if has_gpu_data
             && (state.gpu_info.iter().any(|gpu| gpu.total_memory > 0) || is_apple_silicon)
         {
-            let avg_utilization = state
-                .gpu_info
-                .iter()
-                .map(|gpu| gpu.utilization)
-                .sum::<f64>()
-                / state.gpu_info.len() as f64;
+            // Skip the cycle's GPU samples entirely when nothing reported,
+            // rather than pushing a fabricated 0 into the history graphs.
+            let avg_utilization = crate::metrics::gpu_readings::mean_utilization(&state.gpu_info);
 
             let avg_memory = state
                 .gpu_info
@@ -187,16 +190,15 @@ impl DataAggregator {
                 .sum::<f64>()
                 / state.gpu_info.len() as f64;
 
-            let avg_temperature = state
-                .gpu_info
-                .iter()
-                .map(|gpu| gpu.temperature as f64)
-                .sum::<f64>()
-                / state.gpu_info.len() as f64;
+            let avg_temperature = crate::metrics::gpu_readings::mean_temperature(&state.gpu_info);
 
-            state.utilization_history.push_back(avg_utilization);
+            if let Some(util) = avg_utilization {
+                state.utilization_history.push_back(util);
+            }
             state.memory_history.push_back(avg_memory);
-            state.temperature_history.push_back(avg_temperature);
+            if let Some(temp) = avg_temperature {
+                state.temperature_history.push_back(temp);
+            }
             state
                 .package_power_history
                 .push_back(current_package_power_watts(state));
@@ -293,12 +295,7 @@ impl DataAggregator {
             return 0.0;
         }
 
-        state
-            .gpu_info
-            .iter()
-            .map(|gpu| gpu.utilization)
-            .sum::<f64>()
-            / state.gpu_info.len() as f64
+        crate::metrics::gpu_readings::mean_utilization(&state.gpu_info).unwrap_or(0.0)
     }
 
     /// Calculate average GPU memory usage
@@ -379,18 +376,14 @@ fn current_package_power_watts(state: &AppState) -> f64 {
                     .and_then(|value| value.parse::<f64>().ok())
                     .map(|mw| mw / 1000.0)
             })
-            .unwrap_or_else(|| state.gpu_info.iter().map(|gpu| gpu.power_consumption).sum())
+            .unwrap_or_else(|| crate::metrics::gpu_readings::total_power_watts(&state.gpu_info))
     } else {
-        state.gpu_info.iter().map(|gpu| gpu.power_consumption).sum()
+        crate::metrics::gpu_readings::total_power_watts(&state.gpu_info)
     }
 }
 
 fn current_ane_power_watts(state: &AppState) -> f64 {
-    state
-        .gpu_info
-        .first()
-        .map(|gpu| gpu.ane_utilization / 1000.0)
-        .unwrap_or(0.0)
+    crate::metrics::gpu_readings::first_ane_power_watts(&state.gpu_info).unwrap_or(0.0)
 }
 
 impl Default for DataAggregator {


### PR DESCRIPTION
## Summary

When `NativeMetricsManager::new()` fails, the singleton in `src/device/macos_native/manager.rs:51` stays empty for the life of the process. The Apple Silicon GPU reader fell back to `GpuMetrics::default()` and unwrapped every field to a literal zero, so a macOS host without IOReport published "GPU 0% / 0 W / 0 degrees" for a device that was measuring nothing. Zero is a legitimate reading for an idle GPU or a parked ANE, so no consumer could tell the two apart. This makes absence explicit instead, and aligns the four macOS readers on one written-down policy.

## The four readers as found

| Reader | Before | After |
|---|---|---|
| Memory (`src/device/memory_macos.rs:45`) | Unaffected. Pure `sysinfo`, no failure path. | Unchanged. |
| CPU (`src/device/cpu_macos.rs:160`) | Degraded honestly. `Option` fields go `None`, frequency falls back to `sysctl`. | Unchanged. This was already the correct behavior and became the model for the others. |
| Chassis (`src/device/readers/chassis/apple_silicon_native.rs:52`) | Absent. `get_chassis_info` returns `None`, no series at all. | Unchanged. Every field it reports comes from the manager, so there is nothing left to say. |
| GPU (`src/device/readers/apple_silicon_native.rs:165`) | **Fabricated.** `unwrap_or(0)` at `:216`, `:229`, `:236`, `:237`. | Emits the row with identity and memory intact; the five IOReport/SMC-sourced fields are marked absent. |

The unifying rule, now documented in the `manager` module docs and referenced from the `GpuReader` trait: **a reader emits a row whenever it can still say something true about the device, marks the fields it could not source as absent, and never substitutes 0.** It suppresses the row only when the device cannot be identified at all.

## Omission versus an explicit absence signal

**Both, at different layers, because they answer different questions.**

For the value series, omission. It is Prometheus' own convention for no-data and it is already this exporter's house style: `all_smi_gpu_performance_state` and the four thermal thresholds have been omitted-when-absent since #132, with a comment at `src/api/metrics/gpu.rs` saying exactly why. Introducing a second convention for five neighbouring families in the same exporter would be worse than either convention alone. The obvious objection, that a series vanishing mid-scrape resembles a dead target, is weaker here than it looks: the target is not silent. `all_smi_up` and `all_smi_build_info` from #333 are unconditional, the memory/CPU/disk families still render, and `all_smi_gpu_info` for this very device still renders. "Device present, not reporting" and "device gone" stay distinguishable, and `absent()` over a still-present `all_smi_gpu_info` expresses the first one precisely.

For the reason, an explicit signal. Omission says nothing about *why*, and "no IOReport on this host" is a permanent, actionable condition rather than a transient gap. The reader now sets `detail["native_metrics"] = "available" | "unavailable"`, which rides the already-emitted `all_smi_gpu_info` identity series as a label. This costs no new metric family, adds no new absence pattern to learn, and is queryable directly. `all_smi_gpu_info` already carries a churning label set on this platform (`thermal_pressure`, `combined_power_mw`), so one more conditional label is not a new problem class.

**Does the policy differ per metric?** No, deliberately. Temperature is the one worth arguing about: a vanishing temperature series could break a `max_over_time` thermal alert. But the alternative breaks it worse. `gpu_temp > 80` never fires either way, while a fabricated `0` makes any `gpu_temp < N` alert fire spuriously and drags every cluster temperature average down. More importantly all five fields come from a single subscription and fail together, so a split policy would force a dashboard to learn two rules for one failure mode. The codebase had already reached this conclusion internally: the TUI, the alert engine and the filter DSL all treated `temperature == 0` as unknown before this PR.

## Reader or exposition

**Both, with different jobs, because a fix in either one alone is incomplete.**

The reader must stop fabricating, because its `GpuInfo` feeds three consumers: the Prometheus exporter, the TUI, and `snapshot`. Fixing only the exporter would have left the TUI showing `0.0%`. The exposition must still translate, because the in-band absence encoding the reader uses would itself be fabricated data if it reached the wire.

There is a third boundary that neither of those covers, and missing it would have made the fix local-only. `src/network/metrics_parser.rs` builds a `GpuInfo` for remote monitoring with `utilization: 0.0, temperature: 0, power_consumption: 0.0` and only overwrites the fields whose series appear in the scrape. An omitted series therefore became a zero again on the viewing side. `all-smi view --hosts` scraping a degraded macOS node would still have shown "0.0%". The parser now starts every live field absent, so omission survives the round trip. Nodes that do report overwrite as before, so nothing changes for them.

## Why an in-band encoding rather than `Option<f64>`

`Option` is the better type and would let the compiler enforce every call site. It was rejected on blast radius: these four fields have roughly sixty consumers (gauges, sparklines, LED grid, sort comparators, energy accumulation, three CLI shims, the mock server, twelve readers), and converting them in a bug fix running alongside four sibling units on the same base would be a large regression surface for no behavioral gain over the alternative.

The encoding chosen is the one the codebase already had, rather than a new invention: negative for the `f64` fields, `0` for the `u32` fields. Both are outside the valid range of the quantities they carry. `src/ui/renderers/gpu_renderer.rs` and `src/ui/filter_dsl/eval.rs` were already reading `utilization < 0.0` and `power_consumption < 0.0` as N/A, and `temperature == 0` / `frequency == 0` as N/A, before this PR. Those branches simply had no producer. This PR gives them one, names the constant (`GPU_METRIC_UNAVAILABLE`), and puts five accessors in front of it so the magic numbers stop being scattered.

A practical consequence worth stating: the encoding is opt-in per reader, so **no other platform's exposition changes** except where noted below. `Option` would have forced a decision in all twelve readers.

## What the TUI shows

Verified by test (`absent_readings_render_as_na_not_zero`), which renders a degraded row through the real `print_gpu_info` and strips ANSI before asserting:

- `Util:   N/A`, `Temp:    N/A`, `Freq:    N/A`, `Pwr:     N/A`.
- The Util and ANE gauges draw empty with an `N/A` label. This is the "zero in a different costume" trap: a 0%-filled bar reads as *idle*, so a gauge cannot be left to render the absent value as 0. The test asserts `0.0%` and `0.0W` appear nowhere in the output.
- The paired test `zero_readings_render_as_zero` asserts the complement, so `N/A` unambiguously means no data on screen too.

Aggregations no longer fold absent values in. `src/metrics/gpu_readings.rs` (new) is the single place that skips them, used by the dashboard, the header, the sparkline panel, the LED grid, the snapshot writer and the cluster aggregator. Two of those mattered beyond cosmetics: the energy integrator would have accumulated negative joules, and the history graphs would have drawn a dip that never happened.

## Behavior changes beyond Apple Silicon

Two, both deliberate, both making the exposition agree with what the TUI already displayed:

- `all_smi_gpu_frequency_mhz` is now omitted for readers reporting a static `0` to mean "no clock probe" (Rebellions, Intel Gaudi, AMD via WMI). A flat 0 MHz line was misinformation.
- `all_smi_gpu_temperature_celsius` is now omitted when no sensor answered.

`all_smi_ane_utilization` is unchanged for non-Apple GPUs: they set a literal `0.0` meaning "not applicable" and keep publishing it, covered by a regression test.

## How the degraded path was exercised

IOReport cannot be removed from this host, so the reader was split at an honest seam instead of mocked. `build_gpu_info(static_info, apple_info, sample: Option<&NativeSample>)` holds the whole row-assembly path; `get_gpu_info` acquires the sample and calls it. Passing `sample: None` drives byte-for-byte the branch a macOS VM takes, with no `cfg(test)` switch and no forced-failure flag. Tests then push that row through the real Prometheus exporter (`degraded_row_renders_no_gpu_value_series`) and the real TUI renderer, so the seam between reader and consumer is covered, not just the reader.

The healthy half was confirmed against real hardware, an M1 Ultra, with `all-smi snapshot --format prometheus`: all six families present, `native_metrics="available"`, and `all_smi_ane_power_watts ... 0` demonstrating that a genuine zero from a live subscription is still published.

## What changed

- `src/device/types.rs`: `GPU_METRIC_UNAVAILABLE` plus five `*_reading()` accessors on `GpuInfo`.
- `src/device/readers/apple_silicon_native.rs`: extracted `build_gpu_info` + `NativeSample`; stopped unwrapping to zero; added the `native_metrics` label; 8 tests.
- `src/device/macos_native/manager.rs`, `src/device/traits.rs`: the written policy.
- `src/api/metrics/gpu.rs`: five families gated on availability; 3 tests.
- `src/network/metrics_parser.rs`: absent-by-default init, `native_metrics` allowlisted; 2 tests.
- `src/metrics/gpu_readings.rs` (new): absence-aware aggregations; 6 tests.
- `src/metrics/aggregator.rs`, `src/metrics/coordinator.rs`: cluster stats over reporting devices only; `Option` averages.
- `src/ui/{renderers/gpu_renderer,alerts,dashboard,led_grid,local_header,gpu_sparkline_panel,filter_dsl/eval}.rs`: N/A rendering and absence-aware aggregation; 2 renderer tests.
- `src/view/data_collection/aggregator.rs`, `src/api/collection_loop.rs`, `src/snapshot/collector.rs`: energy and power sums skip absent readings.
- `.github/workflows/ci.yml`: corrected the "degrade to zeros" comment and added an assertion that the runner publishes no fabricated `all_smi_gpu_utilization`.

`src/ui/renderers/gpu_renderer.rs` is one of the eight files PR #334 deliberately left alone to avoid colliding here. The diff in it is confined to the five value readouts, the two gauges, and the new tests; none of its dimension arithmetic is touched.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests -j 9 -- -D warnings`
- [x] `cargo clippy --bin all-smi -j 9 -- -D warnings` (the crate compiles its module tree twice; #309/#310/#311 were bitten by a `pub` item live in the lib and dead in the bin)
- [x] `cargo test --lib -j 9 device::readers::apple_silicon_native` (8 passed)
- [x] `cargo test --lib -j 9 api::metrics` (71 passed), `metrics::gpu_readings` (6), `network::metrics_parser` (51), `ui::renderers::gpu_renderer` (37)
- [x] `cargo test --lib -j 9` by module group: `ui::` 543, `network::` 127, `metrics::` 113, `device::` 169, `snapshot::` 47, `api::` 116, `app_state` 16, `parsing::` 19, all passing
- [x] `cargo test --test {device_tests,library_api_test,snapshot_test,thermal_pstate_integration_test,hardware_details_integration_test}` (60 passed)
- [x] Real hardware: `all-smi snapshot --format prometheus` on an M1 Ultra

Not verified: the actual degraded path on a machine without IOReport, which needs a macOS VM. The launchd smoke test in `.github/workflows/ci.yml` runs on exactly such a host and now asserts the absence, so CI on this PR is the real check.

Closes #325
