### PR TITLE
fix: gate the AMD backend behind a default-on `amd` cargo feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1105,3 +1105,19 @@ jobs:
 
       - name: Build library-only (no default features)
         run: cargo build --no-default-features --lib
+
+      # Guards issue #345: with the `amd` feature off, `libamdgpu_top` must
+      # not be linked, so the binary must not carry libdrm as a NEEDED entry.
+      # `--no-default-features` also drops `cli` and therefore the binary, so
+      # the comparable artifact is built with `cli` re-enabled. This step
+      # overwrites target/release/all-smi from the step above; nothing later
+      # in this job consumes that artifact.
+      - name: Verify the AMD backend is droppable (no libdrm linkage)
+        run: |
+          cargo build --release --no-default-features --features cli --bin all-smi
+          echo "NEEDED entries without the amd feature:"
+          objdump -p target/release/all-smi | grep NEEDED || true
+          if objdump -p target/release/all-smi | grep -q 'NEEDED.*libdrm'; then
+            echo "::error::libdrm is still linked with --no-default-features --features cli"
+            exit 1
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,13 @@ libloading = "0.9"
 # patch releases (0.11.4 renamed get_all_proc_usage → update_proc_usage, #205).
 # 0.11.5 fixes a file-descriptor leak (#218). Re-evaluate the exact version on
 # each bump.
-libamdgpu_top = "=0.11.5"
+#
+# Optional and gated behind the default-on `amd` feature (issue #345). It stays
+# a hard link, not a `dlopen`, because `libdrm_amdgpu_sys` links `libdrm.so.2`
+# and `libdrm_amdgpu.so.1` unconditionally, so every dependent inherits them as
+# `NEEDED` entries. Making the dep optional is what lets a downstream crate that
+# does not need AMD drop those entries; see the `amd` feature comment below.
+libamdgpu_top = { version = "=0.11.5", optional = true }
 
 # Windows-specific dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -120,8 +126,30 @@ tokio = { version = "1.52.3", features = ["full", "test-util"] }
 tonic-prost-build = "0.14"
 
 [features]
-default = ["cli"]
+default = ["cli", "amd"]
 cli = ["dep:clap", "dep:crossterm", "dep:axum", "dep:tower-http", "dep:anyhow", "dep:toml", "dep:dirs"]
+# AMD GPU backend via `libamdgpu_top`. Default ON, unlike `furiosa` and
+# `level_zero`, so every existing distribution path (the glibc release
+# binaries, `cargo install all-smi`, the Homebrew formula, a plain
+# `cargo build`) keeps AMD support with no packaging change.
+#
+# The reason it is a feature at all is that `libamdgpu_top` pulls in
+# `libdrm_amdgpu_sys`, which links `libdrm.so.2` and `libdrm_amdgpu.so.1`
+# unconditionally. Those become hard `NEEDED` entries on every binary that
+# depends on this crate, so a host with no AMD GPU (the common case) fails to
+# start with a loader error before `main` runs, and cannot degrade gracefully.
+# A downstream crate that declares `default-features = false` now stops
+# inheriting them. Note that `--no-default-features` also drops `cli`; a
+# consumer that wants the CLI but not AMD needs
+# `default-features = false, features = ["cli"]`.
+#
+# Disabling it compiles out `src/device/readers/amd.rs`, the `has_amd`
+# detector, and the AMD arm of `reader_factory`, which is the same shape the
+# musl release artifacts have always shipped. `all-smi doctor` reports the
+# feature-off state distinctly from the musl state via `amd.build.target_env`
+# and `amd.libamdgpu_top.abi`. Windows AMD support (`amd_adl` / WMI) is
+# unaffected: it never used `libamdgpu_top`.
+amd = ["dep:libamdgpu_top"]
 mock = ["cli", "dep:rand", "dep:hyper", "dep:hyper-util"]
 # Opt-in Furiosa NPU support. Surfaced by the `furiosa.*` doctor checks
 # (issue #188) and used by the Linux-target `furiosa-smi-rs` optional dep.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -87,11 +87,12 @@ cargo build --release --bin all-smi-mock-server --features="mock"
 
 ### Optional Build Features
 
-The default build (`default = ["cli"]`) includes the full CLI, TUI, and API server. Additional opt-in Cargo features:
+The default build (`default = ["cli", "amd"]`) includes the full CLI, TUI, API server, and the AMD GPU backend. Cargo features:
 
 | Feature | Default | Purpose |
 |---------|---------|---------|
 | `cli` | on | CLI parsing, TUI (`crossterm`), and the `axum` API server. Disable for a lean library-only build. |
+| `amd` | on | AMD GPU backend on glibc Linux via the `libamdgpu_top` crate. Disable to drop the `libdrm.so.2` / `libdrm_amdgpu.so.1` runtime dependency. |
 | `mock` | off | Builds the `all-smi-mock-server` binary that simulates GPU/NPU clusters. |
 | `furiosa` | off | Furiosa NPU backend via the `furiosa-smi-rs` crate (Linux targets). |
 | `level_zero` | off | Intel oneAPI Level Zero (Sysman) backend for Intel client GPUs. Dynamically loads `libze_loader.so.1` (Linux) / `ze_loader.dll` (Windows) at runtime; a missing runtime degrades silently to the sysfs/WMI baseline. |
@@ -100,6 +101,30 @@ The default build (`default = ["cli"]`) includes the full CLI, TUI, and API serv
 # Example: build with the Intel Level Zero backend enabled
 cargo build --release --features level_zero
 ```
+
+#### Dropping the AMD backend (`amd`)
+
+`libamdgpu_top` pulls in `libdrm_amdgpu_sys`, which links `libdrm.so.2` and `libdrm_amdgpu.so.1` unconditionally. Those become hard `NEEDED` entries on every Linux binary that links this crate, so a host without AMD's userspace DRM libraries fails to start with a loader error before `main` runs, which the program cannot catch or report. Turning `amd` off removes the dependency and both `NEEDED` entries.
+
+```bash
+# Library-only build with no AMD backend and no libdrm linkage
+cargo build --release --no-default-features
+
+# CLI without the AMD backend: --no-default-features also drops `cli`,
+# so re-enable it explicitly
+cargo build --release --no-default-features --features cli
+```
+
+For a downstream crate the same rule applies. `default-features = false` turns off `cli` as well as `amd`, so a consumer that wants the CLI but not AMD must ask for `cli` back:
+
+```toml
+[dependencies]
+all-smi = { version = "0.25", default-features = false, features = ["cli"] }
+```
+
+Verify the result with `objdump -p target/release/all-smi | grep NEEDED`; neither `libdrm.so.2` nor `libdrm_amdgpu.so.1` should appear.
+
+The musl release artifacts (`all-smi-linux-x86_64-musl`, `all-smi-linux-aarch64-musl`) have never included AMD support and stay the simplest option for minimal containers. `all-smi doctor` reports which gate applied: `amd.build.target_env` and `amd.libamdgpu_top.abi` distinguish a musl build from a glibc build without the `amd` feature, and `doctor --bundle` lists the enabled features. Windows AMD support goes through ADL/WMI and is unaffected by this feature.
 
 ### Platform-Specific Builds
 

--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ netsh advfirewall firewall delete rule name="all-smi"
   - AMD GPU support is available in **glibc builds only** (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`)
   - **Not available in musl builds** (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) due to library compatibility
   - For static binaries with AMD GPU support, use the glibc builds
+- **Runtime Library Dependency:** the AMD backend links `libdrm.so.2` and `libdrm_amdgpu.so.1`, so a glibc build refuses to start on a host that lacks them, even one with no AMD GPU. Install `libdrm2 libdrm-amdgpu1` (Debian/Ubuntu) or `libdrm` (RHEL/Fedora), or use a build without the backend
+- **Opting Out (`amd` cargo feature):** the backend sits behind the `amd` feature, which is **on by default**, so the release binaries, `cargo install all-smi`, and the Homebrew formula are unchanged. Build with `--no-default-features` to drop it along with both `libdrm` entries. Note that `--no-default-features` also drops `cli`, so a CLI build without AMD is `cargo build --release --no-default-features --features cli`, and a library consumer wanting the CLI but not AMD uses `all-smi = { version = "0.25", default-features = false, features = ["cli"] }`. The musl artifacts have never carried AMD support and remain the simplest choice for minimal containers. `all-smi doctor` names the gate that applied in `amd.build.target_env`
 - **Permissions:** Add user to `video` and `render` groups as an alternative to sudo:
   ```bash
   sudo usermod -a -G video,render $USER

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -536,9 +536,20 @@ pub const MAX_HISTORY_SIZE: usize = 60;
 
 ```toml
 [features]
-default = []
-mock = []  # Enables mock server binary
+default = ["cli", "amd"]
+# CLI parsing, TUI, and the axum API server
+cli = ["dep:clap", "dep:crossterm", "dep:axum", "dep:tower-http", "dep:anyhow", "dep:toml", "dep:dirs"]
+# AMD GPU backend via libamdgpu_top (glibc Linux)
+amd = ["dep:libamdgpu_top"]
+# Enables the mock server binary
+mock = ["cli", "dep:rand", "dep:hyper", "dep:hyper-util"]
+# Furiosa NPU backend
+furiosa = ["furiosa-smi-rs"]
+# Intel Level Zero (Sysman) backend
+level_zero = []
 ```
+
+`amd` is the only backend feature that defaults to on. It exists because `libamdgpu_top` links `libdrm.so.2` and `libdrm_amdgpu.so.1` unconditionally, which every dependent binary inherits as `NEEDED` entries; a consumer that must run on hosts without those libraries builds with `default-features = false` (see `docs/LIB_mode.md`). Disabling it compiles out `src/device/readers/amd.rs`, `platform_detection::has_amd`, and the AMD arm of `reader_factory`, which is the same shape the musl artifacts already ship. Windows AMD support goes through `amd_adl`/WMI and is independent of this feature.
 
 ### Binary Targets
 

--- a/docs/LIB_mode.md
+++ b/docs/LIB_mode.md
@@ -44,18 +44,44 @@ The `all-smi` library provides a unified, cross-platform API for monitoring hard
 
 ## Installation
 
-Add `all-smi` to your `Cargo.toml`:
+Add `all-smi` to your `Cargo.toml`. The package is `all-smi`; the library is imported as `all_smi`.
 
 ```toml
 [dependencies]
-all_smi = "0.15"
+all-smi = "0.25"
 ```
 
 Or using cargo:
 
 ```bash
-cargo add all_smi
+cargo add all-smi
 ```
+
+### Cargo features
+
+| Feature | Default | Effect on a library consumer |
+|---------|---------|------------------------------|
+| `cli` | on | CLI parsing, TUI, and the `axum` API server. A library-only consumer usually does not need it. |
+| `amd` | on | AMD GPU backend on glibc Linux via `libamdgpu_top`. Adds `libdrm.so.2` and `libdrm_amdgpu.so.1` as link-time requirements. |
+| `mock` | off | Builds the mock server binary. |
+| `furiosa` | off | Furiosa NPU backend. |
+| `level_zero` | off | Intel Level Zero (Sysman) backend, loaded at runtime via `dlopen`. |
+
+`amd` is on by default so that adding this crate keeps AMD GPU monitoring without extra configuration. The cost is that `libamdgpu_top` links `libdrm.so.2` and `libdrm_amdgpu.so.1` unconditionally, and those become hard `NEEDED` entries on your binary too. A host that does not have AMD's userspace DRM libraries then fails to start your program with a loader error before `main` runs, which no amount of runtime handling can catch. Turn the feature off if your binary must run on hosts without those libraries:
+
+```toml
+[dependencies]
+all-smi = { version = "0.25", default-features = false }
+```
+
+`default-features = false` turns off `cli` as well, so ask for it back if you need it:
+
+```toml
+[dependencies]
+all-smi = { version = "0.25", default-features = false, features = ["cli"] }
+```
+
+Confirm the result on Linux with `objdump -p <your-binary> | grep NEEDED`; neither `libdrm.so.2` nor `libdrm_amdgpu.so.1` should be listed. Everything except the AMD GPU readers is unaffected: NVIDIA, Apple Silicon, Intel, Tenstorrent, Rebellions, Furiosa, TPU, CPU, and memory collection all behave the same, and `GpuInfo` simply never reports AMD devices. AMD support on Windows goes through ADL/WMI and does not depend on this feature. The prebuilt musl artifacts have never included the AMD backend, so they are already free of the `libdrm` linkage.
 
 ## Quick Start
 
@@ -662,7 +688,7 @@ fn print_chassis_info() -> Result<()> {
 
 | Platform | Device Types | Requirements |
 |----------|--------------|--------------|
-| Linux | NVIDIA GPU, AMD GPU, Intel Gaudi, Furiosa, Rebellions, Tenstorrent, TPU | Vendor SDKs |
+| Linux | NVIDIA GPU, AMD GPU, Intel Gaudi, Furiosa, Rebellions, Tenstorrent, TPU | Vendor SDKs. AMD needs a glibc target and the `amd` feature (see [Cargo features](#cargo-features)) |
 | macOS | Apple Silicon GPU/ANE | macOS 12+ |
 | Windows | NVIDIA GPU | NVML |
 

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -113,7 +113,14 @@ fn detect_nvidia() -> bool {
     false
 }
 
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+/// Check whether at least one AMD GPU is present.
+///
+/// Only compiled on glibc Linux with the default-on `amd` cargo feature, which
+/// is where the `libamdgpu_top` dependency exists. Consumers that need a
+/// configuration-independent answer should use
+/// [`introspection::snapshot`], whose `amd` field is `false` whenever the
+/// backend is compiled out.
+#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
 pub fn has_amd() -> bool {
     static CACHE: OnceLock<bool> = OnceLock::new();
     *CACHE.get_or_init(detect_amd)
@@ -154,7 +161,7 @@ fn detect_intel_gpu() -> bool {
     }
 }
 
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
 fn detect_amd() -> bool {
     // On Linux, check for AMD GPUs
     if std::env::consts::OS == "linux" {
@@ -663,8 +670,9 @@ pub mod introspection {
         pub nvidia: bool,
         pub jetson: bool,
         /// `true` on glibc Linux targets when AMD is detected; always
-        /// `false` on musl builds because the `libamdgpu_top` dep is
-        /// compiled out.
+        /// `false` on musl builds, and on builds with the default-on `amd`
+        /// cargo feature disabled, because the `libamdgpu_top` dep is
+        /// compiled out in both cases.
         pub amd: bool,
         pub apple_silicon: bool,
         pub gaudi: bool,
@@ -696,12 +704,16 @@ pub mod introspection {
         }
     }
 
-    #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+    // These two arms must stay exact complements: the positive one is
+    // compiled only where `super::has_amd` exists, the negative one
+    // everywhere else. Any drift produces either a duplicate definition or a
+    // missing `detect_amd`.
+    #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
     fn detect_amd() -> bool {
         super::has_amd()
     }
 
-    #[cfg(not(all(target_os = "linux", not(target_env = "musl"))))]
+    #[cfg(not(all(target_os = "linux", not(target_env = "musl"), feature = "amd")))]
     fn detect_amd() -> bool {
         false
     }

--- a/src/device/reader_factory.rs
+++ b/src/device/reader_factory.rs
@@ -47,10 +47,10 @@ use crate::device::readers::intel_gpu_linux;
 #[cfg(target_os = "windows")]
 use crate::device::readers::intel_gpu_windows;
 
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
 use crate::device::platform_detection::has_amd;
 
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
 use crate::device::readers::amd;
 
 pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
@@ -100,8 +100,9 @@ pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
                 readers.push(Box::new(google_tpu::GoogleTpuReader::new()));
             }
 
-            // Check for AMD GPU support (glibc only, not musl))
-            #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+            // Check for AMD GPU support (glibc only, not musl, and only when
+            // the default-on `amd` feature is enabled)
+            #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
             if has_amd() {
                 readers.push(Box::new(amd::AmdGpuReader::new()));
             }

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -46,7 +46,10 @@ pub mod tpu_sysfs;
 #[cfg(target_os = "linux")]
 pub mod tenstorrent;
 
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+// Gated on glibc Linux plus the default-on `amd` cargo feature (issue #345).
+// Disabling the feature drops the `libamdgpu_top` dependency and with it the
+// `libdrm.so.2` / `libdrm_amdgpu.so.1` link-time requirements.
+#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
 pub mod amd;
 
 #[cfg(target_os = "windows")]

--- a/src/doctor/bundle.rs
+++ b/src/doctor/bundle.rs
@@ -324,6 +324,11 @@ fn enabled_features() -> Vec<&'static str> {
     let mut v: Vec<&'static str> = Vec::new();
     #[cfg(feature = "cli")]
     v.push("cli");
+    // Recorded so a support bundle shows whether the AMD backend was compiled
+    // in; its absence here is the first thing to check when AMD GPUs are
+    // missing from a glibc build (issue #345).
+    #[cfg(feature = "amd")]
+    v.push("amd");
     #[cfg(feature = "mock")]
     v.push("mock");
     #[cfg(feature = "furiosa")]

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `amd.*` checks — ROCm, libamdgpu_top, DRI access, musl-build gating.
+//! `amd.*` checks: ROCm, libamdgpu_top, DRI access, and build-time gating
+//! (the musl target gate and the default-on `amd` cargo feature).
 
 #[cfg(target_os = "linux")]
 use std::time::Duration;
@@ -25,7 +26,7 @@ static CHECKS: &[&Check] = &[
     &ROCM_VERSION,
     &LIBAMDGPU_TOP_ABI,
     &DRI_PERMS,
-    &MUSL_GATE,
+    &BUILD_GATE,
     &ADL_LIBRARY,
     &ADL_SENSORS,
 ];
@@ -55,11 +56,13 @@ static DRI_PERMS: Check = Check {
     run: check_dri_perms,
 };
 
-static MUSL_GATE: Check = Check {
+// The check id stays `amd.build.target_env` for compatibility with existing
+// bundles and docs even though it now reports the `amd` cargo feature as well.
+static BUILD_GATE: Check = Check {
     id: "amd.build.target_env",
     title: "AMD build-time availability",
     severity_on_fail: Severity::Warn,
-    run: check_musl_gate,
+    run: check_build_gate,
 };
 
 static ADL_LIBRARY: Check = Check {
@@ -226,7 +229,10 @@ fn check_rocm(_ctx: &CheckCtx) -> CheckResult {
 }
 
 fn check_libamdgpu_top(_ctx: &CheckCtx) -> CheckResult {
-    #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+    // Three distinct Linux outcomes, so a user never gets told the wrong
+    // reason for a missing AMD backend: linked, compiled out by the musl
+    // target gate, or compiled out by the `amd` cargo feature (issue #345).
+    #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
     {
         // The `libamdgpu_top` crate is linked at compile time; if this
         // binary was built with AMD support the dep is present. Surface
@@ -235,6 +241,14 @@ fn check_libamdgpu_top(_ctx: &CheckCtx) -> CheckResult {
             "linked libamdgpu_top {}",
             env!("CARGO_PKG_VERSION")
         ))
+    }
+    #[cfg(all(target_os = "linux", not(target_env = "musl"), not(feature = "amd")))]
+    {
+        CheckResult::Skip(
+            "libamdgpu_top not linked: built without the `amd` cargo feature (see \
+             amd.build.target_env)"
+                .to_string(),
+        )
     }
     #[cfg(all(target_os = "linux", target_env = "musl"))]
     {
@@ -280,7 +294,13 @@ fn check_dri_perms(_ctx: &CheckCtx) -> CheckResult {
     }
 }
 
-fn check_musl_gate(_ctx: &CheckCtx) -> CheckResult {
+/// Report which build-time gate, if any, compiled the AMD backend out.
+///
+/// Two independent gates can remove it: the musl target gate, and the
+/// default-on `amd` cargo feature (issue #345). The three arms below are
+/// mutually exclusive and exhaustive, and each names the gate that actually
+/// applies so `all-smi doctor` never blames the wrong one.
+fn check_build_gate(_ctx: &CheckCtx) -> CheckResult {
     #[cfg(target_env = "musl")]
     {
         CheckResult::Warn(
@@ -288,7 +308,22 @@ fn check_musl_gate(_ctx: &CheckCtx) -> CheckResult {
             Some("use a glibc build (x86_64-unknown-linux-gnu) for AMD GPU monitoring".to_string()),
         )
     }
-    #[cfg(not(target_env = "musl"))]
+    #[cfg(all(target_os = "linux", not(target_env = "musl"), not(feature = "amd")))]
+    {
+        CheckResult::Warn(
+            "glibc build without the `amd` cargo feature: AMD support compiled out".to_string(),
+            Some(
+                "rebuild with the default features, or add `--features amd`, for AMD GPU \
+                 monitoring; the feature is off here because something disabled it (typically a \
+                 downstream `default-features = false`) to avoid linking libdrm"
+                    .to_string(),
+            ),
+        )
+    }
+    #[cfg(all(
+        not(target_env = "musl"),
+        any(not(target_os = "linux"), feature = "amd")
+    ))]
     {
         CheckResult::Pass("glibc or non-Linux target — AMD support available".to_string())
     }

--- a/src/doctor/checks/platform.rs
+++ b/src/doctor/checks/platform.rs
@@ -114,13 +114,24 @@ fn check_runtime(_ctx: &CheckCtx) -> CheckResult {
         msg.push_str(&format!(" (env={env})"));
     }
 
-    // The AMD backend is gated on `not(target_env = "musl")`; surface a
-    // warning so users building with musl know AMD is unavailable.
+    // The AMD backend is gated on `not(target_env = "musl")` and on the
+    // default-on `amd` cargo feature; surface a warning naming whichever gate
+    // actually removed it so the reason is never misattributed (issue #345).
     #[cfg(target_env = "musl")]
     {
         return CheckResult::Warn(
             format!("{msg} — musl builds do not include AMD GPU support"),
             Some("rebuild with a glibc target (e.g. x86_64-unknown-linux-gnu) for AMD".to_string()),
+        );
+    }
+
+    #[cfg(all(target_os = "linux", not(target_env = "musl"), not(feature = "amd")))]
+    {
+        return CheckResult::Warn(
+            format!(
+                "{msg}, built without the `amd` cargo feature so AMD GPU support is compiled out"
+            ),
+            Some("rebuild with the default features, or add `--features amd`, for AMD".to_string()),
         );
     }
 

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -98,8 +98,9 @@ pub fn ensure_sudo_permissions() {
     if cfg!(target_os = "macos") {
         // macOS uses native APIs (IOReport, SMC) that don't require sudo
     } else if cfg!(target_os = "linux") {
-        // On Linux, check if we have AMD GPUs that require sudo (glibc only)
-        #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+        // On Linux, check if we have AMD GPUs that require sudo (glibc only,
+        // and only when the default-on `amd` feature is enabled)
+        #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
         {
             use crate::device::platform_detection::has_amd;
 
@@ -171,8 +172,9 @@ pub fn ensure_sudo_permissions_with_fallback() -> bool {
         // macOS uses native APIs (IOReport, SMC) that don't require sudo
         true
     } else if cfg!(target_os = "linux") {
-        // On Linux, check if we have AMD GPUs that require sudo (glibc only)
-        #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+        // On Linux, check if we have AMD GPUs that require sudo (glibc only,
+        // and only when the default-on `amd` feature is enabled)
+        #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
         {
             use crate::device::platform_detection::has_amd;
 
@@ -188,7 +190,8 @@ pub fn ensure_sudo_permissions_with_fallback() -> bool {
                 return true;
             }
         }
-        // For musl builds or when AMD GPU is not detected, no sudo needed
+        // For musl builds, builds without the `amd` feature, or when no AMD
+        // GPU is detected, no sudo is needed
         true
     } else {
         true


### PR DESCRIPTION
## Summary

`libamdgpu_top` was a non-optional dependency, and it pulls in `libdrm_amdgpu_sys`, which links `libdrm.so.2` and `libdrm_amdgpu.so.1` unconditionally. Every Linux binary that depends on all-smi therefore inherited both as hard `NEEDED` entries, so a host without AMD's userspace DRM libraries (the overwhelming majority of deployments) fails to start with a loader error before `main` runs. The program cannot catch that or degrade to "no AMD GPU detected".

This implements option 1 from the issue: the AMD backend moves behind a new `amd` cargo feature, **enabled by default**.

## Why default-on, and why not `dlopen`

Default-on means every existing distribution path is byte-for-byte unchanged and keeps AMD support: the glibc release binaries, `cargo install all-smi`, Homebrew, and a plain `cargo build`. `Cargo.lock` does not move. Release workflows, packaging, and the Homebrew formula need no changes, which is the main reason default-on was chosen over default-off.

A downstream crate that declares `default-features = false` now stops inheriting `libdrm.so.2` and `libdrm_amdgpu.so.1`. `lablup/backend.ai-go` already declares `all-smi = { version = "0.25.0", default-features = false }`, so this fixes their reported startup failure with no change on their side.

Option 2 in the issue (runtime `dlopen` of `libdrm`) was evaluated and rejected for this PR. `libdrm` is linked by the third-party `libamdgpu_top` crate, and `src/device/readers/amd.rs` uses its types throughout, so runtime loading means replacing that crate with hand-rolled FFI. That is tracked as a separate follow-up.

## What changed

**`Cargo.toml`** makes `libamdgpu_top` optional and adds the feature. The target gate is unchanged, so the dep is still only declared for glibc Linux:

```toml
[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
libamdgpu_top = { version = "=0.11.5", optional = true }

[features]
default = ["cli", "amd"]
amd = ["dep:libamdgpu_top"]
```

The existing pin comment (semver-violating patch releases, the 0.11.5 fd-leak fix) is preserved and extended. The `[features]` block documents `amd` in the same voice as `furiosa` and `level_zero`, including why it is default-on where those two are default-off.

**Twelve `cfg` sites widened** from `all(target_os = "linux", not(target_env = "musl"))` to also require `feature = "amd"`:

| File | Site |
|------|------|
| `src/device/readers/mod.rs` | `pub mod amd;` |
| `src/device/reader_factory.rs` | `has_amd` import, `amd` import, the `AmdGpuReader` push |
| `src/device/platform_detection.rs` | `has_amd`, `detect_amd`, and the `introspection::detect_amd` pair |
| `src/utils/system.rs` | both sudo-permission blocks |
| `src/doctor/checks/amd.rs` | `check_libamdgpu_top`, `check_build_gate` |
| `src/doctor/checks/platform.rs` | `check_runtime` |

The negated complement in `introspection` is `not(all(target_os = "linux", not(target_env = "musl"), feature = "amd")))`, which stays an exact complement of the positive arm; a comment marks it so drift does not silently drop or duplicate `detect_amd`. The codebase has no `cfg` alias precedent (no `cfg_aliases` build dependency), so the predicate is written out at each site rather than introducing a new mechanism.

This is not a new configuration. `libamdgpu_top` was already excluded from musl builds, and `release.yml` ships `all-smi-linux-x86_64-musl` and `all-smi-linux-aarch64-musl` on every release. The change makes an already-shipping shape reachable on glibc.

**Diagnosability.** A glibc build with the feature off is a third state the doctor previously could not express, and it would have reported a false musl explanation. `all-smi doctor` on a feature-off build now reports:

```
WARN amd.build.target_env   glibc build without the `amd` cargo feature: AMD support compiled out
     -> Fix: rebuild with the default features, or add `--features amd`, for AMD GPU
        monitoring; the feature is off here because something disabled it (typically a
        downstream `default-features = false`) to avoid linking libdrm
SKIP amd.libamdgpu_top.abi  libamdgpu_top not linked: built without the `amd` cargo feature
                            (see amd.build.target_env)
WARN platform.runtime       target aarch64-unknown-linux-gnu (env=gnu), built without the
                            `amd` cargo feature so AMD GPU support is compiled out
```

On the default build all three of those checks pass instead, with their existing messages unchanged: `amd.build.target_env` reports AMD support available, `amd.libamdgpu_top.abi` reports the linked crate, and `platform.runtime` reports the plain target triple with no warning.

`amd.build.target_env` keeps its check id; only the internal function was renamed from `check_musl_gate` to `check_build_gate` since it now reports two independent gates. `doctor --bundle` records the feature too, so a support bundle answers the question directly: `features: cli,amd` versus `features: cli`.

Warning on a deliberately feature-off build (and the resulting exit code 1) matches the existing musl behaviour exactly, so this introduces no new convention.

**Docs**: `README.md`, `DEVELOPERS.md`, `docs/ARCHITECTURE.md`, and `docs/LIB_mode.md`. All state that `amd` is on by default, that disabling it removes the `libdrm` runtime dependency, that `--no-default-features` also drops `cli` (so a consumer wanting the CLI but not AMD needs `default-features = false, features = ["cli"]`), and that the musl artifacts have never had AMD support and remain the existing option for minimal containers. `docs/ARCHITECTURE.md` had a stale `[features]` block claiming `default = []`; it now matches `Cargo.toml`.

**CI** gains a regression guard in the existing `build-check` job that builds `--no-default-features --features cli` and fails if any `NEEDED` entry matches `libdrm`.

## Test plan

Run on `aarch64-unknown-linux-gnu`.

### 1. `cargo tree -e normal -i libamdgpu_top`

Default features, present:

```
$ cargo tree -e normal -i libamdgpu_top
libamdgpu_top v0.11.5
└── all-smi v0.25.0 (/home/inureyes/Development/backend.ai/all-smi)
exit=0
```

`--no-default-features`, absent (the "package not found" message is the pass condition):

```
$ cargo tree -e normal -i libamdgpu_top --no-default-features
error: package ID specification `libamdgpu_top` did not match any packages
exit=101
```

`--no-default-features --features cli`, also absent:

```
$ cargo tree -e normal -i libamdgpu_top --no-default-features --features cli
error: package ID specification `libamdgpu_top` did not match any packages
exit=101
```

### 2. Cross-target resolution with default features

All three resolve with no error despite `amd` being on for targets where the dep is not declared:

```
$ cargo tree -e normal --target x86_64-pc-windows-msvc
exit=0  libamdgpu_top occurrences: 0

$ cargo tree -e normal --target aarch64-apple-darwin
exit=0  libamdgpu_top occurrences: 0

$ cargo tree -e normal --target x86_64-unknown-linux-musl
exit=0  libamdgpu_top occurrences: 0
```

The musl result confirms the existing musl exclusion still holds.

### 3. `cargo check` for the downstream configurations

```
$ cargo check --no-default-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.52s

$ cargo check --no-default-features --features cli
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.01s
```

### 4. `cargo check` with default features

```
$ cargo check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.07s
```

### 5. `NEEDED` comparison (decisive)

```
$ cargo build --release
    Finished `release` profile [optimized] target(s) in 1m 28s
$ objdump -p target/release/all-smi | grep NEEDED
  NEEDED               libdrm.so.2
  NEEDED               libdrm_amdgpu.so.1
  NEEDED               libgcc_s.so.1
  NEEDED               libm.so.6
  NEEDED               libc.so.6
  NEEDED               ld-linux-aarch64.so.1

$ cargo build --release --no-default-features --features cli
    Finished `release` profile [optimized] target(s) in 1m 07s
$ objdump -p target/release/all-smi | grep NEEDED
  NEEDED               libgcc_s.so.1
  NEEDED               libm.so.6
  NEEDED               libc.so.6
  NEEDED               ld-linux-aarch64.so.1
```

The measured configuration is `--no-default-features --features cli`, because `--no-default-features` alone drops `cli` and therefore the binary. Both `libdrm` entries are gone; nothing else changed.

### 6. Clippy, both configurations

```
$ cargo clippy --lib --tests -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.19s
exit=0

$ cargo clippy --lib --tests --no-default-features --features cli -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.98s
exit=0
```

No dead-code or unused-import fallout appeared behind the disabled feature, and no blanket `#[allow]` was added.

### 7. Narrow tests for the touched modules

```
$ cargo test --lib device::platform_detection
test device::platform_detection::introspection::tests::snapshot_is_default_friendly ... ok
test device::platform_detection::tests::apple_silicon_detection_is_total_and_stable ... ok
test device::platform_detection::introspection::tests::snapshot_os_matches_consts ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1502 filtered out; finished in 0.12s

$ cargo test --lib doctor
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 1481 filtered out; finished in 0.02s

$ cargo test --lib utils::system
test utils::system::tests::test_calculate_adaptive_interval ... ok
test utils::system::tests::test_get_hostname ... ok
test utils::system::tests::test_ensure_sudo_permissions_non_macos ... ok
test utils::system::tests::test_ensure_sudo_permissions_with_fallback_returns_bool ... ok
test utils::system::tests::test_has_sudo_privileges_on_non_macos ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1500 filtered out; finished in 0.03s
```

All three also pass under `--no-default-features --features cli` (3, 24, and 5 tests respectively).

`cargo fmt --check` is clean, and `Cargo.lock` is unmodified.

### Checklist

- [x] `cargo tree -e normal -i libamdgpu_top` present by default, absent with `--no-default-features`
- [x] `cargo tree` resolves for windows-msvc, apple-darwin, and linux-musl under default features
- [x] `cargo check --no-default-features` and `--no-default-features --features cli` pass
- [x] `cargo check` with default features passes
- [x] `libdrm.so.2` and `libdrm_amdgpu.so.1` present by default, gone with `--no-default-features --features cli`
- [x] `cargo clippy --lib --tests -- -D warnings` clean in both configurations
- [x] `cargo test --lib` for `device::platform_detection`, `doctor`, and `utils::system` pass in both configurations
- [x] `all-smi doctor` reports the feature-off state distinctly from the musl state

## Notes for review

Two pre-existing defects were found next to this work and deliberately left alone rather than folded into this PR:

1. `amd.libamdgpu_top.abi` prints `env!("CARGO_PKG_VERSION")`, which is all-smi's own version, not `libamdgpu_top`'s. It reports "linked libamdgpu_top 0.25.0" when the crate is 0.11.5. Cargo exposes no dependency version to the compiler without a build script, so a correct fix needs more than a one-line change.
2. `doctor --bundle`'s `enabled_features()` still does not list `level_zero`. This PR adds `amd` to it because that is what the change is about.

Not verified: nothing was built or run for Windows, macOS, or musl targets. Those configurations were checked only through `cargo tree` resolution, and their `cfg` arms through review of the complement predicates. A broad `cargo test --workspace` and `cargo clippy --workspace --all-targets` were not run.

Closes #345
