### PR TITLE
feat: add vendor-neutral Windows GPU metrics via DXGI and PDH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "whoami",
+ "windows",
  "windows-service",
  "wmi",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,18 @@ libamdgpu_top = "=0.11.5"
 [target.'cfg(target_os = "windows")'.dependencies]
 wmi = "0.18"
 libloading = "0.9"
+# DXGI (true 64-bit VRAM size, adapter LUID / PCI ids) and PDH (GPU
+# Engine utilization, per-adapter and per-process dedicated memory) for
+# the vendor-neutral Windows GPU metrics layer, issue #346. Version
+# pinned to the one `wmi` already resolves, so this promotes an existing
+# transitive dependency to a direct one rather than adding a new entry
+# to the supply chain.
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Dxgi_Common",
+    "Win32_System_Performance",
+] }
 # Service Control Manager integration for `all-smi service` (issue #311).
 # Mullvad's crate, MIT OR Apache-2.0, MSRV 1.71 against this project's
 # rust-version = 1.96. Chosen over shelling to sc.exe so failures arrive

--- a/src/device/readers/amd_windows.rs
+++ b/src/device/readers/amd_windows.rs
@@ -239,14 +239,17 @@ impl GpuReader for AmdWindowsGpuReader {
 
     fn get_process_info(&self) -> Vec<ProcessInfo> {
         // Per-process GPU memory comes from the PDH `GPU Process
-        // Memory` counter. `latest()` reuses the sample `get_gpu_info`
-        // already took: collecting again here would consume a second
-        // PDH collection and halve the interval the utilization rate is
-        // computed over.
+        // Memory` counter, reusing the sample `get_gpu_info` already
+        // took. The closure covers one-shot callers that never call
+        // `get_gpu_info` at all, such as
+        // `all-smi snapshot --include process`.
         let Ok(adapter_index) = self.adapter_index.lock() else {
             return Vec::new();
         };
-        windows_gpu_perf::process_rows(&adapter_index)
+        windows_gpu_perf::process_rows_with(&adapter_index, || {
+            let mut gpus = self.query_amd_gpus();
+            windows_gpu_perf::augment_gpus(&mut gpus)
+        })
     }
 }
 

--- a/src/device/readers/amd_windows.rs
+++ b/src/device/readers/amd_windows.rs
@@ -12,18 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! AMD GPU reader for Windows using WMI
+//! AMD GPU reader for Windows.
 //!
-//! This module provides basic AMD GPU information on Windows via WMI.
-//! Note: Detailed metrics like utilization and temperature require AMD ADL SDK,
-//! which is not currently implemented.
+//! `Win32_VideoController` supplies the card's identity (name, PCI ids,
+//! driver version) and nothing else of substance: no utilization, no
+//! temperature, and a `uint32` `AdapterRAM` field that saturates at
+//! 4 GB. The vendor-neutral [`windows_gpu_perf`] layer is applied on top
+//! to fill in the true VRAM size (DXGI), device utilization and
+//! system-wide used VRAM (PDH), and per-process GPU memory.
+//!
+//! Temperature, power, fan speed, and clocks are still absent here:
+//! WDDM does not publish them, and they need AMD's own ADL library.
 
 use crate::device::GpuReader;
+use crate::device::readers::windows_gpu_perf::{self, ids::AdapterLuid};
 use crate::device::types::{GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
 use chrono::Local;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::sync::Mutex;
 use wmi::WMIConnection;
 
 // Thread-local WMI connection for reuse within the same thread
@@ -69,7 +77,17 @@ struct VideoControllerName {
     name: Option<String>,
 }
 
-pub struct AmdWindowsGpuReader {}
+pub struct AmdWindowsGpuReader {
+    /// Adapter LUID to `(device index, GPU uuid)`, recorded by
+    /// `get_gpu_info` so `get_process_info` can attribute a PDH
+    /// per-process row to the right card without re-querying WMI or
+    /// consuming a second PDH collection.
+    ///
+    /// Empty until the first `get_gpu_info` call, so a
+    /// `get_process_info` that runs first simply reports nothing and the
+    /// next poll fills it in.
+    adapter_index: Mutex<HashMap<AdapterLuid, (usize, String)>>,
+}
 
 impl Default for AmdWindowsGpuReader {
     fn default() -> Self {
@@ -79,7 +97,9 @@ impl Default for AmdWindowsGpuReader {
 
 impl AmdWindowsGpuReader {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            adapter_index: Mutex::new(HashMap::new()),
+        }
     }
 
     fn query_amd_gpus(&self) -> Vec<GpuInfo> {
@@ -112,22 +132,13 @@ impl AmdWindowsGpuReader {
                     .clone()
                     .unwrap_or_else(|| format!("AMD-GPU-{idx}"));
 
-                // Get adapter RAM (in bytes)
-                // LIMITATION: Win32_VideoController.AdapterRAM is a 32-bit uint32 in WMI,
-                // which can only represent up to 4GB (4,294,967,295 bytes). For GPUs with
-                // more than 4GB VRAM, this value will be incorrect (wrapped or capped).
-                // Unfortunately, there's no standard WMI alternative for accurate VRAM
-                // reporting on AMD GPUs without the AMD ADL SDK.
+                // Baseline VRAM size. `Win32_VideoController.AdapterRAM`
+                // is a `uint32` in the WMI schema, so anything above 4 GB
+                // arrives saturated or wrapped. This value is only a
+                // fallback: `windows_gpu_perf` overwrites it with DXGI's
+                // 64-bit `DedicatedVideoMemory` whenever DXGI answers,
+                // which is every machine with a working display driver.
                 let total_memory = controller.adapter_r_a_m.unwrap_or(0);
-
-                // Warn if the reported VRAM is suspiciously close to 4GB limit or 0
-                const FOUR_GB: u64 = 4 * 1024 * 1024 * 1024; // 4,294,967,296 bytes
-                if total_memory == 0 {
-                    eprintln!("AMD GPU '{name}': VRAM size unavailable (reported as 0)");
-                } else if total_memory >= FOUR_GB - (512 * 1024 * 1024) {
-                    // If reported value is >= 3.5GB, it might be capped/wrapped for >4GB GPU
-                    eprintln!("AMD GPU '{name}': VRAM reported as {total_memory} bytes, may be inaccurate for >4GB GPUs due to WMI 32-bit limitation");
-                }
 
                 // Build detail map
                 let mut detail = HashMap::new();
@@ -145,10 +156,24 @@ impl AmdWindowsGpuReader {
                     detail.insert("DAC Type".to_string(), dac_type.clone());
                 }
 
-                // Add note about limited metrics
+                // `Metrics Source` advertises which backends produced
+                // this card's numbers; `windows_gpu_perf` appends to it
+                // as DXGI and PDH contribute. The per-field `Source: *`
+                // keys mirror the Intel Windows reader so both vendors
+                // expose provenance the same way.
+                detail.insert("Metrics Source".to_string(), "WMI".to_string());
                 detail.insert(
                     "Note".to_string(),
-                    "Detailed metrics require AMD ADL SDK".to_string(),
+                    "Temperature, power, and fan need the AMD ADL library".to_string(),
+                );
+                detail.insert("Source: Utilization".to_string(), "unavailable".to_string());
+                detail.insert("Source: Temperature".to_string(), "unavailable".to_string());
+                detail.insert("Source: Power".to_string(), "unavailable".to_string());
+                detail.insert("Source: Frequency".to_string(), "unavailable".to_string());
+                detail.insert("Source: Fan".to_string(), "unavailable".to_string());
+                detail.insert(
+                    "Source: Memory".to_string(),
+                    if total_memory > 0 { "WMI" } else { "unavailable" }.to_string(),
                 );
 
                 gpu_list.push(GpuInfo {
@@ -192,19 +217,36 @@ impl AmdWindowsGpuReader {
         })
         .unwrap_or_default()
     }
+
+    /// Layer the vendor-neutral DXGI and PDH metrics onto the WMI
+    /// baseline, and record the LUID mapping `get_process_info` needs.
+    fn augment_with_windows_perf(&self, gpus: &mut [GpuInfo]) {
+        let adapter_index = windows_gpu_perf::augment_gpus(gpus);
+        if let Ok(mut guard) = self.adapter_index.lock() {
+            *guard = adapter_index;
+        }
+    }
 }
 
 impl GpuReader for AmdWindowsGpuReader {
     fn get_gpu_info(&self) -> Vec<GpuInfo> {
         // Query fresh data each time (timestamp updates)
         // But we could cache the static parts if needed
-        self.query_amd_gpus()
+        let mut gpus = self.query_amd_gpus();
+        self.augment_with_windows_perf(&mut gpus);
+        gpus
     }
 
     fn get_process_info(&self) -> Vec<ProcessInfo> {
-        // GPU process information is not available via WMI
-        // This would require AMD ADL SDK
-        Vec::new()
+        // Per-process GPU memory comes from the PDH `GPU Process
+        // Memory` counter. `latest()` reuses the sample `get_gpu_info`
+        // already took: collecting again here would consume a second
+        // PDH collection and halve the interval the utilization rate is
+        // computed over.
+        let Ok(adapter_index) = self.adapter_index.lock() else {
+            return Vec::new();
+        };
+        windows_gpu_perf::process_rows(&adapter_index)
     }
 }
 

--- a/src/device/readers/intel_gpu_windows.rs
+++ b/src/device/readers/intel_gpu_windows.rs
@@ -278,10 +278,14 @@ impl GpuReader for IntelWindowsGpuReader {
         // Per-process dedicated GPU memory comes from the PDH `GPU
         // Process Memory` counter, reusing the sample `get_gpu_info`
         // already took. Mirrors the AMD-on-Windows reader.
+        use crate::device::readers::windows_gpu_perf;
         let Ok(adapter_index) = self.adapter_index.lock() else {
             return Vec::new();
         };
-        crate::device::readers::windows_gpu_perf::process_rows(&adapter_index)
+        windows_gpu_perf::process_rows_with(&adapter_index, || {
+            let mut gpus = self.query_intel_gpus();
+            windows_gpu_perf::augment_gpus(&mut gpus)
+        })
     }
 }
 

--- a/src/device/readers/intel_gpu_windows.rs
+++ b/src/device/readers/intel_gpu_windows.rs
@@ -42,7 +42,6 @@ use crate::utils::get_hostname;
 use chrono::Local;
 use serde::Deserialize;
 use std::collections::HashMap;
-#[cfg(feature = "level_zero")]
 use std::sync::Mutex;
 use wmi::WMIConnection;
 
@@ -100,6 +99,10 @@ pub struct IntelWindowsGpuReader {
     #[cfg(feature = "level_zero")]
     level_zero_state:
         Mutex<HashMap<String, crate::device::readers::intel_gpu_level_zero::LevelZeroState>>,
+    /// Adapter LUID to `(device index, GPU uuid)`, recorded by
+    /// `get_gpu_info` so `get_process_info` can attribute a PDH
+    /// per-process row to the right card.
+    adapter_index: Mutex<crate::device::readers::windows_gpu_perf::AdapterIndex>,
 }
 
 impl Default for IntelWindowsGpuReader {
@@ -113,6 +116,7 @@ impl IntelWindowsGpuReader {
         Self {
             #[cfg(feature = "level_zero")]
             level_zero_state: Mutex::new(HashMap::new()),
+            adapter_index: Mutex::new(Default::default()),
         }
     }
 
@@ -256,16 +260,28 @@ impl IntelWindowsGpuReader {
 impl GpuReader for IntelWindowsGpuReader {
     fn get_gpu_info(&self) -> Vec<GpuInfo> {
         let mut gpus = self.query_intel_gpus();
+        // The vendor-neutral DXGI / PDH layer runs first so the Level
+        // Zero augmentation below overwrites it wherever both produce a
+        // reading. L0 talks to the driver directly and is the more
+        // authoritative source for utilization and power; DXGI remains
+        // the only source of a correct 64-bit VRAM size either way.
+        let adapter_index = crate::device::readers::windows_gpu_perf::augment_gpus(&mut gpus);
+        if let Ok(mut guard) = self.adapter_index.lock() {
+            *guard = adapter_index;
+        }
         #[cfg(feature = "level_zero")]
         self.augment_with_level_zero(&mut gpus);
         gpus
     }
 
     fn get_process_info(&self) -> Vec<ProcessInfo> {
-        // Per-process GPU memory on Windows requires PDH / D3DKMT or
-        // Level Zero. Not available via Win32_VideoController. Mirrors
-        // the AMD-on-Windows reader.
-        Vec::new()
+        // Per-process dedicated GPU memory comes from the PDH `GPU
+        // Process Memory` counter, reusing the sample `get_gpu_info`
+        // already took. Mirrors the AMD-on-Windows reader.
+        let Ok(adapter_index) = self.adapter_index.lock() else {
+            return Vec::new();
+        };
+        crate::device::readers::windows_gpu_perf::process_rows(&adapter_index)
     }
 }
 

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -85,3 +85,15 @@ pub mod intel_gpu_sysfs;
 
 #[cfg(target_os = "windows")]
 pub mod intel_gpu_windows;
+
+// Vendor-neutral Windows GPU metrics (DXGI + PDH).
+//
+// The `test` arm is load-bearing, not incidental. No CI job builds this
+// crate for Windows at all, so the counter-instance parsing, the
+// utilization aggregation, and the WMI-to-adapter pairing would ship
+// with zero automated coverage if this were gated on Windows alone.
+// Compiling it under `cfg(test)` everywhere puts that logic in front of
+// the Linux test runner, which is the only runner this repository
+// actually has. Same shape as `intel_gpu_sysfs` above.
+#[cfg(any(target_os = "windows", test))]
+pub mod windows_gpu_perf;

--- a/src/device/readers/windows_gpu_perf.rs
+++ b/src/device/readers/windows_gpu_perf.rs
@@ -38,6 +38,17 @@
 //! overwrite afterwards. Each field records where it came from in the
 //! `Source: *` detail keys the Intel reader already established.
 //!
+//! ## Known limitation: one-shot invocations report no utilization
+//!
+//! Utilization is a PDH rate counter, so it only exists once two
+//! collections can be differenced. Any caller that samples exactly once
+//! and exits, `all-smi snapshot` at its default `--samples 1` or a
+//! library consumer doing a single `get_gpu_info`, therefore sees the
+//! WMI baseline utilization rather than a real figure. The polling
+//! paths (`view` and `api`) are unaffected from their second poll
+//! onward. Memory figures are gauges and are correct from the first
+//! collection either way.
+//!
 //! ## Platform gating
 //!
 //! The DXGI and PDH FFI submodules are Windows-only. Everything else
@@ -69,8 +80,15 @@ use std::collections::HashMap;
 #[derive(Clone, Debug)]
 pub struct AdapterMetrics {
     pub identity: AdapterIdentity,
-    /// True dedicated VRAM size in bytes, from DXGI.
+    /// Adapter capacity in bytes, from DXGI.
     pub total_memory: Option<u64>,
+    /// Whether [`Self::total_memory`] is a dedicated VRAM pool or the
+    /// shared system-memory aperture an integrated GPU uses.
+    ///
+    /// Recorded so the provenance the reader publishes does not claim
+    /// more than the number delivers: "DXGI" and "DXGI (shared)" mean
+    /// materially different things to someone reading a memory gauge.
+    pub memory_is_shared: bool,
     /// System-wide dedicated VRAM in use, in bytes, from the PDH
     /// `GPU Adapter Memory` counter.
     pub used_memory: Option<u64>,
@@ -119,13 +137,41 @@ impl Snapshot {
     }
 }
 
-/// Take a fresh sample and cache it for [`latest`].
+/// How long a snapshot stays fresh enough to be reused instead of
+/// taking another PDH collection.
 ///
-/// Cheap to call once per poll; do not call it twice in one poll, as
-/// each call consumes one PDH collection and the utilization rate is
-/// computed between consecutive collections.
+/// This is not an optimisation, it is a correctness requirement.
+/// `Utilization Percentage` is a rate computed between consecutive
+/// collections, so two collections microseconds apart yield a rate over
+/// a microsecond, which reads as 0 or as a clamped 100 rather than as
+/// the load over the poll interval.
+///
+/// More than one reader can be registered at once: `get_gpu_readers`
+/// tests for AMD and Intel adapters with independent `if`s, and a laptop
+/// with an Intel iGPU beside a Radeon dGPU (or an AMD APU beside an Arc
+/// card) registers both. The collectors then call `get_gpu_info` on each
+/// in turn within the same poll. Without coalescing, whichever reader
+/// runs second would always see a near-zero interval, deterministically,
+/// and its utilization would be useless. `get_gpu_info_by_uuid`'s
+/// default body has the same shape when called in a loop.
+///
+/// 500 ms is comfortably below all-smi's fastest poll interval (1 s for
+/// local monitoring) so consecutive polls still each get a fresh
+/// collection, and comfortably above the time it takes to walk a
+/// handful of readers.
+#[cfg(target_os = "windows")]
+const SNAPSHOT_COALESCE_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Take a sample, reusing the cached one when it is younger than
+/// [`SNAPSHOT_COALESCE_WINDOW`].
+///
+/// Safe to call from every registered reader in the same poll: only the
+/// first call collects, and the rest share its result.
 #[cfg(target_os = "windows")]
 pub fn snapshot() -> Snapshot {
+    if let Some(cached) = cached_snapshot(SNAPSHOT_COALESCE_WINDOW) {
+        return cached;
+    }
     let dxgi_adapters = dxgi::enumerate();
     let sample = pdh::sample();
 
@@ -133,10 +179,22 @@ pub fn snapshot() -> Snapshot {
         .into_iter()
         .map(|adapter| {
             let luid = adapter.identity.luid;
+            // Integrated graphics report no dedicated pool at all and
+            // address system RAM instead, so falling back to
+            // `SharedSystemMemory` is the difference between a correct
+            // capacity and leaving the wrong 32-bit WMI value in place
+            // for every Intel iGPU.
+            let (total_memory, memory_is_shared) = if adapter.dedicated_video_memory > 0 {
+                (Some(adapter.dedicated_video_memory), false)
+            } else if adapter.shared_system_memory > 0 {
+                (Some(adapter.shared_system_memory), true)
+            } else {
+                (None, false)
+            };
             AdapterMetrics {
                 identity: adapter.identity,
-                total_memory: (adapter.dedicated_video_memory > 0)
-                    .then_some(adapter.dedicated_video_memory),
+                total_memory,
+                memory_is_shared,
                 used_memory: sample.adapter_memory.get(&luid).copied(),
                 utilization: sample.utilization.get(&luid).copied(),
                 process_budget: adapter.process_budget,
@@ -160,7 +218,7 @@ pub fn snapshot() -> Snapshot {
         adapters,
         processes,
     };
-    cache_snapshot(&snapshot);
+    store_snapshot(&snapshot);
     snapshot
 }
 
@@ -173,33 +231,53 @@ pub fn snapshot() -> Snapshot {
 }
 
 #[cfg(target_os = "windows")]
-static LAST_SNAPSHOT: once_cell::sync::OnceCell<std::sync::Mutex<Snapshot>> =
-    once_cell::sync::OnceCell::new();
+type SnapshotCache = std::sync::Mutex<Option<(std::time::Instant, Snapshot)>>;
 
 #[cfg(target_os = "windows")]
-fn cache_snapshot(snapshot: &Snapshot) {
-    let cell = LAST_SNAPSHOT.get_or_init(|| std::sync::Mutex::new(Snapshot::default()));
-    let mut guard = match cell.lock() {
+static LAST_SNAPSHOT: once_cell::sync::OnceCell<SnapshotCache> = once_cell::sync::OnceCell::new();
+
+#[cfg(target_os = "windows")]
+fn snapshot_cache() -> &'static SnapshotCache {
+    LAST_SNAPSHOT.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// The cached snapshot, if it is younger than `max_age`.
+#[cfg(target_os = "windows")]
+fn cached_snapshot(max_age: std::time::Duration) -> Option<Snapshot> {
+    let guard = match snapshot_cache().lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    *guard = snapshot.clone();
+    guard
+        .as_ref()
+        .and_then(|(taken_at, snapshot)| (taken_at.elapsed() < max_age).then(|| snapshot.clone()))
+}
+
+#[cfg(target_os = "windows")]
+fn store_snapshot(snapshot: &Snapshot) {
+    let mut guard = match snapshot_cache().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *guard = Some((std::time::Instant::now(), snapshot.clone()));
 }
 
 /// The most recent [`snapshot`], without consuming a PDH collection.
 ///
-/// `get_process_info` uses this so that a poll which already called
-/// `snapshot` from `get_gpu_info` does not disturb the utilization rate
-/// by collecting twice.
+/// `get_process_info` uses this so a poll that already sampled from
+/// `get_gpu_info` does not disturb the utilization rate. Unlike
+/// [`snapshot`] this never collects, and returns an empty snapshot when
+/// nothing has been sampled yet.
 #[cfg(target_os = "windows")]
 pub fn latest() -> Snapshot {
-    let Some(cell) = LAST_SNAPSHOT.get() else {
-        return Snapshot::default();
+    let guard = match snapshot_cache().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
     };
-    match cell.lock() {
-        Ok(guard) => guard.clone(),
-        Err(poisoned) => poisoned.into_inner().clone(),
-    }
+    guard
+        .as_ref()
+        .map(|(_, snapshot)| snapshot.clone())
+        .unwrap_or_default()
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -250,8 +328,15 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, metrics: &AdapterMetrics) {
 
     if let Some(total) = metrics.total_memory {
         gpu.total_memory = total;
-        gpu.detail
-            .insert("Source: Memory".to_string(), "DXGI".to_string());
+        gpu.detail.insert(
+            "Source: Memory".to_string(),
+            if metrics.memory_is_shared {
+                "DXGI (shared)"
+            } else {
+                "DXGI"
+            }
+            .to_string(),
+        );
         touched_dxgi = true;
     }
 
@@ -272,8 +357,20 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, metrics: &AdapterMetrics) {
 
     if let Some(used) = metrics.used_memory {
         gpu.used_memory = used;
-        gpu.detail
-            .insert("Source: Memory Used".to_string(), "PDH".to_string());
+        // On an integrated GPU the `GPU Adapter Memory\Dedicated Usage`
+        // counter tracks only the small stolen-memory carve-out, not the
+        // shared aperture the total now reports. Say so rather than
+        // labelling it plain "PDH", which would imply the two numbers
+        // are the same kind of quantity.
+        gpu.detail.insert(
+            "Source: Memory Used".to_string(),
+            if metrics.memory_is_shared {
+                "PDH (dedicated carve-out only)"
+            } else {
+                "PDH"
+            }
+            .to_string(),
+        );
         touched_pdh = true;
     }
 
@@ -338,13 +435,55 @@ pub fn augment_gpus(gpus: &mut [GpuInfo]) -> AdapterIndex {
     pair_and_apply(gpus, &snapshot)
 }
 
-/// Build per-process GPU memory rows from the most recent snapshot.
+/// Build the merged per-process rows a reader's `get_process_info`
+/// should return.
 ///
-/// Uses [`latest`] rather than sampling again: a second collection in
-/// the same poll would halve the interval the utilization rate is
-/// computed over.
-pub fn process_rows(adapter_index: &AdapterIndex) -> Vec<ProcessInfo> {
-    process_rows_from(&latest(), adapter_index)
+/// Two things happen here beyond reading the snapshot:
+///
+/// 1. If `adapter_index` is empty, nothing has paired adapters yet. That
+///    is the case for one-shot entry points such as
+///    `all-smi snapshot --include process`, which never call
+///    `get_gpu_info`. Rather than reporting an empty list forever, the
+///    caller is given a chance to populate the index first via
+///    `refresh`.
+/// 2. The GPU rows are merged against the system process table, matching
+///    what `nvidia`, `nvidia_jetson`, and `tenstorrent` do inside their
+///    own `get_process_info`. The API and snapshot collectors consume
+///    `get_process_info` directly without merging, so returning bare
+///    skeleton rows would export processes with empty names and zeroed
+///    CPU and RSS.
+pub fn process_rows_with<F>(adapter_index: &AdapterIndex, refresh: F) -> Vec<ProcessInfo>
+where
+    F: FnOnce() -> AdapterIndex,
+{
+    let owned;
+    let adapter_index = if adapter_index.is_empty() {
+        owned = refresh();
+        &owned
+    } else {
+        adapter_index
+    };
+    if adapter_index.is_empty() {
+        return Vec::new();
+    }
+
+    let gpu_rows = process_rows_from(&latest(), adapter_index);
+    if gpu_rows.is_empty() {
+        return Vec::new();
+    }
+
+    let gpu_pids: std::collections::HashSet<u32> = gpu_rows.iter().map(|row| row.pid).collect();
+    let all_processes = crate::utils::system::with_global_system(|system| {
+        system.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::All,
+            true,
+            sysinfo::ProcessRefreshKind::everything().with_user(sysinfo::UpdateKind::Always),
+        );
+        system.refresh_memory();
+        crate::device::process_list::get_all_processes(system, &gpu_pids)
+    });
+
+    crate::device::process_list::merge_gpu_processes(all_processes, gpu_rows)
 }
 
 /// Attribute each per-process sample to the card its LUID names.
@@ -464,6 +603,7 @@ mod tests {
                 description: "AMD Radeon RX 7900 XTX".to_string(),
             },
             total_memory: total,
+            memory_is_shared: false,
             used_memory: used,
             utilization,
             process_budget: None,
@@ -660,7 +800,7 @@ mod tests {
         // Windows they touch real hardware, so only assert they return.
         let mut gpus = vec![blank_gpu()];
         let index = augment_gpus(&mut gpus);
-        let _ = process_rows(&index);
+        let _ = process_rows_with(&index, AdapterIndex::new);
         let _ = pdh_query_available();
         let _ = latest();
 
@@ -670,12 +810,41 @@ mod tests {
             assert!(latest().is_empty());
             assert!(!pdh_query_available());
             assert!(index.is_empty());
-            assert!(process_rows(&index).is_empty());
+            // An empty index triggers the refresh closure; when that
+            // also comes back empty the result must be no rows rather
+            // than a panic or a wasted system-process enumeration.
+            assert!(process_rows_with(&index, AdapterIndex::new).is_empty());
             // An inert layer must leave the WMI baseline exactly as it
             // found it.
             assert_eq!(gpus[0].total_memory, 4_294_967_295);
             assert_eq!(gpus[0].detail["Metrics Source"], "WMI");
         }
+    }
+
+    #[test]
+    fn an_empty_index_consults_the_refresh_closure_exactly_once() {
+        use std::cell::Cell;
+
+        // The one-shot path (`all-smi snapshot --include process`) never
+        // calls `get_gpu_info`, so the index starts empty and the
+        // closure is what populates it.
+        let calls = Cell::new(0);
+        let rows = process_rows_with(&AdapterIndex::new(), || {
+            calls.set(calls.get() + 1);
+            AdapterIndex::new()
+        });
+        assert_eq!(calls.get(), 1);
+        assert!(rows.is_empty());
+
+        // A populated index must not pay for the refresh at all.
+        let calls = Cell::new(0);
+        let mut populated = AdapterIndex::new();
+        populated.insert(AdapterLuid::new(0, 1), (0, "uuid".to_string()));
+        let _ = process_rows_with(&populated, || {
+            calls.set(calls.get() + 1);
+            AdapterIndex::new()
+        });
+        assert_eq!(calls.get(), 0);
     }
 
     #[test]

--- a/src/device/readers/windows_gpu_perf.rs
+++ b/src/device/readers/windows_gpu_perf.rs
@@ -1,0 +1,688 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Vendor-neutral Windows GPU metrics, shared by the AMD and Intel
+//! Windows readers.
+//!
+//! Both readers were WMI-only baselines: they could name a card and
+//! little else. `Win32_VideoController` publishes no utilization, no
+//! temperature, no per-process data, and its `AdapterRAM` field is a
+//! `uint32` that saturates at 4 GB. This module closes the gaps that do
+//! not need a vendor SDK, using two facilities every WDDM driver feeds:
+//!
+//! - **DXGI** for the true dedicated VRAM size and the adapter identity
+//!   (LUID, PCI vendor / device).
+//! - **PDH** for device utilization, system-wide used VRAM, and
+//!   per-process VRAM. This is Task Manager's data source.
+//!
+//! Temperature, power, and fan speed are deliberately absent: WDDM does
+//! not publish them, and they remain the job of the vendor backends
+//! (Level Zero for Intel, ADL for AMD).
+//!
+//! ## Precedence
+//!
+//! A vendor backend, when it produces a reading, outranks this layer,
+//! which in turn outranks the WMI baseline. Callers enforce that by
+//! applying this layer first and letting the vendor augmentation
+//! overwrite afterwards. Each field records where it came from in the
+//! `Source: *` detail keys the Intel reader already established.
+//!
+//! ## Platform gating
+//!
+//! The DXGI and PDH FFI submodules are Windows-only. Everything else
+//! here, the identifier parsing in [`ids`], the adapter pairing, and the
+//! field application, is compiled under `cfg(any(target_os = "windows",
+//! test))` so that a `cargo test` run on any host builds and exercises
+//! it.
+//!
+//! That is deliberate rather than incidental. No CI job builds all-smi
+//! for Windows at all, so logic reachable only on Windows ships with no
+//! automated coverage whatsoever. Keeping the parsing and the
+//! arithmetic testable on the Linux runner is the only coverage this
+//! code can actually get; the FFI beneath it is verified by a
+//! cross-compile check and by `all-smi doctor` output from real
+//! machines.
+
+pub mod ids;
+
+#[cfg(target_os = "windows")]
+mod dxgi;
+#[cfg(target_os = "windows")]
+mod pdh;
+
+use crate::device::types::{GpuInfo, ProcessInfo};
+use ids::{AdapterIdentity, AdapterLuid};
+use std::collections::HashMap;
+
+/// Everything the shared layer learned about one adapter.
+#[derive(Clone, Debug)]
+pub struct AdapterMetrics {
+    pub identity: AdapterIdentity,
+    /// True dedicated VRAM size in bytes, from DXGI.
+    pub total_memory: Option<u64>,
+    /// System-wide dedicated VRAM in use, in bytes, from the PDH
+    /// `GPU Adapter Memory` counter.
+    pub used_memory: Option<u64>,
+    /// Device utilization, 0..=100, from the PDH `GPU Engine` counters.
+    pub utilization: Option<f64>,
+    /// Process-scoped DXGI budget, in bytes. Diagnostics only.
+    pub process_budget: Option<u64>,
+    /// Process-scoped DXGI current usage, in bytes. Diagnostics only.
+    pub process_current_usage: Option<u64>,
+}
+
+/// Per-process dedicated GPU memory, keyed by adapter.
+#[derive(Clone, Debug)]
+pub struct ProcessGpuMemory {
+    pub pid: u32,
+    pub luid: AdapterLuid,
+    pub dedicated_bytes: u64,
+}
+
+/// One poll's worth of vendor-neutral GPU data.
+#[derive(Clone, Debug, Default)]
+pub struct Snapshot {
+    pub adapters: Vec<AdapterMetrics>,
+    pub processes: Vec<ProcessGpuMemory>,
+}
+
+impl Snapshot {
+    pub fn is_empty(&self) -> bool {
+        self.adapters.is_empty() && self.processes.is_empty()
+    }
+
+    /// Adapter identities in enumeration order, for
+    /// [`ids::match_adapter`].
+    pub fn identities(&self) -> Vec<AdapterIdentity> {
+        self.adapters
+            .iter()
+            .map(|adapter| adapter.identity.clone())
+            .collect()
+    }
+
+    /// Look up the metrics for a specific adapter.
+    pub fn adapter(&self, luid: AdapterLuid) -> Option<&AdapterMetrics> {
+        self.adapters
+            .iter()
+            .find(|adapter| adapter.identity.luid == luid)
+    }
+}
+
+/// Take a fresh sample and cache it for [`latest`].
+///
+/// Cheap to call once per poll; do not call it twice in one poll, as
+/// each call consumes one PDH collection and the utilization rate is
+/// computed between consecutive collections.
+#[cfg(target_os = "windows")]
+pub fn snapshot() -> Snapshot {
+    let dxgi_adapters = dxgi::enumerate();
+    let sample = pdh::sample();
+
+    let adapters = dxgi_adapters
+        .into_iter()
+        .map(|adapter| {
+            let luid = adapter.identity.luid;
+            AdapterMetrics {
+                identity: adapter.identity,
+                total_memory: (adapter.dedicated_video_memory > 0)
+                    .then_some(adapter.dedicated_video_memory),
+                used_memory: sample.adapter_memory.get(&luid).copied(),
+                utilization: sample.utilization.get(&luid).copied(),
+                process_budget: adapter.process_budget,
+                process_current_usage: adapter.process_current_usage,
+            }
+        })
+        .collect();
+
+    let processes = sample
+        .process_memory
+        .into_iter()
+        .filter(|(_, bytes)| *bytes > 0)
+        .map(|(instance, bytes)| ProcessGpuMemory {
+            pid: instance.pid,
+            luid: instance.luid,
+            dedicated_bytes: bytes,
+        })
+        .collect();
+
+    let snapshot = Snapshot {
+        adapters,
+        processes,
+    };
+    cache_snapshot(&snapshot);
+    snapshot
+}
+
+/// Non-Windows builds have nothing to sample. The readers that call this
+/// are themselves Windows-gated; the stub exists so the surrounding
+/// logic and its tests compile on every platform.
+#[cfg(not(target_os = "windows"))]
+pub fn snapshot() -> Snapshot {
+    Snapshot::default()
+}
+
+#[cfg(target_os = "windows")]
+static LAST_SNAPSHOT: once_cell::sync::OnceCell<std::sync::Mutex<Snapshot>> =
+    once_cell::sync::OnceCell::new();
+
+#[cfg(target_os = "windows")]
+fn cache_snapshot(snapshot: &Snapshot) {
+    let cell = LAST_SNAPSHOT.get_or_init(|| std::sync::Mutex::new(Snapshot::default()));
+    let mut guard = match cell.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    *guard = snapshot.clone();
+}
+
+/// The most recent [`snapshot`], without consuming a PDH collection.
+///
+/// `get_process_info` uses this so that a poll which already called
+/// `snapshot` from `get_gpu_info` does not disturb the utilization rate
+/// by collecting twice.
+#[cfg(target_os = "windows")]
+pub fn latest() -> Snapshot {
+    let Some(cell) = LAST_SNAPSHOT.get() else {
+        return Snapshot::default();
+    };
+    match cell.lock() {
+        Ok(guard) => guard.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn latest() -> Snapshot {
+    Snapshot::default()
+}
+
+/// Whether the PDH GPU counter query could be opened.
+#[cfg(target_os = "windows")]
+pub fn pdh_query_available() -> bool {
+    pdh::query_available()
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn pdh_query_available() -> bool {
+    false
+}
+
+/// Record that `source` contributed to this GPU's metrics.
+///
+/// The Intel reader established `Metrics Source` as a human-readable
+/// composition ("WMI", then "WMI + Level Zero" once Level Zero produced
+/// a readout). This keeps that shape while letting several backends
+/// append, and is idempotent so repeated polls do not grow the string.
+pub fn note_metrics_source(detail: &mut HashMap<String, String>, source: &str) {
+    let entry = detail.entry("Metrics Source".to_string()).or_default();
+    if entry.is_empty() {
+        *entry = source.to_string();
+        return;
+    }
+    if entry.split(" + ").any(|part| part == source) {
+        return;
+    }
+    entry.push_str(" + ");
+    entry.push_str(source);
+}
+
+/// Layer this adapter's metrics onto a WMI-derived [`GpuInfo`].
+///
+/// Only fields that carry real data are written, so a partially
+/// available adapter (DXGI present, PDH counters absent, which is the
+/// shape of a GitHub-hosted Windows runner) upgrades VRAM and leaves
+/// utilization at the baseline rather than zeroing anything that was
+/// already known.
+pub fn apply_to_gpu_info(gpu: &mut GpuInfo, metrics: &AdapterMetrics) {
+    let mut touched_dxgi = false;
+    let mut touched_pdh = false;
+
+    if let Some(total) = metrics.total_memory {
+        gpu.total_memory = total;
+        gpu.detail
+            .insert("Source: Memory".to_string(), "DXGI".to_string());
+        touched_dxgi = true;
+    }
+
+    // Both DXGI video-memory figures are scoped to the calling process.
+    // They are labelled as such and kept out of `used_memory`, which
+    // must stay system-wide; reading either as a device-level number
+    // would understate a busy GPU by whatever other processes hold.
+    if let Some(budget) = metrics.process_budget {
+        gpu.detail
+            .insert("VRAM Budget (this process)".to_string(), budget.to_string());
+        touched_dxgi = true;
+    }
+    if let Some(usage) = metrics.process_current_usage {
+        gpu.detail
+            .insert("VRAM Usage (this process)".to_string(), usage.to_string());
+        touched_dxgi = true;
+    }
+
+    if let Some(used) = metrics.used_memory {
+        gpu.used_memory = used;
+        gpu.detail
+            .insert("Source: Memory Used".to_string(), "PDH".to_string());
+        touched_pdh = true;
+    }
+
+    if let Some(utilization) = metrics.utilization {
+        gpu.utilization = utilization;
+        gpu.detail
+            .insert("Source: Utilization".to_string(), "PDH".to_string());
+        touched_pdh = true;
+    }
+
+    if touched_dxgi {
+        note_metrics_source(&mut gpu.detail, "DXGI");
+    }
+    if touched_pdh {
+        note_metrics_source(&mut gpu.detail, "PDH");
+    }
+}
+
+/// Map from adapter LUID to the `(index, uuid)` of the GPU it was
+/// paired with. Readers keep the most recent one so per-process PDH rows
+/// can be attributed to a card.
+pub type AdapterIndex = HashMap<AdapterLuid, (usize, String)>;
+
+/// Pair each WMI-derived GPU with a DXGI adapter, apply that adapter's
+/// metrics, and return the LUID mapping.
+///
+/// Split from [`augment_gpus`] so the pairing and application logic can
+/// be exercised with a synthetic snapshot on any platform. The Windows
+/// FFI is only reachable through `snapshot()`, which the thin wrapper
+/// calls.
+pub fn pair_and_apply(gpus: &mut [GpuInfo], snapshot: &Snapshot) -> AdapterIndex {
+    let mut adapter_index = AdapterIndex::new();
+    if snapshot.adapters.is_empty() {
+        return adapter_index;
+    }
+    let identities = snapshot.identities();
+
+    for (ordinal, gpu) in gpus.iter_mut().enumerate() {
+        // The reader stores `PNPDeviceID` as the GPU uuid, and that is
+        // what carries the PCI vendor / device ids the matcher prefers.
+        let Some(identity) =
+            ids::match_adapter(&identities, Some(gpu.uuid.as_str()), &gpu.name, ordinal)
+        else {
+            continue;
+        };
+        let luid = identity.luid;
+        if let Some(metrics) = snapshot.adapter(luid) {
+            apply_to_gpu_info(gpu, metrics);
+        }
+        adapter_index.insert(luid, (ordinal, gpu.uuid.clone()));
+    }
+
+    adapter_index
+}
+
+/// Take a fresh sample and layer it onto `gpus`.
+///
+/// Call once per poll from `get_gpu_info`; the returned index feeds
+/// [`process_rows`].
+pub fn augment_gpus(gpus: &mut [GpuInfo]) -> AdapterIndex {
+    let snapshot = snapshot();
+    pair_and_apply(gpus, &snapshot)
+}
+
+/// Build per-process GPU memory rows from the most recent snapshot.
+///
+/// Uses [`latest`] rather than sampling again: a second collection in
+/// the same poll would halve the interval the utilization rate is
+/// computed over.
+pub fn process_rows(adapter_index: &AdapterIndex) -> Vec<ProcessInfo> {
+    process_rows_from(&latest(), adapter_index)
+}
+
+/// Attribute each per-process sample to the card its LUID names.
+///
+/// Split from [`process_rows`] for the same reason as
+/// [`pair_and_apply`]: it makes the attribution testable without
+/// Windows. Rows whose adapter was never paired are dropped rather than
+/// guessed at, so a card the WMI vendor filter excluded (an NVIDIA GPU
+/// alongside an AMD one, say) does not have its processes reported
+/// against the wrong device.
+pub fn process_rows_from(snapshot: &Snapshot, adapter_index: &AdapterIndex) -> Vec<ProcessInfo> {
+    snapshot
+        .processes
+        .iter()
+        .filter_map(|process| {
+            let (device_id, uuid) = adapter_index.get(&process.luid)?;
+            Some(gpu_process_row(
+                *device_id,
+                uuid,
+                process.pid,
+                process.dedicated_bytes,
+            ))
+        })
+        .collect()
+}
+
+/// Build the GPU-attributed process row for a PDH per-process sample.
+///
+/// Only the GPU-specific fields are populated.
+/// [`crate::device::process_list::merge_gpu_processes`] joins these rows
+/// against the system process table by pid and supplies the name, user,
+/// CPU time, and system-memory figures, so filling them here would be
+/// both wasted work and a second source of truth that could disagree.
+pub fn gpu_process_row(
+    device_id: usize,
+    device_uuid: &str,
+    pid: u32,
+    used_memory: u64,
+) -> ProcessInfo {
+    ProcessInfo {
+        device_id,
+        device_uuid: device_uuid.to_string(),
+        pid,
+        process_name: String::new(),
+        used_memory,
+        cpu_percent: 0.0,
+        memory_percent: 0.0,
+        memory_rss: 0,
+        memory_vms: 0,
+        user: String::new(),
+        state: String::new(),
+        start_time: String::new(),
+        cpu_time: 0,
+        command: String::new(),
+        ppid: 0,
+        threads: 0,
+        uses_gpu: true,
+        priority: 0,
+        nice_value: 0,
+        // PDH publishes GPU *memory* per process. Per-process engine
+        // utilization would need the GPU Engine counters keyed by pid,
+        // which report per-engine shares that do not reduce to a single
+        // per-process figure the way memory does. Left at zero rather
+        // than guessed.
+        gpu_utilization: 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::types::GpuInfo;
+
+    fn blank_gpu() -> GpuInfo {
+        let mut detail = HashMap::new();
+        detail.insert("Metrics Source".to_string(), "WMI".to_string());
+        detail.insert("Source: Utilization".to_string(), "unavailable".to_string());
+        detail.insert("Source: Memory".to_string(), "WMI".to_string());
+        GpuInfo {
+            uuid: "PCI\\VEN_1002&DEV_744C".to_string(),
+            time: String::new(),
+            name: "AMD Radeon RX 7900 XTX".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: String::new(),
+            hostname: String::new(),
+            instance: String::new(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 4_294_967_295,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
+            detail,
+        }
+    }
+
+    fn metrics(total: Option<u64>, used: Option<u64>, utilization: Option<f64>) -> AdapterMetrics {
+        AdapterMetrics {
+            identity: AdapterIdentity {
+                luid: AdapterLuid::new(0, 0xD3F5),
+                vendor_id: 0x1002,
+                device_id: 0x744C,
+                description: "AMD Radeon RX 7900 XTX".to_string(),
+            },
+            total_memory: total,
+            used_memory: used,
+            utilization,
+            process_budget: None,
+            process_current_usage: None,
+        }
+    }
+
+    #[test]
+    fn dxgi_total_replaces_the_truncated_wmi_value() {
+        let mut gpu = blank_gpu();
+        // 24 GB, well beyond what Win32_VideoController.AdapterRAM can
+        // represent.
+        apply_to_gpu_info(&mut gpu, &metrics(Some(25_769_803_776), None, None));
+        assert_eq!(gpu.total_memory, 25_769_803_776);
+        assert_eq!(gpu.detail["Source: Memory"], "DXGI");
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI");
+    }
+
+    #[test]
+    fn pdh_fields_are_recorded_with_their_source() {
+        let mut gpu = blank_gpu();
+        apply_to_gpu_info(
+            &mut gpu,
+            &metrics(Some(8_589_934_592), Some(2_147_483_648), Some(42.5)),
+        );
+        assert_eq!(gpu.utilization, 42.5);
+        assert_eq!(gpu.used_memory, 2_147_483_648);
+        assert_eq!(gpu.detail["Source: Utilization"], "PDH");
+        assert_eq!(gpu.detail["Source: Memory Used"], "PDH");
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH");
+    }
+
+    #[test]
+    fn absent_fields_leave_the_baseline_untouched() {
+        // The shape of a GitHub-hosted Windows runner: DXGI answers, no
+        // GPU counter instances exist. VRAM must upgrade while
+        // utilization stays at its baseline and is not falsely
+        // attributed to PDH.
+        let mut gpu = blank_gpu();
+        gpu.utilization = 0.0;
+        apply_to_gpu_info(&mut gpu, &metrics(Some(1_073_741_824), None, None));
+        assert_eq!(gpu.total_memory, 1_073_741_824);
+        assert_eq!(gpu.utilization, 0.0);
+        assert_eq!(gpu.detail["Source: Utilization"], "unavailable");
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI");
+    }
+
+    #[test]
+    fn applying_twice_does_not_grow_the_source_string() {
+        let mut gpu = blank_gpu();
+        let m = metrics(Some(1), Some(2), Some(3.0));
+        apply_to_gpu_info(&mut gpu, &m);
+        apply_to_gpu_info(&mut gpu, &m);
+        apply_to_gpu_info(&mut gpu, &m);
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH");
+    }
+
+    #[test]
+    fn metrics_source_starts_clean_when_absent() {
+        let mut detail = HashMap::new();
+        note_metrics_source(&mut detail, "DXGI");
+        assert_eq!(detail["Metrics Source"], "DXGI");
+        note_metrics_source(&mut detail, "PDH");
+        assert_eq!(detail["Metrics Source"], "DXGI + PDH");
+    }
+
+    fn snapshot_with(adapters: Vec<AdapterMetrics>, processes: Vec<ProcessGpuMemory>) -> Snapshot {
+        Snapshot {
+            adapters,
+            processes,
+        }
+    }
+
+    #[test]
+    fn pairs_gpus_to_adapters_and_returns_the_luid_index() {
+        let mut gpus = vec![blank_gpu()];
+        let snapshot = snapshot_with(
+            vec![metrics(Some(25_769_803_776), Some(1024), Some(77.0))],
+            vec![],
+        );
+
+        let index = pair_and_apply(&mut gpus, &snapshot);
+
+        assert_eq!(gpus[0].total_memory, 25_769_803_776);
+        assert_eq!(gpus[0].utilization, 77.0);
+        assert_eq!(gpus[0].used_memory, 1024);
+        // The uuid is the PNPDeviceID, and it is what the per-process
+        // attribution keys on.
+        assert_eq!(
+            index.get(&AdapterLuid::new(0, 0xD3F5)),
+            Some(&(0usize, "PCI\\VEN_1002&DEV_744C".to_string()))
+        );
+    }
+
+    #[test]
+    fn pairing_an_empty_snapshot_changes_nothing() {
+        let mut gpus = vec![blank_gpu()];
+        let before = gpus[0].total_memory;
+        let index = pair_and_apply(&mut gpus, &Snapshot::default());
+        assert!(index.is_empty());
+        assert_eq!(gpus[0].total_memory, before);
+        assert_eq!(gpus[0].detail["Metrics Source"], "WMI");
+    }
+
+    #[test]
+    fn unmatched_gpus_keep_the_wmi_baseline() {
+        // A DXGI adapter for a different vendor entirely, and a name
+        // that shares no substring, so only the ordinal fallback could
+        // pair them.
+        let mut gpus = vec![blank_gpu(), blank_gpu()];
+        gpus[1].uuid = "PCI\\VEN_10DE&DEV_2684".to_string();
+        gpus[1].name = "NVIDIA GeForce RTX 4090".to_string();
+
+        let snapshot = snapshot_with(vec![metrics(Some(8_589_934_592), None, Some(10.0))], vec![]);
+        let index = pair_and_apply(&mut gpus, &snapshot);
+
+        // First GPU matches on PCI ids.
+        assert_eq!(gpus[0].total_memory, 8_589_934_592);
+        // Second has ordinal 1, which is out of range for a one-adapter
+        // snapshot, so it is left alone rather than mis-attributed.
+        assert_eq!(gpus[1].total_memory, 4_294_967_295);
+        assert_eq!(gpus[1].detail["Metrics Source"], "WMI");
+        assert_eq!(index.len(), 1);
+    }
+
+    #[test]
+    fn process_rows_carry_the_gpu_identity_and_leave_the_rest_to_the_merge() {
+        let row = gpu_process_row(2, "PCI\\VEN_1002&DEV_744C", 4242, 536_870_912);
+        assert_eq!(row.pid, 4242);
+        assert_eq!(row.device_id, 2);
+        assert_eq!(row.device_uuid, "PCI\\VEN_1002&DEV_744C");
+        assert_eq!(row.used_memory, 536_870_912);
+        assert!(row.uses_gpu);
+        // Deliberately blank: merge_gpu_processes fills these from the
+        // system process table.
+        assert!(row.process_name.is_empty());
+        assert!(row.user.is_empty());
+    }
+
+    #[test]
+    fn process_rows_are_attributed_to_the_matching_adapter() {
+        let known = AdapterLuid::new(0, 0xD3F5);
+        let mut adapter_index = AdapterIndex::new();
+        adapter_index.insert(known, (0, "PCI\\VEN_1002&DEV_744C".to_string()));
+
+        let snapshot = snapshot_with(
+            vec![],
+            vec![
+                ProcessGpuMemory {
+                    pid: 4242,
+                    luid: known,
+                    dedicated_bytes: 536_870_912,
+                },
+                // A card this reader never paired, for example an NVIDIA
+                // GPU sitting alongside the AMD one. Its processes must
+                // be dropped, not attributed to the wrong device.
+                ProcessGpuMemory {
+                    pid: 99,
+                    luid: AdapterLuid::new(0, 0xFFFF),
+                    dedicated_bytes: 1,
+                },
+            ],
+        );
+
+        let rows = process_rows_from(&snapshot, &adapter_index);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pid, 4242);
+        assert_eq!(rows[0].used_memory, 536_870_912);
+        assert_eq!(rows[0].device_uuid, "PCI\\VEN_1002&DEV_744C");
+        assert_eq!(rows[0].device_id, 0);
+    }
+
+    #[test]
+    fn process_scoped_dxgi_figures_are_labelled_and_kept_out_of_used_memory() {
+        let mut gpu = blank_gpu();
+        let mut m = metrics(Some(8_589_934_592), None, None);
+        m.process_budget = Some(7_000_000_000);
+        m.process_current_usage = Some(123_456);
+
+        apply_to_gpu_info(&mut gpu, &m);
+
+        // Neither DXGI figure may leak into the device-level number.
+        assert_eq!(gpu.used_memory, 0);
+        assert_eq!(gpu.detail["VRAM Budget (this process)"], "7000000000");
+        assert_eq!(gpu.detail["VRAM Usage (this process)"], "123456");
+        assert!(!gpu.detail.contains_key("Source: Memory Used"));
+    }
+
+    #[test]
+    fn the_platform_entry_points_never_panic() {
+        // The readers that call these are Windows-gated, but the entry
+        // points compile everywhere. On a non-Windows host each must be
+        // an inert no-op so the surrounding logic can be tested; on
+        // Windows they touch real hardware, so only assert they return.
+        let mut gpus = vec![blank_gpu()];
+        let index = augment_gpus(&mut gpus);
+        let _ = process_rows(&index);
+        let _ = pdh_query_available();
+        let _ = latest();
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert!(snapshot().is_empty());
+            assert!(latest().is_empty());
+            assert!(!pdh_query_available());
+            assert!(index.is_empty());
+            assert!(process_rows(&index).is_empty());
+            // An inert layer must leave the WMI baseline exactly as it
+            // found it.
+            assert_eq!(gpus[0].total_memory, 4_294_967_295);
+            assert_eq!(gpus[0].detail["Metrics Source"], "WMI");
+        }
+    }
+
+    #[test]
+    fn snapshot_helpers_behave_on_an_empty_snapshot() {
+        let snapshot = Snapshot::default();
+        assert!(snapshot.is_empty());
+        assert!(snapshot.identities().is_empty());
+        assert!(snapshot.adapter(AdapterLuid::new(0, 1)).is_none());
+    }
+}

--- a/src/device/readers/windows_gpu_perf/dxgi.rs
+++ b/src/device/readers/windows_gpu_perf/dxgi.rs
@@ -28,7 +28,7 @@
 
 use super::ids::{AdapterIdentity, AdapterLuid};
 use windows::Win32::Graphics::Dxgi::{
-    CreateDXGIFactory1, DXGI_ADAPTER_DESC1, DXGI_ADAPTER_FLAG, DXGI_ADAPTER_FLAG_SOFTWARE,
+    CreateDXGIFactory1, DXGI_ADAPTER_DESC1, DXGI_ADAPTER_FLAG_SOFTWARE,
     DXGI_MEMORY_SEGMENT_GROUP_LOCAL, DXGI_QUERY_VIDEO_MEMORY_INFO, IDXGIAdapter1, IDXGIAdapter3,
     IDXGIFactory1,
 };
@@ -39,7 +39,16 @@ use windows::core::Interface;
 pub struct DxgiAdapter {
     pub identity: AdapterIdentity,
     /// `DXGI_ADAPTER_DESC1::DedicatedVideoMemory`, in bytes.
+    ///
+    /// Zero on integrated graphics, which have no dedicated pool. Use
+    /// [`Self::shared_system_memory`] for those.
     pub dedicated_video_memory: u64,
+    /// `DXGI_ADAPTER_DESC1::SharedSystemMemory`, in bytes.
+    ///
+    /// The system RAM the adapter may address. For an integrated GPU
+    /// this is the only meaningful capacity figure, and it is what Task
+    /// Manager labels "Shared GPU memory".
+    pub shared_system_memory: u64,
     /// `DXGI_QUERY_VIDEO_MEMORY_INFO::Budget` for the local memory
     /// segment, in bytes, when `IDXGIAdapter3` is available.
     ///
@@ -85,7 +94,11 @@ pub fn enumerate() -> Vec<DxgiAdapter> {
             Err(_) => continue,
         };
 
-        if DXGI_ADAPTER_FLAG(desc.Flags as i32) == DXGI_ADAPTER_FLAG_SOFTWARE {
+        // Mask, do not compare for equality: `DXGI_ADAPTER_FLAG_REMOTE`
+        // is bit 0 and `_SOFTWARE` is bit 1, so an adapter reporting
+        // both would slip past an `==` test and be admitted as
+        // hardware.
+        if desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE.0 as u32 != 0 {
             continue;
         }
 
@@ -102,6 +115,7 @@ pub fn enumerate() -> Vec<DxgiAdapter> {
                 description: widestring_to_string(&desc.Description),
             },
             dedicated_video_memory: desc.DedicatedVideoMemory as u64,
+            shared_system_memory: desc.SharedSystemMemory as u64,
             process_budget,
             process_current_usage,
         });

--- a/src/device/readers/windows_gpu_perf/dxgi.rs
+++ b/src/device/readers/windows_gpu_perf/dxgi.rs
@@ -1,0 +1,135 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! DXGI adapter enumeration.
+//!
+//! DXGI is the authoritative source for how much dedicated video memory
+//! a card has. `Win32_VideoController.AdapterRAM`, which the WMI-only
+//! readers used before this module existed, is a `uint32` in the WMI
+//! schema and therefore saturates or wraps on anything above 4 GB, which
+//! today is most discrete cards.
+//! `DXGI_ADAPTER_DESC1::DedicatedVideoMemory` is `SIZE_T` and reports
+//! the true figure.
+//!
+//! DXGI also hands out the adapter `LUID` and the PCI vendor / device
+//! identifiers, which is what lets [`super::ids::match_adapter`] pair a
+//! WMI row with a PDH counter instance.
+
+use super::ids::{AdapterIdentity, AdapterLuid};
+use windows::Win32::Graphics::Dxgi::{
+    CreateDXGIFactory1, DXGI_ADAPTER_DESC1, DXGI_ADAPTER_FLAG, DXGI_ADAPTER_FLAG_SOFTWARE,
+    DXGI_MEMORY_SEGMENT_GROUP_LOCAL, DXGI_QUERY_VIDEO_MEMORY_INFO, IDXGIAdapter1, IDXGIAdapter3,
+    IDXGIFactory1,
+};
+use windows::core::Interface;
+
+/// One physical adapter as DXGI describes it.
+#[derive(Clone, Debug)]
+pub struct DxgiAdapter {
+    pub identity: AdapterIdentity,
+    /// `DXGI_ADAPTER_DESC1::DedicatedVideoMemory`, in bytes.
+    pub dedicated_video_memory: u64,
+    /// `DXGI_QUERY_VIDEO_MEMORY_INFO::Budget` for the local memory
+    /// segment, in bytes, when `IDXGIAdapter3` is available.
+    ///
+    /// This is **process-scoped**: it is the budget the OS grants *this*
+    /// process, not a system-wide figure. It is surfaced as a detail
+    /// field for diagnostics and is deliberately not used as the
+    /// device's used-memory value; the system-wide number comes from the
+    /// PDH `GPU Adapter Memory` counter instead.
+    pub process_budget: Option<u64>,
+    /// `DXGI_QUERY_VIDEO_MEMORY_INFO::CurrentUsage`, in bytes. Same
+    /// process-scoped caveat as [`Self::process_budget`].
+    pub process_current_usage: Option<u64>,
+}
+
+/// Enumerate every hardware adapter DXGI knows about.
+///
+/// Software adapters (the Microsoft Basic Render Driver, and the WARP
+/// device that a headless or RDP session presents) are filtered out:
+/// they have no meaningful memory or utilization story and would
+/// otherwise be matched against a real WMI row by the ordinal fallback.
+///
+/// Returns an empty vector rather than an error on any failure. A host
+/// where DXGI cannot be reached is a host that should quietly fall back
+/// to the WMI baseline, not one that should emit diagnostics on every
+/// poll.
+pub fn enumerate() -> Vec<DxgiAdapter> {
+    let factory: IDXGIFactory1 = match unsafe { CreateDXGIFactory1() } {
+        Ok(factory) => factory,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut adapters = Vec::new();
+    for index in 0.. {
+        // Enumeration ends with DXGI_ERROR_NOT_FOUND. Any other error is
+        // equally terminal for our purposes.
+        let adapter: IDXGIAdapter1 = match unsafe { factory.EnumAdapters1(index) } {
+            Ok(adapter) => adapter,
+            Err(_) => break,
+        };
+
+        let desc: DXGI_ADAPTER_DESC1 = match unsafe { adapter.GetDesc1() } {
+            Ok(desc) => desc,
+            Err(_) => continue,
+        };
+
+        if DXGI_ADAPTER_FLAG(desc.Flags as i32) == DXGI_ADAPTER_FLAG_SOFTWARE {
+            continue;
+        }
+
+        let (process_budget, process_current_usage) = query_video_memory(&adapter);
+
+        adapters.push(DxgiAdapter {
+            identity: AdapterIdentity {
+                luid: AdapterLuid {
+                    high: desc.AdapterLuid.HighPart,
+                    low: desc.AdapterLuid.LowPart,
+                },
+                vendor_id: desc.VendorId,
+                device_id: desc.DeviceId,
+                description: widestring_to_string(&desc.Description),
+            },
+            dedicated_video_memory: desc.DedicatedVideoMemory as u64,
+            process_budget,
+            process_current_usage,
+        });
+    }
+
+    adapters
+}
+
+/// Read the local-segment video memory info, when the adapter supports
+/// `IDXGIAdapter3` (Windows 10 and later).
+fn query_video_memory(adapter: &IDXGIAdapter1) -> (Option<u64>, Option<u64>) {
+    let Ok(adapter3) = adapter.cast::<IDXGIAdapter3>() else {
+        return (None, None);
+    };
+    let mut info = DXGI_QUERY_VIDEO_MEMORY_INFO::default();
+    // Node index 0: all-smi does not model linked-adapter (SLI /
+    // CrossFire) node topology, and node 0 is the only one present on a
+    // single-GPU system.
+    if unsafe { adapter3.QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &mut info) }
+        .is_err()
+    {
+        return (None, None);
+    }
+    (Some(info.Budget), Some(info.CurrentUsage))
+}
+
+/// Convert a fixed-size, NUL-padded UTF-16 buffer to a `String`.
+fn widestring_to_string(buffer: &[u16]) -> String {
+    let end = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+    String::from_utf16_lossy(&buffer[..end]).trim().to_string()
+}

--- a/src/device/readers/windows_gpu_perf/ids.rs
+++ b/src/device/readers/windows_gpu_perf/ids.rs
@@ -1,0 +1,651 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Identifier parsing and sample aggregation for the Windows GPU
+//! performance layer.
+//!
+//! Everything here is platform-independent on purpose. The DXGI and PDH
+//! FFI lives in the sibling `dxgi` / `pdh` modules behind
+//! `#[cfg(target_os = "windows")]`, but the string parsing and the
+//! aggregation arithmetic compile and run everywhere.
+//!
+//! That split matters more in this crate than it usually would: no CI
+//! job compiles all-smi for Windows at all (the only Windows workflow
+//! job is gated behind an unset repository variable and has never
+//! executed), so any logic hidden behind a `cfg(windows)` gate ships
+//! with zero automated coverage. Keeping the parsing and the maths out
+//! here means the Linux test runner exercises the part that is actually
+//! easy to get wrong.
+
+use std::collections::HashMap;
+
+/// Windows `LUID`, the locally unique identifier the display stack uses
+/// to name a graphics adapter.
+///
+/// DXGI reports it as `DXGI_ADAPTER_DESC1::AdapterLuid`, and PDH embeds
+/// it in every GPU counter instance name. Correlating the two is what
+/// lets a utilization sample be attributed to a specific card.
+///
+/// The value is only unique until the next reboot, so it is used purely
+/// as an in-process join key and never persisted or exported.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct AdapterLuid {
+    /// `LUID::HighPart`. Signed in the Win32 headers, and almost always
+    /// zero in practice.
+    pub high: i32,
+    /// `LUID::LowPart`.
+    pub low: u32,
+}
+
+impl AdapterLuid {
+    pub fn new(high: i32, low: u32) -> Self {
+        Self { high, low }
+    }
+}
+
+/// PCI vendor and device identifiers parsed out of a WMI `PNPDeviceID`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct PciIds {
+    pub vendor: u32,
+    pub device: u32,
+}
+
+/// A parsed `\GPU Engine(...)` counter instance name.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuEngineInstance {
+    pub pid: u32,
+    pub luid: AdapterLuid,
+    pub phys: u32,
+    pub eng: u32,
+    pub engtype: String,
+}
+
+/// A parsed `\GPU Process Memory(...)` counter instance name.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuProcessMemoryInstance {
+    pub pid: u32,
+    pub luid: AdapterLuid,
+    pub phys: u32,
+}
+
+/// A parsed `\GPU Adapter Memory(...)` counter instance name.
+///
+/// Note the absence of a pid: this counter family is per-adapter and
+/// system-wide, which is exactly why it, rather than DXGI's
+/// process-scoped `QueryVideoMemoryInfo`, is the source for used VRAM.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GpuAdapterMemoryInstance {
+    pub luid: AdapterLuid,
+    pub phys: u32,
+}
+
+/// Minimal identity of a DXGI adapter.
+///
+/// Split out from the FFI struct so [`match_adapter`] can be unit-tested
+/// on a host with no DXGI.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AdapterIdentity {
+    pub luid: AdapterLuid,
+    pub vendor_id: u32,
+    pub device_id: u32,
+    pub description: String,
+}
+
+// ---------------------------------------------------------------------
+// Token helpers
+// ---------------------------------------------------------------------
+
+/// Consume `expected` as the next token, returning the remaining tokens.
+fn expect<'t, 's>(tokens: &'t [&'s str], expected: &str) -> Option<&'t [&'s str]> {
+    match tokens.split_first() {
+        Some((first, rest)) if first.eq_ignore_ascii_case(expected) => Some(rest),
+        _ => None,
+    }
+}
+
+/// Pop the next token.
+fn take<'t, 's>(tokens: &'t [&'s str]) -> Option<(&'s str, &'t [&'s str])> {
+    tokens.split_first().map(|(first, rest)| (*first, rest))
+}
+
+/// Parse `0x0000ABCD`, or a bare hex string, into a `u32`.
+fn parse_hex_u32(text: &str) -> Option<u32> {
+    let body = text
+        .strip_prefix("0x")
+        .or_else(|| text.strip_prefix("0X"))
+        .unwrap_or(text);
+    if body.is_empty() {
+        return None;
+    }
+    u32::from_str_radix(body, 16).ok()
+}
+
+/// Build an [`AdapterLuid`] from the two hex tokens of a counter
+/// instance name.
+///
+/// The counter name renders `HighPart` first and `LowPart` second, both
+/// as unsigned hex, even though `HighPart` is signed in the Win32
+/// headers. Parse wide and reinterpret rather than rejecting the high
+/// bit.
+fn parse_luid_pair(high: &str, low: &str) -> Option<AdapterLuid> {
+    Some(AdapterLuid {
+        high: parse_hex_u32(high)? as i32,
+        low: parse_hex_u32(low)?,
+    })
+}
+
+// ---------------------------------------------------------------------
+// Instance-name parsers
+// ---------------------------------------------------------------------
+
+/// Parse `pid_<pid>_luid_<hi>_<lo>_phys_<n>_eng_<n>_engtype_<type>`.
+pub fn parse_gpu_engine_instance(instance: &str) -> Option<GpuEngineInstance> {
+    let tokens: Vec<&str> = instance.split('_').collect();
+    let rest = expect(&tokens, "pid")?;
+    let (pid, rest) = take(rest)?;
+    let rest = expect(rest, "luid")?;
+    let (high, rest) = take(rest)?;
+    let (low, rest) = take(rest)?;
+    let rest = expect(rest, "phys")?;
+    let (phys, rest) = take(rest)?;
+    let rest = expect(rest, "eng")?;
+    let (eng, rest) = take(rest)?;
+    let rest = expect(rest, "engtype")?;
+    // Shipping engine-type names carry no underscore ("3D", "Compute",
+    // "VideoDecode"), but rejoin the tail defensively so a future
+    // multi-word type is not silently truncated to its first word.
+    //
+    // Test the joined string rather than the token slice: a name ending
+    // in a bare `engtype_` splits to a single empty token, which is not
+    // an empty slice but is still a nameless engine.
+    let engtype = rest.join("_");
+    if engtype.is_empty() {
+        return None;
+    }
+    Some(GpuEngineInstance {
+        pid: pid.parse().ok()?,
+        luid: parse_luid_pair(high, low)?,
+        phys: phys.parse().ok()?,
+        eng: eng.parse().ok()?,
+        engtype,
+    })
+}
+
+/// Parse `pid_<pid>_luid_<hi>_<lo>_phys_<n>`.
+pub fn parse_gpu_process_memory_instance(instance: &str) -> Option<GpuProcessMemoryInstance> {
+    let tokens: Vec<&str> = instance.split('_').collect();
+    let rest = expect(&tokens, "pid")?;
+    let (pid, rest) = take(rest)?;
+    let rest = expect(rest, "luid")?;
+    let (high, rest) = take(rest)?;
+    let (low, rest) = take(rest)?;
+    let rest = expect(rest, "phys")?;
+    let (phys, _rest) = take(rest)?;
+    Some(GpuProcessMemoryInstance {
+        pid: pid.parse().ok()?,
+        luid: parse_luid_pair(high, low)?,
+        phys: phys.parse().ok()?,
+    })
+}
+
+/// Parse `luid_<hi>_<lo>_phys_<n>`.
+pub fn parse_gpu_adapter_memory_instance(instance: &str) -> Option<GpuAdapterMemoryInstance> {
+    let tokens: Vec<&str> = instance.split('_').collect();
+    let rest = expect(&tokens, "luid")?;
+    let (high, rest) = take(rest)?;
+    let (low, rest) = take(rest)?;
+    let rest = expect(rest, "phys")?;
+    let (phys, _rest) = take(rest)?;
+    Some(GpuAdapterMemoryInstance {
+        luid: parse_luid_pair(high, low)?,
+        phys: phys.parse().ok()?,
+    })
+}
+
+/// Extract PCI vendor and device identifiers from a WMI `PNPDeviceID`.
+///
+/// The field looks like
+/// `PCI\VEN_1002&DEV_744C&SUBSYS_00000000&REV_C8\6&1a2b3c4d&0&00000019`.
+/// Only the `VEN_` and `DEV_` fragments are of interest; everything else
+/// varies with slot and revision and is useless as a join key.
+///
+/// Returns `None` for non-PCI enumerations (for example the
+/// `ROOT\BasicDisplay` entry that a headless or RDP session presents),
+/// which is the correct answer: those have no DXGI counterpart worth
+/// matching.
+pub fn parse_pnp_device_id(pnp: &str) -> Option<PciIds> {
+    let upper = pnp.to_ascii_uppercase();
+    Some(PciIds {
+        vendor: extract_hex_after(&upper, "VEN_")?,
+        device: extract_hex_after(&upper, "DEV_")?,
+    })
+}
+
+fn extract_hex_after(haystack: &str, marker: &str) -> Option<u32> {
+    let start = haystack.find(marker)? + marker.len();
+    let digits: String = haystack[start..]
+        .chars()
+        .take_while(|c| c.is_ascii_hexdigit())
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    u32::from_str_radix(&digits, 16).ok()
+}
+
+// ---------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------
+
+/// Engine types that count toward the headline device utilization.
+///
+/// Video decode, encode, and copy engines are deliberately excluded. A
+/// desktop compositor decoding a video stream keeps those engines busy
+/// while the shader cores idle, and folding them in would make an idle
+/// machine report a large non-zero GPU load, which is not what the
+/// gauge in the TUI means.
+pub const UTILIZATION_ENGINE_TYPES: &[&str] = &["3D", "Compute"];
+
+pub fn is_utilization_engine_type(engtype: &str) -> bool {
+    UTILIZATION_ENGINE_TYPES
+        .iter()
+        .any(|candidate| engtype.eq_ignore_ascii_case(candidate))
+}
+
+/// Reduce raw `\GPU Engine(*)\Utilization Percentage` samples to one
+/// utilization figure per adapter.
+///
+/// The reduction is two steps, and the asymmetry between them is
+/// deliberate:
+///
+/// 1. **Sum across processes** for a given engine. Each sample is one
+///    process's share of that engine's time, so their sum is the
+///    engine's total busy fraction.
+/// 2. **Take the maximum across engines** of an adapter rather than
+///    summing them. A card exposes several 3D and Compute engine
+///    instances; adding them together yields figures far above 100% and
+///    would peg every gauge in the UI. The maximum is what Task
+///    Manager's headline GPU percentage reports, so this agrees with the
+///    number a Windows user sees in the tool sitting next to us.
+///
+/// Results are clamped to `0..=100`: PDH can return small negative
+/// values or slight overshoots on the sample right after a counter is
+/// added, and a negative utilization would underflow the gauge maths
+/// downstream.
+pub fn aggregate_engine_utilization(
+    samples: impl IntoIterator<Item = (GpuEngineInstance, f64)>,
+) -> HashMap<AdapterLuid, f64> {
+    // Key on the full counter identity rather than just the engine
+    // index. In shipping drivers one index carries one engine type, so
+    // this is equivalent, but keying on the identity means an unexpected
+    // pairing merges nothing silently.
+    let mut per_engine: HashMap<(AdapterLuid, u32, u32, String), f64> = HashMap::new();
+    for (instance, value) in samples {
+        if !is_utilization_engine_type(&instance.engtype) {
+            continue;
+        }
+        if !value.is_finite() {
+            continue;
+        }
+        let key = (
+            instance.luid,
+            instance.phys,
+            instance.eng,
+            instance.engtype.to_ascii_uppercase(),
+        );
+        *per_engine.entry(key).or_insert(0.0) += value;
+    }
+
+    let mut per_adapter: HashMap<AdapterLuid, f64> = HashMap::new();
+    for ((luid, _, _, _), busy) in per_engine {
+        let slot = per_adapter.entry(luid).or_insert(0.0);
+        if busy > *slot {
+            *slot = busy;
+        }
+    }
+    for value in per_adapter.values_mut() {
+        *value = value.clamp(0.0, 100.0);
+    }
+    per_adapter
+}
+
+/// Sum `\GPU Adapter Memory(*)\Dedicated Usage` samples per adapter.
+///
+/// Summing is right here, unlike for engines: an adapter can expose
+/// several `phys` segments and their dedicated allocations are disjoint.
+pub fn aggregate_adapter_memory(
+    samples: impl IntoIterator<Item = (GpuAdapterMemoryInstance, f64)>,
+) -> HashMap<AdapterLuid, u64> {
+    let mut per_adapter: HashMap<AdapterLuid, f64> = HashMap::new();
+    for (instance, value) in samples {
+        if !value.is_finite() || value < 0.0 {
+            continue;
+        }
+        *per_adapter.entry(instance.luid).or_insert(0.0) += value;
+    }
+    per_adapter
+        .into_iter()
+        .map(|(luid, bytes)| (luid, bytes as u64))
+        .collect()
+}
+
+// ---------------------------------------------------------------------
+// Adapter matching
+// ---------------------------------------------------------------------
+
+/// Pair one `Win32_VideoController` row with the DXGI adapter that
+/// describes the same card.
+///
+/// Three strategies are tried, strongest first:
+///
+/// 1. **PCI vendor and device** parsed from `PNPDeviceID`. Exact.
+///    When two identical cards are installed both adapters match, so
+///    `ordinal` picks within the matching subset.
+/// 2. **Description equality**, case-insensitive, then a containment
+///    check. WMI and DXGI usually report byte-identical marketing
+///    names, but driver updates occasionally add or drop a suffix.
+/// 3. **Ordinal position** in the full adapter list, as a last resort.
+///
+/// `ordinal` is the caller's index among the WMI rows it is iterating,
+/// which for a single-GPU machine (the overwhelming majority) makes
+/// even the weakest strategy correct.
+pub fn match_adapter<'a>(
+    adapters: &'a [AdapterIdentity],
+    pnp_device_id: Option<&str>,
+    name: &str,
+    ordinal: usize,
+) -> Option<&'a AdapterIdentity> {
+    if adapters.is_empty() {
+        return None;
+    }
+
+    if let Some(ids) = pnp_device_id.and_then(parse_pnp_device_id) {
+        let matches: Vec<&AdapterIdentity> = adapters
+            .iter()
+            .filter(|a| a.vendor_id == ids.vendor && a.device_id == ids.device)
+            .collect();
+        match matches.len() {
+            0 => {}
+            1 => return Some(matches[0]),
+            _ => return Some(matches.get(ordinal).copied().unwrap_or(matches[0])),
+        }
+    }
+
+    let trimmed = name.trim();
+    if !trimmed.is_empty() {
+        if let Some(hit) = adapters
+            .iter()
+            .find(|a| a.description.trim().eq_ignore_ascii_case(trimmed))
+        {
+            return Some(hit);
+        }
+        let lowered = trimmed.to_lowercase();
+        if let Some(hit) = adapters.iter().find(|a| {
+            let description = a.description.to_lowercase();
+            description.contains(&lowered) || lowered.contains(&description)
+        }) {
+            return Some(hit);
+        }
+    }
+
+    adapters.get(ordinal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_real_gpu_engine_instance_name() {
+        let parsed = parse_gpu_engine_instance(
+            "pid_9540_luid_0x00000000_0x0000D3F5_phys_0_eng_3_engtype_3D",
+        )
+        .expect("well-formed instance name should parse");
+        assert_eq!(parsed.pid, 9540);
+        assert_eq!(parsed.luid, AdapterLuid::new(0, 0xD3F5));
+        assert_eq!(parsed.phys, 0);
+        assert_eq!(parsed.eng, 3);
+        assert_eq!(parsed.engtype, "3D");
+    }
+
+    #[test]
+    fn parses_multiword_engine_types() {
+        let parsed = parse_gpu_engine_instance(
+            "pid_1_luid_0x00000000_0x00001234_phys_0_eng_1_engtype_VideoDecode",
+        )
+        .unwrap();
+        assert_eq!(parsed.engtype, "VideoDecode");
+        assert!(!is_utilization_engine_type(&parsed.engtype));
+    }
+
+    #[test]
+    fn preserves_a_negative_luid_high_part() {
+        // HighPart is signed; the counter name renders it as unsigned
+        // hex. Round-tripping 0xFFFFFFFF must land on -1, not fail.
+        let parsed = parse_gpu_engine_instance(
+            "pid_7_luid_0xFFFFFFFF_0x0000ABCD_phys_0_eng_0_engtype_Compute",
+        )
+        .unwrap();
+        assert_eq!(parsed.luid, AdapterLuid::new(-1, 0xABCD));
+    }
+
+    #[test]
+    fn rejects_malformed_engine_instance_names() {
+        // Each of these is a shape we could plausibly be handed by a
+        // future driver or a different counter family; none should panic
+        // or produce a bogus LUID.
+        for bad in [
+            "",
+            "pid_9540",
+            "pid_abc_luid_0x0_0x1_phys_0_eng_0_engtype_3D",
+            "luid_0x00000000_0x0000D3F5_phys_0",
+            "pid_1_luid_0x0_0x1_phys_0_eng_0_engtype_",
+            "pid_1_luid_0xZZ_0x1_phys_0_eng_0_engtype_3D",
+        ] {
+            assert!(
+                parse_gpu_engine_instance(bad).is_none(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_process_and_adapter_memory_instances() {
+        let process =
+            parse_gpu_process_memory_instance("pid_4242_luid_0x00000000_0x0000D3F5_phys_0")
+                .unwrap();
+        assert_eq!(process.pid, 4242);
+        assert_eq!(process.luid, AdapterLuid::new(0, 0xD3F5));
+
+        let adapter =
+            parse_gpu_adapter_memory_instance("luid_0x00000000_0x0000D3F5_phys_0").unwrap();
+        assert_eq!(adapter.luid, AdapterLuid::new(0, 0xD3F5));
+        assert_eq!(adapter.phys, 0);
+
+        // The two families must not accept each other's shape.
+        assert!(parse_gpu_adapter_memory_instance("pid_1_luid_0x0_0x1_phys_0").is_none());
+        assert!(parse_gpu_process_memory_instance("luid_0x0_0x1_phys_0").is_none());
+    }
+
+    #[test]
+    fn parses_pnp_device_ids() {
+        let ids =
+            parse_pnp_device_id(r"PCI\VEN_1002&DEV_744C&SUBSYS_00000000&REV_C8\6&1a2b&0&00000019")
+                .unwrap();
+        assert_eq!(ids.vendor, 0x1002);
+        assert_eq!(ids.device, 0x744C);
+
+        // Lower-case hex and a different vendor.
+        let intel = parse_pnp_device_id(r"pci\ven_8086&dev_56a0&subsys_00000000").unwrap();
+        assert_eq!(intel.vendor, 0x8086);
+        assert_eq!(intel.device, 0x56A0);
+
+        // Non-PCI enumerations have no counterpart to match.
+        assert!(parse_pnp_device_id(r"ROOT\BasicDisplay\0000").is_none());
+        assert!(parse_pnp_device_id("").is_none());
+    }
+
+    fn engine(pid: u32, luid: u32, eng: u32, engtype: &str) -> GpuEngineInstance {
+        GpuEngineInstance {
+            pid,
+            luid: AdapterLuid::new(0, luid),
+            phys: 0,
+            eng,
+            engtype: engtype.to_string(),
+        }
+    }
+
+    #[test]
+    fn sums_processes_within_an_engine_and_maxes_across_engines() {
+        // Engine 0 is 30% + 25% busy across two processes; engine 1 is
+        // 40%. The adapter figure must be 55 (the busier engine), not 95
+        // (the sum of both).
+        let samples = vec![
+            (engine(100, 0xAAAA, 0, "3D"), 30.0),
+            (engine(200, 0xAAAA, 0, "3D"), 25.0),
+            (engine(100, 0xAAAA, 1, "Compute"), 40.0),
+        ];
+        let aggregated = aggregate_engine_utilization(samples);
+        assert_eq!(aggregated.len(), 1);
+        let value = aggregated[&AdapterLuid::new(0, 0xAAAA)];
+        assert!((value - 55.0).abs() < f64::EPSILON, "got {value}");
+    }
+
+    #[test]
+    fn keeps_adapters_separate_and_ignores_non_compute_engines() {
+        let samples = vec![
+            (engine(1, 0xAAAA, 0, "3D"), 70.0),
+            (engine(1, 0xBBBB, 0, "3D"), 10.0),
+            // Video engines must not contribute at all.
+            (engine(1, 0xBBBB, 1, "VideoDecode"), 95.0),
+            (engine(1, 0xBBBB, 2, "Copy"), 88.0),
+        ];
+        let aggregated = aggregate_engine_utilization(samples);
+        assert_eq!(aggregated[&AdapterLuid::new(0, 0xAAAA)], 70.0);
+        assert_eq!(aggregated[&AdapterLuid::new(0, 0xBBBB)], 10.0);
+    }
+
+    #[test]
+    fn clamps_out_of_range_and_drops_non_finite_samples() {
+        let samples = vec![
+            (engine(1, 0xAAAA, 0, "3D"), 80.0),
+            (engine(2, 0xAAAA, 0, "3D"), 80.0), // sums to 160, clamps to 100
+            (engine(1, 0xBBBB, 0, "3D"), -5.0), // negative clamps to 0
+            (engine(1, 0xCCCC, 0, "3D"), f64::NAN),
+            (engine(1, 0xCCCC, 0, "3D"), f64::INFINITY),
+        ];
+        let aggregated = aggregate_engine_utilization(samples);
+        assert_eq!(aggregated[&AdapterLuid::new(0, 0xAAAA)], 100.0);
+        assert_eq!(aggregated[&AdapterLuid::new(0, 0xBBBB)], 0.0);
+        // Every sample for CCCC was non-finite, so it contributes no
+        // entry rather than a NaN one.
+        assert!(!aggregated.contains_key(&AdapterLuid::new(0, 0xCCCC)));
+    }
+
+    #[test]
+    fn sums_adapter_memory_across_segments() {
+        let samples = vec![
+            (
+                GpuAdapterMemoryInstance {
+                    luid: AdapterLuid::new(0, 0xAAAA),
+                    phys: 0,
+                },
+                1024.0,
+            ),
+            (
+                GpuAdapterMemoryInstance {
+                    luid: AdapterLuid::new(0, 0xAAAA),
+                    phys: 1,
+                },
+                2048.0,
+            ),
+        ];
+        let aggregated = aggregate_adapter_memory(samples);
+        assert_eq!(aggregated[&AdapterLuid::new(0, 0xAAAA)], 3072);
+    }
+
+    fn identity(luid: u32, vendor: u32, device: u32, description: &str) -> AdapterIdentity {
+        AdapterIdentity {
+            luid: AdapterLuid::new(0, luid),
+            vendor_id: vendor,
+            device_id: device,
+            description: description.to_string(),
+        }
+    }
+
+    #[test]
+    fn matches_on_pci_ids_before_anything_else() {
+        let adapters = vec![
+            identity(1, 0x8086, 0x56A0, "Intel(R) Arc(TM) A770 Graphics"),
+            identity(2, 0x1002, 0x744C, "AMD Radeon RX 7900 XTX"),
+        ];
+        // The name deliberately disagrees with the PNPDeviceID; the PCI
+        // ids must win.
+        let hit = match_adapter(
+            &adapters,
+            Some(r"PCI\VEN_1002&DEV_744C&SUBSYS_0&REV_C8"),
+            "Intel(R) Arc(TM) A770 Graphics",
+            0,
+        )
+        .unwrap();
+        assert_eq!(hit.luid, AdapterLuid::new(0, 2));
+    }
+
+    #[test]
+    fn disambiguates_identical_cards_by_ordinal() {
+        let adapters = vec![
+            identity(1, 0x1002, 0x744C, "AMD Radeon RX 7900 XTX"),
+            identity(2, 0x1002, 0x744C, "AMD Radeon RX 7900 XTX"),
+        ];
+        let pnp = Some(r"PCI\VEN_1002&DEV_744C");
+        assert_eq!(
+            match_adapter(&adapters, pnp, "AMD Radeon RX 7900 XTX", 0)
+                .unwrap()
+                .luid,
+            AdapterLuid::new(0, 1)
+        );
+        assert_eq!(
+            match_adapter(&adapters, pnp, "AMD Radeon RX 7900 XTX", 1)
+                .unwrap()
+                .luid,
+            AdapterLuid::new(0, 2)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_name_then_ordinal() {
+        let adapters = vec![
+            identity(1, 0x8086, 0x56A0, "Intel(R) Arc(TM) A770 Graphics"),
+            identity(2, 0x1002, 0x744C, "AMD Radeon RX 7900 XTX"),
+        ];
+        // No PNPDeviceID at all: fall through to the name.
+        let hit = match_adapter(&adapters, None, "AMD Radeon RX 7900 XTX", 0).unwrap();
+        assert_eq!(hit.luid, AdapterLuid::new(0, 2));
+
+        // PCI ids that match nothing, and a name that matches nothing:
+        // ordinal is the last resort.
+        let hit = match_adapter(
+            &adapters,
+            Some(r"PCI\VEN_DEAD&DEV_BEEF"),
+            "Some Unknown Display Adapter",
+            1,
+        )
+        .unwrap();
+        assert_eq!(hit.luid, AdapterLuid::new(0, 2));
+
+        // An out-of-range ordinal yields nothing rather than panicking.
+        assert!(match_adapter(&adapters, None, "Unknown", 9).is_none());
+        assert!(match_adapter(&[], None, "anything", 0).is_none());
+    }
+}

--- a/src/device/readers/windows_gpu_perf/ids.rs
+++ b/src/device/readers/windows_gpu_perf/ids.rs
@@ -357,9 +357,19 @@ pub fn aggregate_adapter_memory(
 ///    names, but driver updates occasionally add or drop a suffix.
 /// 3. **Ordinal position** in the full adapter list, as a last resort.
 ///
-/// `ordinal` is the caller's index among the WMI rows it is iterating,
-/// which for a single-GPU machine (the overwhelming majority) makes
-/// even the weakest strategy correct.
+/// `ordinal` is the caller's index among the WMI rows it is iterating.
+///
+/// Note that `ordinal` indexes a *vendor-filtered* list (the AMD reader
+/// only iterates AMD controllers) while `adapters` is the *unfiltered*
+/// DXGI enumeration, so the two are not generally aligned. Every
+/// weaker-than-PCI strategy is therefore constrained to adapters whose
+/// vendor id agrees with the WMI row, and when the vendor cannot be
+/// determined at all the function gives up rather than guessing.
+///
+/// Returning `None` costs only the augmentation: the caller keeps the
+/// WMI baseline, which is honestly empty. Guessing wrong is worse than
+/// that, because it silently reports one card's memory and utilization
+/// against another.
 pub fn match_adapter<'a>(
     adapters: &'a [AdapterIdentity],
     pnp_device_id: Option<&str>,
@@ -370,36 +380,58 @@ pub fn match_adapter<'a>(
         return None;
     }
 
-    if let Some(ids) = pnp_device_id.and_then(parse_pnp_device_id) {
-        let matches: Vec<&AdapterIdentity> = adapters
+    let ids = pnp_device_id.and_then(parse_pnp_device_id);
+
+    // Strongest: exact PCI vendor and device.
+    if let Some(ids) = ids {
+        let exact: Vec<&AdapterIdentity> = adapters
             .iter()
             .filter(|a| a.vendor_id == ids.vendor && a.device_id == ids.device)
             .collect();
-        match matches.len() {
+        match exact.len() {
             0 => {}
-            1 => return Some(matches[0]),
-            _ => return Some(matches.get(ordinal).copied().unwrap_or(matches[0])),
+            1 => return Some(exact[0]),
+            // Two identical cards. Their WMI rows and DXGI entries are
+            // both vendor-homogeneous here, so the ordinal is meaningful
+            // within this subset.
+            _ => return Some(exact.get(ordinal).copied().unwrap_or(exact[0])),
         }
+    }
+
+    // Everything below may only consider adapters from the same vendor.
+    // Without a vendor there is nothing to constrain a guess with.
+    let ids = ids?;
+    let same_vendor: Vec<&AdapterIdentity> = adapters
+        .iter()
+        .filter(|a| a.vendor_id == ids.vendor)
+        .collect();
+    if same_vendor.is_empty() {
+        return None;
     }
 
     let trimmed = name.trim();
     if !trimmed.is_empty() {
-        if let Some(hit) = adapters
+        if let Some(hit) = same_vendor
             .iter()
             .find(|a| a.description.trim().eq_ignore_ascii_case(trimmed))
         {
             return Some(hit);
         }
         let lowered = trimmed.to_lowercase();
-        if let Some(hit) = adapters.iter().find(|a| {
-            let description = a.description.to_lowercase();
-            description.contains(&lowered) || lowered.contains(&description)
+        if let Some(hit) = same_vendor.iter().find(|a| {
+            let description = a.description.trim().to_lowercase();
+            // An empty description would make `lowered.contains` true
+            // for every row and swallow the whole list, so require a
+            // real string on both sides.
+            !description.is_empty()
+                && (description.contains(&lowered) || lowered.contains(&description))
         }) {
             return Some(hit);
         }
     }
 
-    adapters.get(ordinal)
+    // Last resort, still inside the vendor subset.
+    same_vendor.get(ordinal).copied()
 }
 
 #[cfg(test)]
@@ -624,28 +656,78 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_name_then_ordinal() {
+    fn falls_back_to_name_within_the_same_vendor() {
         let adapters = vec![
             identity(1, 0x8086, 0x56A0, "Intel(R) Arc(TM) A770 Graphics"),
-            identity(2, 0x1002, 0x744C, "AMD Radeon RX 7900 XTX"),
+            // Same vendor as the WMI row below, but a device id the row
+            // does not carry, so only the name can pair them.
+            identity(2, 0x1002, 0x1234, "AMD Radeon RX 7900 XTX"),
         ];
-        // No PNPDeviceID at all: fall through to the name.
-        let hit = match_adapter(&adapters, None, "AMD Radeon RX 7900 XTX", 0).unwrap();
-        assert_eq!(hit.luid, AdapterLuid::new(0, 2));
-
-        // PCI ids that match nothing, and a name that matches nothing:
-        // ordinal is the last resort.
         let hit = match_adapter(
             &adapters,
-            Some(r"PCI\VEN_DEAD&DEV_BEEF"),
-            "Some Unknown Display Adapter",
-            1,
+            Some(r"PCI\VEN_1002&DEV_744C"),
+            "AMD Radeon RX 7900 XTX",
+            0,
         )
         .unwrap();
         assert_eq!(hit.luid, AdapterLuid::new(0, 2));
+    }
 
-        // An out-of-range ordinal yields nothing rather than panicking.
-        assert!(match_adapter(&adapters, None, "Unknown", 9).is_none());
+    #[test]
+    fn never_pairs_across_vendors() {
+        // The heart of the mis-attribution risk: `ordinal` indexes the
+        // caller's vendor-filtered WMI rows while `adapters` is the full
+        // DXGI list, so an unconstrained ordinal fallback would hand an
+        // AMD row the Intel iGPU's memory and utilization. Reporting
+        // nothing (and keeping the honest WMI baseline) is required.
+        let adapters = vec![
+            identity(1, 0x8086, 0x56A0, "Intel(R) Arc(TM) A770 Graphics"),
+            identity(2, 0x10DE, 0x2684, "NVIDIA GeForce RTX 4090"),
+        ];
+        assert!(
+            match_adapter(
+                &adapters,
+                Some(r"PCI\VEN_1002&DEV_744C"),
+                "AMD Radeon RX 7900 XTX",
+                0
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn declines_to_guess_without_a_vendor() {
+        let adapters = vec![identity(1, 0x1002, 0x744C, "AMD Radeon RX 7900 XTX")];
+        // `amd_windows` synthesizes `AMD-GPU-{idx}` as the uuid when a
+        // controller has no PNPDeviceID; that parses to no vendor, so
+        // there is nothing to constrain a match with.
+        assert!(match_adapter(&adapters, None, "AMD Radeon RX 7900 XTX", 0).is_none());
+        assert!(match_adapter(&adapters, Some("AMD-GPU-0"), "AMD Radeon RX 7900 XTX", 0).is_none());
+    }
+
+    #[test]
+    fn an_empty_adapter_description_does_not_swallow_every_row() {
+        // `widestring_to_string` yields "" for a NUL-first Description.
+        // A naive containment check treats "" as a substring of
+        // everything, so one such adapter would capture every WMI row.
+        let adapters = vec![
+            identity(1, 0x1002, 0x1111, ""),
+            identity(2, 0x1002, 0x2222, "AMD Radeon RX 7900 XTX"),
+        ];
+        let hit = match_adapter(
+            &adapters,
+            Some(r"PCI\VEN_1002&DEV_744C"),
+            "AMD Radeon RX 7900 XTX",
+            9,
+        )
+        .unwrap();
+        assert_eq!(hit.luid, AdapterLuid::new(0, 2));
+    }
+
+    #[test]
+    fn out_of_range_and_empty_inputs_yield_nothing() {
+        let adapters = vec![identity(1, 0x1002, 0x744C, "AMD Radeon RX 7900 XTX")];
+        assert!(match_adapter(&adapters, Some(r"PCI\VEN_1002&DEV_9999"), "Unknown", 9).is_none());
         assert!(match_adapter(&[], None, "anything", 0).is_none());
     }
 }

--- a/src/device/readers/windows_gpu_perf/pdh.rs
+++ b/src/device/readers/windows_gpu_perf/pdh.rs
@@ -66,6 +66,15 @@ use windows::core::{PCWSTR, w};
 
 /// `PDH_CSTATUS_VALID_DATA`, the per-item success status.
 const PDH_CSTATUS_VALID_DATA: u32 = 0;
+/// `PDH_CSTATUS_NEW_DATA`, the *other* per-item success status.
+///
+/// `pdhmsg.h` defines both 0 and 1 as valid, and MSDN's
+/// `PDH_FMT_COUNTERVALUE` page documents `NEW_DATA` as "the counter was
+/// updated since the last collection". That is precisely the case for a
+/// GPU under load, so treating it as an error would silently drop every
+/// interesting sample and degrade the whole feature back to the WMI
+/// baseline while the doctor check still reported success.
+const PDH_CSTATUS_NEW_DATA: u32 = 1;
 /// `PDH_MORE_DATA`, returned by the buffer-sizing probe call.
 const PDH_MORE_DATA: u32 = 0x8000_07D2;
 
@@ -208,61 +217,89 @@ fn read_counter_array(counter: PDH_HCOUNTER) -> Vec<(String, f64)> {
         return Vec::new();
     }
 
-    let mut buffer_size = 0u32;
-    let mut item_count = 0u32;
-    let status = unsafe {
-        PdhGetFormattedCounterArrayW(
-            counter,
-            PDH_FMT_DOUBLE,
-            &mut buffer_size,
-            &mut item_count,
-            None,
-        )
-    };
-    if status != PDH_MORE_DATA || buffer_size == 0 {
-        // No instances at all is the normal case on a machine with no
-        // WDDM GPU, and on GitHub-hosted Windows runners.
-        return Vec::new();
+    // The instance set is snapshotted into the query by
+    // `PdhCollectQueryData`, so the size returned by the probe should
+    // still be valid on the fetch. Retry once anyway: if the size did
+    // grow, a single extra attempt recovers the poll instead of silently
+    // dropping the whole counter family.
+    for _ in 0..2 {
+        let mut buffer_size = 0u32;
+        let mut item_count = 0u32;
+        let status = unsafe {
+            PdhGetFormattedCounterArrayW(
+                counter,
+                PDH_FMT_DOUBLE,
+                &mut buffer_size,
+                &mut item_count,
+                None,
+            )
+        };
+        if status != PDH_MORE_DATA || buffer_size == 0 {
+            // No instances at all is the normal case on a machine with
+            // no WDDM GPU, and on GitHub-hosted Windows runners.
+            return Vec::new();
+        }
+
+        let item_size = std::mem::size_of::<PDH_FMT_COUNTERVALUE_ITEM_W>();
+        let capacity = (buffer_size as usize).div_ceil(item_size);
+        // Allocating as `Vec<PDH_FMT_COUNTERVALUE_ITEM_W>` rather than
+        // `Vec<u8>` also buys the 8-byte alignment the `f64` in the
+        // union requires.
+        let mut items: Vec<PDH_FMT_COUNTERVALUE_ITEM_W> = Vec::with_capacity(capacity);
+
+        let status = unsafe {
+            PdhGetFormattedCounterArrayW(
+                counter,
+                PDH_FMT_DOUBLE,
+                &mut buffer_size,
+                &mut item_count,
+                Some(items.as_mut_ptr()),
+            )
+        };
+        if status == PDH_MORE_DATA {
+            continue;
+        }
+        if status != 0 {
+            return Vec::new();
+        }
+
+        // SAFETY: PDH reported `item_count` initialised items, and the
+        // allocation covers `buffer_size` bytes which by PDH's own
+        // contract is at least `item_count * item_size`. The `min`
+        // holds the invariant even if PDH were to over-report.
+        let item_count = (item_count as usize).min(capacity);
+        unsafe { items.set_len(item_count) };
+
+        return items
+            .iter()
+            .filter_map(|item| {
+                // Both 0 and 1 are documented success statuses; see the
+                // constants above.
+                if !matches!(
+                    item.FmtValue.CStatus,
+                    PDH_CSTATUS_VALID_DATA | PDH_CSTATUS_NEW_DATA
+                ) {
+                    return None;
+                }
+                // PDH always fills `szName` for a returned item, but
+                // `PWSTR::to_string` calls `wcslen` with no null check,
+                // so a null would be a segfault rather than an error.
+                if item.szName.is_null() {
+                    return None;
+                }
+                // SAFETY: the array was requested with PDH_FMT_DOUBLE,
+                // so the union holds the double variant.
+                let value = unsafe { item.FmtValue.Anonymous.doubleValue };
+                // SAFETY: szName points into the tail of the same
+                // allocation, which outlives this eager iteration, and
+                // `to_string` copies into an owned String.
+                let name = unsafe { item.szName.to_string() }.ok()?;
+                Some((name, value))
+            })
+            .collect();
     }
 
-    let item_size = std::mem::size_of::<PDH_FMT_COUNTERVALUE_ITEM_W>();
-    let capacity = (buffer_size as usize).div_ceil(item_size);
-    let mut items: Vec<PDH_FMT_COUNTERVALUE_ITEM_W> = Vec::with_capacity(capacity);
-
-    let status = unsafe {
-        PdhGetFormattedCounterArrayW(
-            counter,
-            PDH_FMT_DOUBLE,
-            &mut buffer_size,
-            &mut item_count,
-            Some(items.as_mut_ptr()),
-        )
-    };
-    if status != 0 {
-        return Vec::new();
-    }
-
-    // SAFETY: PDH reported `item_count` initialised items, and the
-    // allocation covers `buffer_size` bytes which by PDH's own contract
-    // is at least `item_count * item_size`.
-    let item_count = (item_count as usize).min(capacity);
-    unsafe { items.set_len(item_count) };
-
-    items
-        .iter()
-        .filter_map(|item| {
-            if item.FmtValue.CStatus != PDH_CSTATUS_VALID_DATA {
-                return None;
-            }
-            // SAFETY: the array was requested with PDH_FMT_DOUBLE, so
-            // the union holds the double variant.
-            let value = unsafe { item.FmtValue.Anonymous.doubleValue };
-            // SAFETY: szName points into the tail of the same buffer,
-            // which is alive for the duration of this iteration.
-            let name = unsafe { item.szName.to_string() }.ok()?;
-            Some((name, value))
-        })
-        .collect()
+    Vec::new()
 }
 
 /// Process-wide sampler. `None` once opening the query has failed, so a

--- a/src/device/readers/windows_gpu_perf/pdh.rs
+++ b/src/device/readers/windows_gpu_perf/pdh.rs
@@ -1,0 +1,302 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Performance Data Helper (PDH) sampling of the Windows GPU counter
+//! families.
+//!
+//! Three counter families are read:
+//!
+//! | Counter | Shape | Gives us |
+//! |---|---|---|
+//! | `\GPU Engine(*)\Utilization Percentage` | rate | device utilization |
+//! | `\GPU Adapter Memory(*)\Dedicated Usage` | gauge | system-wide used VRAM |
+//! | `\GPU Process Memory(*)\Dedicated Usage` | gauge | per-process VRAM |
+//!
+//! This is the same data Task Manager's GPU pane shows, and it is
+//! vendor-neutral: AMD, Intel, and NVIDIA adapters all publish it
+//! through WDDM.
+//!
+//! ## Why the query is persistent
+//!
+//! `Utilization Percentage` is a rate counter. A single
+//! `PdhCollectQueryData` call establishes a baseline and yields no
+//! usable value; the rate only exists once there are two samples to
+//! difference. Rather than sleeping inside the reader to manufacture a
+//! second sample, the query is opened once and kept alive in a process
+//! global, and each all-smi poll contributes one collection. The first
+//! poll after start-up reports no utilization, and every poll after that
+//! reports the rate over the real poll interval. That matches how
+//! all-smi already drives its other rate-like sources and keeps
+//! `get_gpu_info` non-blocking.
+//!
+//! The two memory counters are gauges and are valid from the very first
+//! collection, so they are returned immediately.
+//!
+//! ## Locale
+//!
+//! Counters are added with `PdhAddEnglishCounterW`, not
+//! `PdhAddCounterW`. Counter path components are localized on non-English
+//! Windows installations, so the literal English path only resolves
+//! through the English-specific entry point.
+
+use super::ids::{
+    AdapterLuid, GpuAdapterMemoryInstance, GpuEngineInstance, GpuProcessMemoryInstance,
+    aggregate_adapter_memory, aggregate_engine_utilization, parse_gpu_adapter_memory_instance,
+    parse_gpu_engine_instance, parse_gpu_process_memory_instance,
+};
+use once_cell::sync::OnceCell;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use windows::Win32::System::Performance::{
+    PDH_FMT_COUNTERVALUE_ITEM_W, PDH_FMT_DOUBLE, PDH_HCOUNTER, PDH_HQUERY, PdhAddEnglishCounterW,
+    PdhCloseQuery, PdhCollectQueryData, PdhGetFormattedCounterArrayW, PdhOpenQueryW,
+};
+use windows::core::{PCWSTR, w};
+
+/// `PDH_CSTATUS_VALID_DATA`, the per-item success status.
+const PDH_CSTATUS_VALID_DATA: u32 = 0;
+/// `PDH_MORE_DATA`, returned by the buffer-sizing probe call.
+const PDH_MORE_DATA: u32 = 0x8000_07D2;
+
+/// What one poll of the GPU counters produced.
+#[derive(Debug, Default)]
+pub struct PdhSample {
+    /// Device utilization per adapter, 0..=100. Empty on the first poll
+    /// after start-up, and on hosts that publish no GPU Engine
+    /// instances.
+    pub utilization: HashMap<AdapterLuid, f64>,
+    /// System-wide dedicated VRAM in use, per adapter, in bytes.
+    pub adapter_memory: HashMap<AdapterLuid, u64>,
+    /// Dedicated VRAM in use per (pid, adapter), in bytes.
+    pub process_memory: Vec<(GpuProcessMemoryInstance, u64)>,
+}
+
+struct GpuCounterQuery {
+    query: PDH_HQUERY,
+    engine: PDH_HCOUNTER,
+    adapter_memory: PDH_HCOUNTER,
+    process_memory: PDH_HCOUNTER,
+    /// Set once a collection has happened, which is when the rate
+    /// counter starts producing values.
+    primed: bool,
+}
+
+// PDH handles are opaque values, not thread-affine resources; the
+// wrapping `Mutex` is what serialises access to the query.
+unsafe impl Send for GpuCounterQuery {}
+
+impl Drop for GpuCounterQuery {
+    fn drop(&mut self) {
+        // Unreachable while the sampler lives in a process global, but
+        // correct if the storage is ever made per-reader.
+        unsafe {
+            let _ = PdhCloseQuery(self.query);
+        }
+    }
+}
+
+impl GpuCounterQuery {
+    fn open() -> Option<Self> {
+        let mut query = PDH_HQUERY::default();
+        // A null data source means "live data from this machine".
+        if unsafe { PdhOpenQueryW(PCWSTR::null(), 0, &mut query) } != 0 {
+            return None;
+        }
+
+        let engine = match add_counter(query, w!("\\GPU Engine(*)\\Utilization Percentage")) {
+            Some(counter) => counter,
+            None => {
+                unsafe {
+                    let _ = PdhCloseQuery(query);
+                }
+                return None;
+            }
+        };
+        // The two memory families are optional: a host can publish GPU
+        // Engine without them, and losing them should cost only those
+        // fields.
+        let adapter_memory =
+            add_counter(query, w!("\\GPU Adapter Memory(*)\\Dedicated Usage")).unwrap_or_default();
+        let process_memory =
+            add_counter(query, w!("\\GPU Process Memory(*)\\Dedicated Usage")).unwrap_or_default();
+
+        Some(Self {
+            query,
+            engine,
+            adapter_memory,
+            process_memory,
+            primed: false,
+        })
+    }
+
+    fn collect(&mut self) -> PdhSample {
+        if unsafe { PdhCollectQueryData(self.query) } != 0 {
+            return PdhSample::default();
+        }
+        let was_primed = self.primed;
+        self.primed = true;
+
+        let mut sample = PdhSample::default();
+
+        // Rate counter: skip entirely until a previous collection has
+        // established the baseline.
+        if was_primed {
+            let engine_samples = read_counter_array(self.engine)
+                .into_iter()
+                .filter_map(|(name, value)| {
+                    parse_gpu_engine_instance(&name).map(|instance| (instance, value))
+                })
+                .collect::<Vec<(GpuEngineInstance, f64)>>();
+            sample.utilization = aggregate_engine_utilization(engine_samples);
+        }
+
+        if !self.adapter_memory.is_invalid() {
+            let adapter_samples = read_counter_array(self.adapter_memory)
+                .into_iter()
+                .filter_map(|(name, value)| {
+                    parse_gpu_adapter_memory_instance(&name).map(|instance| (instance, value))
+                })
+                .collect::<Vec<(GpuAdapterMemoryInstance, f64)>>();
+            sample.adapter_memory = aggregate_adapter_memory(adapter_samples);
+        }
+
+        if !self.process_memory.is_invalid() {
+            sample.process_memory = read_counter_array(self.process_memory)
+                .into_iter()
+                .filter_map(|(name, value)| {
+                    if !value.is_finite() || value < 0.0 {
+                        return None;
+                    }
+                    parse_gpu_process_memory_instance(&name)
+                        .map(|instance| (instance, value as u64))
+                })
+                .collect();
+        }
+
+        sample
+    }
+}
+
+fn add_counter(query: PDH_HQUERY, path: PCWSTR) -> Option<PDH_HCOUNTER> {
+    let mut counter = PDH_HCOUNTER::default();
+    if unsafe { PdhAddEnglishCounterW(query, path, 0, &mut counter) } != 0 {
+        return None;
+    }
+    Some(counter)
+}
+
+/// Read every instance of a wildcard counter as `(instance name, value)`.
+///
+/// PDH wants the caller to size the buffer: the first call with a zero
+/// size returns `PDH_MORE_DATA` and fills in the byte count, the second
+/// call fills the buffer. The buffer holds the item array followed by
+/// the instance-name strings the items point into, so it is allocated as
+/// a `Vec` of items large enough to cover the whole byte count.
+fn read_counter_array(counter: PDH_HCOUNTER) -> Vec<(String, f64)> {
+    if counter.is_invalid() {
+        return Vec::new();
+    }
+
+    let mut buffer_size = 0u32;
+    let mut item_count = 0u32;
+    let status = unsafe {
+        PdhGetFormattedCounterArrayW(
+            counter,
+            PDH_FMT_DOUBLE,
+            &mut buffer_size,
+            &mut item_count,
+            None,
+        )
+    };
+    if status != PDH_MORE_DATA || buffer_size == 0 {
+        // No instances at all is the normal case on a machine with no
+        // WDDM GPU, and on GitHub-hosted Windows runners.
+        return Vec::new();
+    }
+
+    let item_size = std::mem::size_of::<PDH_FMT_COUNTERVALUE_ITEM_W>();
+    let capacity = (buffer_size as usize).div_ceil(item_size);
+    let mut items: Vec<PDH_FMT_COUNTERVALUE_ITEM_W> = Vec::with_capacity(capacity);
+
+    let status = unsafe {
+        PdhGetFormattedCounterArrayW(
+            counter,
+            PDH_FMT_DOUBLE,
+            &mut buffer_size,
+            &mut item_count,
+            Some(items.as_mut_ptr()),
+        )
+    };
+    if status != 0 {
+        return Vec::new();
+    }
+
+    // SAFETY: PDH reported `item_count` initialised items, and the
+    // allocation covers `buffer_size` bytes which by PDH's own contract
+    // is at least `item_count * item_size`.
+    let item_count = (item_count as usize).min(capacity);
+    unsafe { items.set_len(item_count) };
+
+    items
+        .iter()
+        .filter_map(|item| {
+            if item.FmtValue.CStatus != PDH_CSTATUS_VALID_DATA {
+                return None;
+            }
+            // SAFETY: the array was requested with PDH_FMT_DOUBLE, so
+            // the union holds the double variant.
+            let value = unsafe { item.FmtValue.Anonymous.doubleValue };
+            // SAFETY: szName points into the tail of the same buffer,
+            // which is alive for the duration of this iteration.
+            let name = unsafe { item.szName.to_string() }.ok()?;
+            Some((name, value))
+        })
+        .collect()
+}
+
+/// Process-wide sampler. `None` once opening the query has failed, so a
+/// host without GPU counters pays the failed-open cost exactly once.
+static SAMPLER: OnceCell<Mutex<Option<GpuCounterQuery>>> = OnceCell::new();
+
+/// Collect one sample of the GPU counter families.
+///
+/// Returns an all-empty sample when PDH is unavailable, when the host
+/// publishes no GPU counter instances, or on the very first call (for
+/// the utilization field only). Callers treat an empty field as "no
+/// data" and keep whatever the WMI baseline provided.
+pub fn sample() -> PdhSample {
+    let cell = SAMPLER.get_or_init(|| Mutex::new(GpuCounterQuery::open()));
+    let mut guard = match cell.lock() {
+        Ok(guard) => guard,
+        // A panic in another thread while holding the query lock leaves
+        // the handle in an unknown state; recovering the guard is still
+        // better than poisoning every later poll.
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    match guard.as_mut() {
+        Some(query) => query.collect(),
+        None => PdhSample::default(),
+    }
+}
+
+/// Whether the GPU counter query could be opened at all. Used by the
+/// doctor check to distinguish "PDH is broken" from "this machine has no
+/// GPU counter instances".
+pub fn query_available() -> bool {
+    let cell = SAMPLER.get_or_init(|| Mutex::new(GpuCounterQuery::open()));
+    match cell.lock() {
+        Ok(guard) => guard.is_some(),
+        Err(poisoned) => poisoned.into_inner().is_some(),
+    }
+}

--- a/src/doctor/checks/windows.rs
+++ b/src/doctor/checks/windows.rs
@@ -18,7 +18,7 @@
 
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
-static CHECKS: &[&Check] = &[&WMI, &RYZEN_MASTER, &INTEL_WMI, &LHM];
+static CHECKS: &[&Check] = &[&WMI, &GPU_PERF_COUNTERS, &RYZEN_MASTER, &INTEL_WMI, &LHM];
 
 pub fn checks() -> &'static [&'static Check] {
     CHECKS
@@ -29,6 +29,13 @@ static WMI: Check = Check {
     title: "WMI thermal-zone access",
     severity_on_fail: Severity::Warn,
     run: check_wmi,
+};
+
+static GPU_PERF_COUNTERS: Check = Check {
+    id: "windows.gpu.perf_counters",
+    title: "GPU performance counters (DXGI / PDH)",
+    severity_on_fail: Severity::Info,
+    run: check_gpu_perf_counters,
 };
 
 static RYZEN_MASTER: Check = Check {
@@ -67,6 +74,99 @@ fn check_wmi(_ctx: &CheckCtx) -> CheckResult {
                 Some("ensure the WinMgmt service is running".to_string()),
             ),
         }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        CheckResult::Skip("not Windows".to_string())
+    }
+}
+
+/// Report what the vendor-neutral GPU metrics layer can actually see.
+///
+/// This is the main field-verification path for issue #346: no CI job
+/// builds all-smi for Windows, and the GitHub-hosted Windows runners
+/// expose only the Microsoft Basic Display Adapter, so the real answer
+/// only ever comes from an operator running `all-smi doctor` on their
+/// own machine.
+///
+/// The three states are deliberately distinguished, because they call
+/// for different responses:
+///
+/// - no DXGI adapters at all: the display stack is not reachable
+/// - DXGI answers but PDH publishes no GPU counter instances: normal on
+///   a VM, an RDP session, or a host whose performance counters have
+///   been disabled; utilization degrades to the WMI baseline
+/// - both answer: the full feature set is live
+fn check_gpu_perf_counters(_ctx: &CheckCtx) -> CheckResult {
+    #[cfg(target_os = "windows")]
+    {
+        use crate::device::readers::windows_gpu_perf;
+
+        let snapshot = windows_gpu_perf::snapshot();
+        let pdh_open = windows_gpu_perf::pdh_query_available();
+
+        if snapshot.adapters.is_empty() {
+            return CheckResult::Warn(
+                "DXGI reported no hardware adapters".to_string(),
+                Some(
+                    "expected on a session with no display driver (headless VM, some RDP \
+                     configurations); GPU memory and utilization fall back to the WMI baseline"
+                        .to_string(),
+                ),
+            );
+        }
+
+        let described: Vec<String> = snapshot
+            .adapters
+            .iter()
+            .map(|adapter| {
+                let total_gib =
+                    adapter.total_memory.unwrap_or(0) as f64 / (1024.0 * 1024.0 * 1024.0);
+                let description = &adapter.identity.description;
+                let utilization = match adapter.utilization {
+                    Some(value) => format!("{value:.1}%"),
+                    None => "unavailable".to_string(),
+                };
+                format!("{description} ({total_gib:.1} GiB, utilization {utilization})")
+            })
+            .collect();
+
+        if !pdh_open {
+            return CheckResult::Warn(
+                format!(
+                    "DXGI sees {} adapter(s) but the PDH GPU counter query could not be opened: {}",
+                    snapshot.adapters.len(),
+                    described.join("; ")
+                ),
+                Some(
+                    "VRAM size still comes from DXGI; utilization and per-process memory need \
+                     the GPU performance counters. Check that the Performance Logs and Alerts \
+                     service is enabled."
+                        .to_string(),
+                ),
+            );
+        }
+
+        // A single utilization reading is expected to be absent here:
+        // the rate counter needs two collections and `doctor` performs
+        // one. Report the counter instance availability instead.
+        let has_utilization = snapshot
+            .adapters
+            .iter()
+            .any(|adapter| adapter.utilization.is_some());
+        let processes = snapshot.processes.len();
+        let adapters = snapshot.adapters.len();
+        let summary = described.join("; ");
+        let utilization_note = if has_utilization {
+            ""
+        } else {
+            " (utilization needs a second poll; absent here is normal)"
+        };
+
+        CheckResult::Pass(format!(
+            "{adapters} adapter(s): {summary}; PDH query open, \
+             {processes} per-process row(s){utilization_note}"
+        ))
     }
     #[cfg(not(target_os = "windows"))]
     {


### PR DESCRIPTION
## Summary

Closes #346.

The AMD and Intel Windows readers were WMI-only baselines: `utilization`, `used_memory`, `frequency`, and `power_consumption` were hardcoded to `0`, `get_process_info()` returned an empty `Vec`, and `total_memory` was wrong for any card above 4 GB because `Win32_VideoController.AdapterRAM` is a `uint32` in the WMI schema.

This adds `src/device/readers/windows_gpu_perf.rs`, a shared layer built on two OS facilities that need no vendor SDK, consumed by both vendor readers rather than duplicated.

| Source | Supplies |
|---|---|
| DXGI `DXGI_ADAPTER_DESC1` | true 64-bit `DedicatedVideoMemory`, adapter LUID, PCI vendor/device ids |
| PDH `\GPU Engine(*)` | device utilization |
| PDH `\GPU Adapter Memory(*)` | system-wide used VRAM |
| PDH `\GPU Process Memory(*)` | per-process VRAM, which populates `get_process_info()` |

Level Zero keeps precedence over this layer for Intel. Per-field provenance goes in the existing `Source: *` detail keys, and `Metrics Source` composes as backends contribute (`WMI + DXGI + PDH`), following the pattern #248 established.

## Design decisions worth reviewing

**The PDH query is persistent.** `Utilization Percentage` is a rate counter: a single `PdhCollectQueryData` establishes a baseline and yields nothing usable. Rather than sleeping inside the reader to manufacture a second sample, the query is opened once and each poll contributes one collection. The first poll after start-up reports no utilization; every poll after that reports the rate over the real interval. `get_process_info()` reuses that sample via `latest()` instead of collecting again, which would halve the interval the rate is computed over.

**Utilization sums within an engine but maxes across engines.** Each sample is one process's share of one engine, so summing across processes gives the engine's busy fraction. Summing across a card's several 3D and Compute engines yields figures well above 100% and would peg every gauge. The maximum is what Task Manager's headline GPU percentage reports. This is a deliberate deviation from the issue text, which said "summing the 3D and Compute engine types per LUID"; flagging it explicitly.

**DXGI `QueryVideoMemoryInfo` is process-scoped.** MSDN defines `CurrentUsage` and `Budget` as this process's view, not the system's. Reading either as the device's used memory would understate a busy GPU by whatever other processes hold, so both are exposed as clearly labelled diagnostic detail fields (`VRAM Usage (this process)`) and `used_memory` comes from the PDH adapter counter instead.

**Video engines are excluded from utilization.** A compositor decoding video keeps `VideoDecode` busy while the shader cores idle; folding it in would make an idle desktop report a large non-zero load.

**Counters are added with `PdhAddEnglishCounterW`.** Counter path components are localized on non-English Windows, so the literal English path only resolves through the English-specific entry point.

## Verification

**No CI job in this repository compiles all-smi for Windows.** The only Windows job (`windows-service` in `ci.yml`) is gated behind `vars.ENABLE_WINDOWS_SERVICE_SMOKE`, which is unset, and its own comment states it has never executed. Windows-only code therefore ships with zero automated coverage by default. Two things were done about that:

1. The module is gated `cfg(any(target_os = "windows", test))`, matching the existing `intel_gpu_sysfs` pattern, so the counter-instance parsing, the utilization aggregation, the PNPDeviceID matching, and the field application are all exercised by the Linux test runner. 28 new tests.
2. The FFI itself was verified by cross-compiling to the real release target from macOS.

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo test` | 3118 pass, 0 fail |
| `cargo xwin check --target x86_64-pc-windows-msvc` | pass |
| `cargo xwin clippy --target x86_64-pc-windows-msvc -- -D warnings` | pass for this change |

The Windows cross-check needed `cargo-xwin` plus `llvm-lib` (rustup's `llvm-tools` provides `llvm-ar`, which acts as `llvm-lib` under that name); `zstd-sys` otherwise blocks any Windows cross-compile from macOS.

## Pre-existing findings, not fixed here

Windows clippy reports three lints in files this PR does not touch, surfaced only because nothing had ever linted that target:

- `src/device/cpu_windows.rs:49` and `:63`, collapsible `if`
- `src/device/windows_temp/amd_ryzen.rs:228`, collapsible `if`

Left alone to keep this diff scoped. Worth a follow-up together with a CI job that actually compiles the Windows target, which `windows-latest` runners would do for free on this public repository.

## Not verified

Acceptance criteria that need real hardware: non-zero utilization on a busy AMD and Intel Windows machine, correct VRAM on a card above 4 GB, and populated per-process rows. The `windows.gpu.perf_counters` doctor check exists to produce exactly that evidence from an operator's machine; it distinguishes "no DXGI adapters", "DXGI works but PDH publishes no instances" (normal on VMs and RDP), and the full path.
