### PR TITLE
chore: remove the dead vendored OpenSSL dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,6 @@ dependencies = [
  "num_cpus",
  "nvml-wrapper",
  "once_cell",
- "openssl",
  "prost 0.14.4",
  "prost-types 0.14.4",
  "rand",
@@ -2775,15 +2774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,7 +2781,6 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,12 +79,6 @@ libloading = "0.9"
 # each bump.
 libamdgpu_top = "=0.11.5"
 
-[target.'cfg(target_env = "musl")'.dependencies]
-openssl = { version = "0.10.80", features = ["vendored"] }
-
-[target.'cfg(all(target_arch = "aarch64", target_env = "gnu"))'.dependencies]
-openssl = { version = "0.10.80", features = ["vendored"] }
-
 # Windows-specific dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
 wmi = "0.18"


### PR DESCRIPTION
## Summary

Deletes the two target-conditional `openssl = { features = ["vendored"] }` blocks from `Cargo.toml`. Nothing in the tree uses OpenSSL, and those two entries were the only reason it was in the dependency graph at all. Because `.github/workflows/release.yml` builds `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-gnu`, and `aarch64-unknown-linux-musl`, which are exactly the targets the two `cfg`s covered, every release was compiling OpenSSL from source three times for a dependency nothing links against.

## Why they were there, and why they are not needed now

`f1eeb4e` added both blocks while the manifest still declared reqwest 0.12, which resolved with native-tls and therefore carried a live transitive `openssl-sys`. The direct `vendored` dependency forced that to link statically, which suited the musl and cross-compiled aarch64 release binaries. `3de545d` then moved to reqwest 0.13, which defaults to rustls, and the live transitive dependency disappeared. Both blocks have been vestigial since.

Confirmed independently rather than taken on faith: `grep -rn openssl src/ --include='*.rs'` returns nothing, and before this change `cargo tree -i openssl` reported `all-smi` itself as the sole reverse dependency on `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`, `x86_64-unknown-linux-musl`, and `--target all`, while returning nothing at all on `x86_64-unknown-linux-gnu`.

## What changed

- `Cargo.toml`: removed the `[target.'cfg(target_env = "musl")'.dependencies]` and `[target.'cfg(all(target_arch = "aarch64", target_env = "gnu"))'.dependencies]` blocks (former lines 82-83 and 85-86).
- `Cargo.lock`: 11 lines removed. `openssl` drops out of the `all-smi` dependency list, and the `openssl-src` package entry plus its edge from `openssl-sys` are removed.

## Two things that deliberately did not change

- **`openssl`, `openssl-sys`, `foreign-types`, and `native-tls` remain in `Cargo.lock`.** The lockfile records the union of the graph including feature-gated edges, and `furiosa-smi-rs -> attohttpc -> native-tls -> openssl` keeps them recorded even though that edge activates for no target. "openssl disappeared from `Cargo.lock`" is therefore the wrong success check. The right one is `cargo tree --target all -i openssl` returning nothing, which it now does.
- **`openssl-probe` is untouched.** Despite the name it has nothing to do with the `openssl` crate, and it is live via `reqwest -> rustls-platform-verifier -> rustls-native-certs -> openssl-probe`. It still compiles in every Linux build below, which is the expected rustls behavior.

## Test plan

Cross-target builds were run in Linux containers from this branch, because `cargo tree` is an argument and not a build. Each produced a real release binary and none compiled `openssl-sys`.

- [x] `aarch64-unknown-linux-gnu` fully **built** (native arm64 container, `cargo build --release --locked --bin all-smi`), finished in 2m58s, 9.6MB binary, no `openssl-*` build directories
- [x] `aarch64-unknown-linux-musl` fully **built** (native arm64 container), finished in 2m40s, 9.0MB binary, no `openssl-*` build directories
- [x] `x86_64-unknown-linux-musl` fully **built** (emulated amd64 container), finished in 19m28s, 12.0MB binary, no `openssl-*` build directories
- [x] `cargo tree --target all -i openssl` returns nothing, and likewise for each of the three targets individually
- [x] `cargo tree --target all -i openssl-probe` still resolves through `rustls-native-certs`, confirming the live path survived
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo clippy --bin all-smi -- -D warnings`
- [x] `cargo test --test docker_build_context_test` (7 passed)

`x86_64-unknown-linux-gnu` was not built here: the `cfg`s never applied to it, and `cargo tree -i openssl` returned nothing for it even before this change, so it had no OpenSSL to lose. CI's own `build-check` covers it.

## Scope note

This PR does not touch the `Dockerfile` or the `docker-check` CI job. #341 was originally filed as a container bug and carried acceptance criteria about building `linux/amd64,linux/arm64`; those are obsolete because the Docker image is being removed rather than fixed, tracked in #342. The issue body has been rewritten to record that, with the dropped criteria struck through and explained rather than deleted. Removing these two blocks stands on its own as a release-build change.

Closes #341
