### PR TITLE
ci: build the Docker image on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1106,11 +1106,67 @@ jobs:
       - name: Build library-only (no default features)
         run: cargo build --no-default-features --lib
 
+  # ═══════════════════════════════════════════════════════════════
+  # Job: Docker Build Check (issue #328)
+  # ═══════════════════════════════════════════════════════════════
+  # This job runs on pull requests as well as pushes. It used to be
+  # gated on `github.event_name == 'push' && github.ref ==
+  # 'refs/heads/main'`, so an image break could only ever appear as a
+  # red default branch. #309 hit exactly that: the crate gained its
+  # first `include_str!` asset, the builder stage did not copy
+  # packaging/, PR #319 was fully green, and main went red on the
+  # merge commit 74f75d2.
+  #
+  # Decision: run the full build on pull requests rather than one of
+  # the cheaper variants, because the full build turns out to be
+  # nearly free in wall-clock terms. Measured over 10 runs on main:
+  #
+  #   - docker-check takes 313-354s (mean 326s) when the build context
+  #     changed, and 12-20s when it did not. GHA caching does not help
+  #     the expensive part: `COPY src/` invalidates its layer, so
+  #     `cargo build --release` reruns in full on any source change.
+  #     Only the base and apt layers are ever reused.
+  #   - build-check already runs on every PR, takes 319-378s (mean
+  #     339s), and starts at the same moment (both are `needs: test`).
+  #   - docker-check therefore finishes 0-15s after build-check
+  #     (mean 2s). It is not on the critical path; it occupies a
+  #     parallel runner slot beside a job that already costs the same.
+  #
+  # The repository is public, so standard runner minutes are not
+  # billed. The net cost of PR coverage is about 2s of wall clock.
+  #
+  # Rejected alternatives:
+  #   - Path filter on Dockerfile/.dockerignore/Cargo.*/build.rs. Over
+  #     the last 40 commits on main it would have skipped the build on
+  #     19 of 40 (48%), including 74f75d2 itself, the commit that
+  #     actually broke main. It saves ~2s and drops the one empirical
+  #     failure case we have.
+  #   - `--target builder` only. Skips the runtime stage, which is apt
+  #     + useradd + `COPY --from=builder`: a few seconds against a
+  #     ~5.5min compile, and it stops verifying that the built binary
+  #     is where the runtime stage expects to find it.
+  #   - Context-assembly check with no compile. Cheapest and worth
+  #     having, but as a complement, not a replacement: it cannot see
+  #     a missing system dependency in the builder stage. That half
+  #     lives in tests/docker_build_context_test.rs, which runs in the
+  #     `test` job. Because this job is `needs: test`, those checks
+  #     fail fast and this job never starts for the classes they
+  #     cover.
+  #
+  # Still uncovered: a moved or retagged base image breaks on its own
+  # schedule rather than per-PR, so it surfaces on whichever build
+  # runs next, not on the PR that happens to be open.
+  #
+  # cache-to is deliberately push-only. The GHA cache already holds
+  # ~13.3GB across 41 entries; `mode=max` exports from every PR would
+  # churn a shared LRU-evicted budget and could evict the warm layers
+  # main depends on, and PR-scoped caches are unreadable from other
+  # PRs anyway. Pull requests read main's cache and write nothing.
+  # ───────────────────────────────────────────────────────────────
   docker-check:
     name: Docker Build Check
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1125,4 +1181,4 @@ jobs:
           platforms: linux/amd64
           push: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max' || '' }}

--- a/tests/docker_build_context_test.rs
+++ b/tests/docker_build_context_test.rs
@@ -22,15 +22,32 @@
 //! the Dockerfile, so an asset outside that set fails the image build and
 //! nothing else.
 //!
-//! That failure is invisible until after merge: `docker-check` in
-//! `.github/workflows/ci.yml` is gated on `github.event_name == 'push' &&
-//! github.ref == 'refs/heads/main'`, so it never runs on a pull request.
 //! Issue #309 added `packaging/systemd/all-smi.service` as the first such
-//! asset, every PR check passed, and `main` went red on the merge commit
-//! with `couldn't read src/service_cmd/../../packaging/systemd/all-smi.service`.
+//! asset. Every PR check passed and `main` went red on the merge commit
+//! with `couldn't read src/service_cmd/../../packaging/systemd/all-smi.service`,
+//! because `docker-check` was then gated on pushes to main and never ran
+//! on a pull request.
 //!
-//! This test moves that class of break back onto the pull request, where
-//! it costs a few milliseconds instead of a red default branch.
+//! Since #328 that gate is gone and `docker-check` builds the image on
+//! pull requests too, so a real `docker build` now backs every PR. These
+//! tests are still the first line of defence rather than a leftover:
+//! they run in the `test` job, `docker-check` is `needs: test`, and they
+//! finish in milliseconds. For the classes they cover, the 5-6 minute
+//! image build never starts, and the failure message names the offending
+//! asset and the `COPY` line to add instead of surfacing as a raw
+//! BuildKit error partway through a compile.
+//!
+//! Two directions are checked, and they are not the same check:
+//!
+//! - every embedded asset is reachable from some builder-stage `COPY`
+//!   (the #309 break), and
+//! - every builder-stage `COPY` source actually exists in the context
+//!   (a `COPY` left pointing at a path an unrelated change renamed or
+//!   deleted).
+//!
+//! What neither can see, and what the image build on the PR is for: a
+//! missing system dependency in the builder stage, and anything that
+//! only shows up once `cargo` actually runs inside the image.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -148,6 +165,19 @@ fn copy_covers(copied: &str, target: &Path) -> bool {
     target == copied_path.as_path() || target.starts_with(&copied_path)
 }
 
+/// True when a `COPY` source is a shell-style pattern rather than a
+/// literal path.
+///
+/// The COPY-source existence check skips patterns instead of resolving
+/// them. Reproducing BuildKit's glob semantics is more surface than this
+/// test needs, and a false failure here blocks a merge, so the safe
+/// direction is to not judge what cannot be resolved cheaply. This
+/// repository uses literal paths only; if a pattern is ever introduced,
+/// the image build that now runs on every pull request still covers it.
+fn is_glob(source: &str) -> bool {
+    source.contains(['*', '?', '['])
+}
+
 /// Patterns in `.dockerignore` that would strip `target` back out of the
 /// context even though a `COPY` names it.
 ///
@@ -257,10 +287,82 @@ fn embedded_assets_are_inside_the_docker_build_context() {
         failures.is_empty(),
         "These embedded assets are unreachable from the Docker build context, so \
          `docker build` fails at compile time even though every other check passes.\n\
-         Note that the `docker-check` CI job only runs on pushes to main, so this \
-         would otherwise surface as a red default branch after merge.\n\n{detail}\n\n\
+         The `docker-check` CI job would catch this too, but only after a 5-6 minute \
+         image build and with a raw BuildKit error; this test names the fix directly.\
+         \n\n{detail}\n\n\
          Dockerfile builder stage copies: {copies:?}"
     );
+}
+
+/// The reverse of the check above: a `COPY` in the builder stage must
+/// name a path that is actually in the build context.
+///
+/// The other direction catches an asset nothing copies. This one catches
+/// a `COPY` left pointing at a path that an unrelated change renamed or
+/// deleted, which BuildKit rejects before it runs a single build step.
+#[test]
+fn builder_stage_copy_sources_exist_in_the_context() {
+    let root = repo_root();
+
+    let dockerfile = fs::read_to_string(root.join("Dockerfile")).expect("Dockerfile must exist");
+    let copies = builder_copy_sources(&dockerfile);
+    assert!(
+        !copies.is_empty(),
+        "parsed no COPY sources from the Dockerfile builder stage"
+    );
+
+    let ignore_patterns: Vec<String> = fs::read_to_string(root.join(".dockerignore"))
+        .map(|text| text.lines().map(|l| l.to_string()).collect())
+        .unwrap_or_default();
+
+    let mut failures = Vec::new();
+    for source in &copies {
+        if is_glob(source) {
+            continue;
+        }
+        let trimmed = source.trim_end_matches('/');
+        if trimmed == "." || trimmed.is_empty() {
+            continue;
+        }
+        let relative = Path::new(trimmed);
+
+        if !root.join(relative).exists() {
+            failures.push(format!(
+                "  COPY {source}\n    No such path in the build context.\n    \
+                 To fix: drop the COPY line, or repoint it at wherever this path moved to."
+            ));
+            continue;
+        }
+
+        if let Some(pattern) = dockerignore_hit(&ignore_patterns, relative) {
+            failures.push(format!(
+                "  COPY {source}\n    The path exists, but .dockerignore pattern `{pattern}` \
+                 strips it back out of the context.\n    \
+                 To fix: narrow that pattern or add a `!` negation for this path."
+            ));
+        }
+    }
+
+    let detail = failures.join("\n");
+    assert!(
+        failures.is_empty(),
+        "The Dockerfile builder stage copies paths that are not in the build context. \
+         BuildKit rejects such a build before running any build step, so `docker build` \
+         fails for everyone the moment this lands.\n\n{detail}"
+    );
+}
+
+#[test]
+fn glob_copy_sources_are_recognised() {
+    assert!(is_glob("packaging/*.service"));
+    assert!(is_glob("src/**"));
+    assert!(is_glob("file?.txt"));
+    assert!(is_glob("[abc].txt"));
+
+    assert!(!is_glob("src/"));
+    assert!(!is_glob("Cargo.toml"));
+    assert!(!is_glob("packaging/systemd/all-smi.service"));
+    assert!(!is_glob("."));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`docker-check` was gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so an image break could only ever surface as a red default branch. This removes the gate so pull requests build the image, and records the decision and its arithmetic in a comment on the job.

## The measurement

The issue asked for measured cost, not an estimate. Job timings pulled from `gh api repos/lablup/all-smi/actions/runs/<id>/jobs` over 10 runs on `main`:

| | duration |
|---|---|
| `docker-check`, build context changed | 313-354s (mean 326s), n=7 |
| `docker-check`, context unchanged (docs/workflow-only commits) | 12-20s (mean 15s), n=3 |
| `build-check`, which already runs on every PR | 319-378s (mean 339s) |
| **`docker-check` finishing after `build-check`** | **0-15s, mean 2s** |

Two things fall out of this:

GHA caching does not help the expensive part. `COPY src/` invalidates its layer, so `cargo build --release` reruns in full on any source change; only the base and apt layers are ever reused. That is why the 313-354s band is flat and why the 12-20s runs are exactly the commits that touched no build-context file.

More importantly, `docker-check` is not on the critical path. It and `build-check` are both `needs: test`, so they start together and run in parallel, and they do roughly the same work (a release compile of this crate). `docker-check` finishes a mean of 2s after `build-check`. The repository is public, so standard runner minutes are not billed. **The measured cost of PR coverage is about 2 seconds of wall clock and one parallel runner slot.**

## Decision

Run the full build on pull requests. At ~2s marginal cost, every cheaper variant trades away real coverage for a saving that rounds to nothing.

**Rejected: path filter** on `Dockerfile`/`.dockerignore`/`Cargo.toml`/`Cargo.lock`/`build.rs`. Over the last 40 commits on `main` it would have skipped the build on 19 of 40 (48%). That set includes `74f75d2`, the commit that actually broke `main` and motivated this issue: it added an `include_str!` asset under `src/` and touched none of the filter paths. A filter that misses the one empirical failure we have, to save ~2s, is a bad trade.

**Rejected: `--target builder` only.** Skips the runtime stage, which is apt + `useradd` + `COPY --from=builder`: a few seconds against a ~5.5min compile. It also stops verifying that the built binary lands where the runtime stage looks for it.

**Rejected as a replacement, adopted as a complement: context-assembly check.** It cannot see a missing system dependency in the builder stage, so it cannot stand in for the build. It is worth having anyway, and this PR extends it (below).

**`cache-to` is now push-only.** The GHA cache already holds ~13.3GB across 41 entries. `mode=max` exports from every PR would churn a shared, LRU-evicted budget and could evict the warm layers `main` depends on, and PR-scoped caches are unreadable from other PRs anyway. Pull requests read `main`'s cache and write nothing.

## Relationship to `tests/docker_build_context_test.rs`

Both are kept, and they cover different classes.

The test covers embedded assets: every `include_str!`/`include_bytes!` target must be reachable from a builder-stage `COPY`. This PR adds the reverse direction, which was uncovered: every builder-stage `COPY` source must exist in the context, catching a `COPY` left pointing at a path an unrelated change renamed or deleted.

The image build covers what neither can: a missing system dependency in the builder stage, and anything that only appears once `cargo` runs inside the image.

The tests are not made redundant by building on PRs. They run in the `test` job, `docker-check` is `needs: test`, and they finish in milliseconds. For the classes they cover the 5-6 minute build never starts, and the failure names the offending path and the fix rather than a raw BuildKit error partway through a compile.

## What stays uncovered

A moved or retagged base image breaks on its own schedule rather than per-PR, so it surfaces on whichever build happens to run next, not on the PR that is open. Nothing here turns that into a PR-time signal; a scheduled build would be the right tool if it ever becomes a problem.

## What changed

- `.github/workflows/ci.yml`: drop the `if:` gate on `docker-check`; make `cache-to` push-only; add a comment block recording the decision, the measurements, and the rejected alternatives.
- `tests/docker_build_context_test.rs`: add `builder_stage_copy_sources_exist_in_the_context` and `glob_copy_sources_are_recognised`; update the module doc, which claimed `docker-check` never runs on a pull request; reword the failure message that said the job only runs on pushes to main.

## Test plan

Negative controls, each paired with a real `docker build` on the same input:

- [x] **New check.** Adding `COPY nonexistent-assets/` to the builder stage fails `builder_stage_copy_sources_exist_in_the_context` with `No such path in the build context. To fix: drop the COPY line, or repoint it at wherever this path moved to.` A real `docker buildx build --target builder` on the identical Dockerfile fails in 2s with `failed to compute cache key: ... "/nonexistent-assets": not found`.
- [x] **Existing check (PR #322's control, re-verified).** Removing `COPY packaging/` fails `embedded_assets_are_inside_the_docker_build_context`, now naming both embedded assets (`packaging/systemd/all-smi.service` and `packaging/launchd/com.lablup.all-smi.plist`). A probe build over the same COPY set confirms the asset is genuinely absent from the assembled context (`PROBE: ... is NOT in the build context`), while the unmodified COPY set has it.
- [x] `cargo test --test docker_build_context_test` (7 passed)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo clippy --bin all-smi -- -D warnings`
- [x] `cargo fmt --check`
- [x] `actionlint .github/workflows/ci.yml`: no findings beyond the 5 already present on `main` (3x SC2015, 1x SC2251, 1x unknown self-hosted runner label), none in `docker-check`.
- [x] This PR's own CI run is the positive control for the trigger change: `docker-check` now appears on a pull request and builds the image.

Closes #328
