### PR TITLE
fix: unify GPU detail keys with the shared reader convention

### DIFF
--- a/src/device/readers/amd_adl.rs
+++ b/src/device/readers/amd_adl.rs
@@ -100,8 +100,15 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
         // represented, so it floors at 0 and the true value stays
         // visible in the detail below.
         gpu.temperature = temperature.max(0) as u32;
-        gpu.detail
-            .insert("Temperature (C)".to_string(), temperature.to_string());
+        if temperature < 0 {
+            // A sub-zero die is real on a cold-started machine but
+            // cannot be represented in the unsigned field, which floors
+            // at 0 above. Surface the true reading only in that case,
+            // rather than adding a key that duplicates `temperature` on
+            // every normal poll.
+            gpu.detail
+                .insert("Temperature".to_string(), format!("{temperature} C"));
+        }
         // The label names which sensor was used. Edge, gfx, and hotspot
         // are not interchangeable (hotspot runs 15-30 C higher), and an
         // aggregated multi-host view would otherwise mix them with
@@ -115,11 +122,11 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
     // are surfaced as details rather than dropped.
     if let Some(hotspot) = readout.temperature_hotspot_c {
         gpu.detail
-            .insert("Hotspot Temperature (C)".to_string(), hotspot.to_string());
+            .insert("Hotspot Temperature".to_string(), format!("{hotspot} C"));
     }
     if let Some(memory) = readout.temperature_mem_c {
         gpu.detail
-            .insert("Memory Temperature (C)".to_string(), memory.to_string());
+            .insert("Memory Temperature".to_string(), format!("{memory} C"));
     }
 
     if let Some(power) = readout.power_w {
@@ -137,14 +144,18 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
     }
     if let Some(clock) = readout.clock_mem_mhz {
         gpu.detail
-            .insert("Memory Clock (MHz)".to_string(), clock.to_string());
+            .insert("Memory Clock".to_string(), format!("{clock} MHz"));
     }
 
     if let Some(rpm) = readout.fan_rpm {
-        // `GpuInfo` has no fan field; the Intel reader already
-        // advertises fan provenance the same way.
+        // `GpuInfo` has no fan field, so this rides in `detail`. The key
+        // and value format match `amd.rs`, `intel_gpu_linux`, and the
+        // Level Zero reader exactly. A divergent key would sit outside
+        // the `contains_key("Fan Speed")` guard those readers coordinate
+        // overwrites through, and would need special-casing by whatever
+        // eventually promotes fan speed to a real field.
         gpu.detail
-            .insert("Fan Speed (RPM)".to_string(), rpm.to_string());
+            .insert("Fan Speed".to_string(), format!("{rpm} RPM"));
         gpu.detail
             .insert("Source: Fan".to_string(), "ADL".to_string());
         applied.push("fan");
@@ -158,8 +169,8 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
     }
     if let Some(activity) = readout.activity_mem_pct {
         gpu.detail.insert(
-            "Memory Controller Activity (%)".to_string(),
-            format!("{activity:.0}"),
+            "Memory Controller Activity".to_string(),
+            format!("{activity:.0}%"),
         );
     }
 
@@ -268,17 +279,70 @@ mod tests {
         assert_eq!(gpu.temperature, 62);
         assert_eq!(gpu.power_consumption, 310.0);
         assert_eq!(gpu.frequency, 2400);
-        assert_eq!(gpu.detail["Hotspot Temperature (C)"], "81");
-        assert_eq!(gpu.detail["Memory Temperature (C)"], "70");
-        assert_eq!(gpu.detail["Fan Speed (RPM)"], "1450");
-        assert_eq!(gpu.detail["Memory Clock (MHz)"], "1250");
-        assert_eq!(gpu.detail["Memory Controller Activity (%)"], "44");
+        assert_eq!(gpu.detail["Hotspot Temperature"], "81 C");
+        assert_eq!(gpu.detail["Memory Temperature"], "70 C");
+        assert_eq!(gpu.detail["Fan Speed"], "1450 RPM");
+        assert_eq!(gpu.detail["Memory Clock"], "1250 MHz");
+        assert_eq!(gpu.detail["Memory Controller Activity"], "44%");
 
         assert_eq!(gpu.detail["Source: Temperature"], "ADL (edge)");
         assert_eq!(gpu.detail["Source: Power"], "ADL");
         assert_eq!(gpu.detail["Source: Frequency"], "ADL");
         assert_eq!(gpu.detail["Source: Fan"], "ADL");
         assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH + ADL");
+    }
+
+    #[test]
+    fn detail_keys_follow_the_shared_reader_convention() {
+        // Every reader that publishes these quantities uses the same
+        // key with the unit carried in the *value*, not the key:
+        // `amd.rs` (Linux) writes `Fan Speed` = "1450 RPM" and
+        // `Memory Clock` = "1250 MHz", and `intel_gpu_linux` and the
+        // Level Zero reader match it.
+        //
+        // Two concrete costs of diverging, which is why this is locked
+        // by a test rather than left to convention:
+        //
+        // 1. `intel_gpu_level_zero::apply_fan` guards an overwrite with
+        //    `detail.contains_key("Fan Speed")`. A reader using a
+        //    different key silently opts out of that coordination.
+        // 2. Anything that later promotes fan speed to a real `GpuInfo`
+        //    field has to special-case each spelling instead of reading
+        //    one key.
+        let mut gpu = baseline_gpu();
+        apply_to_gpu_info(&mut gpu, &full_readout());
+
+        for (key, expected) in [
+            ("Fan Speed", "1450 RPM"),
+            ("Memory Clock", "1250 MHz"),
+            ("Hotspot Temperature", "81 C"),
+            ("Memory Temperature", "70 C"),
+            ("Memory Controller Activity", "44%"),
+        ] {
+            assert_eq!(gpu.detail.get(key).map(String::as_str), Some(expected));
+        }
+
+        // The unit must not migrate back into the key.
+        for stale in [
+            "Fan Speed (RPM)",
+            "Memory Clock (MHz)",
+            "Hotspot Temperature (C)",
+            "Memory Temperature (C)",
+            "Memory Controller Activity (%)",
+        ] {
+            assert!(!gpu.detail.contains_key(stale), "{stale} should not exist");
+        }
+    }
+
+    #[test]
+    fn a_normal_temperature_adds_no_redundant_detail_key() {
+        // `Temperature` exists only to preserve a sub-zero reading the
+        // unsigned `GpuInfo.temperature` cannot hold. On every normal
+        // poll it would just duplicate that field, so it is absent.
+        let mut gpu = baseline_gpu();
+        apply_to_gpu_info(&mut gpu, &full_readout());
+        assert_eq!(gpu.temperature, 62);
+        assert!(!gpu.detail.contains_key("Temperature"));
     }
 
     #[test]
@@ -349,7 +413,7 @@ mod tests {
         // `GpuInfo.temperature` is u32 and cannot hold it.
         assert_eq!(gpu.temperature, 0);
         // The true reading survives where it can be represented.
-        assert_eq!(gpu.detail["Temperature (C)"], "-8");
+        assert_eq!(gpu.detail["Temperature"], "-8 C");
     }
 
     #[test]
@@ -365,7 +429,7 @@ mod tests {
         assert_eq!(gpu.utilization, before.utilization);
         assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH");
         assert_eq!(gpu.detail["Source: Temperature"], "unavailable");
-        assert!(!gpu.detail.contains_key("Hotspot Temperature (C)"));
+        assert!(!gpu.detail.contains_key("Hotspot Temperature"));
     }
 
     #[test]

--- a/src/device/readers/windows_gpu_perf.rs
+++ b/src/device/readers/windows_gpu_perf.rs
@@ -345,13 +345,17 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, metrics: &AdapterMetrics) {
     // must stay system-wide; reading either as a device-level number
     // would understate a busy GPU by whatever other processes hold.
     if let Some(budget) = metrics.process_budget {
-        gpu.detail
-            .insert("VRAM Budget (this process)".to_string(), budget.to_string());
+        gpu.detail.insert(
+            "VRAM Budget (this process)".to_string(),
+            format!("{budget} bytes"),
+        );
         touched_dxgi = true;
     }
     if let Some(usage) = metrics.process_current_usage {
-        gpu.detail
-            .insert("VRAM Usage (this process)".to_string(), usage.to_string());
+        gpu.detail.insert(
+            "VRAM Usage (this process)".to_string(),
+            format!("{usage} bytes"),
+        );
         touched_dxgi = true;
     }
 
@@ -787,8 +791,8 @@ mod tests {
 
         // Neither DXGI figure may leak into the device-level number.
         assert_eq!(gpu.used_memory, 0);
-        assert_eq!(gpu.detail["VRAM Budget (this process)"], "7000000000");
-        assert_eq!(gpu.detail["VRAM Usage (this process)"], "123456");
+        assert_eq!(gpu.detail["VRAM Budget (this process)"], "7000000000 bytes");
+        assert_eq!(gpu.detail["VRAM Usage (this process)"], "123456 bytes");
         assert!(!gpu.detail.contains_key("Source: Memory Used"));
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #348 and #349. Every reader that publishes fan speed, clocks, or temperatures through the `detail` map uses the same key with the unit carried in the **value**, not the key:

| Reader | Key | Value |
|---|---|---|
| `amd.rs` (Linux) | `Fan Speed` | `1450 RPM` |
| `intel_gpu_linux/sources.rs` | `Fan Speed` | `1450 RPM` |
| `intel_gpu_level_zero/apply.rs` | `Fan Speed` | `1450 RPM` |
| `amd_adl.rs` (#349) | `Fan Speed (RPM)` | `1450` |

The ADL reader was the odd one out, and #348 did the same thing with its two VRAM diagnostics. This aligns them.

## Why fan speed specifically had a cost

The other renames are consistency. Fan speed was a real defect:

`intel_gpu_level_zero::apply_fan` guards an overwrite with `detail.contains_key("Fan Speed")` (`apply.rs:118`). A reader spelling the key differently silently opts out of that coordination. And anything that later promotes fan speed to a proper `GpuInfo` field, which is now tracked as its own issue, would have to special-case every spelling instead of reading one key.

No live bug today, since the ADL reader is AMD-only and the guard is in the Intel path, but the two would collide the moment either moves.

## Changes

| Before | After | Value |
|---|---|---|
| `Fan Speed (RPM)` | `Fan Speed` | `1450 RPM` |
| `Memory Clock (MHz)` | `Memory Clock` | `1250 MHz` |
| `Hotspot Temperature (C)` | `Hotspot Temperature` | `81 C` |
| `Memory Temperature (C)` | `Memory Temperature` | `70 C` |
| `Memory Controller Activity (%)` | `Memory Controller Activity` | `44%` |
| `VRAM Budget (this process)` | unchanged | `7000000000 bytes` |
| `VRAM Usage (this process)` | unchanged | `123456 bytes` |

The two VRAM keys keep their qualifier: `(this process)` is a **scope**, not a unit. Those DXGI figures are process-scoped rather than system-wide, and dropping the qualifier would invite exactly the misreading it exists to prevent. Only their values gained the `bytes` unit, matching `VRAM Total` in the existing readers.

`Temperature` is now emitted **only when the reading is below zero**. It exists to preserve a sub-zero die that the unsigned `GpuInfo.temperature` floors at 0, and on every normal poll it merely duplicated that field.

## Guard against recurrence

`detail_keys_follow_the_shared_reader_convention` asserts both the new spellings and the *absence* of the old ones, and its comment records the two concrete costs of diverging. The next reader to publish these quantities fails a test rather than drifting quietly.

## Compatibility

None of these keys have appeared in a tagged release, so no consumer depends on the old spellings.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | exit 0 |
| `cargo test` | exit 0, 3176 passed, 0 failed across 23 binaries |
| `cargo xwin check --target x86_64-pc-windows-msvc` | exit 0, 0 warnings |

Note on the test count: figures quoted in #348 and #349 were read through a shell pipe that intermittently truncated cargo's output, so they undercounted slightly. Counting from a captured file gives 3176 here. The authoritative signal in all three PRs was the exit code, which was 0 throughout.

## Follow-ups filed separately

- Promoting fan speed to a real `GpuInfo` field so it reaches the TUI and Prometheus, not just `snapshot` JSON. Four readers would benefit; `Source: Fan` already exports as `source__fan` while the value does not.
- ADL `AdapterInfo` for multi-AMD-GPU attribution.
