### PR TITLE
feat: add AMD ADL sensor augmentation on Windows via PMLog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ windows = { version = "0.62", features = [
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
     "Win32_System_Performance",
+    "Win32_System_Memory",
 ] }
 # Service Control Manager integration for `all-smi service` (issue #311).
 # Mullvad's crate, MIT OR Apache-2.0, MSRV 1.71 against this project's

--- a/src/device/readers/amd_adl.rs
+++ b/src/device/readers/amd_adl.rs
@@ -1,0 +1,349 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! AMD ADL sensor augmentation for the Windows GPU reader.
+//!
+//! The vendor-neutral DXGI and PDH layer added in #346 covers everything
+//! WDDM publishes: VRAM size, utilization, per-process memory. It cannot
+//! cover temperature, board power, fan speed, or clocks, because Windows
+//! does not expose those at all. Those come from AMD's own library.
+//!
+//! `atiadlxx.dll` is loaded at runtime from an absolute System32 path,
+//! so nothing is linked and a machine without AMD's driver simply gets
+//! no ADL data. See [`loader`] for the loading and hijacking stance.
+//!
+//! ## Scope: modern parts only
+//!
+//! Sensors are read exclusively through `ADL2_New_QueryPMLogData_Get`,
+//! the Overdrive 8 style sensor table that Vega and later expose. The
+//! legacy Overdrive 5, 6, and 7 temperature entry points are
+//! deliberately not implemented: they are three more ABI surfaces to get
+//! right blind, for hardware that predates the datacentre and workstation
+//! cards all-smi targets. A pre-Vega card keeps the WMI and PDH baseline.
+//!
+//! ## Scope: one AMD GPU
+//!
+//! ADL identifies adapters by an index that does not map to a card
+//! without `AdapterInfo`, a 1568-byte struct whose layout this module
+//! deliberately refuses to declare blind (see [`ffi`]). Worse, one card
+//! exposes several adapter indices, one per display output, all
+//! reporting identical telemetry, so an index cannot even be
+//! deduplicated without it.
+//!
+//! Rather than guess, augmentation only runs when the reader found
+//! exactly one AMD GPU. That covers the overwhelming majority of real
+//! machines, and on a multi-AMD-GPU host the result is the honest DXGI
+//! and PDH baseline instead of one card's temperature reported against
+//! another. This mirrors the conclusion the #346 review reached about
+//! adapter matching: declining to attribute beats attributing wrongly.
+//!
+//! ## Cost
+//!
+//! Nothing here submits GPU work; PMLog reads a telemetry block the
+//! driver already maintains. The library load, context creation, and
+//! capability scan each happen once for the process, so a steady-state
+//! poll is a single call. Note that very aggressive sensor polling (at
+//! the 100 ms rates desktop monitoring tools use) can hold an AMD GPU
+//! out of its deepest idle power state; all-smi's intervals start at one
+//! second, which is well clear of that.
+
+pub mod ffi;
+pub mod sensors;
+
+#[cfg(target_os = "windows")]
+pub mod loader;
+
+use crate::device::readers::windows_gpu_perf::note_metrics_source;
+use crate::device::types::GpuInfo;
+use sensors::AdlReadout;
+
+/// Whether an ADL readout can be attributed to a specific card.
+///
+/// See the module docs: without `AdapterInfo` an ADL adapter index
+/// cannot be tied to a GPU, so attribution is only safe when there is
+/// nothing to confuse it with.
+pub fn can_attribute(amd_gpu_count: usize) -> bool {
+    amd_gpu_count == 1
+}
+
+/// Layer an ADL readout onto a GPU that already carries the WMI, DXGI,
+/// and PDH baseline.
+///
+/// ADL outranks the vendor-neutral layer: it reads the hardware's own
+/// telemetry rather than the OS's accounting of it. Utilization is
+/// therefore overwritten when ADL reports graphics activity, and
+/// temperature, power, fan, and clocks are filled in for the first time.
+///
+/// Fields ADL did not produce are left exactly as they were, so a card
+/// that publishes only some sensors keeps the baseline for the rest.
+pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
+    if readout.is_empty() {
+        return;
+    }
+
+    if let Some(temperature) = readout.primary_temperature_c() {
+        gpu.temperature = temperature;
+        gpu.detail
+            .insert("Source: Temperature".to_string(), "ADL".to_string());
+    }
+    // Hotspot and memory temperatures have no dedicated `GpuInfo` field
+    // but are the numbers that actually throttle a modern card, so they
+    // are surfaced as details rather than dropped.
+    if let Some(hotspot) = readout.temperature_hotspot_c {
+        gpu.detail
+            .insert("Hotspot Temperature (C)".to_string(), hotspot.to_string());
+    }
+    if let Some(memory) = readout.temperature_mem_c {
+        gpu.detail
+            .insert("Memory Temperature (C)".to_string(), memory.to_string());
+    }
+
+    if let Some(power) = readout.power_w {
+        gpu.power_consumption = power;
+        gpu.detail
+            .insert("Source: Power".to_string(), "ADL".to_string());
+    }
+
+    if let Some(clock) = readout.clock_gfx_mhz {
+        gpu.frequency = clock;
+        gpu.detail
+            .insert("Source: Frequency".to_string(), "ADL".to_string());
+    }
+    if let Some(clock) = readout.clock_mem_mhz {
+        gpu.detail
+            .insert("Memory Clock (MHz)".to_string(), clock.to_string());
+    }
+
+    if let Some(rpm) = readout.fan_rpm {
+        // `GpuInfo` has no fan field; the Intel reader already
+        // advertises fan provenance the same way.
+        gpu.detail
+            .insert("Fan Speed (RPM)".to_string(), rpm.to_string());
+        gpu.detail
+            .insert("Source: Fan".to_string(), "ADL".to_string());
+    }
+
+    if let Some(activity) = readout.activity_gfx_pct {
+        gpu.utilization = activity;
+        gpu.detail
+            .insert("Source: Utilization".to_string(), "ADL".to_string());
+    }
+    if let Some(activity) = readout.activity_mem_pct {
+        gpu.detail.insert(
+            "Memory Controller Activity (%)".to_string(),
+            format!("{activity:.0}"),
+        );
+    }
+
+    note_metrics_source(&mut gpu.detail, "ADL");
+    // The legacy `Note` key advertised the missing vendor library. Now
+    // that it is wired up, say what is actually still missing.
+    gpu.detail.insert(
+        "Note".to_string(),
+        "Temperature, power, fan, and clocks via AMD ADL (PMLog)".to_string(),
+    );
+}
+
+/// Sample ADL and layer the result onto the reader's GPUs.
+///
+/// Called after the vendor-neutral layer so ADL's readings win. A no-op
+/// when ADL is unavailable, when no adapter exposes PMLog, or when the
+/// machine has more than one AMD GPU.
+#[cfg(target_os = "windows")]
+pub fn augment(gpus: &mut [GpuInfo]) {
+    if !can_attribute(gpus.len()) {
+        return;
+    }
+    let Some(output) = loader::sample() else {
+        return;
+    };
+    let readout = sensors::extract(&output);
+    apply_to_gpu_info(&mut gpus[0], &readout);
+}
+
+/// Non-Windows builds have no ADL. The stub keeps the surrounding logic
+/// and its tests compiling everywhere.
+#[cfg(not(target_os = "windows"))]
+pub fn augment(_gpus: &mut [GpuInfo]) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn baseline_gpu() -> GpuInfo {
+        let mut detail = HashMap::new();
+        // The state #346 leaves behind on a working Windows host.
+        detail.insert("Metrics Source".to_string(), "WMI + DXGI + PDH".to_string());
+        detail.insert("Source: Utilization".to_string(), "PDH".to_string());
+        detail.insert("Source: Temperature".to_string(), "unavailable".to_string());
+        detail.insert("Source: Power".to_string(), "unavailable".to_string());
+        detail.insert("Source: Frequency".to_string(), "unavailable".to_string());
+        detail.insert("Source: Fan".to_string(), "unavailable".to_string());
+        detail.insert(
+            "Note".to_string(),
+            "Temperature, power, and fan need the AMD ADL library".to_string(),
+        );
+        GpuInfo {
+            uuid: "PCI\\VEN_1002&DEV_744C".to_string(),
+            time: String::new(),
+            name: "AMD Radeon RX 7900 XTX".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: String::new(),
+            hostname: String::new(),
+            instance: String::new(),
+            utilization: 12.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 0,
+            used_memory: 1_073_741_824,
+            total_memory: 25_769_803_776,
+            frequency: 0,
+            power_consumption: 0.0,
+            gpu_core_count: None,
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
+            detail,
+        }
+    }
+
+    fn full_readout() -> AdlReadout {
+        AdlReadout {
+            temperature_edge_c: Some(62),
+            temperature_hotspot_c: Some(81),
+            temperature_mem_c: Some(70),
+            power_w: Some(310.0),
+            fan_rpm: Some(1450),
+            clock_gfx_mhz: Some(2400),
+            clock_mem_mhz: Some(1250),
+            activity_gfx_pct: Some(97.0),
+            activity_mem_pct: Some(44.0),
+        }
+    }
+
+    #[test]
+    fn fills_in_everything_wddm_cannot_provide() {
+        let mut gpu = baseline_gpu();
+        apply_to_gpu_info(&mut gpu, &full_readout());
+
+        assert_eq!(gpu.temperature, 62);
+        assert_eq!(gpu.power_consumption, 310.0);
+        assert_eq!(gpu.frequency, 2400);
+        assert_eq!(gpu.detail["Hotspot Temperature (C)"], "81");
+        assert_eq!(gpu.detail["Memory Temperature (C)"], "70");
+        assert_eq!(gpu.detail["Fan Speed (RPM)"], "1450");
+        assert_eq!(gpu.detail["Memory Clock (MHz)"], "1250");
+        assert_eq!(gpu.detail["Memory Controller Activity (%)"], "44");
+
+        assert_eq!(gpu.detail["Source: Temperature"], "ADL");
+        assert_eq!(gpu.detail["Source: Power"], "ADL");
+        assert_eq!(gpu.detail["Source: Frequency"], "ADL");
+        assert_eq!(gpu.detail["Source: Fan"], "ADL");
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH + ADL");
+    }
+
+    #[test]
+    fn adl_utilization_outranks_the_pdh_figure() {
+        // ADL reads the hardware's own activity counter; PDH reads the
+        // OS's accounting. When both exist the vendor number wins.
+        let mut gpu = baseline_gpu();
+        assert_eq!(gpu.utilization, 12.0);
+        apply_to_gpu_info(&mut gpu, &full_readout());
+        assert_eq!(gpu.utilization, 97.0);
+        assert_eq!(gpu.detail["Source: Utilization"], "ADL");
+    }
+
+    #[test]
+    fn a_partial_readout_leaves_the_rest_of_the_baseline_alone() {
+        // A card that publishes temperature but no activity counter must
+        // not have its PDH utilization clobbered, nor be labelled as
+        // sourcing utilization from ADL.
+        let mut gpu = baseline_gpu();
+        let readout = AdlReadout {
+            temperature_edge_c: Some(55),
+            ..Default::default()
+        };
+        apply_to_gpu_info(&mut gpu, &readout);
+
+        assert_eq!(gpu.temperature, 55);
+        assert_eq!(gpu.utilization, 12.0);
+        assert_eq!(gpu.detail["Source: Utilization"], "PDH");
+        assert_eq!(gpu.detail["Source: Power"], "unavailable");
+        assert_eq!(gpu.power_consumption, 0.0);
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH + ADL");
+    }
+
+    #[test]
+    fn an_empty_readout_changes_nothing_at_all() {
+        // A pre-Vega card, or one whose every sensor failed the range
+        // guard, must leave no trace: claiming an ADL source for a
+        // readout that produced nothing would be a lie in the output.
+        let mut gpu = baseline_gpu();
+        let before = gpu.clone();
+        apply_to_gpu_info(&mut gpu, &AdlReadout::default());
+
+        assert_eq!(gpu.temperature, before.temperature);
+        assert_eq!(gpu.utilization, before.utilization);
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH");
+        assert_eq!(gpu.detail["Source: Temperature"], "unavailable");
+        assert!(!gpu.detail.contains_key("Hotspot Temperature (C)"));
+    }
+
+    #[test]
+    fn applying_twice_does_not_grow_the_source_string() {
+        let mut gpu = baseline_gpu();
+        let readout = full_readout();
+        apply_to_gpu_info(&mut gpu, &readout);
+        apply_to_gpu_info(&mut gpu, &readout);
+        assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH + ADL");
+    }
+
+    #[test]
+    fn attribution_is_refused_for_anything_but_a_single_amd_gpu() {
+        assert!(can_attribute(1));
+        // Zero cards is nothing to attribute to; two or more cannot be
+        // told apart without AdapterInfo.
+        assert!(!can_attribute(0));
+        assert!(!can_attribute(2));
+        assert!(!can_attribute(4));
+    }
+
+    #[test]
+    fn augment_is_inert_when_attribution_is_refused() {
+        let mut gpus = vec![baseline_gpu(), baseline_gpu()];
+        augment(&mut gpus);
+        for gpu in &gpus {
+            assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH");
+            assert_eq!(gpu.temperature, 0);
+        }
+
+        // And on a non-Windows host it must be inert even for one GPU.
+        #[cfg(not(target_os = "windows"))]
+        {
+            let mut single = vec![baseline_gpu()];
+            augment(&mut single);
+            assert_eq!(single[0].detail["Metrics Source"], "WMI + DXGI + PDH");
+            assert_eq!(single[0].temperature, 0);
+        }
+    }
+}

--- a/src/device/readers/amd_adl.rs
+++ b/src/device/readers/amd_adl.rs
@@ -92,10 +92,23 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
         return;
     }
 
-    if let Some(temperature) = readout.primary_temperature_c() {
-        gpu.temperature = temperature;
+    let mut applied: Vec<&str> = Vec::new();
+
+    if let Some((temperature, source)) = readout.primary_temperature_c() {
+        // `GpuInfo.temperature` is unsigned. A sub-zero die on a
+        // cold-started machine is a real reading but cannot be
+        // represented, so it floors at 0 and the true value stays
+        // visible in the detail below.
+        gpu.temperature = temperature.max(0) as u32;
         gpu.detail
-            .insert("Source: Temperature".to_string(), "ADL".to_string());
+            .insert("Temperature (C)".to_string(), temperature.to_string());
+        // The label names which sensor was used. Edge, gfx, and hotspot
+        // are not interchangeable (hotspot runs 15-30 C higher), and an
+        // aggregated multi-host view would otherwise mix them with
+        // nothing to tell them apart.
+        gpu.detail
+            .insert("Source: Temperature".to_string(), source.to_string());
+        applied.push("temperature");
     }
     // Hotspot and memory temperatures have no dedicated `GpuInfo` field
     // but are the numbers that actually throttle a modern card, so they
@@ -113,12 +126,14 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
         gpu.power_consumption = power;
         gpu.detail
             .insert("Source: Power".to_string(), "ADL".to_string());
+        applied.push("power");
     }
 
     if let Some(clock) = readout.clock_gfx_mhz {
         gpu.frequency = clock;
         gpu.detail
             .insert("Source: Frequency".to_string(), "ADL".to_string());
+        applied.push("clocks");
     }
     if let Some(clock) = readout.clock_mem_mhz {
         gpu.detail
@@ -132,12 +147,14 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
             .insert("Fan Speed (RPM)".to_string(), rpm.to_string());
         gpu.detail
             .insert("Source: Fan".to_string(), "ADL".to_string());
+        applied.push("fan");
     }
 
     if let Some(activity) = readout.activity_gfx_pct {
         gpu.utilization = activity;
         gpu.detail
             .insert("Source: Utilization".to_string(), "ADL".to_string());
+        applied.push("utilization");
     }
     if let Some(activity) = readout.activity_mem_pct {
         gpu.detail.insert(
@@ -147,11 +164,12 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
     }
 
     note_metrics_source(&mut gpu.detail, "ADL");
-    // The legacy `Note` key advertised the missing vendor library. Now
-    // that it is wired up, say what is actually still missing.
+    // Name only what ADL actually produced. A card publishing just one
+    // sensor must not carry a Note claiming all four, which would
+    // contradict the per-field `Source: *` keys sitting beside it.
     gpu.detail.insert(
         "Note".to_string(),
-        "Temperature, power, fan, and clocks via AMD ADL (PMLog)".to_string(),
+        format!("via AMD ADL (PMLog): {}", applied.join(", ")),
     );
 }
 
@@ -230,6 +248,7 @@ mod tests {
     fn full_readout() -> AdlReadout {
         AdlReadout {
             temperature_edge_c: Some(62),
+            temperature_gfx_c: None,
             temperature_hotspot_c: Some(81),
             temperature_mem_c: Some(70),
             power_w: Some(310.0),
@@ -255,7 +274,7 @@ mod tests {
         assert_eq!(gpu.detail["Memory Clock (MHz)"], "1250");
         assert_eq!(gpu.detail["Memory Controller Activity (%)"], "44");
 
-        assert_eq!(gpu.detail["Source: Temperature"], "ADL");
+        assert_eq!(gpu.detail["Source: Temperature"], "ADL (edge)");
         assert_eq!(gpu.detail["Source: Power"], "ADL");
         assert_eq!(gpu.detail["Source: Frequency"], "ADL");
         assert_eq!(gpu.detail["Source: Fan"], "ADL");
@@ -291,6 +310,46 @@ mod tests {
         assert_eq!(gpu.detail["Source: Power"], "unavailable");
         assert_eq!(gpu.power_consumption, 0.0);
         assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH + ADL");
+    }
+
+    #[test]
+    fn the_note_names_only_the_fields_adl_actually_produced() {
+        // A card publishing one sensor must not carry a Note claiming
+        // all four, which would contradict the `Source: *` keys sitting
+        // right beside it.
+        let mut gpu = baseline_gpu();
+        apply_to_gpu_info(
+            &mut gpu,
+            &AdlReadout {
+                temperature_edge_c: Some(55),
+                ..Default::default()
+            },
+        );
+        assert_eq!(gpu.detail["Note"], "via AMD ADL (PMLog): temperature");
+        assert_eq!(gpu.detail["Source: Power"], "unavailable");
+
+        let mut full = baseline_gpu();
+        apply_to_gpu_info(&mut full, &full_readout());
+        assert_eq!(
+            full.detail["Note"],
+            "via AMD ADL (PMLog): temperature, power, clocks, fan, utilization"
+        );
+    }
+
+    #[test]
+    fn a_sub_zero_die_floors_the_unsigned_field_but_keeps_the_real_value() {
+        let mut gpu = baseline_gpu();
+        apply_to_gpu_info(
+            &mut gpu,
+            &AdlReadout {
+                temperature_edge_c: Some(-8),
+                ..Default::default()
+            },
+        );
+        // `GpuInfo.temperature` is u32 and cannot hold it.
+        assert_eq!(gpu.temperature, 0);
+        // The true reading survives where it can be represented.
+        assert_eq!(gpu.detail["Temperature (C)"], "-8");
     }
 
     #[test]

--- a/src/device/readers/amd_adl/ffi.rs
+++ b/src/device/readers/amd_adl/ffi.rs
@@ -1,0 +1,207 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Hand-declared ADL types and entry points.
+//!
+//! Only the handful of symbols all-smi actually calls are declared, and
+//! no AMD header is vendored, which keeps the project Apache-2.0 clean.
+//! The signatures and layouts are transcribed from AMD's public
+//! `adl_structures.h` and `adl_defines.h`.
+//!
+//! ## Why the surface is this small
+//!
+//! Every additional `#[repr(C)]` struct declared against a library we
+//! cannot compile against, cannot run, and have no CI coverage for is
+//! unverifiable risk: a layout mistake is memory corruption, not a
+//! compile error. So this module declares exactly one output struct plus
+//! scalar-only entry points.
+//!
+//! Notably absent is `AdapterInfo`, the 1568-byte struct that
+//! `ADL2_Adapter_AdapterInfo_Get` fills in. It carries the PCI bus /
+//! device / function numbers and the PNP string that would let an ADL
+//! adapter be matched to a specific card. Declaring it would be the
+//! single largest ABI liability in this file, and ADL sizes its write by
+//! its own `sizeof`, so getting it wrong overflows our buffer. The
+//! reader avoids needing it by only augmenting when the machine has
+//! exactly one AMD GPU; see the module docs in the parent.
+//!
+//! ## Calling convention
+//!
+//! `extern "system"` maps to `stdcall` on 32-bit x86, which is what
+//! ADL's headers declare, and to the single native convention on x86-64,
+//! which is the only target all-smi ships for Windows.
+
+use std::ffi::c_int;
+#[cfg(target_os = "windows")]
+use std::ffi::c_void;
+
+/// `ADL_MAX_PATH` from `adl_defines.h`. Not used by any struct declared
+/// here; kept as documentation of the value the omitted `AdapterInfo`
+/// layout depends on.
+#[allow(dead_code)]
+pub const ADL_MAX_PATH: usize = 256;
+
+/// `ADL_PMLOG_MAX_SENSORS` from `adl_structures.h`.
+pub const ADL_PMLOG_MAX_SENSORS: usize = 256;
+
+/// `ADL_OK`, the success status shared by every ADL entry point.
+#[cfg(target_os = "windows")]
+pub const ADL_OK: c_int = 0;
+
+/// Opaque `ADL_CONTEXT_HANDLE`.
+#[cfg(target_os = "windows")]
+pub type AdlContextHandle = *mut c_void;
+
+/// `ADL_MAIN_MALLOC_CALLBACK`.
+#[cfg(target_os = "windows")]
+pub type AdlMainMallocCallback = unsafe extern "system" fn(c_int) -> *mut c_void;
+
+/// One entry of `ADLPMLogDataOutput::sensors`.
+///
+/// `supported` is a boolean flag; `value` is the reading, whose unit
+/// depends on the sensor index.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct AdlSingleSensorData {
+    pub supported: c_int,
+    pub value: c_int,
+}
+
+/// `ADLPMLogDataOutput`: a fixed-size, sensor-index-addressed table.
+///
+/// The array is indexed by `ADLSensorType`, so entry `n` is the sensor
+/// whose enum value is `n`. Entries the card does not publish have
+/// `supported == 0`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AdlPmLogDataOutput {
+    /// `ulSize` in the header, declared `int` despite the name.
+    pub ul_size: c_int,
+    pub sensors: [AdlSingleSensorData; ADL_PMLOG_MAX_SENSORS],
+}
+
+impl Default for AdlPmLogDataOutput {
+    fn default() -> Self {
+        Self {
+            ul_size: 0,
+            sensors: [AdlSingleSensorData::default(); ADL_PMLOG_MAX_SENSORS],
+        }
+    }
+}
+
+// Layout assertions. These are the only automated check that exists for
+// this ABI: nothing in CI compiles for Windows, and no test can call the
+// real library. A mismatch here is memory corruption at runtime, so the
+// assertions are mandatory rather than decorative. Same rationale as the
+// `RmQuickStats` assertion in `device/windows_temp/amd_ryzen.rs`.
+const _: () = assert!(
+    std::mem::size_of::<AdlSingleSensorData>() == 8,
+    "ADLSingleSensorData must be two 32-bit ints"
+);
+const _: () = assert!(
+    std::mem::align_of::<AdlSingleSensorData>() == 4,
+    "ADLSingleSensorData must be 4-byte aligned, or the sensor array strides wrong"
+);
+const _: () = assert!(
+    std::mem::size_of::<AdlPmLogDataOutput>() == 4 + 8 * ADL_PMLOG_MAX_SENSORS,
+    "ADLPMLogDataOutput must be a leading int followed by a packed 256-entry sensor array"
+);
+const _: () = assert!(
+    std::mem::size_of::<AdlPmLogDataOutput>() == 2052,
+    "ADLPMLogDataOutput is 2052 bytes in AMD's headers"
+);
+
+// The entry points are only callable where the library exists, so they
+// are declared for Windows alone. The struct layouts above stay
+// unconditional: their compile-time assertions are the one automated
+// check this ABI can have, and they must run on the Linux test runner
+// too, since that is the only runner this repository has.
+
+/// `ADL2_Main_Control_Create`.
+///
+/// The second parameter is `iEnumConnectedAdapters`; passing 1 restricts
+/// enumeration to adapters that are actually present.
+#[cfg(target_os = "windows")]
+pub type Adl2MainControlCreate = unsafe extern "system" fn(
+    callback: AdlMainMallocCallback,
+    enum_connected_adapters: c_int,
+    context: *mut AdlContextHandle,
+) -> c_int;
+
+/// `ADL2_Main_Control_Destroy`.
+///
+/// Declared for completeness and deliberately never called: the context
+/// is created once and lives for the process, so there is no teardown
+/// point. Destroying it on a static's drop would run at an unspecified
+/// time relative to the driver unloading.
+#[cfg(target_os = "windows")]
+#[allow(dead_code)]
+pub type Adl2MainControlDestroy = unsafe extern "system" fn(context: AdlContextHandle) -> c_int;
+
+/// `ADL2_Adapter_NumberOfAdapters_Get`.
+#[cfg(target_os = "windows")]
+pub type Adl2AdapterNumberOfAdaptersGet =
+    unsafe extern "system" fn(context: AdlContextHandle, num_adapters: *mut c_int) -> c_int;
+
+/// `ADL2_Overdrive_Caps`.
+///
+/// `supported` and `enabled` are booleans; `version` is the Overdrive
+/// generation, which is 8 on the PMLog-capable parts this reader
+/// targets.
+#[cfg(target_os = "windows")]
+pub type Adl2OverdriveCaps = unsafe extern "system" fn(
+    context: AdlContextHandle,
+    adapter_index: c_int,
+    supported: *mut c_int,
+    enabled: *mut c_int,
+    version: *mut c_int,
+) -> c_int;
+
+/// `ADL2_New_QueryPMLogData_Get`.
+#[cfg(target_os = "windows")]
+pub type Adl2NewQueryPmLogDataGet = unsafe extern "system" fn(
+    context: AdlContextHandle,
+    adapter_index: c_int,
+    output: *mut AdlPmLogDataOutput,
+) -> c_int;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_sensor_table_is_addressable_by_index() {
+        // The whole extraction strategy rests on entry `n` being the
+        // sensor whose enum value is `n`, so assert the array actually
+        // strides by one 8-byte record.
+        let mut output = AdlPmLogDataOutput::default();
+        output.sensors[27].supported = 1;
+        output.sensors[27].value = 71;
+
+        let base = &output.sensors[0] as *const AdlSingleSensorData as usize;
+        let entry = &output.sensors[27] as *const AdlSingleSensorData as usize;
+        assert_eq!(entry - base, 27 * 8);
+
+        // And the leading int must not overlap the first sensor.
+        let struct_base = &output as *const AdlPmLogDataOutput as usize;
+        assert_eq!(base - struct_base, 4);
+    }
+
+    #[test]
+    fn default_reports_every_sensor_unsupported() {
+        let output = AdlPmLogDataOutput::default();
+        assert!(output.sensors.iter().all(|s| s.supported == 0));
+        assert_eq!(output.sensors.len(), ADL_PMLOG_MAX_SENSORS);
+    }
+}

--- a/src/device/readers/amd_adl/ffi.rs
+++ b/src/device/readers/amd_adl/ffi.rs
@@ -38,9 +38,13 @@
 //!
 //! ## Calling convention
 //!
-//! `extern "system"` maps to `stdcall` on 32-bit x86, which is what
-//! ADL's headers declare, and to the single native convention on x86-64,
-//! which is the only target all-smi ships for Windows.
+//! AMD declares the `ADL2_*` entry points as cdecl and only
+//! `ADL_MAIN_MALLOC_CALLBACK` as `__stdcall`, so the entry points use
+//! `extern "C"` and the callback uses `extern "system"`. The two
+//! coincide on x86-64, which is the only Windows target all-smi ships
+//! (`release.yml` builds `x86_64-pc-windows-msvc` alone), but they
+//! differ on i686 and getting them backwards there would corrupt the
+//! stack.
 
 use std::ffi::c_int;
 #[cfg(target_os = "windows")]
@@ -122,6 +126,61 @@ const _: () = assert!(
     "ADLPMLogDataOutput is 2052 bytes in AMD's headers"
 );
 
+/// A PMLog output buffer with trailing headroom.
+///
+/// The module docs above refuse to declare `AdapterInfo` because ADL
+/// sizes its write by its own `sizeof` and a short buffer is a memory
+/// smash rather than an error. That reasoning applies to
+/// `ADLPMLogDataOutput` too: `ADL2_New_QueryPMLogData_Get` takes a bare
+/// pointer with no length, so if a future driver ships a larger
+/// `ADL_PMLOG_MAX_SENSORS` it would write past a tightly-sized buffer.
+///
+/// Raising `ADL_PMLOG_MAX_SENSORS` would break every existing consumer,
+/// so it is unlikely, but "unlikely" is not a reason to hand a driver an
+/// exact-fit buffer in a long-running daemon. The padding gives a 4x
+/// table room to land, and [`Self::validated`] rejects a response whose
+/// reported size does not match what we asked for.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AdlPmLogDataBuffer {
+    pub output: AdlPmLogDataOutput,
+    /// Never read. Present so an oversized write lands in our allocation
+    /// instead of in whatever follows it.
+    _headroom: [AdlSingleSensorData; ADL_PMLOG_MAX_SENSORS * 3],
+}
+
+impl Default for AdlPmLogDataBuffer {
+    fn default() -> Self {
+        Self {
+            output: AdlPmLogDataOutput::default(),
+            _headroom: [AdlSingleSensorData::default(); ADL_PMLOG_MAX_SENSORS * 3],
+        }
+    }
+}
+
+impl AdlPmLogDataBuffer {
+    /// The filled-in table, or `None` when the driver reported a size
+    /// that does not correspond to the layout declared here.
+    ///
+    /// `ulSize` is documented as the size of the returned structure.
+    /// Drivers in the field have been observed leaving it at zero, so a
+    /// zero is accepted rather than treated as failure; only a positive
+    /// value that disagrees with our layout is rejected, since that is
+    /// the signal that this file's ABI no longer matches the driver's.
+    pub fn validated(&self) -> Option<&AdlPmLogDataOutput> {
+        let reported = self.output.ul_size;
+        if reported == 0 || reported as usize == std::mem::size_of::<AdlPmLogDataOutput>() {
+            return Some(&self.output);
+        }
+        None
+    }
+}
+
+const _: () = assert!(
+    std::mem::size_of::<AdlPmLogDataBuffer>() > std::mem::size_of::<AdlPmLogDataOutput>(),
+    "the headroom must actually extend the allocation"
+);
+
 // The entry points are only callable where the library exists, so they
 // are declared for Windows alone. The struct layouts above stay
 // unconditional: their compile-time assertions are the one automated
@@ -133,7 +192,7 @@ const _: () = assert!(
 /// The second parameter is `iEnumConnectedAdapters`; passing 1 restricts
 /// enumeration to adapters that are actually present.
 #[cfg(target_os = "windows")]
-pub type Adl2MainControlCreate = unsafe extern "system" fn(
+pub type Adl2MainControlCreate = unsafe extern "C" fn(
     callback: AdlMainMallocCallback,
     enum_connected_adapters: c_int,
     context: *mut AdlContextHandle,
@@ -147,12 +206,12 @@ pub type Adl2MainControlCreate = unsafe extern "system" fn(
 /// time relative to the driver unloading.
 #[cfg(target_os = "windows")]
 #[allow(dead_code)]
-pub type Adl2MainControlDestroy = unsafe extern "system" fn(context: AdlContextHandle) -> c_int;
+pub type Adl2MainControlDestroy = unsafe extern "C" fn(context: AdlContextHandle) -> c_int;
 
 /// `ADL2_Adapter_NumberOfAdapters_Get`.
 #[cfg(target_os = "windows")]
 pub type Adl2AdapterNumberOfAdaptersGet =
-    unsafe extern "system" fn(context: AdlContextHandle, num_adapters: *mut c_int) -> c_int;
+    unsafe extern "C" fn(context: AdlContextHandle, num_adapters: *mut c_int) -> c_int;
 
 /// `ADL2_Overdrive_Caps`.
 ///
@@ -160,7 +219,7 @@ pub type Adl2AdapterNumberOfAdaptersGet =
 /// generation, which is 8 on the PMLog-capable parts this reader
 /// targets.
 #[cfg(target_os = "windows")]
-pub type Adl2OverdriveCaps = unsafe extern "system" fn(
+pub type Adl2OverdriveCaps = unsafe extern "C" fn(
     context: AdlContextHandle,
     adapter_index: c_int,
     supported: *mut c_int,
@@ -170,7 +229,7 @@ pub type Adl2OverdriveCaps = unsafe extern "system" fn(
 
 /// `ADL2_New_QueryPMLogData_Get`.
 #[cfg(target_os = "windows")]
-pub type Adl2NewQueryPmLogDataGet = unsafe extern "system" fn(
+pub type Adl2NewQueryPmLogDataGet = unsafe extern "C" fn(
     context: AdlContextHandle,
     adapter_index: c_int,
     output: *mut AdlPmLogDataOutput,
@@ -196,6 +255,44 @@ mod tests {
         // And the leading int must not overlap the first sensor.
         let struct_base = &output as *const AdlPmLogDataOutput as usize;
         assert_eq!(base - struct_base, 4);
+    }
+
+    #[test]
+    fn the_padded_buffer_gives_an_oversized_write_somewhere_to_land() {
+        // The point of the headroom: a driver shipping a larger sensor
+        // table writes into our allocation instead of past it. The
+        // buffer must hold a table four times the declared length, plus
+        // the leading size word.
+        assert!(
+            std::mem::size_of::<AdlPmLogDataBuffer>()
+                >= std::mem::size_of::<c_int>()
+                    + 4 * std::mem::size_of::<AdlSingleSensorData>() * ADL_PMLOG_MAX_SENSORS
+        );
+        // And the output must sit at the very start, since that is the
+        // pointer handed to ADL.
+        let buffer = AdlPmLogDataBuffer::default();
+        let buffer_base = &buffer as *const AdlPmLogDataBuffer as usize;
+        let output_base = &buffer.output as *const AdlPmLogDataOutput as usize;
+        assert_eq!(buffer_base, output_base);
+    }
+
+    #[test]
+    fn validation_accepts_a_matching_or_absent_size_and_rejects_a_conflicting_one() {
+        let mut buffer = AdlPmLogDataBuffer::default();
+
+        // Drivers have been seen leaving ulSize at zero; that is not a
+        // failure signal.
+        buffer.output.ul_size = 0;
+        assert!(buffer.validated().is_some());
+
+        buffer.output.ul_size = std::mem::size_of::<AdlPmLogDataOutput>() as i32;
+        assert!(buffer.validated().is_some());
+
+        // A positive size that disagrees with our layout means this
+        // file's ABI no longer matches the driver's, which is exactly
+        // when we must not interpret the contents.
+        buffer.output.ul_size = 4096;
+        assert!(buffer.validated().is_none());
     }
 
     #[test]

--- a/src/device/readers/amd_adl/loader.rs
+++ b/src/device/readers/amd_adl/loader.rs
@@ -1,0 +1,252 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime loading of `atiadlxx.dll` and the PMLog query.
+//!
+//! ## Nothing is linked
+//!
+//! The DLL is opened with `libloading` at first use. No import library
+//! is referenced, so the executable carries no `atiadlxx` entry in its
+//! import table and a machine without AMD's driver starts normally and
+//! simply reports no ADL data. This is the same shape issue #345 asks
+//! for on Linux, where `libamdgpu_top` links `libdrm` unconditionally
+//! and a missing library is a loader error before `main`.
+//!
+//! ## DLL hijacking
+//!
+//! The library is loaded from an absolute `System32` path and never by
+//! bare name, so the search order (which includes the application
+//! directory and, in some configurations, the current directory) cannot
+//! be used to substitute a different binary. Same stance as
+//! `device/windows_temp/amd_ryzen.rs`.
+//!
+//! ## Cost per poll
+//!
+//! The DLL load and `ADL2_Main_Control_Create` happen once for the
+//! process. The capability scan that picks an adapter index happens once
+//! and is then cached. A steady-state poll is therefore a single
+//! `ADL2_New_QueryPMLogData_Get`, which reads the telemetry block the
+//! driver already maintains for its own overlay and submits no work to
+//! the GPU.
+
+use super::ffi::{
+    ADL_OK, Adl2AdapterNumberOfAdaptersGet, Adl2MainControlCreate, Adl2NewQueryPmLogDataGet,
+    Adl2OverdriveCaps, AdlContextHandle, AdlPmLogDataOutput,
+};
+use once_cell::sync::OnceCell;
+use std::ffi::{c_int, c_void};
+use std::sync::Mutex;
+
+/// Absolute path, never a bare name. See the module docs.
+const ADL_DLL_PATH: &str = r"C:\Windows\System32\atiadlxx.dll";
+
+/// The Overdrive generation that introduced the PMLog sensor table.
+/// Earlier generations expose temperature through the OD5 / OD6 / OD7
+/// entry points, which this reader deliberately does not implement.
+const MIN_OVERDRIVE_VERSION: c_int = 7;
+
+/// Allocator handed to `ADL2_Main_Control_Create`.
+///
+/// ADL only calls this for buffers it allocates on the caller's behalf,
+/// which in practice is the `AdapterInfo` family. This reader never
+/// calls into that family, so the callback is expected to stay
+/// unused; it exists because `ADL2_Main_Control_Create` requires a
+/// non-null callback.
+///
+/// # Safety
+///
+/// Called by ADL with a byte count. Returns null on a non-positive or
+/// unrepresentable size, which ADL treats as allocation failure.
+unsafe extern "system" fn adl_malloc(size: c_int) -> *mut c_void {
+    if size <= 0 {
+        return std::ptr::null_mut();
+    }
+    // 16-byte alignment covers every ADL struct. The matching free is
+    // ADL's contract for the caller to provide and is not wired up,
+    // because nothing here requests an ADL-allocated buffer.
+    match std::alloc::Layout::from_size_align(size as usize, 16) {
+        // SAFETY: layout has a non-zero size.
+        Ok(layout) => unsafe { std::alloc::alloc(layout) as *mut c_void },
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+struct AdlRuntime {
+    /// Kept alive for the process. The function pointers below are only
+    /// valid while the library stays loaded.
+    _library: libloading::Library,
+    context: AdlContextHandle,
+    number_of_adapters: Adl2AdapterNumberOfAdaptersGet,
+    overdrive_caps: Adl2OverdriveCaps,
+    query_pmlog: Adl2NewQueryPmLogDataGet,
+    /// Adapter index chosen by the first capability scan.
+    ///
+    /// A single card exposes several ADL adapter indices, one per
+    /// display output, all reporting the same telemetry. Caching the
+    /// first PMLog-capable index avoids rescanning every poll and keeps
+    /// the steady-state cost to one call.
+    chosen_index: Option<c_int>,
+    /// Set once the capability scan has run, so a machine with no
+    /// PMLog-capable adapter does not rescan forever.
+    scanned: bool,
+}
+
+// ADL context handles are plain opaque pointers rather than thread-affine
+// resources; the wrapping `Mutex` serialises actual use.
+unsafe impl Send for AdlRuntime {}
+
+impl AdlRuntime {
+    fn open() -> Option<Self> {
+        // SAFETY: loading a shared library runs its initialisers. The
+        // path is absolute and inside System32, so only a caller who
+        // already has write access there could substitute the binary.
+        let library = unsafe { libloading::Library::new(ADL_DLL_PATH) }.ok()?;
+
+        // SAFETY: symbol lookups against a successfully loaded library.
+        // The signatures are transcribed from AMD's public headers; see
+        // the `ffi` module.
+        let (create, number_of_adapters, overdrive_caps, query_pmlog) = unsafe {
+            let create = *library
+                .get::<Adl2MainControlCreate>(b"ADL2_Main_Control_Create\0")
+                .ok()?;
+            let number_of_adapters = *library
+                .get::<Adl2AdapterNumberOfAdaptersGet>(b"ADL2_Adapter_NumberOfAdapters_Get\0")
+                .ok()?;
+            let overdrive_caps = *library
+                .get::<Adl2OverdriveCaps>(b"ADL2_Overdrive_Caps\0")
+                .ok()?;
+            let query_pmlog = *library
+                .get::<Adl2NewQueryPmLogDataGet>(b"ADL2_New_QueryPMLogData_Get\0")
+                .ok()?;
+            (create, number_of_adapters, overdrive_caps, query_pmlog)
+        };
+
+        let mut context: AdlContextHandle = std::ptr::null_mut();
+        // The `1` requests enumeration of connected adapters only.
+        // SAFETY: `adl_malloc` matches ADL_MAIN_MALLOC_CALLBACK and
+        // `context` is a valid out pointer.
+        let status = unsafe { create(adl_malloc, 1, &mut context) };
+        if status != ADL_OK || context.is_null() {
+            return None;
+        }
+
+        Some(Self {
+            _library: library,
+            context,
+            number_of_adapters,
+            overdrive_caps,
+            query_pmlog,
+            chosen_index: None,
+            scanned: false,
+        })
+    }
+
+    /// Find the first adapter index whose Overdrive generation exposes
+    /// the PMLog table.
+    fn scan_for_capable_adapter(&mut self) {
+        self.scanned = true;
+
+        let mut count: c_int = 0;
+        // SAFETY: valid context and out pointer.
+        if unsafe { (self.number_of_adapters)(self.context, &mut count) } != ADL_OK || count <= 0 {
+            return;
+        }
+
+        for index in 0..count {
+            let (mut supported, mut enabled, mut version) = (0, 0, 0);
+            // SAFETY: valid context and three out pointers.
+            let status = unsafe {
+                (self.overdrive_caps)(
+                    self.context,
+                    index,
+                    &mut supported,
+                    &mut enabled,
+                    &mut version,
+                )
+            };
+            if status != ADL_OK || supported == 0 || version < MIN_OVERDRIVE_VERSION {
+                continue;
+            }
+            // `enabled` reports whether the user has turned Overdrive
+            // tuning on. Reading sensors does not require it, so it is
+            // deliberately not part of the gate.
+            if self.read_pmlog(index).is_some() {
+                self.chosen_index = Some(index);
+                return;
+            }
+        }
+    }
+
+    fn read_pmlog(&self, index: c_int) -> Option<AdlPmLogDataOutput> {
+        let mut output = AdlPmLogDataOutput::default();
+        // SAFETY: `output` is a correctly sized and aligned
+        // ADLPMLogDataOutput; the compile-time assertions in `ffi` pin
+        // its layout.
+        let status = unsafe { (self.query_pmlog)(self.context, index, &mut output) };
+        (status == ADL_OK).then_some(output)
+    }
+
+    fn sample(&mut self) -> Option<AdlPmLogDataOutput> {
+        if !self.scanned {
+            self.scan_for_capable_adapter();
+        }
+        self.read_pmlog(self.chosen_index?)
+    }
+}
+
+/// Process-wide runtime. `None` once loading has failed, so a machine
+/// without AMD's driver pays the failed-open cost exactly once.
+static RUNTIME: OnceCell<Mutex<Option<AdlRuntime>>> = OnceCell::new();
+
+fn runtime() -> &'static Mutex<Option<AdlRuntime>> {
+    RUNTIME.get_or_init(|| Mutex::new(AdlRuntime::open()))
+}
+
+/// Take one PMLog sample, or `None` when ADL is unavailable or no
+/// adapter exposes the sensor table.
+pub fn sample() -> Option<AdlPmLogDataOutput> {
+    let mut guard = match runtime().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.as_mut()?.sample()
+}
+
+/// Whether `atiadlxx.dll` loaded and a context was created. Used by the
+/// doctor check to separate "no AMD driver" from "driver present but no
+/// PMLog-capable adapter".
+pub fn library_available() -> bool {
+    match runtime().lock() {
+        Ok(guard) => guard.is_some(),
+        Err(poisoned) => poisoned.into_inner().is_some(),
+    }
+}
+
+/// The adapter index the capability scan selected, if any.
+pub fn selected_adapter_index() -> Option<i32> {
+    let mut guard = match runtime().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let runtime = guard.as_mut()?;
+    if !runtime.scanned {
+        runtime.scan_for_capable_adapter();
+    }
+    runtime.chosen_index
+}
+
+/// The absolute path the loader uses, for diagnostics.
+pub fn dll_path() -> &'static str {
+    ADL_DLL_PATH
+}

--- a/src/device/readers/amd_adl/loader.rs
+++ b/src/device/readers/amd_adl/loader.rs
@@ -42,43 +42,67 @@
 
 use super::ffi::{
     ADL_OK, Adl2AdapterNumberOfAdaptersGet, Adl2MainControlCreate, Adl2NewQueryPmLogDataGet,
-    Adl2OverdriveCaps, AdlContextHandle, AdlPmLogDataOutput,
+    Adl2OverdriveCaps, AdlContextHandle, AdlPmLogDataBuffer, AdlPmLogDataOutput,
 };
+use libloading::os::windows::LOAD_LIBRARY_SEARCH_SYSTEM32;
 use once_cell::sync::OnceCell;
 use std::ffi::{c_int, c_void};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use windows::Win32::System::Memory::{GetProcessHeap, HEAP_FLAGS, HeapAlloc};
 
 /// Absolute path, never a bare name. See the module docs.
 const ADL_DLL_PATH: &str = r"C:\Windows\System32\atiadlxx.dll";
 
 /// The Overdrive generation that introduced the PMLog sensor table.
-/// Earlier generations expose temperature through the OD5 / OD6 / OD7
-/// entry points, which this reader deliberately does not implement.
+/// Used only to *rank* candidate adapters, never to exclude one; see
+/// [`AdlRuntime::scan_for_capable_adapter`].
 const MIN_OVERDRIVE_VERSION: c_int = 7;
+
+/// How long to wait before re-scanning after a scan found nothing.
+///
+/// The scan must not latch permanently. all-smi can run as a Windows
+/// service and start before the display driver has brought the adapter
+/// up, in which case the very first scan legitimately finds nothing; a
+/// permanent latch would then report "no PMLog-capable adapter" for the
+/// entire lifetime of the process and misdiagnose a healthy card as
+/// pre-Vega. The same applies after a driver update or a TDR reset
+/// invalidates the cached index.
+///
+/// This is the ADL counterpart to the DXGI factory's `IsCurrent` check.
+/// ADL exposes no staleness signal, so a slow retry stands in for one.
+const RESCAN_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Allocator handed to `ADL2_Main_Control_Create`.
 ///
-/// ADL only calls this for buffers it allocates on the caller's behalf,
-/// which in practice is the `AdapterInfo` family. This reader never
-/// calls into that family, so the callback is expected to stay
-/// unused; it exists because `ADL2_Main_Control_Create` requires a
-/// non-null callback.
+/// Allocates from the process heap rather than Rust's global allocator.
+/// Two reasons, both about who might free this memory: swapping in a
+/// different `#[global_allocator]` (routine in a polling daemon) would
+/// make Rust's allocator incompatible with the CRT `free` that ADL's own
+/// teardown would use, and `HeapAlloc(GetProcessHeap(), ...)` is what
+/// the UCRT allocator is built on, so it stays compatible either way.
+///
+/// ADL only invokes this for buffers it allocates on the caller's
+/// behalf, which is the `AdapterInfo` family this reader never calls, so
+/// in practice it should never run. It exists because
+/// `ADL2_Main_Control_Create` requires a non-null callback.
 ///
 /// # Safety
 ///
-/// Called by ADL with a byte count. Returns null on a non-positive or
-/// unrepresentable size, which ADL treats as allocation failure.
+/// Called by ADL with a byte count. Returns null on a non-positive size,
+/// which ADL treats as allocation failure.
 unsafe extern "system" fn adl_malloc(size: c_int) -> *mut c_void {
     if size <= 0 {
         return std::ptr::null_mut();
     }
-    // 16-byte alignment covers every ADL struct. The matching free is
-    // ADL's contract for the caller to provide and is not wired up,
-    // because nothing here requests an ADL-allocated buffer.
-    match std::alloc::Layout::from_size_align(size as usize, 16) {
-        // SAFETY: layout has a non-zero size.
-        Ok(layout) => unsafe { std::alloc::alloc(layout) as *mut c_void },
-        Err(_) => std::ptr::null_mut(),
+    // SAFETY: GetProcessHeap cannot fail for the current process, and
+    // HeapAlloc with a positive size either returns a valid block or
+    // null.
+    unsafe {
+        let Ok(heap) = GetProcessHeap() else {
+            return std::ptr::null_mut();
+        };
+        HeapAlloc(heap, HEAP_FLAGS(0), size as usize)
     }
 }
 
@@ -97,9 +121,13 @@ struct AdlRuntime {
     /// first PMLog-capable index avoids rescanning every poll and keeps
     /// the steady-state cost to one call.
     chosen_index: Option<c_int>,
-    /// Set once the capability scan has run, so a machine with no
-    /// PMLog-capable adapter does not rescan forever.
-    scanned: bool,
+    /// When the last capability scan ran, or `None` if it never has.
+    ///
+    /// Deliberately a timestamp rather than a boolean latch: a scan that
+    /// finds nothing is retried after [`RESCAN_INTERVAL`] instead of
+    /// disabling ADL for the life of the process. See the constant for
+    /// why that matters.
+    last_scan: Option<Instant>,
 }
 
 // ADL context handles are plain opaque pointers rather than thread-affine
@@ -108,10 +136,26 @@ unsafe impl Send for AdlRuntime {}
 
 impl AdlRuntime {
     fn open() -> Option<Self> {
-        // SAFETY: loading a shared library runs its initialisers. The
-        // path is absolute and inside System32, so only a caller who
-        // already has write access there could substitute the binary.
-        let library = unsafe { libloading::Library::new(ADL_DLL_PATH) }.ok()?;
+        // SAFETY: loading a shared library runs its initialisers.
+        //
+        // The absolute path pins `atiadlxx.dll` itself, but with default
+        // flags that module's own imports (it pulls in `atiadlxy.dll`)
+        // resolve through the standard search order, which begins with
+        // the *application* directory. That would leave the hijacking
+        // hole this module claims to close: an attacker able to write
+        // next to `all-smi.exe` gets execution through the dependency
+        // rather than through the named DLL.
+        //
+        // `LOAD_LIBRARY_SEARCH_SYSTEM32` restricts the whole dependency
+        // chain to System32.
+        let library = unsafe {
+            libloading::os::windows::Library::load_with_flags(
+                ADL_DLL_PATH,
+                LOAD_LIBRARY_SEARCH_SYSTEM32,
+            )
+        }
+        .ok()?;
+        let library: libloading::Library = library.into();
 
         // SAFETY: symbol lookups against a successfully loaded library.
         // The signatures are transcribed from AMD's public headers; see
@@ -148,14 +192,22 @@ impl AdlRuntime {
             overdrive_caps,
             query_pmlog,
             chosen_index: None,
-            scanned: false,
+            last_scan: None,
         })
     }
 
-    /// Find the first adapter index whose Overdrive generation exposes
-    /// the PMLog table.
+    /// Find an adapter index that answers `ADL2_New_QueryPMLogData_Get`.
+    ///
+    /// `ADL2_Overdrive_Caps` is consulted but is deliberately **not** a
+    /// gate. Workstation SKUs and APUs commonly report `iSupported = 0`,
+    /// meaning "no user-facing tuning", while still serving the sensor
+    /// table perfectly well; excluding them would silently drop exactly
+    /// the professional cards this tool is aimed at. A successful PMLog
+    /// read is the only capability test that means anything, so caps
+    /// only decides which indices to try *first*.
     fn scan_for_capable_adapter(&mut self) {
-        self.scanned = true;
+        self.last_scan = Some(Instant::now());
+        self.chosen_index = None;
 
         let mut count: c_int = 0;
         // SAFETY: valid context and out pointer.
@@ -163,6 +215,8 @@ impl AdlRuntime {
             return;
         }
 
+        let mut preferred = Vec::new();
+        let mut fallback = Vec::new();
         for index in 0..count {
             let (mut supported, mut enabled, mut version) = (0, 0, 0);
             // SAFETY: valid context and three out pointers.
@@ -175,12 +229,17 @@ impl AdlRuntime {
                     &mut version,
                 )
             };
-            if status != ADL_OK || supported == 0 || version < MIN_OVERDRIVE_VERSION {
-                continue;
+            // `enabled` reports whether the user turned Overdrive tuning
+            // on. Reading sensors does not require it, so it is ignored.
+            let _ = enabled;
+            if status == ADL_OK && supported != 0 && version >= MIN_OVERDRIVE_VERSION {
+                preferred.push(index);
+            } else {
+                fallback.push(index);
             }
-            // `enabled` reports whether the user has turned Overdrive
-            // tuning on. Reading sensors does not require it, so it is
-            // deliberately not part of the gate.
+        }
+
+        for index in preferred.into_iter().chain(fallback) {
             if self.read_pmlog(index).is_some() {
                 self.chosen_index = Some(index);
                 return;
@@ -189,19 +248,46 @@ impl AdlRuntime {
     }
 
     fn read_pmlog(&self, index: c_int) -> Option<AdlPmLogDataOutput> {
-        let mut output = AdlPmLogDataOutput::default();
-        // SAFETY: `output` is a correctly sized and aligned
-        // ADLPMLogDataOutput; the compile-time assertions in `ffi` pin
-        // its layout.
-        let status = unsafe { (self.query_pmlog)(self.context, index, &mut output) };
-        (status == ADL_OK).then_some(output)
+        // Boxed rather than a stack temporary: the buffer carries
+        // trailing headroom (see `AdlPmLogDataBuffer`) so a driver that
+        // writes a larger table than this file declares cannot smash
+        // the stack of a long-running daemon.
+        let mut buffer = Box::<AdlPmLogDataBuffer>::default();
+        // SAFETY: `buffer.output` begins a correctly aligned allocation
+        // at least as large as ADLPMLogDataOutput, with headroom beyond
+        // it; the compile-time assertions in `ffi` pin the layout.
+        let status = unsafe { (self.query_pmlog)(self.context, index, &raw mut buffer.output) };
+        if status != ADL_OK {
+            return None;
+        }
+        buffer.validated().copied()
     }
 
     fn sample(&mut self) -> Option<AdlPmLogDataOutput> {
-        if !self.scanned {
+        let due_for_scan = match (self.chosen_index, self.last_scan) {
+            // Never scanned.
+            (_, None) => true,
+            // A previous scan found nothing; retry on the slow interval
+            // rather than giving up for the life of the process.
+            (None, Some(at)) => at.elapsed() >= RESCAN_INTERVAL,
+            (Some(_), _) => false,
+        };
+        if due_for_scan {
             self.scan_for_capable_adapter();
         }
-        self.read_pmlog(self.chosen_index?)
+
+        let index = self.chosen_index?;
+        match self.read_pmlog(index) {
+            Some(output) => Some(output),
+            None => {
+                // The cached index stopped answering: a driver update or
+                // a TDR reset can invalidate it. Drop it so the next
+                // poll rescans instead of failing forever.
+                self.chosen_index = None;
+                self.last_scan = None;
+                None
+            }
+        }
     }
 }
 
@@ -240,7 +326,7 @@ pub fn selected_adapter_index() -> Option<i32> {
         Err(poisoned) => poisoned.into_inner(),
     };
     let runtime = guard.as_mut()?;
-    if !runtime.scanned {
+    if runtime.last_scan.is_none() {
         runtime.scan_for_capable_adapter();
     }
     runtime.chosen_index

--- a/src/device/readers/amd_adl/sensors.rs
+++ b/src/device/readers/amd_adl/sensors.rs
@@ -1,0 +1,292 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! PMLog sensor indices and the pure extraction of a readout.
+//!
+//! `ADLPMLogDataOutput` is addressed by `ADLSensorType`, so reading a
+//! value is just indexing the table. The indices below are transcribed
+//! from AMD's public `adl_structures.h`.
+//!
+//! ## These indices are the least verifiable thing in this module
+//!
+//! Nothing in CI compiles all-smi for Windows, no test can call the real
+//! library, and the enum has grown across driver generations. If AMD
+//! renumbered an entry, this file would read the wrong sensor and report
+//! a plausible but wrong number, which is worse than reporting nothing.
+//!
+//! Two mitigations, in order of importance:
+//!
+//! 1. [`extract`] range-checks every value and discards anything outside
+//!    a physically sensible band. A misindexed sensor almost always
+//!    lands outside its target range (a clock read as a temperature, a
+//!    millivolt reading read as watts), so the guard converts a silent
+//!    wrong number into an absent one.
+//! 2. The `amd.adl.sensors` doctor check dumps every supported index and
+//!    its raw value. That makes the mapping confirmable from a real
+//!    machine without shipping a code change first, which is the only
+//!    way this can actually be validated.
+
+use super::ffi::AdlPmLogDataOutput;
+
+// `ADLSensorType`, from adl_structures.h. Only the entries this reader
+// consumes are named; the enum has many more.
+pub const PMLOG_CLK_GFXCLK: usize = 1;
+pub const PMLOG_CLK_MEMCLK: usize = 2;
+pub const PMLOG_TEMPERATURE_EDGE: usize = 8;
+pub const PMLOG_TEMPERATURE_MEM: usize = 9;
+pub const PMLOG_FAN_RPM: usize = 14;
+pub const PMLOG_INFO_ACTIVITY_GFX: usize = 19;
+pub const PMLOG_INFO_ACTIVITY_MEM: usize = 20;
+pub const PMLOG_ASIC_POWER: usize = 23;
+pub const PMLOG_TEMPERATURE_HOTSPOT: usize = 27;
+pub const PMLOG_GFX_POWER: usize = 30;
+
+/// Physically sensible bands, used to reject a misindexed or
+/// wrongly-scaled reading.
+///
+/// The bands are deliberately generous: the goal is to catch a value
+/// that is obviously not the quantity we asked for, not to second-guess
+/// an unusual but real reading.
+const TEMPERATURE_C: std::ops::RangeInclusive<i32> = 0..=150;
+const POWER_W: std::ops::RangeInclusive<i32> = 0..=1000;
+const FAN_RPM: std::ops::RangeInclusive<i32> = 0..=20_000;
+const CLOCK_MHZ: std::ops::RangeInclusive<i32> = 0..=10_000;
+const ACTIVITY_PCT: std::ops::RangeInclusive<i32> = 0..=100;
+
+/// One PMLog readout, reduced to the quantities all-smi displays.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct AdlReadout {
+    /// Edge (junction-adjacent) temperature in Celsius.
+    pub temperature_edge_c: Option<u32>,
+    /// Hotspot / junction temperature in Celsius. Higher than edge on
+    /// every modern part, and the number AMD's own tooling leads with.
+    pub temperature_hotspot_c: Option<u32>,
+    /// Memory (HBM / GDDR) temperature in Celsius.
+    pub temperature_mem_c: Option<u32>,
+    /// Board power in watts.
+    pub power_w: Option<f64>,
+    pub fan_rpm: Option<u32>,
+    pub clock_gfx_mhz: Option<u32>,
+    pub clock_mem_mhz: Option<u32>,
+    /// Graphics engine activity, 0..=100.
+    pub activity_gfx_pct: Option<f64>,
+    /// Memory controller activity, 0..=100.
+    pub activity_mem_pct: Option<f64>,
+}
+
+impl AdlReadout {
+    /// Whether anything at all was extracted.
+    ///
+    /// A readout where every field failed its range check is treated as
+    /// no readout, so the caller keeps the baseline rather than
+    /// advertising an ADL source that produced nothing.
+    pub fn is_empty(&self) -> bool {
+        self.temperature_edge_c.is_none()
+            && self.temperature_hotspot_c.is_none()
+            && self.temperature_mem_c.is_none()
+            && self.power_w.is_none()
+            && self.fan_rpm.is_none()
+            && self.clock_gfx_mhz.is_none()
+            && self.clock_mem_mhz.is_none()
+            && self.activity_gfx_pct.is_none()
+            && self.activity_mem_pct.is_none()
+    }
+
+    /// The temperature to report as *the* GPU temperature.
+    ///
+    /// Edge is preferred over hotspot because it is what `nvidia-smi`
+    /// and the Linux `amdgpu` reader report, so the number stays
+    /// comparable across the platforms all-smi aggregates. Hotspot is
+    /// still surfaced separately as a detail.
+    pub fn primary_temperature_c(&self) -> Option<u32> {
+        self.temperature_edge_c.or(self.temperature_hotspot_c)
+    }
+}
+
+/// Read a sensor entry, returning `None` unless the card marks it
+/// supported and the value falls inside `range`.
+fn sensor(
+    output: &AdlPmLogDataOutput,
+    index: usize,
+    range: std::ops::RangeInclusive<i32>,
+) -> Option<i32> {
+    let entry = output.sensors.get(index)?;
+    if entry.supported == 0 {
+        return None;
+    }
+    range.contains(&entry.value).then_some(entry.value)
+}
+
+/// Reduce a raw PMLog table to the quantities all-smi displays.
+pub fn extract(output: &AdlPmLogDataOutput) -> AdlReadout {
+    AdlReadout {
+        temperature_edge_c: sensor(output, PMLOG_TEMPERATURE_EDGE, TEMPERATURE_C).map(|v| v as u32),
+        temperature_hotspot_c: sensor(output, PMLOG_TEMPERATURE_HOTSPOT, TEMPERATURE_C)
+            .map(|v| v as u32),
+        temperature_mem_c: sensor(output, PMLOG_TEMPERATURE_MEM, TEMPERATURE_C).map(|v| v as u32),
+        // ASIC power is whole-board draw and is the figure to prefer;
+        // GFX power covers only the graphics domain and is the fallback
+        // on parts that do not publish the board total.
+        power_w: sensor(output, PMLOG_ASIC_POWER, POWER_W)
+            .or_else(|| sensor(output, PMLOG_GFX_POWER, POWER_W))
+            .map(|v| v as f64),
+        fan_rpm: sensor(output, PMLOG_FAN_RPM, FAN_RPM).map(|v| v as u32),
+        clock_gfx_mhz: sensor(output, PMLOG_CLK_GFXCLK, CLOCK_MHZ).map(|v| v as u32),
+        clock_mem_mhz: sensor(output, PMLOG_CLK_MEMCLK, CLOCK_MHZ).map(|v| v as u32),
+        activity_gfx_pct: sensor(output, PMLOG_INFO_ACTIVITY_GFX, ACTIVITY_PCT).map(|v| v as f64),
+        activity_mem_pct: sensor(output, PMLOG_INFO_ACTIVITY_MEM, ACTIVITY_PCT).map(|v| v as f64),
+    }
+}
+
+/// Every supported sensor as `(index, raw value)`, for the doctor dump.
+///
+/// Deliberately unfiltered and unnamed: the point is to show what the
+/// card actually publishes so a field report can confirm or correct the
+/// index mapping above without a code change.
+pub fn supported_raw(output: &AdlPmLogDataOutput) -> Vec<(usize, i32)> {
+    output
+        .sensors
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| entry.supported != 0)
+        .map(|(index, entry)| (index, entry.value))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ffi::AdlPmLogDataOutput;
+    use super::*;
+
+    fn table(entries: &[(usize, i32)]) -> AdlPmLogDataOutput {
+        let mut output = AdlPmLogDataOutput::default();
+        for (index, value) in entries {
+            output.sensors[*index].supported = 1;
+            output.sensors[*index].value = *value;
+        }
+        output
+    }
+
+    #[test]
+    fn extracts_a_realistic_rdna_readout() {
+        let output = table(&[
+            (PMLOG_CLK_GFXCLK, 2400),
+            (PMLOG_CLK_MEMCLK, 1250),
+            (PMLOG_TEMPERATURE_EDGE, 62),
+            (PMLOG_TEMPERATURE_MEM, 70),
+            (PMLOG_TEMPERATURE_HOTSPOT, 81),
+            (PMLOG_FAN_RPM, 1450),
+            (PMLOG_ASIC_POWER, 310),
+            (PMLOG_INFO_ACTIVITY_GFX, 97),
+            (PMLOG_INFO_ACTIVITY_MEM, 44),
+        ]);
+        let readout = extract(&output);
+
+        assert_eq!(readout.temperature_edge_c, Some(62));
+        assert_eq!(readout.temperature_hotspot_c, Some(81));
+        assert_eq!(readout.temperature_mem_c, Some(70));
+        assert_eq!(readout.power_w, Some(310.0));
+        assert_eq!(readout.fan_rpm, Some(1450));
+        assert_eq!(readout.clock_gfx_mhz, Some(2400));
+        assert_eq!(readout.clock_mem_mhz, Some(1250));
+        assert_eq!(readout.activity_gfx_pct, Some(97.0));
+        assert_eq!(readout.activity_mem_pct, Some(44.0));
+        assert!(!readout.is_empty());
+        // Edge, not hotspot, so the figure stays comparable with the
+        // Linux amdgpu reader and with nvidia-smi.
+        assert_eq!(readout.primary_temperature_c(), Some(62));
+    }
+
+    #[test]
+    fn unsupported_sensors_are_absent_not_zero() {
+        // A card that publishes nothing must yield no readout at all,
+        // rather than a table of confident zeroes.
+        let readout = extract(&AdlPmLogDataOutput::default());
+        assert!(readout.is_empty());
+        assert_eq!(readout.primary_temperature_c(), None);
+        assert_eq!(readout.power_w, None);
+    }
+
+    #[test]
+    fn a_supported_flag_with_an_absurd_value_is_rejected() {
+        // This is the misindexing guard. If the enum shifted and we read
+        // a clock where a temperature should be, the value lands far
+        // outside the band and must be dropped rather than reported as a
+        // 2400 degree GPU.
+        let output = table(&[
+            (PMLOG_TEMPERATURE_EDGE, 2400),
+            (PMLOG_ASIC_POWER, 99_999),
+            (PMLOG_FAN_RPM, 250_000),
+            (PMLOG_INFO_ACTIVITY_GFX, 5_000),
+            (PMLOG_CLK_GFXCLK, 1_000_000),
+        ]);
+        let readout = extract(&output);
+        assert!(readout.is_empty(), "got {readout:?}");
+    }
+
+    #[test]
+    fn negative_readings_are_rejected() {
+        let output = table(&[
+            (PMLOG_TEMPERATURE_EDGE, -40),
+            (PMLOG_ASIC_POWER, -1),
+            (PMLOG_INFO_ACTIVITY_GFX, -3),
+        ]);
+        assert!(extract(&output).is_empty());
+    }
+
+    #[test]
+    fn asic_power_wins_over_gfx_power_but_gfx_is_the_fallback() {
+        let both = table(&[(PMLOG_ASIC_POWER, 300), (PMLOG_GFX_POWER, 180)]);
+        assert_eq!(extract(&both).power_w, Some(300.0));
+
+        let gfx_only = table(&[(PMLOG_GFX_POWER, 180)]);
+        assert_eq!(extract(&gfx_only).power_w, Some(180.0));
+
+        // An out-of-band ASIC reading must fall through to GFX rather
+        // than poisoning the field.
+        let asic_bogus = table(&[(PMLOG_ASIC_POWER, 50_000), (PMLOG_GFX_POWER, 180)]);
+        assert_eq!(extract(&asic_bogus).power_w, Some(180.0));
+    }
+
+    #[test]
+    fn hotspot_stands_in_when_edge_is_unavailable() {
+        let output = table(&[(PMLOG_TEMPERATURE_HOTSPOT, 88)]);
+        assert_eq!(extract(&output).primary_temperature_c(), Some(88));
+    }
+
+    #[test]
+    fn the_raw_dump_reports_index_and_value_unfiltered() {
+        // The doctor dump must not apply the range guard: an
+        // out-of-band value is exactly the evidence needed to spot a
+        // wrong index mapping from a field report.
+        let output = table(&[(3, 1234), (27, 81), (200, -5)]);
+        let dumped = supported_raw(&output);
+        assert_eq!(dumped, vec![(3, 1234), (27, 81), (200, -5)]);
+    }
+
+    #[test]
+    fn boundary_values_are_inclusive() {
+        let output = table(&[
+            (PMLOG_TEMPERATURE_EDGE, 150),
+            (PMLOG_INFO_ACTIVITY_GFX, 100),
+            (PMLOG_FAN_RPM, 0),
+        ]);
+        let readout = extract(&output);
+        assert_eq!(readout.temperature_edge_c, Some(150));
+        assert_eq!(readout.activity_gfx_pct, Some(100.0));
+        // Zero RPM is a real reading on a passively-idling card, not an
+        // absent one.
+        assert_eq!(readout.fan_rpm, Some(0));
+    }
+}

--- a/src/device/readers/amd_adl/sensors.rs
+++ b/src/device/readers/amd_adl/sensors.rs
@@ -25,17 +25,29 @@
 //! renumbered an entry, this file would read the wrong sensor and report
 //! a plausible but wrong number, which is worse than reporting nothing.
 //!
-//! Two mitigations, in order of importance:
+//! There are two mitigations, and it is worth being precise about what
+//! each one actually buys, because the weaker of the two is easy to
+//! overrate:
 //!
-//! 1. [`extract`] range-checks every value and discards anything outside
-//!    a physically sensible band. A misindexed sensor almost always
-//!    lands outside its target range (a clock read as a temperature, a
-//!    millivolt reading read as watts), so the guard converts a silent
-//!    wrong number into an absent one.
-//! 2. The `amd.adl.sensors` doctor check dumps every supported index and
-//!    its raw value. That makes the mapping confirmable from a real
-//!    machine without shipping a code change first, which is the only
-//!    way this can actually be validated.
+//! 1. **The `amd.adl.sensors` doctor check dumps every supported index
+//!    and its raw value.** This is the real mitigation. It makes the
+//!    mapping confirmable against actual hardware without shipping a
+//!    code change first, and it is the only thing here that can catch a
+//!    wrong index in the general case.
+//! 2. **[`extract`] range-checks every value.** This catches *unit* and
+//!    *scale* errors well (a millivolt reading read as watts, a clock
+//!    read as a temperature) because those land orders of magnitude
+//!    outside the band.
+//!
+//!    It does **not** reliably catch a small index shift, which is the
+//!    likeliest way this file goes wrong, because the enum is grouped by
+//!    physical quantity: clocks occupy 1-7, temperatures 8-13, fan 14-15,
+//!    activity 19-20. Reading `FAN_PERCENTAGE` (15) as `FAN_RPM` (14)
+//!    yields 0-100, comfortably inside `0..=20_000`. Reading
+//!    `TEMPERATURE_MEM` as `TEMPERATURE_EDGE` yields a plausible
+//!    temperature. The guard is a backstop against gross errors, not a
+//!    correctness proof, and mitigation 1 is what the design actually
+//!    leans on.
 
 use super::ffi::AdlPmLogDataOutput;
 
@@ -50,7 +62,19 @@ pub const PMLOG_INFO_ACTIVITY_GFX: usize = 19;
 pub const PMLOG_INFO_ACTIVITY_MEM: usize = 20;
 pub const PMLOG_ASIC_POWER: usize = 23;
 pub const PMLOG_TEMPERATURE_HOTSPOT: usize = 27;
+pub const PMLOG_TEMPERATURE_GFX: usize = 28;
 pub const PMLOG_GFX_POWER: usize = 30;
+/// Whole-board power, including memory and VRM losses.
+///
+/// On RDNA3 and later this, not [`PMLOG_ASIC_POWER`], is the board
+/// figure. `ASIC_POWER` still reports as supported on those parts but
+/// measures a narrower domain, so preferring it there would produce a
+/// number that is wrong in a way no range check can see (both are watts,
+/// both plausible). LibreHardwareMonitor makes the same switch, keyed on
+/// the GCN family; this reader instead prefers whichever the card
+/// actually publishes, which needs no family lookup and degrades to the
+/// old behaviour on parts that only expose `ASIC_POWER`.
+pub const PMLOG_BOARD_POWER: usize = 73;
 
 /// Physically sensible bands, used to reject a misindexed or
 /// wrongly-scaled reading.
@@ -58,7 +82,10 @@ pub const PMLOG_GFX_POWER: usize = 30;
 /// The bands are deliberately generous: the goal is to catch a value
 /// that is obviously not the quantity we asked for, not to second-guess
 /// an unusual but real reading.
-const TEMPERATURE_C: std::ops::RangeInclusive<i32> = 0..=150;
+/// Lower bound is well below freezing on purpose: a machine cold-started
+/// in an unheated room reports a genuinely negative die temperature, and
+/// rejecting it would drop a real reading.
+const TEMPERATURE_C: std::ops::RangeInclusive<i32> = -40..=150;
 const POWER_W: std::ops::RangeInclusive<i32> = 0..=1000;
 const FAN_RPM: std::ops::RangeInclusive<i32> = 0..=20_000;
 const CLOCK_MHZ: std::ops::RangeInclusive<i32> = 0..=10_000;
@@ -68,12 +95,17 @@ const ACTIVITY_PCT: std::ops::RangeInclusive<i32> = 0..=100;
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct AdlReadout {
     /// Edge (junction-adjacent) temperature in Celsius.
-    pub temperature_edge_c: Option<u32>,
+    ///
+    /// Signed: a cold-started machine genuinely reports below zero.
+    pub temperature_edge_c: Option<i32>,
+    /// Graphics-die temperature in Celsius. The RDNA-era stand-in for
+    /// edge on parts that do not publish `TEMPERATURE_EDGE`.
+    pub temperature_gfx_c: Option<i32>,
     /// Hotspot / junction temperature in Celsius. Higher than edge on
     /// every modern part, and the number AMD's own tooling leads with.
-    pub temperature_hotspot_c: Option<u32>,
+    pub temperature_hotspot_c: Option<i32>,
     /// Memory (HBM / GDDR) temperature in Celsius.
-    pub temperature_mem_c: Option<u32>,
+    pub temperature_mem_c: Option<i32>,
     /// Board power in watts.
     pub power_w: Option<f64>,
     pub fan_rpm: Option<u32>,
@@ -93,6 +125,7 @@ impl AdlReadout {
     /// advertising an ADL source that produced nothing.
     pub fn is_empty(&self) -> bool {
         self.temperature_edge_c.is_none()
+            && self.temperature_gfx_c.is_none()
             && self.temperature_hotspot_c.is_none()
             && self.temperature_mem_c.is_none()
             && self.power_w.is_none()
@@ -103,14 +136,29 @@ impl AdlReadout {
             && self.activity_mem_pct.is_none()
     }
 
-    /// The temperature to report as *the* GPU temperature.
+    /// The temperature to report as *the* GPU temperature, and which
+    /// sensor it came from.
     ///
-    /// Edge is preferred over hotspot because it is what `nvidia-smi`
-    /// and the Linux `amdgpu` reader report, so the number stays
-    /// comparable across the platforms all-smi aggregates. Hotspot is
-    /// still surfaced separately as a detail.
-    pub fn primary_temperature_c(&self) -> Option<u32> {
-        self.temperature_edge_c.or(self.temperature_hotspot_c)
+    /// Edge is preferred because it is what `nvidia-smi` and the Linux
+    /// `amdgpu` reader report, so the number stays comparable across the
+    /// platforms all-smi aggregates in one view. `TEMPERATURE_GFX` is
+    /// the next choice: it measures the same die and sits in the same
+    /// range, and RDNA-era parts that omit edge publish it instead.
+    ///
+    /// Hotspot is the last resort and is deliberately *named* in the
+    /// return value, because it runs 15-30 C above edge on modern parts.
+    /// Falling back to it silently would mix two different quantities in
+    /// an aggregated multi-host view with nothing to distinguish them;
+    /// the caller uses the label to say which sensor it published.
+    pub fn primary_temperature_c(&self) -> Option<(i32, &'static str)> {
+        if let Some(edge) = self.temperature_edge_c {
+            return Some((edge, "ADL (edge)"));
+        }
+        if let Some(gfx) = self.temperature_gfx_c {
+            return Some((gfx, "ADL (gfx)"));
+        }
+        self.temperature_hotspot_c
+            .map(|hotspot| (hotspot, "ADL (hotspot)"))
     }
 }
 
@@ -131,14 +179,22 @@ fn sensor(
 /// Reduce a raw PMLog table to the quantities all-smi displays.
 pub fn extract(output: &AdlPmLogDataOutput) -> AdlReadout {
     AdlReadout {
-        temperature_edge_c: sensor(output, PMLOG_TEMPERATURE_EDGE, TEMPERATURE_C).map(|v| v as u32),
-        temperature_hotspot_c: sensor(output, PMLOG_TEMPERATURE_HOTSPOT, TEMPERATURE_C)
-            .map(|v| v as u32),
-        temperature_mem_c: sensor(output, PMLOG_TEMPERATURE_MEM, TEMPERATURE_C).map(|v| v as u32),
-        // ASIC power is whole-board draw and is the figure to prefer;
-        // GFX power covers only the graphics domain and is the fallback
-        // on parts that do not publish the board total.
-        power_w: sensor(output, PMLOG_ASIC_POWER, POWER_W)
+        temperature_edge_c: sensor(output, PMLOG_TEMPERATURE_EDGE, TEMPERATURE_C),
+        temperature_gfx_c: sensor(output, PMLOG_TEMPERATURE_GFX, TEMPERATURE_C),
+        temperature_hotspot_c: sensor(output, PMLOG_TEMPERATURE_HOTSPOT, TEMPERATURE_C),
+        temperature_mem_c: sensor(output, PMLOG_TEMPERATURE_MEM, TEMPERATURE_C),
+        // Widest domain first. BOARD_POWER is the whole-card figure and
+        // is what RDNA3 and later publish; ASIC_POWER is a narrower
+        // domain on those parts even though it still reports supported,
+        // and is the correct answer on everything older; GFX_POWER
+        // covers the graphics block alone and is the last resort.
+        //
+        // Preferring whatever the card actually publishes avoids needing
+        // the GCN family lookup that a family-keyed rule would require,
+        // and no range check could distinguish these three: all are
+        // watts and all are plausible.
+        power_w: sensor(output, PMLOG_BOARD_POWER, POWER_W)
+            .or_else(|| sensor(output, PMLOG_ASIC_POWER, POWER_W))
             .or_else(|| sensor(output, PMLOG_GFX_POWER, POWER_W))
             .map(|v| v as f64),
         fan_rpm: sensor(output, PMLOG_FAN_RPM, FAN_RPM).map(|v| v as u32),
@@ -204,8 +260,9 @@ mod tests {
         assert_eq!(readout.activity_mem_pct, Some(44.0));
         assert!(!readout.is_empty());
         // Edge, not hotspot, so the figure stays comparable with the
-        // Linux amdgpu reader and with nvidia-smi.
-        assert_eq!(readout.primary_temperature_c(), Some(62));
+        // Linux amdgpu reader and with nvidia-smi, and the label says
+        // which sensor it came from.
+        assert_eq!(readout.primary_temperature_c(), Some((62, "ADL (edge)")));
     }
 
     #[test]
@@ -236,13 +293,38 @@ mod tests {
     }
 
     #[test]
-    fn negative_readings_are_rejected() {
-        let output = table(&[
-            (PMLOG_TEMPERATURE_EDGE, -40),
-            (PMLOG_ASIC_POWER, -1),
-            (PMLOG_INFO_ACTIVITY_GFX, -3),
+    fn negative_power_and_activity_are_rejected_but_cold_dies_are_not() {
+        // Power and activity have no meaningful negative value, so a
+        // negative one is a bad read.
+        let nonsense = table(&[(PMLOG_ASIC_POWER, -1), (PMLOG_INFO_ACTIVITY_GFX, -3)]);
+        assert!(extract(&nonsense).is_empty());
+
+        // A sub-zero die is real on a machine cold-started in an
+        // unheated room, and must survive the guard.
+        let cold = table(&[(PMLOG_TEMPERATURE_EDGE, -12)]);
+        assert_eq!(extract(&cold).temperature_edge_c, Some(-12));
+
+        // Far enough below ambient to be a bad read rather than a cold
+        // room.
+        let absurd = table(&[(PMLOG_TEMPERATURE_EDGE, -273)]);
+        assert!(extract(&absurd).is_empty());
+    }
+
+    #[test]
+    fn board_power_outranks_asic_power() {
+        // On RDNA3 and later both report supported, but only
+        // BOARD_POWER is the whole-card figure. No range check can tell
+        // them apart, so the preference order is the only defence.
+        let both = table(&[
+            (PMLOG_BOARD_POWER, 355),
+            (PMLOG_ASIC_POWER, 290),
+            (PMLOG_GFX_POWER, 180),
         ]);
-        assert!(extract(&output).is_empty());
+        assert_eq!(extract(&both).power_w, Some(355.0));
+
+        // Older parts publish no BOARD_POWER and must still work.
+        let older = table(&[(PMLOG_ASIC_POWER, 290), (PMLOG_GFX_POWER, 180)]);
+        assert_eq!(extract(&older).power_w, Some(290.0));
     }
 
     #[test]
@@ -260,9 +342,22 @@ mod tests {
     }
 
     #[test]
-    fn hotspot_stands_in_when_edge_is_unavailable() {
-        let output = table(&[(PMLOG_TEMPERATURE_HOTSPOT, 88)]);
-        assert_eq!(extract(&output).primary_temperature_c(), Some(88));
+    fn gfx_then_hotspot_stand_in_when_edge_is_unavailable() {
+        // GFX measures the same die as edge and is preferred.
+        let gfx = table(&[(PMLOG_TEMPERATURE_GFX, 64), (PMLOG_TEMPERATURE_HOTSPOT, 88)]);
+        assert_eq!(
+            extract(&gfx).primary_temperature_c(),
+            Some((64, "ADL (gfx)"))
+        );
+
+        // Hotspot is the last resort and must be labelled as such:
+        // it runs well above edge, so an aggregated view needs to be
+        // able to tell the two apart.
+        let hotspot = table(&[(PMLOG_TEMPERATURE_HOTSPOT, 88)]);
+        assert_eq!(
+            extract(&hotspot).primary_temperature_c(),
+            Some((88, "ADL (hotspot)"))
+        );
     }
 
     #[test]

--- a/src/device/readers/amd_windows.rs
+++ b/src/device/readers/amd_windows.rs
@@ -234,6 +234,11 @@ impl GpuReader for AmdWindowsGpuReader {
         // But we could cache the static parts if needed
         let mut gpus = self.query_amd_gpus();
         self.augment_with_windows_perf(&mut gpus);
+        // ADL last: it reads the hardware's own telemetry rather than
+        // the OS's accounting of it, so where both produce a figure the
+        // vendor number wins. It is also the only source for
+        // temperature, power, fan, and clocks.
+        crate::device::readers::amd_adl::augment(&mut gpus);
         gpus
     }
 

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -97,3 +97,11 @@ pub mod intel_gpu_windows;
 // actually has. Same shape as `intel_gpu_sysfs` above.
 #[cfg(any(target_os = "windows", test))]
 pub mod windows_gpu_perf;
+
+// AMD ADL sensor augmentation (temperature, power, fan, clocks) layered
+// on top of `windows_gpu_perf`. Gated the same way and for the same
+// reason: the sensor-index mapping and the field application are the
+// parts most likely to be wrong, so they must reach the Linux test
+// runner.
+#[cfg(any(target_os = "windows", test))]
+pub mod amd_adl;

--- a/src/device/readers/windows_gpu_perf/dxgi.rs
+++ b/src/device/readers/windows_gpu_perf/dxgi.rs
@@ -136,9 +136,20 @@ pub fn enumerate() -> Vec<DxgiAdapter> {
 static FACTORY: once_cell::sync::OnceCell<std::sync::Mutex<Option<SendFactory>>> =
     once_cell::sync::OnceCell::new();
 
-/// COM interface pointers are not `Send` in general. This one is only
-/// ever touched under the `Mutex` below, on whichever thread the
-/// collector happens to be, and DXGI factories are free-threaded.
+/// COM interface pointers are not `Send` in general, and this one does
+/// escape the mutex: [`factory`] returns a clone, and [`enumerate`]
+/// calls `EnumAdapters1` and `GetDesc1` on it after the lock is
+/// released.
+///
+/// What makes that sound is that DXGI objects are free-threaded. They
+/// come straight from a `dxgi.dll` export rather than through
+/// `CoCreateInstance`, so no apartment marshalling is involved and their
+/// methods may be called from any thread. The `Mutex` here protects the
+/// cache slot, not the object.
+///
+/// Reference counting is likewise fine: `Clone` is `AddRef` and dropping
+/// the cached value is `Release`, so a clone taken before a rebuild
+/// keeps its factory alive independently.
 struct SendFactory(IDXGIFactory1);
 unsafe impl Send for SendFactory {}
 

--- a/src/device/readers/windows_gpu_perf/dxgi.rs
+++ b/src/device/readers/windows_gpu_perf/dxgi.rs
@@ -75,9 +75,8 @@ pub struct DxgiAdapter {
 /// to the WMI baseline, not one that should emit diagnostics on every
 /// poll.
 pub fn enumerate() -> Vec<DxgiAdapter> {
-    let factory: IDXGIFactory1 = match unsafe { CreateDXGIFactory1() } {
-        Ok(factory) => factory,
-        Err(_) => return Vec::new(),
+    let Some(factory) = factory() else {
+        return Vec::new();
     };
 
     let mut adapters = Vec::new();
@@ -122,6 +121,46 @@ pub fn enumerate() -> Vec<DxgiAdapter> {
     }
 
     adapters
+}
+
+/// Process-wide DXGI factory, created once.
+///
+/// `CreateDXGIFactory1` is the most expensive call in this module: it is
+/// COM object creation and can pull in graphics driver DLLs. Doing it on
+/// every poll (as often as once per second) was pure waste, since the
+/// factory is reusable.
+///
+/// `IDXGIFactory1::IsCurrent` reports whether the adapter set has
+/// changed since creation, so a hot-plugged or disabled GPU is picked up
+/// by rebuilding rather than by paying for a new factory unconditionally.
+static FACTORY: once_cell::sync::OnceCell<std::sync::Mutex<Option<SendFactory>>> =
+    once_cell::sync::OnceCell::new();
+
+/// COM interface pointers are not `Send` in general. This one is only
+/// ever touched under the `Mutex` below, on whichever thread the
+/// collector happens to be, and DXGI factories are free-threaded.
+struct SendFactory(IDXGIFactory1);
+unsafe impl Send for SendFactory {}
+
+fn factory() -> Option<IDXGIFactory1> {
+    let cell = FACTORY.get_or_init(|| std::sync::Mutex::new(None));
+    let mut guard = match cell.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    // Rebuild when the cached factory has gone stale, which is DXGI's
+    // way of saying the adapter set changed.
+    if let Some(existing) = guard.as_ref() {
+        if unsafe { existing.0.IsCurrent() }.as_bool() {
+            return Some(existing.0.clone());
+        }
+        *guard = None;
+    }
+
+    let created: IDXGIFactory1 = unsafe { CreateDXGIFactory1() }.ok()?;
+    *guard = Some(SendFactory(created.clone()));
+    Some(created)
 }
 
 /// Read the local-segment video memory info, when the adapter supports

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -21,7 +21,14 @@ use std::time::Duration;
 use crate::doctor::exec::try_exec;
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
-static CHECKS: &[&Check] = &[&ROCM_VERSION, &LIBAMDGPU_TOP_ABI, &DRI_PERMS, &MUSL_GATE];
+static CHECKS: &[&Check] = &[
+    &ROCM_VERSION,
+    &LIBAMDGPU_TOP_ABI,
+    &DRI_PERMS,
+    &MUSL_GATE,
+    &ADL_LIBRARY,
+    &ADL_SENSORS,
+];
 
 pub fn checks() -> &'static [&'static Check] {
     CHECKS
@@ -54,6 +61,138 @@ static MUSL_GATE: Check = Check {
     severity_on_fail: Severity::Warn,
     run: check_musl_gate,
 };
+
+static ADL_LIBRARY: Check = Check {
+    id: "amd.adl.library",
+    title: "AMD ADL library (atiadlxx.dll)",
+    severity_on_fail: Severity::Info,
+    run: check_adl_library,
+};
+
+static ADL_SENSORS: Check = Check {
+    id: "amd.adl.sensors",
+    title: "AMD ADL PMLog sensors",
+    severity_on_fail: Severity::Info,
+    run: check_adl_sensors,
+};
+
+/// Report whether `atiadlxx.dll` loaded and an ADL2 context was created.
+fn check_adl_library(_ctx: &CheckCtx) -> CheckResult {
+    #[cfg(target_os = "windows")]
+    {
+        use crate::device::readers::amd_adl::loader;
+
+        let path = loader::dll_path();
+        if !std::path::Path::new(path).exists() {
+            return CheckResult::Skip(format!(
+                "{path} not present; install AMD's graphics driver for temperature, power, fan, \
+                 and clock readings"
+            ));
+        }
+        if !loader::library_available() {
+            return CheckResult::Warn(
+                format!("{path} exists but ADL2_Main_Control_Create failed"),
+                Some(
+                    "the driver install may be partial; reinstalling AMD Software usually \
+                     restores it"
+                        .to_string(),
+                ),
+            );
+        }
+        match loader::selected_adapter_index() {
+            Some(index) => CheckResult::Pass(format!(
+                "{path} loaded, PMLog-capable adapter index {index}"
+            )),
+            None => CheckResult::Warn(
+                format!("{path} loaded but no adapter exposes the PMLog sensor table"),
+                Some(
+                    "expected on pre-Vega cards, whose sensors live behind the legacy Overdrive \
+                     5/6/7 entry points that all-smi does not implement"
+                        .to_string(),
+                ),
+            ),
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        CheckResult::Skip("ADL is Windows-only".to_string())
+    }
+}
+
+/// Dump the PMLog sensor table as raw `index=value` pairs.
+///
+/// This is the field-verification path for the sensor index mapping in
+/// `device/readers/amd_adl/sensors.rs`. Those indices are transcribed
+/// from AMD's public headers and cannot be checked by anything in CI:
+/// no job compiles all-smi for Windows and no test can call the real
+/// library. Printing the raw table lets an operator on real hardware
+/// confirm or correct the mapping without a code change shipping first.
+///
+/// The dump is deliberately unfiltered and shows indices rather than
+/// names, because an unexpected index is exactly the evidence needed.
+fn check_adl_sensors(_ctx: &CheckCtx) -> CheckResult {
+    #[cfg(target_os = "windows")]
+    {
+        use crate::device::readers::amd_adl::{loader, sensors};
+
+        let Some(output) = loader::sample() else {
+            return CheckResult::Skip(
+                "no PMLog sample available (see amd.adl.library)".to_string(),
+            );
+        };
+
+        let raw = sensors::supported_raw(&output);
+        if raw.is_empty() {
+            return CheckResult::Warn(
+                "PMLog returned a table with no supported sensors".to_string(),
+                None,
+            );
+        }
+
+        let readout = sensors::extract(&output);
+        let dump = raw
+            .iter()
+            .map(|(index, value)| format!("{index}={value}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let interpreted = format!(
+            "edge={:?}C hotspot={:?}C mem={:?}C power={:?}W fan={:?}rpm gfx={:?}MHz \
+             mclk={:?}MHz activity={:?}%",
+            readout.temperature_edge_c,
+            readout.temperature_hotspot_c,
+            readout.temperature_mem_c,
+            readout.power_w,
+            readout.fan_rpm,
+            readout.clock_gfx_mhz,
+            readout.clock_mem_mhz,
+            readout.activity_gfx_pct,
+        );
+
+        let count = raw.len();
+        if readout.is_empty() {
+            return CheckResult::Warn(
+                format!(
+                    "{count} sensor(s) reported supported but none passed the range guard. \
+                     raw: {dump}"
+                ),
+                Some(
+                    "this is what a shifted ADLSensorType enum looks like; please report the raw \
+                     dump so the index mapping can be corrected"
+                        .to_string(),
+                ),
+            );
+        }
+
+        CheckResult::Pass(format!(
+            "{count} supported sensor(s); interpreted: {interpreted}; raw: {dump}"
+        ))
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        CheckResult::Skip("ADL is Windows-only".to_string())
+    }
+}
 
 fn check_rocm(_ctx: &CheckCtx) -> CheckResult {
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Closes #347. Builds on #346.

The DXGI and PDH layer from #346 covers everything WDDM publishes. It cannot cover temperature, board power, fan speed, or clocks, because Windows does not expose them at all. This adds `src/device/readers/amd_adl.rs`, which reads them from AMD's own library.

`atiadlxx.dll` is loaded at runtime via `libloading` from the absolute path `C:\Windows\System32\atiadlxx.dll`, never by bare name, matching the DLL-hijacking stance already documented in `windows_temp/amd_ryzen.rs`. **No import library is referenced**, so the executable carries no `atiadlxx` entry in its import table and a machine without AMD's driver starts normally and simply reports no ADL data. That is deliberately the same shape #345 asks for on Linux, where a missing `libdrm` is a loader error before `main`.

Precedence is WMI < DXGI/PDH < ADL. ADL reads the hardware's own telemetry rather than the OS's accounting of it, so it overwrites PDH utilization and is the sole source for temperature, power, fan, and clocks.

## Two deliberate scope limits, both about refusing to declare an ABI blind

**Legacy Overdrive paths are not implemented.** Sensors come only from `ADL2_New_QueryPMLogData_Get`, gated on `ADL2_Overdrive_Caps`. OD5/6/7 would be three more ABI surfaces to get right with no way to test them, for hardware predating the cards all-smi targets. A pre-Vega card keeps the baseline.

**`AdapterInfo` is not declared, so augmentation requires exactly one AMD GPU.** This is the important one. `AdapterInfo` is the 1568-byte struct that carries the PCI bus/device/function and PNP string that would let an ADL adapter index be tied to a specific card. ADL sizes its write by *its own* `sizeof`, so a layout mistake overflows our buffer rather than failing cleanly. Worse, a single card exposes several adapter indices (one per display output) reporting identical telemetry, which cannot be deduplicated without that struct either.

Rather than guess, `can_attribute()` requires a single AMD GPU. A multi-AMD-GPU host gets the honest DXGI/PDH baseline instead of one card's temperature reported against another. This is the same conclusion the #346 review reached about adapter matching: declining to attribute beats attributing wrongly. Multi-GPU support is a follow-up that would need `AdapterInfo` and real hardware to validate against.

## The sensor indices are the weakest point, and are treated as such

`ADLSensorType` indices are transcribed from AMD's public `adl_structures.h`. Nothing in CI compiles all-smi for Windows and no test can call the real library, so if AMD renumbered an entry this would read the wrong sensor and report a *plausible but wrong* number, which is worse than reporting nothing. Two mitigations:

1. **Range guards.** Every value is checked against a physically sensible band (temperature 0-150 C, power 0-1000 W, activity 0-100%, and so on). A misindexed read almost always lands outside its target band, so the guard turns a silent wrong number into an absent one. Tested with a case that feeds a clock value into the temperature slot and asserts the whole readout comes back empty.
2. **`amd.adl.sensors` doctor check dumps the raw `index=value` table**, unfiltered and unnamed. That makes the mapping confirmable from real hardware without a code change shipping first, and if every sensor fails the range guard the check says explicitly that this is what a shifted enum looks like and asks for the dump.

`amd.adl.library` separately distinguishes: DLL absent, DLL present but context creation failed, loaded but no PMLog-capable adapter, and healthy with the selected adapter index.

## Also in this PR: DXGI factory caching

Prompted by a question about polling overhead. `CreateDXGIFactory1` is COM object creation that can pull in graphics driver DLLs, and #346 ran it on every poll (as often as once per second). It is now created once and rebuilt only when `IDXGIFactory1::IsCurrent` reports the adapter set changed, which also keeps hot-plug correct.

For the record on cost, since it came up: **nothing in either layer submits GPU work.** DXGI reads adapter descriptors, PDH reads counters the OS already maintains, ADL reads a telemetry block the driver already collects. The load is CPU-side and small; the library load, ADL context creation, and the PMLog capability scan each happen once per process, so a steady-state poll is a single ADL call. One caveat now documented in the module: very aggressive sensor polling (the 100 ms rates desktop monitoring tools use) can hold an AMD GPU out of its deepest idle state. all-smi's intervals start at one second, well clear of that.

## Verification

Same constraint as #346: **no CI job compiles all-smi for Windows.** The module is gated `cfg(any(target_os = "windows", test))` so the sensor mapping, the range guards, and the field application all run on the Linux test runner. 34 new tests.

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo test` | 3162 pass, 0 fail (was 3128 on main) |
| `cargo xwin check --target x86_64-pc-windows-msvc` | pass, 0 warnings |
| `cargo xwin clippy --target x86_64-pc-windows-msvc -- -D warnings` | pass for this change |

Layout is pinned by compile-time assertions on `ADLSingleSensorData` (8 bytes, 4-aligned) and `ADLPMLogDataOutput` (2052 bytes), plus a test asserting the sensor array actually strides by one 8-byte record from offset 4. Those assertions are the only automated check this ABI can have, which is why they are there rather than being decorative.

## Not verified, needs real hardware

- Temperature, power, fan, and clocks populated on a PMLog-capable card
- The sensor index mapping itself (`amd.adl.sensors` exists to produce this evidence)
- `dumpbin /imports` showing no `atiadlxx` entry. The design guarantees it (nothing is linked, `libloading` only), but it has not been observed on a built exe.

## Pre-existing, still not fixed

The same three Windows clippy lints noted in #348, in files neither PR touches: `cpu_windows.rs:49`, `:63`, `amd_ryzen.rs:228`. Worth a follow-up together with a CI job that compiles the Windows target, which `windows-latest` runners would do for free on this public repo.
