### PR TITLE
feat: attribute ADL telemetry per card on multi-GPU AMD Windows hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ Stable check IDs (greppable across versions):
 | `privileges.*` | `privileges.user`, `privileges.root`, `privileges.video_render_group`, `privileges.dev_dri`, `privileges.dev_tenstorrent` |
 | `container.*` | `container.runtime`, `container.cgroup`, `container.k8s_serviceaccount` |
 | `nvidia.*` | `nvidia.nvml.loadable`, `nvidia.smi.binary`, `nvidia.driver.version`, `nvidia.env.visible_devices`, `nvidia.mig.mode` |
-| `amd.*` | `amd.rocm.version`, `amd.libamdgpu_top.abi`, `amd.dri.perms`, `amd.build.target_env` |
+| `amd.*` | `amd.rocm.version`, `amd.libamdgpu_top.abi`, `amd.dri.perms`, `amd.build.target_env`, `amd.adl.library`, `amd.adl.sensors`, `amd.adl.adapters` |
 | `apple.*` | `apple.macos.version`, `apple.silicon`, `apple.smc` |
 | `gaudi.*` | `gaudi.hlsmi`, `gaudi.devices`, `gaudi.driver` |
 | `tpu.*` | `tpu.libtpu`, `tpu.env.name`, `tpu.accel.vendor` |

--- a/src/device/readers/amd_adl.rs
+++ b/src/device/readers/amd_adl.rs
@@ -32,21 +32,28 @@
 //! right blind, for hardware that predates the datacentre and workstation
 //! cards all-smi targets. A pre-Vega card keeps the WMI and PDH baseline.
 //!
-//! ## Scope: one AMD GPU
+//! ## Scope: attribution across cards
 //!
-//! ADL identifies adapters by an index that does not map to a card
-//! without `AdapterInfo`, a 1568-byte struct whose layout this module
-//! deliberately refuses to declare blind (see [`ffi`]). Worse, one card
-//! exposes several adapter indices, one per display output, all
-//! reporting identical telemetry, so an index cannot even be
-//! deduplicated without it.
+//! ADL identifies adapters by an index, and one card exposes several
+//! indices, one per display output, all reporting identical telemetry.
+//! `AdapterInfo` (see [`ffi`]) ties each index to a physical card by
+//! PCI bus/device/function and carries the Windows PNP string, which
+//! is the same `PNPDeviceID` the reader stores as the GPU uuid, so on
+//! a multi-GPU host the join is exact. See [`adapters`] for the
+//! grouping and matching rules.
 //!
-//! Rather than guess, augmentation only runs when the reader found
-//! exactly one AMD GPU. That covers the overwhelming majority of real
-//! machines, and on a multi-AMD-GPU host the result is the honest DXGI
-//! and PDH baseline instead of one card's temperature reported against
-//! another. This mirrors the conclusion the #346 review reached about
-//! adapter matching: declining to attribute beats attributing wrongly.
+//! The whole scheme is conditioned on the runtime layout verification
+//! in [`ffi::AdapterInfoArray::validated`]: the `AdapterInfo` layout is
+//! transcribed blind (nothing in CI compiles for Windows), so rows are
+//! only trusted after their string fields prove the layout at runtime.
+//! If verification, the ADL call, or the matching fails, multi-GPU
+//! hosts keep the honest DXGI and PDH baseline; and a machine with
+//! exactly one AMD GPU never consults `AdapterInfo` at all, keeping
+//! the behavior it had before #353. Either way the failure mode stays
+//! the one the #346 review settled on: declining to attribute beats
+//! attributing wrongly. The `amd.adl.adapters` doctor check dumps the
+//! raw rows so both the layout and the matching can be confirmed from
+//! a real machine.
 //!
 //! ## Cost
 //!
@@ -58,6 +65,7 @@
 //! out of its deepest idle power state; all-smi's intervals start at one
 //! second, which is well clear of that.
 
+pub mod adapters;
 pub mod ffi;
 pub mod sensors;
 
@@ -67,15 +75,6 @@ pub mod loader;
 use crate::device::readers::windows_gpu_perf::note_metrics_source;
 use crate::device::types::{GpuInfo, MAX_GPU_FAN_RPM};
 use sensors::AdlReadout;
-
-/// Whether an ADL readout can be attributed to a specific card.
-///
-/// See the module docs: without `AdapterInfo` an ADL adapter index
-/// cannot be tied to a GPU, so attribution is only safe when there is
-/// nothing to confuse it with.
-pub fn can_attribute(amd_gpu_count: usize) -> bool {
-    amd_gpu_count == 1
-}
 
 /// Layer an ADL readout onto a GPU that already carries the WMI, DXGI,
 /// and PDH baseline.
@@ -194,18 +193,52 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, readout: &AdlReadout) {
 /// Sample ADL and layer the result onto the reader's GPUs.
 ///
 /// Called after the vendor-neutral layer so ADL's readings win. A no-op
-/// when ADL is unavailable, when no adapter exposes PMLog, or when the
-/// machine has more than one AMD GPU.
+/// when ADL is unavailable or when no adapter exposes PMLog. On a
+/// single-GPU machine the process-wide sample is attributed directly,
+/// exactly as before #353; on a multi-GPU machine each GPU is
+/// augmented only when [`adapters::plan_attribution`] matched it to a
+/// card exactly, and a failed match or failed `AdapterInfo` layout
+/// verification leaves the DXGI and PDH baseline untouched.
 #[cfg(target_os = "windows")]
 pub fn augment(gpus: &mut [GpuInfo]) {
-    if !can_attribute(gpus.len()) {
-        return;
-    }
-    let Some(output) = loader::sample() else {
-        return;
+    use adapters::AttributionPlan;
+
+    // Only a multi-GPU host needs the adapter inventory; the sole-GPU
+    // path must not depend on `AdapterInfo` in any way, including not
+    // paying for the call.
+    let inventory = if gpus.len() > 1 {
+        loader::adapter_inventory()
+    } else {
+        None
     };
-    let readout = sensors::extract(&output);
-    apply_to_gpu_info(&mut gpus[0], &readout);
+    let uuids: Vec<&str> = gpus.iter().map(|gpu| gpu.uuid.as_str()).collect();
+    match adapters::plan_attribution(&uuids, inventory.as_deref()) {
+        AttributionPlan::SoleGpu => {
+            let Some(output) = loader::sample() else {
+                return;
+            };
+            let readout = sensors::extract(&output);
+            apply_to_gpu_info(&mut gpus[0], &readout);
+        }
+        AttributionPlan::PerCard(matches) => {
+            for card in matches {
+                // Every index of a card reports the same telemetry, so
+                // take the first one that answers; a card where none
+                // answers (a pre-Vega APU next to a modern dGPU) keeps
+                // its baseline.
+                let Some(output) = card
+                    .adl_indices
+                    .iter()
+                    .find_map(|&index| loader::sample_adapter(index))
+                else {
+                    continue;
+                };
+                let readout = sensors::extract(&output);
+                apply_to_gpu_info(&mut gpus[card.gpu_index], &readout);
+            }
+        }
+        AttributionPlan::Decline => {}
+    }
 }
 
 /// Non-Windows builds have no ADL. The stub keeps the surrounding logic
@@ -473,17 +506,42 @@ mod tests {
     }
 
     #[test]
-    fn attribution_is_refused_for_anything_but_a_single_amd_gpu() {
-        assert!(can_attribute(1));
-        // Zero cards is nothing to attribute to; two or more cannot be
-        // told apart without AdapterInfo.
-        assert!(!can_attribute(0));
-        assert!(!can_attribute(2));
-        assert!(!can_attribute(4));
+    fn a_single_gpu_never_depends_on_adapterinfo() {
+        // The regression pin for pre-#353 behavior: with exactly one
+        // AMD GPU the plan is SoleGpu whether the adapter inventory is
+        // present, absent, or failed layout verification, so the
+        // single-GPU machine that worked before AdapterInfo existed
+        // keeps working when it lies. The matching-level counterpart
+        // tests live in `adapters`.
+        use adapters::{AttributionPlan, plan_attribution};
+
+        let gpu = baseline_gpu();
+        let uuids = [gpu.uuid.as_str()];
+        assert_eq!(plan_attribution(&uuids, None), AttributionPlan::SoleGpu);
+        assert_eq!(
+            plan_attribution(&uuids, Some(&[])),
+            AttributionPlan::SoleGpu
+        );
+    }
+
+    #[test]
+    fn multi_gpu_attribution_declines_without_a_validated_inventory() {
+        // Two AMD GPUs and no validated AdapterInfo rows (unavailable
+        // entry point, failed call, or failed layout verification all
+        // arrive here as `None`): the reader must decline rather than
+        // guess, exactly as it did before #353.
+        use adapters::{AttributionPlan, plan_attribution};
+
+        let uuids = ["PCI\\VEN_1002&DEV_744C", "PCI\\VEN_1002&DEV_164E"];
+        assert_eq!(plan_attribution(&uuids, None), AttributionPlan::Decline);
     }
 
     #[test]
     fn augment_is_inert_when_attribution_is_refused() {
+        // On a Linux test runner the stub is inert; on a Windows dev
+        // machine without a validated adapter inventory the multi-GPU
+        // path declines. Either way two baseline GPUs must come back
+        // untouched.
         let mut gpus = vec![baseline_gpu(), baseline_gpu()];
         augment(&mut gpus);
         for gpu in &gpus {

--- a/src/device/readers/amd_adl/adapters.rs
+++ b/src/device/readers/amd_adl/adapters.rs
@@ -236,32 +236,62 @@ fn plausible_bdf(adapter: &AdlAdapter) -> bool {
         && (0..=7).contains(&adapter.function)
 }
 
+/// Whether two ADL `strPNPString` values name the same physical device.
+///
+/// ADL does not repeat one instance path across a card's rows. Observed
+/// on an AMD Radeon(TM) 8060S (driver 32.0.31035.1003): the primary row
+/// carries the base device instance path, the path WMI reports as
+/// `PNPDeviceID`, and each additional display-output row carries that
+/// same path with a `&02`, `&03`, ... suffix appended. So sameness is
+/// "one extends the other at a separator", not equality.
+///
+/// The `&` boundary is load-bearing. Without it two genuinely distinct
+/// paths that merely share a prefix, `...&0&0041` and `...&0&00410`,
+/// would read as one card. Comparison is ASCII-case-insensitive because
+/// WMI and ADL do not agree on case.
+fn shares_device_instance(a: &str, b: &str) -> bool {
+    let (short, long) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    let (short, long) = (short.as_bytes(), long.as_bytes());
+    if !long[..short.len()].eq_ignore_ascii_case(short) {
+        return false;
+    }
+    long.len() == short.len() || long[short.len()] == b'&'
+}
+
 /// Group adapter rows into one [`CardGroup`] per physical card.
 ///
 /// Groups are sorted by bus/device/function and their indices sorted
 /// ascending, so the output is deterministic regardless of the order
 /// the driver enumerated in.
 ///
-/// A group whose rows carry two different non-empty PNP instance paths
+/// A group whose rows carry two unrelated non-empty PNP instance paths
 /// is dropped rather than returned. Grouping trusts the PCI
 /// bus/device/function to identify a physical card, so a driver that
 /// leaves those fields unfilled collapses every card into one group.
 /// The caller then samples telemetry from the first index of the group
 /// that answers PMLog, which can be a different physical card's index,
 /// and one card's temperature, power, and fan would be reported for
-/// another GPU with nothing in the output saying so. Two different
+/// another GPU with nothing in the output saying so. Two unrelated
 /// instance paths under one PCI address is the observable signature of
 /// that state, and dropping the group is the same answer the rest of
-/// this module gives everywhere else: decline rather than guess. Rows
-/// of one real card share their instance path; a secondary
-/// display-output row may leave it blank, which is backfilled and is
-/// not a conflict, and case differences are not a conflict either,
-/// since WMI and ADL do not agree on case.
+/// this module gives everywhere else: decline rather than guess.
+///
+/// "Unrelated" is judged by [`shares_device_instance`], not by string
+/// equality: a card's display-output rows extend its base path rather
+/// than repeating it (see that function). A row may also leave the path
+/// blank, which is no evidence either way and is skipped. The group's
+/// own `pnp_string` is the shortest path its rows carried, which is the
+/// base path, and therefore the only form the exact join in
+/// [`plan_attribution`] can match against a WMI `PNPDeviceID`.
+///
+/// Agreement is judged once per group against that base rather than
+/// pairwise as rows arrive, so the verdict does not depend on which row
+/// the driver enumerated first.
 pub fn group_by_card(adapters: &[AdlAdapter]) -> Vec<CardGroup> {
     let mut groups: Vec<CardGroup> = Vec::new();
-    // Parallel to `groups`: whether the group saw contradictory PNP
-    // strings and therefore cannot be trusted to be one card.
-    let mut conflicting: Vec<bool> = Vec::new();
+    // Parallel to `groups`: every non-empty instance path the group's
+    // rows carried, checked for agreement once the group is complete.
+    let mut paths: Vec<Vec<String>> = Vec::new();
     for adapter in adapters {
         if !plausible_bdf(adapter) {
             continue;
@@ -271,22 +301,14 @@ pub fn group_by_card(adapters: &[AdlAdapter]) -> Vec<CardGroup> {
                 && group.device == adapter.device
                 && group.function == adapter.function
         });
-        match existing {
+        let position = match existing {
             Some(position) => {
                 let group = &mut groups[position];
                 group.indices.push(adapter.index);
-                // Prefer any row that actually carries the string; a
-                // secondary display-output row can leave one blank.
-                if !adapter.pnp_string.is_empty() {
-                    if group.pnp_string.is_empty() {
-                        group.pnp_string = adapter.pnp_string.clone();
-                    } else if !group.pnp_string.eq_ignore_ascii_case(&adapter.pnp_string) {
-                        conflicting[position] = true;
-                    }
-                }
                 if group.adapter_name.is_empty() && !adapter.adapter_name.is_empty() {
                     group.adapter_name = adapter.adapter_name.clone();
                 }
+                position
             }
             None => {
                 groups.push(CardGroup {
@@ -294,17 +316,35 @@ pub fn group_by_card(adapters: &[AdlAdapter]) -> Vec<CardGroup> {
                     device: adapter.device,
                     function: adapter.function,
                     adapter_name: adapter.adapter_name.clone(),
-                    pnp_string: adapter.pnp_string.clone(),
+                    // Resolved below, once every row of this group has
+                    // been seen and the shortest path is known.
+                    pnp_string: String::new(),
                     indices: vec![adapter.index],
                 });
-                conflicting.push(false);
+                paths.push(Vec::new());
+                groups.len() - 1
             }
+        };
+        if !adapter.pnp_string.is_empty() {
+            paths[position].push(adapter.pnp_string.clone());
         }
     }
     let mut groups: Vec<CardGroup> = groups
         .into_iter()
-        .zip(conflicting)
-        .filter_map(|(group, conflicted)| (!conflicted).then_some(group))
+        .zip(paths)
+        .filter_map(|(mut group, paths)| {
+            // No row carried a path: nothing contradicts anything, so
+            // the group survives with an empty `pnp_string` that simply
+            // matches no GPU downstream, exactly as before.
+            let Some(base) = paths.iter().min_by_key(|path| path.len()) else {
+                return Some(group);
+            };
+            if !paths.iter().all(|path| shares_device_instance(base, path)) {
+                return None;
+            }
+            group.pnp_string = base.clone();
+            Some(group)
+        })
         .collect();
     for group in &mut groups {
         group.indices.sort_unstable();
@@ -503,6 +543,96 @@ mod tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].indices, vec![0, 1, 2]);
         assert_eq!(groups[0].pnp_string, DGPU_PNP);
+    }
+
+    // Observed on a real host, 2026-08-18: AMD Radeon(TM) 8060S
+    // Graphics (Strix Halo APU), driver 32.0.31035.1003, Windows 11.
+    // ADL enumerated five rows for the single physical card, all
+    // sharing bus 189 / device 0 / function 0, but each secondary
+    // display-output row carried a *distinct* instance path: the base
+    // path with an `&02`..`&05` suffix appended. Not blank, not merely
+    // case-differing, genuinely different -- which is the one shape
+    // `group_by_card` treats as a conflict and drops.
+    const REAL_8060S_BASE: &str = r"PCI\VEN_1002&DEV_1586&SUBSYS_B0261F4C&REV_C1\4&2368981F&0&0041";
+
+    #[test]
+    fn real_display_output_rows_do_not_dissolve_their_card() {
+        let mut adapters = vec![adapter(0, (189, 0, 0), REAL_8060S_BASE)];
+        let suffixed: Vec<String> = (2..=5).map(|n| format!("{REAL_8060S_BASE}&0{n}")).collect();
+        for (offset, pnp) in suffixed.iter().enumerate() {
+            adapters.push(adapter(offset as i32 + 1, (189, 0, 0), pnp));
+        }
+        let groups = group_by_card(&adapters);
+        assert_eq!(
+            groups.len(),
+            1,
+            "five ADL rows of one physical card must yield one group"
+        );
+        assert_eq!(groups[0].indices, vec![0, 1, 2, 3, 4]);
+        // The base path is the one WMI reports as PNPDeviceID, so it is
+        // the only value the exact join in `plan_attribution` can match.
+        assert_eq!(groups[0].pnp_string, REAL_8060S_BASE);
+    }
+
+    #[test]
+    fn the_base_path_wins_however_the_driver_enumerated_the_rows() {
+        // Display-output rows first, base path last. Grouping decides
+        // against the shortest path once the group is complete, so the
+        // verdict does not depend on enumeration order.
+        let second = format!("{REAL_8060S_BASE}&02");
+        let third = format!("{REAL_8060S_BASE}&03");
+        let adapters = vec![
+            adapter(1, (189, 0, 0), &second),
+            adapter(2, (189, 0, 0), &third),
+            adapter(0, (189, 0, 0), REAL_8060S_BASE),
+        ];
+        let groups = group_by_card(&adapters);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].indices, vec![0, 1, 2]);
+        assert_eq!(groups[0].pnp_string, REAL_8060S_BASE);
+    }
+
+    #[test]
+    fn a_shared_prefix_that_is_not_a_path_boundary_is_still_a_conflict() {
+        // `...&0&0041` and `...&0&00410` are different devices that
+        // happen to share a prefix. Only an extension at a `&` boundary
+        // is a display-output sibling, so these must not merge.
+        let lookalike = format!("{REAL_8060S_BASE}0");
+        let adapters = vec![
+            adapter(0, (189, 0, 0), REAL_8060S_BASE),
+            adapter(1, (189, 0, 0), &lookalike),
+        ];
+        assert!(group_by_card(&adapters).is_empty());
+    }
+
+    #[test]
+    fn display_output_rows_no_longer_block_multi_gpu_attribution() {
+        // The configuration this feature exists for, in the row shape
+        // real hardware produces: an APU and a dGPU, each enumerating a
+        // base row plus a display-output row. Before grouping keyed on
+        // the base path, both groups were dropped as conflicting and
+        // this returned `Decline`, which made the whole feature inert.
+        let apu_second = format!("{APU_PNP}&02");
+        let dgpu_second = format!("{DGPU_PNP}&02");
+        let adapters = vec![
+            adapter(0, (4, 0, 0), APU_PNP),
+            adapter(1, (4, 0, 0), &apu_second),
+            adapter(2, (8, 0, 0), DGPU_PNP),
+            adapter(3, (8, 0, 0), &dgpu_second),
+        ];
+        assert_eq!(
+            plan_attribution(&[DGPU_PNP, APU_PNP], Some(&adapters)),
+            AttributionPlan::PerCard(vec![
+                CardMatch {
+                    gpu_index: 0,
+                    adl_indices: vec![2, 3],
+                },
+                CardMatch {
+                    gpu_index: 1,
+                    adl_indices: vec![0, 1],
+                },
+            ])
+        );
     }
 
     #[test]

--- a/src/device/readers/amd_adl/adapters.rs
+++ b/src/device/readers/amd_adl/adapters.rs
@@ -146,38 +146,71 @@ fn plausible_bdf(adapter: &AdlAdapter) -> bool {
 /// Groups are sorted by bus/device/function and their indices sorted
 /// ascending, so the output is deterministic regardless of the order
 /// the driver enumerated in.
+///
+/// A group whose rows carry two different non-empty PNP instance paths
+/// is dropped rather than returned. Grouping trusts the PCI
+/// bus/device/function to identify a physical card, so a driver that
+/// leaves those fields unfilled collapses every card into one group.
+/// The caller then samples telemetry from the first index of the group
+/// that answers PMLog, which can be a different physical card's index,
+/// and one card's temperature, power, and fan would be reported for
+/// another GPU with nothing in the output saying so. Two different
+/// instance paths under one PCI address is the observable signature of
+/// that state, and dropping the group is the same answer the rest of
+/// this module gives everywhere else: decline rather than guess. Rows
+/// of one real card share their instance path; a secondary
+/// display-output row may leave it blank, which is backfilled and is
+/// not a conflict, and case differences are not a conflict either,
+/// since WMI and ADL do not agree on case.
 pub fn group_by_card(adapters: &[AdlAdapter]) -> Vec<CardGroup> {
     let mut groups: Vec<CardGroup> = Vec::new();
+    // Parallel to `groups`: whether the group saw contradictory PNP
+    // strings and therefore cannot be trusted to be one card.
+    let mut conflicting: Vec<bool> = Vec::new();
     for adapter in adapters {
         if !plausible_bdf(adapter) {
             continue;
         }
-        match groups.iter_mut().find(|group| {
+        let existing = groups.iter().position(|group| {
             group.bus == adapter.bus
                 && group.device == adapter.device
                 && group.function == adapter.function
-        }) {
-            Some(group) => {
+        });
+        match existing {
+            Some(position) => {
+                let group = &mut groups[position];
                 group.indices.push(adapter.index);
                 // Prefer any row that actually carries the string; a
                 // secondary display-output row can leave one blank.
-                if group.pnp_string.is_empty() && !adapter.pnp_string.is_empty() {
-                    group.pnp_string = adapter.pnp_string.clone();
+                if !adapter.pnp_string.is_empty() {
+                    if group.pnp_string.is_empty() {
+                        group.pnp_string = adapter.pnp_string.clone();
+                    } else if !group.pnp_string.eq_ignore_ascii_case(&adapter.pnp_string) {
+                        conflicting[position] = true;
+                    }
                 }
                 if group.adapter_name.is_empty() && !adapter.adapter_name.is_empty() {
                     group.adapter_name = adapter.adapter_name.clone();
                 }
             }
-            None => groups.push(CardGroup {
-                bus: adapter.bus,
-                device: adapter.device,
-                function: adapter.function,
-                adapter_name: adapter.adapter_name.clone(),
-                pnp_string: adapter.pnp_string.clone(),
-                indices: vec![adapter.index],
-            }),
+            None => {
+                groups.push(CardGroup {
+                    bus: adapter.bus,
+                    device: adapter.device,
+                    function: adapter.function,
+                    adapter_name: adapter.adapter_name.clone(),
+                    pnp_string: adapter.pnp_string.clone(),
+                    indices: vec![adapter.index],
+                });
+                conflicting.push(false);
+            }
         }
     }
+    let mut groups: Vec<CardGroup> = groups
+        .into_iter()
+        .zip(conflicting)
+        .filter_map(|(group, conflicted)| (!conflicted).then_some(group))
+        .collect();
     for group in &mut groups {
         group.indices.sort_unstable();
         group.indices.dedup();
@@ -397,6 +430,43 @@ mod tests {
         let groups = group_by_card(&adapters);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].pnp_string, DGPU_PNP);
+    }
+
+    #[test]
+    fn a_bdf_group_with_contradictory_pnp_strings_is_dropped_rather_than_merged() {
+        // A driver that leaves bus/device/function unfilled puts two
+        // physical cards under one PCI address. Merging them yields a
+        // card whose index list spans both, and the caller samples the
+        // first index that answers, so one card's telemetry would be
+        // reported for the other GPU with nothing in the output saying
+        // so. Two different instance paths under one address is the
+        // signature of that state.
+        let adapters = vec![
+            adapter(0, (0, 0, 0), APU_PNP),
+            adapter(1, (0, 0, 0), DGPU_PNP),
+        ];
+        assert!(group_by_card(&adapters).is_empty());
+        // With no trustworthy group left, attribution declines rather
+        // than guessing.
+        assert_eq!(
+            plan_attribution(&[DGPU_PNP, APU_PNP], Some(&adapters)),
+            AttributionPlan::Decline
+        );
+    }
+
+    #[test]
+    fn a_case_differing_pnp_string_on_a_sibling_row_is_not_a_conflict() {
+        // WMI and ADL do not agree on case, and neither need two rows
+        // of one card; only a genuinely different instance path is a
+        // conflict.
+        let lowered = DGPU_PNP.to_lowercase();
+        let adapters = vec![
+            adapter(0, (3, 0, 0), DGPU_PNP),
+            adapter(1, (3, 0, 0), &lowered),
+        ];
+        let groups = group_by_card(&adapters);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].indices, vec![0, 1]);
     }
 
     #[test]

--- a/src/device/readers/amd_adl/adapters.rs
+++ b/src/device/readers/amd_adl/adapters.rs
@@ -89,27 +89,62 @@ pub fn clamp_scan_count(count: i32) -> i32 {
     count.min(MAX_ADAPTER_ROWS)
 }
 
-/// Describe which direction a failed `AdapterInfo` layout verification
-/// points in, for the `amd.adl.adapters` doctor check.
+/// Describe which failure shape a rejected `AdapterInfo` table shows,
+/// for the `amd.adl.adapters` doctor check.
 ///
-/// The two failure modes call for opposite corrections. A blank row
-/// means ADL wrote fewer rows than `iInputSize` asked for, which is what
-/// a declared `AdapterInfo` larger than the driver's produces; legible
-/// bytes with an illegible string mean the opposite, a wrong field
-/// offset or stride.
+/// The failure shapes call for different corrections, so name the one
+/// that was seen, most specific first:
+///
+/// - **Garbled rows**: written bytes that contradict the layout, the
+///   unambiguous wrong-field-offset-or-stride error. A declared struct
+///   *larger* than the driver's lands here too: more rows fit
+///   `iInputSize` than the driver's own stride assumes, so the driver
+///   writes at a smaller stride and row 1 onward reads misaligned.
+/// - **Row 0 untouched**: the poison pre-fill is intact, the call
+///   wrote nothing at all.
+/// - **No populated rows**: the driver memset the buffer (or parts of
+///   it) but described no adapter.
+/// - **Duplicate adapter indices**: two populated rows claim the same
+///   `iAdapterIndex`, which no healthy enumeration produces and a
+///   stride mismatch does.
+///
+/// A trailing untouched run *with* a populated row 0, and blank rows in
+/// any position, are no longer failures (see
+/// `ffi::AdapterInfoArray::validated`); they do not reach this
+/// function through the verification path.
 pub fn describe_layout_failure(rows: &[ffi::AdapterInfo]) -> String {
-    let blank = rows.iter().filter(|row| row.is_blank()).count();
-    if blank > 0 {
-        format!(
-            "the driver left {blank} of {} row(s) untouched, which is what a declared \
-             AdapterInfo larger than the driver's produces",
-            rows.len()
-        )
-    } else {
-        "the rows were written but their string fields are not legible, which is what a \
-         wrong field offset or stride produces"
-            .to_string()
+    let states: Vec<ffi::RowState> = rows.iter().map(ffi::AdapterInfo::classify).collect();
+    let count = |wanted: ffi::RowState| states.iter().filter(|state| **state == wanted).count();
+    let garbled = count(ffi::RowState::Garbled);
+    let untouched = count(ffi::RowState::Untouched);
+    let populated = count(ffi::RowState::Populated);
+    let total = rows.len();
+
+    if garbled > 0 {
+        return format!(
+            "{garbled} of {total} row(s) hold written bytes that contradict the layout, \
+             which is what a wrong field offset or stride produces (a declared AdapterInfo \
+             larger than the driver's also lands here: the driver strides shorter and later \
+             rows read misaligned)"
+        );
     }
+    if states.first() == Some(&ffi::RowState::Untouched) {
+        return format!(
+            "row 0 still carries the poison pre-fill ({untouched} of {total} row(s) \
+             untouched): the call wrote nothing at all"
+        );
+    }
+    if populated == 0 {
+        return format!(
+            "the driver memset the buffer but populated none of the {total} row(s): no \
+             adapter was described"
+        );
+    }
+    // The remaining rejection: duplicate iAdapterIndex among the
+    // populated rows.
+    "the populated rows repeat an iAdapterIndex value, which no healthy enumeration \
+     produces and a stride mismatch does"
+        .to_string()
 }
 
 /// One ADL adapter row in owned, parsed form.
@@ -403,20 +438,39 @@ fn has_duplicate_assignment(assigned: &[Option<usize>]) -> bool {
 /// One diagnostic line for a raw adapter row, valid or not.
 ///
 /// Used by the `amd.adl.adapters` doctor check, whose whole purpose is
-/// field verification of the transcribed layout: the strings are
-/// rendered lossily and quoted so that garbage bytes, the signature of
-/// a wrong layout, survive into the report instead of being hidden.
+/// field verification of the transcribed layout. Each line names the
+/// row's [`ffi::RowState`], which is the distinction the poison
+/// pre-fill exists to make visible: a real-hardware dump then says
+/// decisively whether a non-populated row was memset by the driver
+/// (normal `iPresent`-style filtering) or never written at all (a
+/// short write). Populated and garbled rows render their fields, the
+/// strings lossily and quoted so that garbage bytes, the signature of
+/// a wrong layout, survive into the report instead of being hidden;
+/// blank and untouched rows have no field content worth printing, so
+/// they render as their state alone.
 pub fn describe_raw_entry(slot: usize, entry: &ffi::AdapterInfo) -> String {
-    format!(
-        "[{slot}] index={} bus={} device={} function={} vendor={} name={:?} pnp={:?}",
-        entry.i_adapter_index,
-        entry.i_bus_number,
-        entry.i_device_number,
-        entry.i_function_number,
-        entry.i_vendor_id,
-        ffi::adl_string_lossy(&entry.str_adapter_name),
-        ffi::adl_string_lossy(&entry.str_pnp_string),
-    )
+    match entry.classify() {
+        ffi::RowState::Untouched => {
+            format!("[{slot}] UNTOUCHED (poison intact, driver never wrote)")
+        }
+        ffi::RowState::Blank => format!("[{slot}] BLANK (driver memset, not populated)"),
+        state => {
+            let tag = match state {
+                ffi::RowState::Garbled => "GARBLED ",
+                _ => "",
+            };
+            format!(
+                "[{slot}] {tag}index={} bus={} device={} function={} vendor={} name={:?} pnp={:?}",
+                entry.i_adapter_index,
+                entry.i_bus_number,
+                entry.i_device_number,
+                entry.i_function_number,
+                entry.i_vendor_id,
+                ffi::adl_string_lossy(&entry.str_adapter_name),
+                ffi::adl_string_lossy(&entry.str_pnp_string),
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -758,9 +812,8 @@ mod tests {
         assert_eq!(clamp_scan_count(10_000), MAX_ADAPTER_ROWS);
     }
 
-    /// A non-blank `AdapterInfo` row: enough for `describe_layout_failure`
-    /// to see it as written, regardless of whether it would also pass
-    /// `looks_sane`.
+    /// A populated `AdapterInfo` row: written and passing `looks_sane`,
+    /// which is what `classify` requires for `RowState::Populated`.
     fn written_row(index: i32) -> ffi::AdapterInfo {
         let mut entry = ffi::AdapterInfo {
             i_adapter_index: index,
@@ -771,24 +824,49 @@ mod tests {
         entry
     }
 
-    #[test]
-    fn layout_failure_names_a_short_write_when_rows_are_blank() {
-        let rows = vec![
-            written_row(0),
-            ffi::AdapterInfo::default(),
-            ffi::AdapterInfo::default(),
-        ];
-        let shape = describe_layout_failure(&rows);
-        assert!(shape.contains("2 of 3"), "{shape}");
-        assert!(shape.contains("untouched"), "{shape}");
+    /// A garbled row: written bytes whose strings cannot be parsed.
+    fn garbled_row(index: i32) -> ffi::AdapterInfo {
+        let mut entry = written_row(index);
+        entry.str_pnp_string = [0xFF; ffi::ADL_MAX_PATH];
+        entry
     }
 
     #[test]
-    fn layout_failure_names_garbled_strings_when_no_row_is_blank() {
-        let rows = vec![written_row(0), written_row(1)];
+    fn layout_failure_names_garbled_rows_first() {
+        // Garbled bytes are the unambiguous layout error, so they win
+        // over any other shape present in the same table.
+        let rows = vec![written_row(0), garbled_row(1), ffi::AdapterInfo::poisoned()];
         let shape = describe_layout_failure(&rows);
-        assert!(!shape.contains("untouched"), "{shape}");
-        assert!(shape.contains("not legible"), "{shape}");
+        assert!(shape.contains("1 of 3"), "{shape}");
+        assert!(shape.contains("contradict the layout"), "{shape}");
+        assert!(shape.contains("stride"), "{shape}");
+    }
+
+    #[test]
+    fn layout_failure_names_a_dead_call_when_row_zero_is_untouched() {
+        let rows = vec![ffi::AdapterInfo::poisoned(), ffi::AdapterInfo::poisoned()];
+        let shape = describe_layout_failure(&rows);
+        assert!(shape.contains("poison"), "{shape}");
+        assert!(shape.contains("2 of 2"), "{shape}");
+        assert!(shape.contains("wrote nothing at all"), "{shape}");
+    }
+
+    #[test]
+    fn layout_failure_names_an_empty_memset_when_nothing_was_populated() {
+        let rows = vec![ffi::AdapterInfo::default(), ffi::AdapterInfo::default()];
+        let shape = describe_layout_failure(&rows);
+        assert!(shape.contains("memset"), "{shape}");
+        assert!(shape.contains("no adapter was described"), "{shape}");
+    }
+
+    #[test]
+    fn layout_failure_names_duplicate_indices_as_the_remaining_shape() {
+        // Two populated rows with the same iAdapterIndex: the only
+        // rejection left once nothing is garbled, row 0 is populated,
+        // and something was populated.
+        let rows = vec![written_row(0), written_row(0)];
+        let shape = describe_layout_failure(&rows);
+        assert!(shape.contains("repeat an iAdapterIndex"), "{shape}");
     }
 
     #[test]
@@ -804,9 +882,30 @@ mod tests {
         entry.str_adapter_name[..4].copy_from_slice(b"card");
         entry.str_pnp_string[..3].copy_from_slice(b"PCI");
         let line = describe_raw_entry(0, &entry);
+        // A populated row keeps the plain field format, untagged.
         assert_eq!(
             line,
             "[0] index=2 bus=8 device=0 function=0 vendor=1002 name=\"card\" pnp=\"PCI\""
         );
+    }
+
+    #[test]
+    fn raw_rows_carry_their_state_so_the_dump_is_decisive() {
+        // The poison fill exists so the eventual real-hardware dump can
+        // settle whether a non-populated row was memset by the driver
+        // or never written; the per-row tag is where that distinction
+        // becomes visible to the operator.
+        assert_eq!(
+            describe_raw_entry(1, &ffi::AdapterInfo::default()),
+            "[1] BLANK (driver memset, not populated)"
+        );
+        assert_eq!(
+            describe_raw_entry(2, &ffi::AdapterInfo::poisoned()),
+            "[2] UNTOUCHED (poison intact, driver never wrote)"
+        );
+        let line = describe_raw_entry(3, &garbled_row(7));
+        assert!(line.starts_with("[3] GARBLED index=7"), "{line}");
+        // The garbage bytes survive, lossily, as evidence.
+        assert!(line.contains("pnp="), "{line}");
     }
 }

--- a/src/device/readers/amd_adl/adapters.rs
+++ b/src/device/readers/amd_adl/adapters.rs
@@ -1,0 +1,628 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Adapter grouping and GPU matching for the ADL reader.
+//!
+//! Everything here is platform-independent on purpose, the same split
+//! `windows_gpu_perf::ids` uses: the FFI call that fills in
+//! [`ffi::AdapterInfo`] lives in [`super::loader`] behind
+//! `cfg(target_os = "windows")`, but the logic that turns those rows
+//! into an attribution decision compiles and is tested on the Linux
+//! runner, the only runner this repository has.
+//!
+//! ## Grouping
+//!
+//! One physical card exposes several ADL adapter indices, one per
+//! display output, all reporting identical telemetry. The rows are
+//! therefore grouped by PCI bus/device/function into one
+//! [`CardGroup`] per card before any matching happens.
+//!
+//! ## Matching, strongest first
+//!
+//! 1. **Exact PNP instance path.** ADL's `strPNPString` is the same
+//!    Windows `PNPDeviceID` that `amd_windows` stores as the GPU uuid,
+//!    so the join is exact and distinguishes two identical cards.
+//! 2. **PCI vendor and device**, parsed from both sides with
+//!    `windows_gpu_perf::ids::parse_pnp_device_id`. Used only when the
+//!    pair is unambiguous on *both* sides: exactly one unmatched GPU
+//!    and exactly one unclaimed card carry that identity. Requiring
+//!    the full vendor+device pair honours the `match_adapter` rule
+//!    from the #346 review that anything weaker than PCI identity must
+//!    be vendor-constrained, and giving up on ambiguity honours its
+//!    conclusion that declining to attribute beats attributing
+//!    wrongly.
+//!
+//! There is deliberately no ordinal or name fallback here: unlike the
+//! DXGI matching this feeds temperature and power, where a swap
+//! between two cards is silent and misleading.
+
+use std::collections::HashSet;
+
+use super::ffi;
+use crate::device::readers::windows_gpu_perf::ids::{PciIds, parse_pnp_device_id};
+
+/// One ADL adapter row in owned, parsed form.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdlAdapter {
+    /// The ADL adapter index, the handle sensor queries take.
+    pub index: i32,
+    pub bus: i32,
+    pub device: i32,
+    pub function: i32,
+    pub adapter_name: String,
+    /// Windows PNP device instance path; empty when the driver left it
+    /// blank.
+    pub pnp_string: String,
+}
+
+/// One physical card: every ADL index that resolves to the same PCI
+/// bus/device/function.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CardGroup {
+    pub bus: i32,
+    pub device: i32,
+    pub function: i32,
+    pub adapter_name: String,
+    pub pnp_string: String,
+    /// Sorted, deduplicated ADL indices. All report the same
+    /// telemetry, so a caller tries them in order until one answers.
+    pub indices: Vec<i32>,
+}
+
+/// A GPU that matched a card exactly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CardMatch {
+    /// Position in the caller's GPU slice.
+    pub gpu_index: usize,
+    /// The matched card's ADL indices, in the order to try them.
+    pub adl_indices: Vec<i32>,
+}
+
+/// The attribution decision for one poll.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AttributionPlan {
+    /// Exactly one AMD GPU: attribute the process-wide sample to it
+    /// without consulting `AdapterInfo` at all. This arm is what keeps
+    /// the single-GPU behavior identical to before #353, including
+    /// when `AdapterInfo` is unavailable or fails verification.
+    SoleGpu,
+    /// Two or more AMD GPUs with at least one exact card match. GPUs
+    /// absent from the list keep their DXGI/PDH baseline.
+    PerCard(Vec<CardMatch>),
+    /// Nothing can be attributed: no GPUs, no validated adapter rows,
+    /// or no unambiguous match. The honest baseline stands.
+    Decline,
+}
+
+/// Parse validated `AdapterInfo` rows into owned adapters.
+///
+/// Rows are expected to have passed
+/// [`ffi::AdapterInfoArray::validated`] already; a string that still
+/// fails to parse becomes empty rather than aborting, since an empty
+/// string simply cannot match anything downstream.
+pub fn parse_adapters(entries: &[ffi::AdapterInfo]) -> Vec<AdlAdapter> {
+    entries
+        .iter()
+        .map(|entry| AdlAdapter {
+            index: entry.i_adapter_index,
+            bus: entry.i_bus_number,
+            device: entry.i_device_number,
+            function: entry.i_function_number,
+            adapter_name: ffi::adl_string(&entry.str_adapter_name)
+                .unwrap_or_default()
+                .to_string(),
+            pnp_string: ffi::adl_string(&entry.str_pnp_string)
+                .unwrap_or_default()
+                .to_string(),
+        })
+        .collect()
+}
+
+/// Whether a row's bus/device/function is a plausible PCI address.
+///
+/// This is the data-quality counterpart of the layout check in
+/// `AdapterInfo::looks_sane`: a row with an implausible address is
+/// excluded from grouping (it cannot be attributed to), but it does
+/// not disable attribution for the machine's other, plausible rows.
+fn plausible_bdf(adapter: &AdlAdapter) -> bool {
+    (0..=255).contains(&adapter.bus)
+        && (0..=31).contains(&adapter.device)
+        && (0..=7).contains(&adapter.function)
+}
+
+/// Group adapter rows into one [`CardGroup`] per physical card.
+///
+/// Groups are sorted by bus/device/function and their indices sorted
+/// ascending, so the output is deterministic regardless of the order
+/// the driver enumerated in.
+pub fn group_by_card(adapters: &[AdlAdapter]) -> Vec<CardGroup> {
+    let mut groups: Vec<CardGroup> = Vec::new();
+    for adapter in adapters {
+        if !plausible_bdf(adapter) {
+            continue;
+        }
+        match groups.iter_mut().find(|group| {
+            group.bus == adapter.bus
+                && group.device == adapter.device
+                && group.function == adapter.function
+        }) {
+            Some(group) => {
+                group.indices.push(adapter.index);
+                // Prefer any row that actually carries the string; a
+                // secondary display-output row can leave one blank.
+                if group.pnp_string.is_empty() && !adapter.pnp_string.is_empty() {
+                    group.pnp_string = adapter.pnp_string.clone();
+                }
+                if group.adapter_name.is_empty() && !adapter.adapter_name.is_empty() {
+                    group.adapter_name = adapter.adapter_name.clone();
+                }
+            }
+            None => groups.push(CardGroup {
+                bus: adapter.bus,
+                device: adapter.device,
+                function: adapter.function,
+                adapter_name: adapter.adapter_name.clone(),
+                pnp_string: adapter.pnp_string.clone(),
+                indices: vec![adapter.index],
+            }),
+        }
+    }
+    for group in &mut groups {
+        group.indices.sort_unstable();
+        group.indices.dedup();
+    }
+    groups.sort_by_key(|group| (group.bus, group.device, group.function));
+    groups
+}
+
+/// Decide what, if anything, ADL readouts may be attributed to.
+///
+/// `gpu_uuids` are the reader's GPU uuids in slice order, which
+/// `amd_windows` populates from the WMI `PNPDeviceID` (or a synthetic
+/// `AMD-GPU-{n}` that matches nothing, which is the correct outcome
+/// for it). `adapters` is the validated adapter inventory, or `None`
+/// when it is unavailable or failed layout verification.
+///
+/// Every returned `gpu_index` is a valid index into `gpu_uuids`, each
+/// GPU appears at most once, and no two GPUs share a card. Any state
+/// that would violate that (duplicate identities on either side)
+/// declines outright.
+pub fn plan_attribution(gpu_uuids: &[&str], adapters: Option<&[AdlAdapter]>) -> AttributionPlan {
+    match gpu_uuids.len() {
+        0 => return AttributionPlan::Decline,
+        1 => return AttributionPlan::SoleGpu,
+        _ => {}
+    }
+    let Some(adapters) = adapters else {
+        return AttributionPlan::Decline;
+    };
+    let groups = group_by_card(adapters);
+    if groups.is_empty() {
+        return AttributionPlan::Decline;
+    }
+
+    // gpu position -> group position.
+    let mut assigned: Vec<Option<usize>> = vec![None; gpu_uuids.len()];
+
+    // Phase 1: exact PNP instance path, case-insensitive (WMI and ADL
+    // do not guarantee matching case). A uuid matching several groups
+    // is treated as no match; duplicate PNP strings across cards mean
+    // the identity cannot be trusted.
+    for (gpu_index, uuid) in gpu_uuids.iter().enumerate() {
+        if uuid.is_empty() {
+            continue;
+        }
+        let hits: Vec<usize> = groups
+            .iter()
+            .enumerate()
+            .filter(|(_, group)| {
+                !group.pnp_string.is_empty() && group.pnp_string.eq_ignore_ascii_case(uuid)
+            })
+            .map(|(position, _)| position)
+            .collect();
+        if hits.len() == 1 {
+            assigned[gpu_index] = Some(hits[0]);
+        }
+    }
+    if has_duplicate_assignment(&assigned) {
+        // Two GPUs resolved to one card: duplicate uuids in WMI or
+        // duplicate PNP strings in ADL. Nothing derived from that
+        // state is trustworthy.
+        return AttributionPlan::Decline;
+    }
+
+    // Phase 2: PCI vendor+device, for GPUs the exact join missed.
+    // Both the peer set (unmatched GPUs) and the candidate set
+    // (unclaimed groups) are snapshotted before the loop so the
+    // uniqueness tests are order-independent.
+    let claimed: HashSet<usize> = assigned.iter().flatten().copied().collect();
+    let gpu_ids: Vec<Option<PciIds>> = gpu_uuids
+        .iter()
+        .map(|uuid| parse_pnp_device_id(uuid))
+        .collect();
+    let group_ids: Vec<Option<PciIds>> = groups
+        .iter()
+        .map(|group| parse_pnp_device_id(&group.pnp_string))
+        .collect();
+    let unmatched: Vec<usize> = (0..gpu_uuids.len())
+        .filter(|&gpu_index| assigned[gpu_index].is_none())
+        .collect();
+    for &gpu_index in &unmatched {
+        let Some(ids) = gpu_ids[gpu_index] else {
+            continue;
+        };
+        // Two unmatched identical cards cannot be told apart at this
+        // strength; guessing between them is exactly what this module
+        // must never do.
+        let peers = unmatched
+            .iter()
+            .filter(|&&other| gpu_ids[other] == Some(ids))
+            .count();
+        if peers != 1 {
+            continue;
+        }
+        let candidates: Vec<usize> = (0..groups.len())
+            .filter(|position| !claimed.contains(position))
+            .filter(|&position| group_ids[position] == Some(ids))
+            .collect();
+        if candidates.len() == 1 {
+            assigned[gpu_index] = Some(candidates[0]);
+        }
+    }
+    if has_duplicate_assignment(&assigned) {
+        return AttributionPlan::Decline;
+    }
+
+    let matches: Vec<CardMatch> = assigned
+        .iter()
+        .enumerate()
+        .filter_map(|(gpu_index, group)| {
+            group.map(|position| CardMatch {
+                gpu_index,
+                adl_indices: groups[position].indices.clone(),
+            })
+        })
+        .collect();
+    if matches.is_empty() {
+        AttributionPlan::Decline
+    } else {
+        AttributionPlan::PerCard(matches)
+    }
+}
+
+fn has_duplicate_assignment(assigned: &[Option<usize>]) -> bool {
+    let taken: Vec<usize> = assigned.iter().flatten().copied().collect();
+    let unique: HashSet<usize> = taken.iter().copied().collect();
+    taken.len() != unique.len()
+}
+
+/// One diagnostic line for a raw adapter row, valid or not.
+///
+/// Used by the `amd.adl.adapters` doctor check, whose whole purpose is
+/// field verification of the transcribed layout: the strings are
+/// rendered lossily and quoted so that garbage bytes, the signature of
+/// a wrong layout, survive into the report instead of being hidden.
+pub fn describe_raw_entry(slot: usize, entry: &ffi::AdapterInfo) -> String {
+    format!(
+        "[{slot}] index={} bus={} device={} function={} vendor={} name={:?} pnp={:?}",
+        entry.i_adapter_index,
+        entry.i_bus_number,
+        entry.i_device_number,
+        entry.i_function_number,
+        entry.i_vendor_id,
+        ffi::adl_string_lossy(&entry.str_adapter_name),
+        ffi::adl_string_lossy(&entry.str_pnp_string),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn adapter(index: i32, bdf: (i32, i32, i32), pnp: &str) -> AdlAdapter {
+        AdlAdapter {
+            index,
+            bus: bdf.0,
+            device: bdf.1,
+            function: bdf.2,
+            adapter_name: "AMD Radeon RX 7900 XTX".to_string(),
+            pnp_string: pnp.to_string(),
+        }
+    }
+
+    const DGPU_PNP: &str = r"PCI\VEN_1002&DEV_744C&SUBSYS_0E3A1002&REV_C8\6&2C6B35A1&0&00000019";
+    const APU_PNP: &str = r"PCI\VEN_1002&DEV_164E&SUBSYS_00000000&REV_C1\4&2FD5AB1F&0&0041";
+
+    #[test]
+    fn several_indices_for_one_card_collapse_to_one_group() {
+        // One card, three display outputs, enumerated out of order.
+        let adapters = vec![
+            adapter(2, (3, 0, 0), DGPU_PNP),
+            adapter(0, (3, 0, 0), DGPU_PNP),
+            adapter(1, (3, 0, 0), DGPU_PNP),
+        ];
+        let groups = group_by_card(&adapters);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].indices, vec![0, 1, 2]);
+        assert_eq!(groups[0].pnp_string, DGPU_PNP);
+    }
+
+    #[test]
+    fn two_cards_stay_two_groups_and_order_is_deterministic() {
+        let adapters = vec![
+            adapter(3, (8, 0, 0), DGPU_PNP),
+            adapter(0, (4, 0, 0), APU_PNP),
+            adapter(4, (8, 0, 0), DGPU_PNP),
+            adapter(1, (4, 0, 0), APU_PNP),
+        ];
+        let groups = group_by_card(&adapters);
+        assert_eq!(groups.len(), 2);
+        // Sorted by BDF regardless of enumeration order.
+        assert_eq!((groups[0].bus, groups[0].indices.clone()), (4, vec![0, 1]));
+        assert_eq!((groups[1].bus, groups[1].indices.clone()), (8, vec![3, 4]));
+    }
+
+    #[test]
+    fn an_implausible_bdf_row_is_excluded_without_poisoning_the_rest() {
+        let adapters = vec![
+            adapter(0, (3, 0, 0), DGPU_PNP),
+            // Garbage BDF: not a PCI address anything could match.
+            adapter(1, (-1, 900, 3), APU_PNP),
+        ];
+        let groups = group_by_card(&adapters);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].bus, 3);
+    }
+
+    #[test]
+    fn a_blank_pnp_on_a_secondary_output_is_backfilled_from_a_sibling() {
+        let adapters = vec![
+            AdlAdapter {
+                pnp_string: String::new(),
+                ..adapter(0, (3, 0, 0), "")
+            },
+            adapter(1, (3, 0, 0), DGPU_PNP),
+        ];
+        let groups = group_by_card(&adapters);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].pnp_string, DGPU_PNP);
+    }
+
+    #[test]
+    fn a_single_gpu_attributes_without_adapterinfo_exactly_as_before() {
+        // The regression pin for pre-#353 behavior: one AMD GPU is
+        // SoleGpu no matter what the adapter inventory says, including
+        // when it is absent (old driver, failed layout verification).
+        assert_eq!(
+            plan_attribution(&["anything"], None),
+            AttributionPlan::SoleGpu
+        );
+        let adapters = vec![adapter(0, (3, 0, 0), DGPU_PNP)];
+        assert_eq!(
+            plan_attribution(&[DGPU_PNP], Some(&adapters)),
+            AttributionPlan::SoleGpu
+        );
+        assert_eq!(
+            plan_attribution(&["AMD-GPU-0"], Some(&adapters)),
+            AttributionPlan::SoleGpu
+        );
+    }
+
+    #[test]
+    fn zero_gpus_and_missing_or_invalid_inventory_decline() {
+        assert_eq!(plan_attribution(&[], None), AttributionPlan::Decline);
+        // Two GPUs but no validated inventory: the exact situation a
+        // failed layout verification produces. Must fall back to the
+        // baseline, not guess.
+        assert_eq!(
+            plan_attribution(&[DGPU_PNP, APU_PNP], None),
+            AttributionPlan::Decline
+        );
+        // An inventory whose every row was implausible is as good as
+        // no inventory.
+        let garbage = vec![adapter(0, (-1, 900, 3), DGPU_PNP)];
+        assert_eq!(
+            plan_attribution(&[DGPU_PNP, APU_PNP], Some(&garbage)),
+            AttributionPlan::Decline
+        );
+    }
+
+    #[test]
+    fn the_apu_plus_dgpu_laptop_matches_both_cards_exactly() {
+        // The issue's motivating configuration: a Ryzen APU and a
+        // Radeon dGPU, each with several display-output rows.
+        let adapters = vec![
+            adapter(0, (4, 0, 0), APU_PNP),
+            adapter(1, (4, 0, 0), APU_PNP),
+            adapter(2, (8, 0, 0), DGPU_PNP),
+            adapter(3, (8, 0, 0), DGPU_PNP),
+        ];
+        // GPU order deliberately disagrees with adapter order, and the
+        // uuid case differs: the join must be exact and case-blind.
+        let uuids = [DGPU_PNP.to_lowercase(), APU_PNP.to_string()];
+        let uuid_refs: Vec<&str> = uuids.iter().map(String::as_str).collect();
+        let plan = plan_attribution(&uuid_refs, Some(&adapters));
+        assert_eq!(
+            plan,
+            AttributionPlan::PerCard(vec![
+                CardMatch {
+                    gpu_index: 0,
+                    adl_indices: vec![2, 3],
+                },
+                CardMatch {
+                    gpu_index: 1,
+                    adl_indices: vec![0, 1],
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn a_gpu_the_inventory_does_not_know_keeps_its_baseline() {
+        let adapters = vec![adapter(0, (8, 0, 0), DGPU_PNP)];
+        let plan = plan_attribution(&[DGPU_PNP, "AMD-GPU-1"], Some(&adapters));
+        // Partial attribution: the matched card is augmented, the
+        // unknown one is simply left alone.
+        assert_eq!(
+            plan,
+            AttributionPlan::PerCard(vec![CardMatch {
+                gpu_index: 0,
+                adl_indices: vec![0],
+            }])
+        );
+    }
+
+    #[test]
+    fn a_card_matched_only_by_pci_ids_still_matches_when_unambiguous() {
+        // The PNP strings disagree (a driver rendering the instance
+        // suffix differently), but each vendor+device pair is unique
+        // on both sides, so the fallback may pair them.
+        let adapters = vec![
+            adapter(0, (4, 0, 0), r"PCI\VEN_1002&DEV_164E&SUBSYS_0&REV_C1\OTHER"),
+            adapter(1, (8, 0, 0), r"PCI\VEN_1002&DEV_744C&SUBSYS_0&REV_C8\OTHER"),
+        ];
+        let plan = plan_attribution(&[DGPU_PNP, APU_PNP], Some(&adapters));
+        assert_eq!(
+            plan,
+            AttributionPlan::PerCard(vec![
+                CardMatch {
+                    gpu_index: 0,
+                    adl_indices: vec![1],
+                },
+                CardMatch {
+                    gpu_index: 1,
+                    adl_indices: vec![0],
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn two_identical_cards_with_mismatched_pnp_strings_decline() {
+        // Same vendor+device twice on both sides, and the exact join
+        // failed: there is no way to know which is which. Declining is
+        // required; ordinal guessing here would silently swap the two
+        // cards' temperatures.
+        let uuid_a = r"PCI\VEN_1002&DEV_744C&SUBSYS_0\6&AAAA&0&19";
+        let uuid_b = r"PCI\VEN_1002&DEV_744C&SUBSYS_0\6&BBBB&0&19";
+        let adapters = vec![
+            adapter(0, (3, 0, 0), r"PCI\VEN_1002&DEV_744C&SUBSYS_0\6&CCCC&0&19"),
+            adapter(1, (8, 0, 0), r"PCI\VEN_1002&DEV_744C&SUBSYS_0\6&DDDD&0&19"),
+        ];
+        assert_eq!(
+            plan_attribution(&[uuid_a, uuid_b], Some(&adapters)),
+            AttributionPlan::Decline
+        );
+    }
+
+    #[test]
+    fn the_fallback_never_pairs_across_vendors_or_devices() {
+        // A vendor id that disagrees (an Intel iGPU uuid arriving in
+        // an AMD reader through some future refactoring accident) must
+        // find nothing, per the match_adapter rule.
+        let intel_uuid = r"PCI\VEN_8086&DEV_56A0&SUBSYS_0\3&11583659&0&10";
+        let adapters = vec![
+            adapter(0, (4, 0, 0), APU_PNP),
+            adapter(1, (8, 0, 0), DGPU_PNP),
+        ];
+        let plan = plan_attribution(&[intel_uuid, DGPU_PNP], Some(&adapters));
+        // The AMD dGPU still matches exactly; the foreign uuid matches
+        // nothing rather than being ordinal-guessed onto the APU.
+        assert_eq!(
+            plan,
+            AttributionPlan::PerCard(vec![CardMatch {
+                gpu_index: 1,
+                adl_indices: vec![1],
+            }])
+        );
+    }
+
+    #[test]
+    fn duplicate_identities_on_either_side_decline_entirely() {
+        // Two GPUs with the same uuid resolving to one card is a
+        // corrupt-identity state; attributing either would be a guess.
+        let adapters = vec![adapter(0, (8, 0, 0), DGPU_PNP)];
+        assert_eq!(
+            plan_attribution(&[DGPU_PNP, DGPU_PNP], Some(&adapters)),
+            AttributionPlan::Decline
+        );
+    }
+
+    #[test]
+    fn synthetic_uuids_match_nothing() {
+        // `amd_windows` synthesizes `AMD-GPU-{n}` when WMI has no
+        // PNPDeviceID; those carry no identity and must never match.
+        let adapters = vec![
+            adapter(0, (4, 0, 0), APU_PNP),
+            adapter(1, (8, 0, 0), DGPU_PNP),
+        ];
+        assert_eq!(
+            plan_attribution(&["AMD-GPU-0", "AMD-GPU-1"], Some(&adapters)),
+            AttributionPlan::Decline
+        );
+    }
+
+    #[test]
+    fn ffi_rows_round_trip_into_owned_adapters() {
+        let mut entry = ffi::AdapterInfo {
+            i_adapter_index: 3,
+            i_bus_number: 8,
+            i_device_number: 0,
+            i_function_number: 0,
+            i_vendor_id: 1002,
+            ..ffi::AdapterInfo::default()
+        };
+        entry.str_adapter_name[..22].copy_from_slice(b"AMD Radeon RX 7900 XTX");
+        entry.str_pnp_string[..DGPU_PNP.len()].copy_from_slice(DGPU_PNP.as_bytes());
+
+        let parsed = parse_adapters(&[entry]);
+        assert_eq!(
+            parsed,
+            vec![AdlAdapter {
+                index: 3,
+                bus: 8,
+                device: 0,
+                function: 0,
+                adapter_name: "AMD Radeon RX 7900 XTX".to_string(),
+                pnp_string: DGPU_PNP.to_string(),
+            }]
+        );
+
+        // A row whose string field is garbage (only reachable if a
+        // caller skips validation) degrades to an empty string, which
+        // matches nothing, rather than panicking or carrying garbage
+        // into the matcher.
+        entry.str_pnp_string = [0xFF; ffi::ADL_MAX_PATH];
+        assert_eq!(parse_adapters(&[entry])[0].pnp_string, "");
+    }
+
+    #[test]
+    fn raw_rows_render_with_quoted_strings_for_the_doctor() {
+        let mut entry = ffi::AdapterInfo {
+            i_adapter_index: 2,
+            i_bus_number: 8,
+            i_device_number: 0,
+            i_function_number: 0,
+            i_vendor_id: 1002,
+            ..ffi::AdapterInfo::default()
+        };
+        entry.str_adapter_name[..4].copy_from_slice(b"card");
+        entry.str_pnp_string[..3].copy_from_slice(b"PCI");
+        let line = describe_raw_entry(0, &entry);
+        assert_eq!(
+            line,
+            "[0] index=2 bus=8 device=0 function=0 vendor=1002 name=\"card\" pnp=\"PCI\""
+        );
+    }
+}

--- a/src/device/readers/amd_adl/adapters.rs
+++ b/src/device/readers/amd_adl/adapters.rs
@@ -52,6 +52,66 @@ use std::collections::HashSet;
 use super::ffi;
 use crate::device::readers::windows_gpu_perf::ids::{PciIds, parse_pnp_device_id};
 
+/// Upper bound on the adapter count accepted from the driver.
+///
+/// A real machine has a handful of ADL rows (one per display output per
+/// card; a four-card workstation with six outputs each is 24). The bound
+/// keeps a garbage count from demanding an absurd `AdapterInfo`
+/// allocation, and it keeps `ffi::AdapterInfoArray::input_size` far away
+/// from `c_int` overflow. Kept here, not in `loader`, so
+/// [`plausible_adapter_count`] and [`clamp_scan_count`] are testable on
+/// the Linux runner even though every caller lives behind
+/// `cfg(target_os = "windows")`.
+pub const MAX_ADAPTER_ROWS: i32 = 64;
+
+/// Whether a driver-reported adapter count is plausible enough to trust
+/// for identity-bearing `AdapterInfo` attribution.
+///
+/// Used by `loader::probe_adapter_info`: a count outside
+/// `1..=MAX_ADAPTER_ROWS` is treated as a failed call, which multi-GPU
+/// attribution then answers by declining rather than guessing at a
+/// buffer size for a count that does not look real.
+pub fn plausible_adapter_count(count: i32) -> bool {
+    (1..=MAX_ADAPTER_ROWS).contains(&count)
+}
+
+/// Clamp a driver-reported adapter count for the PMLog capability scan.
+///
+/// Unlike [`plausible_adapter_count`], an implausibly large count here is
+/// clamped rather than rejected outright. `loader::scan_for_capable_adapter`
+/// makes one `ADL2_Overdrive_Caps` call per index and may make one PMLog
+/// read per index, all while holding the process-wide runtime lock, so a
+/// garbage count would wedge the refresh loop rather than merely waste a
+/// little work; clamping instead of rejecting keeps a machine with an
+/// implausibly long adapter list working on its first rows, since the
+/// scan only needs *one* PMLog-capable index, not an exhaustive one.
+pub fn clamp_scan_count(count: i32) -> i32 {
+    count.min(MAX_ADAPTER_ROWS)
+}
+
+/// Describe which direction a failed `AdapterInfo` layout verification
+/// points in, for the `amd.adl.adapters` doctor check.
+///
+/// The two failure modes call for opposite corrections. A blank row
+/// means ADL wrote fewer rows than `iInputSize` asked for, which is what
+/// a declared `AdapterInfo` larger than the driver's produces; legible
+/// bytes with an illegible string mean the opposite, a wrong field
+/// offset or stride.
+pub fn describe_layout_failure(rows: &[ffi::AdapterInfo]) -> String {
+    let blank = rows.iter().filter(|row| row.is_blank()).count();
+    if blank > 0 {
+        format!(
+            "the driver left {blank} of {} row(s) untouched, which is what a declared \
+             AdapterInfo larger than the driver's produces",
+            rows.len()
+        )
+    } else {
+        "the rows were written but their string fields are not legible, which is what a \
+         wrong field offset or stride produces"
+            .to_string()
+    }
+}
+
 /// One ADL adapter row in owned, parsed form.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AdlAdapter {
@@ -675,6 +735,60 @@ mod tests {
         // into the matcher.
         entry.str_pnp_string = [0xFF; ffi::ADL_MAX_PATH];
         assert_eq!(parse_adapters(&[entry])[0].pnp_string, "");
+    }
+
+    #[test]
+    fn adapter_count_is_plausible_only_within_the_positive_bound() {
+        assert!(!plausible_adapter_count(0));
+        assert!(!plausible_adapter_count(-1));
+        assert!(plausible_adapter_count(1));
+        assert!(plausible_adapter_count(MAX_ADAPTER_ROWS));
+        assert!(!plausible_adapter_count(MAX_ADAPTER_ROWS + 1));
+    }
+
+    #[test]
+    fn scan_count_clamps_to_the_upper_bound_without_rejecting_it() {
+        // Below the bound: untouched.
+        assert_eq!(clamp_scan_count(3), 3);
+        // At the bound: untouched.
+        assert_eq!(clamp_scan_count(MAX_ADAPTER_ROWS), MAX_ADAPTER_ROWS);
+        // Above the bound: clamped, not rejected, unlike
+        // `plausible_adapter_count`.
+        assert_eq!(clamp_scan_count(MAX_ADAPTER_ROWS + 1), MAX_ADAPTER_ROWS);
+        assert_eq!(clamp_scan_count(10_000), MAX_ADAPTER_ROWS);
+    }
+
+    /// A non-blank `AdapterInfo` row: enough for `describe_layout_failure`
+    /// to see it as written, regardless of whether it would also pass
+    /// `looks_sane`.
+    fn written_row(index: i32) -> ffi::AdapterInfo {
+        let mut entry = ffi::AdapterInfo {
+            i_adapter_index: index,
+            i_bus_number: 3,
+            ..ffi::AdapterInfo::default()
+        };
+        entry.str_adapter_name[..4].copy_from_slice(b"card");
+        entry
+    }
+
+    #[test]
+    fn layout_failure_names_a_short_write_when_rows_are_blank() {
+        let rows = vec![
+            written_row(0),
+            ffi::AdapterInfo::default(),
+            ffi::AdapterInfo::default(),
+        ];
+        let shape = describe_layout_failure(&rows);
+        assert!(shape.contains("2 of 3"), "{shape}");
+        assert!(shape.contains("untouched"), "{shape}");
+    }
+
+    #[test]
+    fn layout_failure_names_garbled_strings_when_no_row_is_blank() {
+        let rows = vec![written_row(0), written_row(1)];
+        let shape = describe_layout_failure(&rows);
+        assert!(!shape.contains("untouched"), "{shape}");
+        assert!(shape.contains("not legible"), "{shape}");
     }
 
     #[test]

--- a/src/device/readers/amd_adl/ffi.rs
+++ b/src/device/readers/amd_adl/ffi.rs
@@ -24,17 +24,45 @@
 //! Every additional `#[repr(C)]` struct declared against a library we
 //! cannot compile against, cannot run, and have no CI coverage for is
 //! unverifiable risk: a layout mistake is memory corruption, not a
-//! compile error. So this module declares exactly one output struct plus
-//! scalar-only entry points.
+//! compile error. So this module declares exactly two output structs
+//! plus scalar-only entry points, and both structs carry a defence
+//! beyond the compile-time assertions.
 //!
-//! Notably absent is `AdapterInfo`, the 1568-byte struct that
-//! `ADL2_Adapter_AdapterInfo_Get` fills in. It carries the PCI bus /
-//! device / function numbers and the PNP string that would let an ADL
-//! adapter be matched to a specific card. Declaring it would be the
-//! single largest ABI liability in this file, and ADL sizes its write by
-//! its own `sizeof`, so getting it wrong overflows our buffer. The
-//! reader avoids needing it by only augmenting when the machine has
-//! exactly one AMD GPU; see the module docs in the parent.
+//! ## `AdapterInfo`, and why declaring it became acceptable
+//!
+//! Earlier revisions refused to declare [`AdapterInfo`], the struct that
+//! carries the PCI bus / device / function numbers and the PNP string
+//! tying an ADL adapter index to a physical card, on the grounds that
+//! ADL sizes its write by its own `sizeof` and a wrong layout overflows
+//! the buffer. That reasoning was half right. Unlike
+//! `ADL2_New_QueryPMLogData_Get`, which takes a bare pointer,
+//! `ADL2_Adapter_AdapterInfo_Get` takes the buffer size as its
+//! `iInputSize` parameter, so a correct input size, plus the same
+//! padded-buffer pattern proven on [`AdlPmLogDataBuffer`], reduces the
+//! failure mode from a buffer overflow to reading fields at wrong
+//! offsets: garbage, not corruption.
+//!
+//! And the struct is self-verifying against exactly that residual
+//! failure. Four of its fields are 256-byte NUL-terminated ASCII
+//! strings at known offsets; a correct layout reads them as legible
+//! device paths, a wrong one reads them as garbage.
+//! [`AdapterInfoArray::validated`] performs that check at runtime, per
+//! entry, so a wrong stride is caught on the second entry even when the
+//! first happens to parse. Whenever verification fails the reader
+//! declines multi-GPU attribution, leaving the DXGI and PDH baseline
+//! (the pre-#353 behavior, which a single-GPU machine keeps
+//! unconditionally), and the `amd.adl.adapters` doctor check dumps the
+//! same fields so the transcribed layout can be confirmed or refuted
+//! from real hardware.
+//!
+//! The declared layout is the **Windows** variant: `adl_structures.h`
+//! appends `iExist`, the two driver-path strings, `strPNPString`, and
+//! `iOSDisplayIndex` under `#if defined(_WIN32) || defined(_WIN64)`,
+//! and appends a different tail on Linux, so the struct is 1572 bytes
+//! here and a different size elsewhere. That is fine: the only caller
+//! sits behind `cfg(target_os = "windows")`, and the declaration stays
+//! unconditional so its assertions and tests run on the Linux runner,
+//! the only runner this repository has.
 //!
 //! ## Calling convention
 //!
@@ -50,10 +78,8 @@ use std::ffi::c_int;
 #[cfg(target_os = "windows")]
 use std::ffi::c_void;
 
-/// `ADL_MAX_PATH` from `adl_defines.h`. Not used by any struct declared
-/// here; kept as documentation of the value the omitted `AdapterInfo`
-/// layout depends on.
-#[allow(dead_code)]
+/// `ADL_MAX_PATH` from `adl_defines.h`: the length of every string
+/// field in [`AdapterInfo`].
 pub const ADL_MAX_PATH: usize = 256;
 
 /// `ADL_PMLOG_MAX_SENSORS` from `adl_structures.h`.
@@ -128,12 +154,12 @@ const _: () = assert!(
 
 /// A PMLog output buffer with trailing headroom.
 ///
-/// The module docs above refuse to declare `AdapterInfo` because ADL
-/// sizes its write by its own `sizeof` and a short buffer is a memory
-/// smash rather than an error. That reasoning applies to
-/// `ADLPMLogDataOutput` too: `ADL2_New_QueryPMLogData_Get` takes a bare
-/// pointer with no length, so if a future driver ships a larger
+/// `ADL2_New_QueryPMLogData_Get` takes a bare pointer with no length,
+/// so ADL sizes its write by its own `sizeof` and a short buffer is a
+/// memory smash rather than an error: if a future driver ships a larger
 /// `ADL_PMLOG_MAX_SENSORS` it would write past a tightly-sized buffer.
+/// (This is the risk the module docs describe for `AdapterInfo`, in its
+/// worse no-`iInputSize` form.)
 ///
 /// Raising `ADL_PMLOG_MAX_SENSORS` would break every existing consumer,
 /// so it is unlikely, but "unlikely" is not a reason to hand a driver an
@@ -180,6 +206,229 @@ const _: () = assert!(
     std::mem::size_of::<AdlPmLogDataBuffer>() > std::mem::size_of::<AdlPmLogDataOutput>(),
     "the headroom must actually extend the allocation"
 );
+
+/// `AdapterInfo` from `adl_structures.h`, **Windows layout**.
+///
+/// Transcribed field by field from AMD's public header. Everything is a
+/// 32-bit `int` or a `char[ADL_MAX_PATH]` array, so the natural
+/// alignment is 4 and there is no padding anywhere; the compile-time
+/// assertions below pin every load-bearing offset and the 1572-byte
+/// total. The header's `#if defined(_WIN32) || defined(_WIN64)` block
+/// contributes the last five fields; the Linux variant has a different
+/// tail and a different size, and is deliberately not declared because
+/// nothing outside `cfg(target_os = "windows")` ever calls the entry
+/// point that fills this in.
+///
+/// The string fields are declared `[u8; ADL_MAX_PATH]` rather than C's
+/// signed `char`: the two types have identical size and alignment, and
+/// `u8` is what the byte-level string handling in [`adl_string`] wants.
+///
+/// This transcription cannot be checked by any compiler or CI job (see
+/// the module docs), which is why nothing consumes an `AdapterInfo`
+/// without it first passing [`AdapterInfoArray::validated`].
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AdapterInfo {
+    /// Size of the structure. Some ADL revisions fill it in, some leave
+    /// the caller's zero; [`Self::looks_sane`] accepts either but
+    /// rejects a positive value that disagrees with our layout.
+    pub i_size: c_int,
+    /// The ADL adapter index this row describes.
+    pub i_adapter_index: c_int,
+    /// Unique driver-assigned device identifier.
+    pub str_udid: [u8; ADL_MAX_PATH],
+    /// PCI bus number.
+    pub i_bus_number: c_int,
+    /// PCI device number.
+    pub i_device_number: c_int,
+    /// PCI function number.
+    pub i_function_number: c_int,
+    pub i_vendor_id: c_int,
+    /// Marketing name, e.g. "AMD Radeon RX 7900 XTX".
+    pub str_adapter_name: [u8; ADL_MAX_PATH],
+    /// OS display name, e.g. `\\.\DISPLAY1`.
+    pub str_display_name: [u8; ADL_MAX_PATH],
+    pub i_present: c_int,
+    // --- Windows-only tail below ---
+    pub i_exist: c_int,
+    pub str_driver_path: [u8; ADL_MAX_PATH],
+    pub str_driver_path_ext: [u8; ADL_MAX_PATH],
+    /// The Windows PNP device instance path, e.g.
+    /// `PCI\VEN_1002&DEV_744C&SUBSYS_...\6&...&0&00000019`. The same
+    /// string WMI reports as `PNPDeviceID`, which `amd_windows` stores
+    /// as the GPU uuid; this field is what makes the ADL-to-GPU join
+    /// exact.
+    pub str_pnp_string: [u8; ADL_MAX_PATH],
+    pub i_os_display_index: c_int,
+}
+
+impl Default for AdapterInfo {
+    fn default() -> Self {
+        Self {
+            i_size: 0,
+            i_adapter_index: 0,
+            str_udid: [0; ADL_MAX_PATH],
+            i_bus_number: 0,
+            i_device_number: 0,
+            i_function_number: 0,
+            i_vendor_id: 0,
+            str_adapter_name: [0; ADL_MAX_PATH],
+            str_display_name: [0; ADL_MAX_PATH],
+            i_present: 0,
+            i_exist: 0,
+            str_driver_path: [0; ADL_MAX_PATH],
+            str_driver_path_ext: [0; ADL_MAX_PATH],
+            str_pnp_string: [0; ADL_MAX_PATH],
+            i_os_display_index: 0,
+        }
+    }
+}
+
+// AdapterInfo layout assertions. 9 ints (36 bytes) + 6 char[256] arrays
+// (1536 bytes) = 1572, every field naturally 4-aligned, no padding.
+// Note this is NOT the 1568 some derivations arrive at by dropping
+// `iAdapterIndex`. The string offsets are individually pinned because
+// the runtime self-verification and the GPU matching both read through
+// them.
+const _: () = assert!(
+    std::mem::size_of::<AdapterInfo>() == 1572,
+    "AdapterInfo (Windows layout) is 1572 bytes in AMD's headers"
+);
+const _: () = assert!(
+    std::mem::align_of::<AdapterInfo>() == 4,
+    "AdapterInfo must be 4-byte aligned, or the adapter array strides wrong"
+);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, str_udid) == 8);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, i_bus_number) == 264);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, i_device_number) == 268);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, i_function_number) == 272);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, i_vendor_id) == 276);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, str_adapter_name) == 280);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, str_display_name) == 536);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, i_present) == 792);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, str_pnp_string) == 1312);
+const _: () = assert!(std::mem::offset_of!(AdapterInfo, i_os_display_index) == 1568);
+
+/// The NUL-terminated printable-ASCII prefix of an ADL string field, or
+/// `None` when the bytes do not look like a string at all: no
+/// terminator anywhere, or a non-printable byte before it. Garbage
+/// here is the signature of a misdeclared layout, which is exactly what
+/// [`AdapterInfo::looks_sane`] uses it to detect. An empty string (NUL
+/// at offset 0) is a valid string, not garbage.
+pub fn adl_string(bytes: &[u8]) -> Option<&str> {
+    let len = bytes.iter().position(|&b| b == 0)?;
+    let prefix = &bytes[..len];
+    if !prefix.iter().all(|&b| (0x20..=0x7E).contains(&b)) {
+        return None;
+    }
+    // Printable ASCII is valid UTF-8 by construction.
+    std::str::from_utf8(prefix).ok()
+}
+
+/// Best-effort rendering of an ADL string field for diagnostics: up to
+/// the first NUL, or the whole array when no NUL exists, with invalid
+/// UTF-8 replaced. Used by the `amd.adl.adapters` doctor dump, where
+/// garbage bytes are precisely the evidence being collected.
+pub fn adl_string_lossy(bytes: &[u8]) -> String {
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+impl AdapterInfo {
+    /// Whether this entry is consistent with the layout declared above.
+    ///
+    /// Three independent signals, all of which a correct layout passes
+    /// trivially and a wrong one fails almost surely:
+    ///
+    /// - the four string fields must be NUL-terminated printable ASCII
+    ///   (a shifted or misdeclared layout puts binary data there);
+    /// - `iSize`, when the driver fills it in, must equal our
+    ///   `size_of` (zero is accepted: the PMLog path has seen drivers
+    ///   leave size fields untouched);
+    /// - `iAdapterIndex` must be a plausible small index rather than,
+    ///   say, the first four bytes of a string that landed there.
+    ///
+    /// This is a *layout* check, not a data-quality check: plausibility
+    /// of the PCI bus/device/function values is judged at grouping
+    /// time, per entry, so one odd row cannot disable attribution for
+    /// the whole machine.
+    pub fn looks_sane(&self) -> bool {
+        let size_ok = self.i_size == 0 || self.i_size as usize == std::mem::size_of::<Self>();
+        let index_ok = (0..256).contains(&self.i_adapter_index);
+        size_ok
+            && index_ok
+            && adl_string(&self.str_udid).is_some()
+            && adl_string(&self.str_adapter_name).is_some()
+            && adl_string(&self.str_display_name).is_some()
+            && adl_string(&self.str_pnp_string).is_some()
+    }
+}
+
+/// An `AdapterInfo` array with trailing headroom, the counterpart of
+/// [`AdlPmLogDataBuffer`] for `ADL2_Adapter_AdapterInfo_Get`.
+///
+/// That entry point does take an `iInputSize` parameter, so unlike the
+/// PMLog call the driver is *told* how large the buffer is. The
+/// headroom (a full second copy of the requested rows, plus slack) is
+/// kept anyway: it is cheap, and it means a driver that sizes its write
+/// by its own larger `sizeof` in disregard of `iInputSize` still lands
+/// inside our allocation instead of behind it.
+///
+/// Callers must keep `requested` small enough that
+/// `requested * size_of::<AdapterInfo>()` fits a `c_int`; the loader
+/// bounds the adapter count long before this matters.
+pub struct AdapterInfoArray {
+    entries: Vec<AdapterInfo>,
+    requested: usize,
+}
+
+impl AdapterInfoArray {
+    /// Allocate a zeroed buffer for `requested` adapter rows plus
+    /// headroom.
+    pub fn for_count(requested: usize) -> Self {
+        let allocated = requested * 2 + 4;
+        Self {
+            entries: vec![AdapterInfo::default(); allocated],
+            requested,
+        }
+    }
+
+    /// Base pointer handed to `ADL2_Adapter_AdapterInfo_Get`.
+    pub fn as_mut_ptr(&mut self) -> *mut AdapterInfo {
+        self.entries.as_mut_ptr()
+    }
+
+    /// The `iInputSize` argument: the size of the `requested` rows the
+    /// caller asked for, *not* the (larger) allocation. Reporting the
+    /// true request keeps the driver's own bounds accounting honest;
+    /// the headroom exists for drivers that ignore it.
+    pub fn input_size(&self) -> c_int {
+        (self.requested * std::mem::size_of::<AdapterInfo>()) as c_int
+    }
+
+    /// The requested rows without any validation. For diagnostics only:
+    /// the doctor dump wants to show exactly what the driver wrote even
+    /// (especially) when it fails verification.
+    pub fn requested_entries(&self) -> &[AdapterInfo] {
+        &self.entries[..self.requested]
+    }
+
+    /// The filled-in rows, or `None` when any row fails
+    /// [`AdapterInfo::looks_sane`].
+    ///
+    /// Every row is checked, not just the first: with a wrong struct
+    /// *size* the first row still parses (offsets within it are right)
+    /// and it is the second row onward that garbles, so on the
+    /// multi-adapter machines this struct exists for, the later rows
+    /// are the stride check.
+    pub fn validated(&self) -> Option<&[AdapterInfo]> {
+        let entries = self.requested_entries();
+        entries
+            .iter()
+            .all(AdapterInfo::looks_sane)
+            .then_some(entries)
+    }
+}
 
 // The entry points are only callable where the library exists, so they
 // are declared for Windows alone. The struct layouts above stay
@@ -233,6 +482,21 @@ pub type Adl2NewQueryPmLogDataGet = unsafe extern "C" fn(
     context: AdlContextHandle,
     adapter_index: c_int,
     output: *mut AdlPmLogDataOutput,
+) -> c_int;
+
+/// `ADL2_Adapter_AdapterInfo_Get`.
+///
+/// Fills `info` with one [`AdapterInfo`] per adapter index.
+/// `input_size` is the byte size of the buffer the caller allocated,
+/// conventionally `count * sizeof(AdapterInfo)` after asking
+/// `ADL2_Adapter_NumberOfAdapters_Get` for the count. Called through
+/// [`AdapterInfoArray`], which over-allocates and reports the honest
+/// request size.
+#[cfg(target_os = "windows")]
+pub type Adl2AdapterAdapterInfoGet = unsafe extern "C" fn(
+    context: AdlContextHandle,
+    info: *mut AdapterInfo,
+    input_size: c_int,
 ) -> c_int;
 
 #[cfg(test)]
@@ -300,5 +564,143 @@ mod tests {
         let output = AdlPmLogDataOutput::default();
         assert!(output.sensors.iter().all(|s| s.supported == 0));
         assert_eq!(output.sensors.len(), ADL_PMLOG_MAX_SENSORS);
+    }
+
+    /// Write a NUL-terminated ASCII string into an ADL char array.
+    fn fill(field: &mut [u8; ADL_MAX_PATH], text: &str) {
+        field.fill(0);
+        field[..text.len()].copy_from_slice(text.as_bytes());
+    }
+
+    /// An entry that looks like what a real driver writes.
+    fn sane_entry(index: i32, pnp: &str) -> AdapterInfo {
+        let mut entry = AdapterInfo {
+            i_adapter_index: index,
+            i_bus_number: 3,
+            i_device_number: 0,
+            i_function_number: 0,
+            i_vendor_id: 1002,
+            i_present: 1,
+            i_exist: 1,
+            ..AdapterInfo::default()
+        };
+        fill(
+            &mut entry.str_udid,
+            "PCI_VEN_1002&DEV_744C&REV_C8_6&12A2C3D4&0&19A",
+        );
+        fill(&mut entry.str_adapter_name, "AMD Radeon RX 7900 XTX");
+        fill(&mut entry.str_display_name, r"\\.\DISPLAY1");
+        fill(&mut entry.str_pnp_string, pnp);
+        entry
+    }
+
+    #[test]
+    fn the_four_string_fields_sit_at_their_transcribed_offsets() {
+        // The runtime self-verification and the GPU matching both read
+        // through these offsets, so pin them against an instance and
+        // not just via the const assertions: this is the test the issue
+        // asks for, phrased so a failure names the field.
+        let info = AdapterInfo::default();
+        let base = &info as *const AdapterInfo as usize;
+        for (name, offset, expected) in [
+            ("strUDID", info.str_udid.as_ptr() as usize - base, 8),
+            (
+                "strAdapterName",
+                info.str_adapter_name.as_ptr() as usize - base,
+                280,
+            ),
+            (
+                "strDisplayName",
+                info.str_display_name.as_ptr() as usize - base,
+                536,
+            ),
+            (
+                "strPNPString",
+                info.str_pnp_string.as_ptr() as usize - base,
+                1312,
+            ),
+        ] {
+            assert_eq!(offset, expected, "{name} is misplaced");
+        }
+    }
+
+    #[test]
+    fn adl_strings_accept_device_paths_and_reject_binary_garbage() {
+        let mut field = [0u8; ADL_MAX_PATH];
+        assert_eq!(adl_string(&field), Some(""));
+
+        fill(&mut field, r"PCI\VEN_1002&DEV_744C");
+        assert_eq!(adl_string(&field), Some(r"PCI\VEN_1002&DEV_744C"));
+
+        // No terminator anywhere: what a shifted layout reads out of
+        // the middle of a neighbouring field.
+        let unterminated = [b'A'; ADL_MAX_PATH];
+        assert_eq!(adl_string(&unterminated), None);
+
+        // Binary bytes before the terminator: an int reinterpreted as
+        // the start of a string.
+        let mut binary = [0u8; ADL_MAX_PATH];
+        binary[0] = 0x01;
+        binary[1] = 0x9F;
+        assert_eq!(adl_string(&binary), None);
+
+        // The lossy variant renders both anyway; it exists to collect
+        // evidence, not to gatekeep.
+        assert_eq!(adl_string_lossy(&field), r"PCI\VEN_1002&DEV_744C");
+        assert_eq!(adl_string_lossy(&unterminated).len(), ADL_MAX_PATH);
+    }
+
+    #[test]
+    fn a_realistic_entry_passes_and_layout_garbage_fails() {
+        assert!(sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19").looks_sane());
+
+        // iSize agreeing with our size_of, or left at zero, are both
+        // fine; a positive disagreement is the ABI-drift signal.
+        let mut entry = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        entry.i_size = std::mem::size_of::<AdapterInfo>() as c_int;
+        assert!(entry.looks_sane());
+        entry.i_size = 1568; // the off-by-one-int derivation
+        assert!(!entry.looks_sane());
+
+        // An adapter index that is really string bytes.
+        let mut entry = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        entry.i_adapter_index = i32::from_le_bytes(*b"PCI\\");
+        assert!(!entry.looks_sane());
+
+        // A string field holding unterminated bytes.
+        let mut entry = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        entry.str_pnp_string = [b'x'; ADL_MAX_PATH];
+        assert!(!entry.looks_sane());
+    }
+
+    #[test]
+    fn the_adapter_array_reports_the_requested_size_but_allocates_more() {
+        let mut array = AdapterInfoArray::for_count(3);
+        assert_eq!(
+            array.input_size() as usize,
+            3 * std::mem::size_of::<AdapterInfo>()
+        );
+        assert_eq!(array.requested_entries().len(), 3);
+        // The headroom: the allocation must hold at least a full second
+        // copy of the requested rows.
+        assert!(array.entries.len() >= 2 * array.requested);
+        // And the pointer handed to ADL must be the first entry.
+        let base = array.as_mut_ptr() as usize;
+        assert_eq!(base, array.entries.as_ptr() as usize);
+    }
+
+    #[test]
+    fn validation_rejects_the_whole_table_when_any_row_is_garbage() {
+        let mut array = AdapterInfoArray::for_count(2);
+        array.entries[0] = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        array.entries[1] = sane_entry(1, r"PCI\VEN_1002&DEV_164E\4&FEDC&0&41");
+        assert!(array.validated().is_some());
+        assert_eq!(array.validated().unwrap().len(), 2);
+
+        // A wrong stride leaves the first row parseable and garbles the
+        // second; that must reject everything, because a layout that is
+        // wrong for one row is wrong for all of them.
+        array.entries[1].str_udid = [0xFF; ADL_MAX_PATH];
+        assert!(array.validated().is_none());
     }
 }

--- a/src/device/readers/amd_adl/ffi.rs
+++ b/src/device/readers/amd_adl/ffi.rs
@@ -47,14 +47,18 @@
 //! strings at known offsets; a correct layout reads them as legible
 //! device paths, a wrong one reads them as garbage.
 //! [`AdapterInfoArray::validated`] performs that check at runtime, per
-//! entry, so a wrong stride is caught on the second entry even when the
-//! first happens to parse, and a row ADL never wrote is a failure
-//! rather than an empty adapter. Whenever verification fails the reader
-//! declines multi-GPU attribution, leaving the DXGI and PDH baseline
-//! (the pre-#353 behavior, which a single-GPU machine keeps
+//! row, so a wrong stride is caught on the second row even when the
+//! first happens to parse. The buffer is pre-filled with a poison
+//! pattern rather than zeros, so a row ADL never wrote
+//! ([`RowState::Untouched`]) is distinguishable from a row the driver
+//! memset but did not populate ([`RowState::Blank`]), which AMD's own
+//! SDK sample treats as normal (it zero-fills and then filters by
+//! `iPresent`). Whenever verification fails the reader declines
+//! multi-GPU attribution, leaving the DXGI and PDH baseline (the
+//! pre-#353 behavior, which a single-GPU machine keeps
 //! unconditionally), and the `amd.adl.adapters` doctor check dumps the
-//! same fields so the transcribed layout can be confirmed or refuted
-//! from real hardware.
+//! same fields with a per-row state tag so the transcribed layout can
+//! be confirmed or refuted from real hardware.
 //!
 //! The declared layout is the **Windows** variant: `adl_structures.h`
 //! appends `iExist`, the two driver-path strings, `strPNPString`, and
@@ -335,58 +339,114 @@ pub fn adl_string_lossy(bytes: &[u8]) -> String {
     String::from_utf8_lossy(&bytes[..end]).into_owned()
 }
 
+/// The byte every field of [`AdapterInfo::poisoned`] is filled with.
+///
+/// `0xAA` is deliberately neither NUL nor printable ASCII, so a poison
+/// row can never pass the string checks by accident, and a poisoned
+/// `c_int` (`0xAAAAAAAA`, a large negative value) can never pass the
+/// index or size checks either.
+pub const ADAPTER_POISON_BYTE: u8 = 0xAA;
+
+/// What the driver did to one row of an [`AdapterInfoArray`].
+///
+/// Distinguishing these four states is the entire reason the buffer is
+/// poison-filled rather than zero-filled: with a zero fill, "the driver
+/// never wrote this row" and "the driver memset the array and did not
+/// populate this row" are the same bytes, and the second is the healthy
+/// behavior AMD's own SDK sample expects (it zero-fills, calls, then
+/// filters by `iPresent`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowState {
+    /// The poison fill is intact: ADL never wrote this row. A trailing
+    /// run of these is what a declared struct *smaller* than the
+    /// driver's produces (the driver derives its row count as
+    /// `iInputSize / sizeof` and stops early); row 0 untouched means
+    /// the call wrote nothing at all.
+    Untouched,
+    /// All zero: the driver memset the row but did not populate it,
+    /// the normal shape for an adapter slot filtered out by
+    /// `iPresent`-style logic.
+    Blank,
+    /// Written and consistent with the transcribed layout
+    /// ([`AdapterInfo::looks_sane`]).
+    Populated,
+    /// Written but inconsistent with the transcribed layout: the
+    /// unambiguous signature of a wrong field offset or stride.
+    Garbled,
+}
+
 impl AdapterInfo {
-    /// Whether ADL left this row exactly as [`AdapterInfoArray::for_count`]
-    /// pre-filled it: every byte still zero.
+    /// The poison pre-fill [`AdapterInfoArray::for_count`] uses: every
+    /// `int` is `0xAAAAAAAA` and every string byte is `0xAA`.
     ///
-    /// A row ADL actually wrote always carries something, a UDID, a
-    /// marketing name, a vendor id, so an untouched row means ADL
-    /// filled fewer rows than `iInputSize` asked for. That is what
-    /// happens when the real `sizeof(AdapterInfo)` is larger than the
-    /// one transcribed here: ADL derives its row count as
-    /// `iInputSize / sizeof` and stops early, leaving the tail blank.
-    /// Since that is precisely the transcription error the runtime
-    /// verification exists to catch, [`Self::looks_sane`] treats a
-    /// blank row as a failure rather than as an empty adapter. Without
-    /// it a short write reads as a table of valid rows whose strings
-    /// are all legitimately empty, and the `amd.adl.adapters` doctor
-    /// check would report PASS over a buffer the driver never touched.
+    /// `AdapterInfo` is all plain old data (nine `c_int`s and six byte
+    /// arrays, no padding, pinned by the layout assertions above), so
+    /// every bit pattern is a valid value and a poison-filled buffer is
+    /// fully initialized memory; the pattern only has to be one no
+    /// driver write could plausibly reproduce.
+    pub fn poisoned() -> Self {
+        let poison_int = u32::from_ne_bytes([ADAPTER_POISON_BYTE; 4]) as c_int;
+        Self {
+            i_size: poison_int,
+            i_adapter_index: poison_int,
+            str_udid: [ADAPTER_POISON_BYTE; ADL_MAX_PATH],
+            i_bus_number: poison_int,
+            i_device_number: poison_int,
+            i_function_number: poison_int,
+            i_vendor_id: poison_int,
+            str_adapter_name: [ADAPTER_POISON_BYTE; ADL_MAX_PATH],
+            str_display_name: [ADAPTER_POISON_BYTE; ADL_MAX_PATH],
+            i_present: poison_int,
+            i_exist: poison_int,
+            str_driver_path: [ADAPTER_POISON_BYTE; ADL_MAX_PATH],
+            str_driver_path_ext: [ADAPTER_POISON_BYTE; ADL_MAX_PATH],
+            str_pnp_string: [ADAPTER_POISON_BYTE; ADL_MAX_PATH],
+            i_os_display_index: poison_int,
+        }
+    }
+
+    /// Whether the driver memset this row without populating it: every
+    /// byte zero. One of the two inputs to [`Self::classify`], which is
+    /// the single source of truth on how a row is treated.
     ///
-    /// ## Open risk: this may be too strict for a real driver
+    /// A blank row is **not** a failure. AMD's own ADL SDK sample
+    /// zero-fills its `AdapterInfo` array, calls
+    /// `ADL2_Adapter_AdapterInfo_Get`, and then filters the result by
+    /// `iPresent` / `ADL2_Adapter_Active_Get` rather than assuming
+    /// every requested row comes back populated, so a real driver
+    /// plausibly leaves some rows at their memset zeros on perfectly
+    /// healthy hardware. An earlier revision rejected any blank row as
+    /// short-write evidence; that conflated two different facts, which
+    /// the poison pre-fill now separates: a row the driver *never
+    /// wrote* still carries the poison ([`RowState::Untouched`]), while
+    /// a zeroed row proves the driver wrote zeros over it
+    /// ([`RowState::Blank`]).
     ///
-    /// AMD's own ADL SDK sample zero-fills its `AdapterInfo` array
-    /// before calling `ADL2_Adapter_AdapterInfo_Get` and then filters
-    /// the result by `iPresent` / `ADL2_Adapter_Active_Get` rather than
-    /// assuming every requested row comes back populated. That implies
-    /// a real driver may legitimately leave some rows untouched even on
-    /// correctly enumerated, healthy hardware, in which case this check
-    /// would disable multi-GPU attribution on a host whose layout is
-    /// actually right.
-    ///
-    /// This must **not** be relaxed on that suspicion alone: tolerating
-    /// blank rows again reopens exactly the short-write detection hole
-    /// `is_blank` exists to close (see the module docs and the history
-    /// of this check). The evidence that would justify revisiting it is
-    /// specific: an `amd.adl.adapters` dump from real hardware showing
-    /// blank rows *interleaved with* otherwise legible, `looks_sane`-passing
-    /// rows in the same call. That pattern is the signature of a driver
-    /// that legitimately leaves some rows unused; a `sizeof` mismatch
-    /// instead produces a run of blank rows from some index onward with
-    /// nothing legible past it. Until that evidence exists, a blank row
-    /// is treated as a layout failure, not as a normal driver response,
-    /// and the fix belongs in the caller's requested count, not here.
+    /// Accepting blank rows is safe because the worst case is
+    /// under-attribution, never mis-attribution. A populated row 0
+    /// proves every field offset through 1568 is right (a mid-struct
+    /// size error such as a different `ADL_MAX_PATH` would garble its
+    /// strings), so the residual unknown is only the stride, and a
+    /// wrong stride shows up either as a garbled later row (rejected by
+    /// [`AdapterInfoArray::validated`]) or as the driver writing fewer
+    /// rows, which costs attribution of the missing cards but can never
+    /// report one card's telemetry against another. Interleaved blanks
+    /// are the signature of healthy `iPresent` filtering and are
+    /// deliberately not rejected; a stride mismatch produces garbled
+    /// rows or a trailing untouched run, not interleaving.
     pub fn is_blank(&self) -> bool {
         *self == Self::default()
     }
 
-    /// Whether this entry is consistent with the layout declared above.
+    /// Whether a *written* row is consistent with the layout declared
+    /// above. One of the inputs to [`Self::classify`]; callers should
+    /// use `classify`, which first separates the untouched and blank
+    /// rows this predicate is not meant to judge (an all-zero row
+    /// passes every check below vacuously).
     ///
-    /// Four independent signals, all of which a correct layout passes
+    /// Three independent signals, all of which a correct layout passes
     /// trivially and a wrong one fails almost surely:
     ///
-    /// - the row must not be blank, i.e. ADL must have written it at
-    ///   all (see [`Self::is_blank`] for why a short write is a layout
-    ///   signal and not an empty adapter);
     /// - the four string fields must be NUL-terminated printable ASCII
     ///   (a shifted or misdeclared layout puts binary data there);
     /// - `iSize`, when the driver fills it in, must equal our
@@ -416,9 +476,6 @@ impl AdapterInfo {
     /// time, per entry, so one odd row cannot disable attribution for
     /// the whole machine.
     pub fn looks_sane(&self) -> bool {
-        if self.is_blank() {
-            return false;
-        }
         let size_ok = self.i_size == 0 || self.i_size as usize == std::mem::size_of::<Self>();
         let index_ok = (0..256).contains(&self.i_adapter_index);
         size_ok
@@ -427,6 +484,28 @@ impl AdapterInfo {
             && adl_string(&self.str_adapter_name).is_some()
             && adl_string(&self.str_display_name).is_some()
             && adl_string(&self.str_pnp_string).is_some()
+    }
+
+    /// Classify what the driver did to this row. The single source of
+    /// truth for row handling: [`AdapterInfoArray::validated`] builds
+    /// its accept/reject decision on it and the `amd.adl.adapters`
+    /// doctor check prints it per row.
+    ///
+    /// The order matters. The poison bytes are neither NUL nor
+    /// printable ASCII, so an untouched row would otherwise fall
+    /// through to [`RowState::Garbled`]; and an all-zero row passes
+    /// [`Self::looks_sane`] vacuously, so blankness must be decided
+    /// before saneness.
+    pub fn classify(&self) -> RowState {
+        if *self == Self::poisoned() {
+            RowState::Untouched
+        } else if self.is_blank() {
+            RowState::Blank
+        } else if self.looks_sane() {
+            RowState::Populated
+        } else {
+            RowState::Garbled
+        }
     }
 }
 
@@ -450,12 +529,18 @@ pub struct AdapterInfoArray {
 }
 
 impl AdapterInfoArray {
-    /// Allocate a zeroed buffer for `requested` adapter rows plus
-    /// headroom.
+    /// Allocate a poison-filled buffer for `requested` adapter rows
+    /// plus headroom.
+    ///
+    /// Poison rather than zeros so that after the call, a row ADL never
+    /// wrote is distinguishable from a row the driver memset without
+    /// populating; see [`RowState`]. `AdapterInfo` is all plain old
+    /// data, so the poison-filled buffer is fully initialized valid
+    /// memory before the driver ever sees it.
     pub fn for_count(requested: usize) -> Self {
         let allocated = requested * 2 + 4;
         Self {
-            entries: vec![AdapterInfo::default(); allocated],
+            entries: vec![AdapterInfo::poisoned(); allocated],
             requested,
         }
     }
@@ -475,9 +560,9 @@ impl AdapterInfoArray {
     /// would be a buffer overflow inside a closed-source driver, so a
     /// silent wrap must not be able to produce it. A request too large
     /// to express in a `c_int` reports 0, which makes the driver write
-    /// nothing and leaves every row blank, which
-    /// [`AdapterInfo::looks_sane`] then rejects. The loader bounds the
-    /// adapter count long before this matters.
+    /// nothing and leaves every row with its poison fill intact, which
+    /// [`Self::validated`] rejects because row 0 is not populated. The
+    /// loader bounds the adapter count long before this matters.
     pub fn input_size(&self) -> c_int {
         self.requested
             .checked_mul(std::mem::size_of::<AdapterInfo>())
@@ -492,24 +577,86 @@ impl AdapterInfoArray {
         &self.entries[..self.requested]
     }
 
-    /// The filled-in rows, or `None` when any row fails
-    /// [`AdapterInfo::looks_sane`].
-    ///
-    /// Every row is checked, not just the first: with a wrong struct
-    /// *size* the first row still parses (offsets within it are right)
-    /// and it is the second row onward that garbles, so on the
-    /// multi-adapter machines this struct exists for, the later rows
-    /// are the stride check. A size wrong in the other direction (ours
-    /// larger than the driver's) makes ADL write fewer rows than we
-    /// requested rather than garbled ones, so the later rows stay
-    /// blank; [`AdapterInfo::is_blank`] is what turns that into a
-    /// failure instead of a table of empty adapters.
-    pub fn validated(&self) -> Option<&[AdapterInfo]> {
-        let entries = self.requested_entries();
-        entries
+    /// Per-row [`RowState`] for the requested rows, in order. This is
+    /// what the `amd.adl.adapters` doctor check prints next to each
+    /// dump line, so a real-hardware report says decisively whether the
+    /// driver populated, memset, or never touched each row.
+    pub fn row_states(&self) -> Vec<RowState> {
+        self.requested_entries()
             .iter()
-            .all(AdapterInfo::looks_sane)
-            .then_some(entries)
+            .map(AdapterInfo::classify)
+            .collect()
+    }
+
+    /// The populated rows, or `None` when the table as a whole cannot
+    /// be trusted.
+    ///
+    /// Rejected when any of the following holds; otherwise the
+    /// [`RowState::Populated`] rows are returned and blank or untouched
+    /// rows are dropped silently (they were already harmless
+    /// downstream: they group to an empty PNP string, which
+    /// `plan_attribution` matches against nothing):
+    ///
+    /// 1. **Any row is [`RowState::Garbled`].** Written bytes that
+    ///    contradict the layout are the unambiguous transcription
+    ///    error, whichever field or stride produced them.
+    /// 2. **Row 0 is not [`RowState::Populated`].** ADL always has at
+    ///    least one adapter to describe when the call succeeds, so an
+    ///    untouched or blank row 0 means the call wrote nothing usable;
+    ///    this also keeps the `input_size() == 0` refusal and the
+    ///    "declared size so much smaller than the driver's that zero
+    ///    rows fit" case rejected.
+    /// 3. **No row is [`RowState::Populated`].** Implied by rule 2 but
+    ///    kept explicit: an accepted table always carries at least one
+    ///    adapter.
+    /// 4. **The `iAdapterIndex` values of the populated rows are not
+    ///    all distinct.** A stride mismatch tends to repeat or scramble
+    ///    them, so distinctness is cheap extra stride evidence.
+    ///
+    /// Every row participates, not just the first, because the stride
+    /// errors point in opposite directions. A declared size *larger*
+    /// than the driver's fits more rows than the driver's own stride,
+    /// so the driver writes at a smaller stride and our row 1 reads
+    /// misaligned bytes: garbled, caught by rule 1 (row 0 alone would
+    /// pass, since offsets within one row are self-consistent). A
+    /// declared size *smaller* than the driver's makes the driver
+    /// derive a lower row count from `iInputSize` and stop early,
+    /// leaving a trailing untouched run; when at least one row was
+    /// still written that shape is accepted, because it is
+    /// indistinguishable from healthy `iPresent` filtering and its
+    /// worst case is under-attribution of the missing cards, never
+    /// mis-attribution.
+    ///
+    /// The real gate downstream is the PNP join in `plan_attribution`,
+    /// which is far stronger evidence than anything here: a garbled
+    /// read cannot produce a `strPNPString` that exactly equals a WMI
+    /// `PNPDeviceID`, so a successful match confirms the layout
+    /// empirically on every poll.
+    pub fn validated(&self) -> Option<Vec<AdapterInfo>> {
+        let entries = self.requested_entries();
+        let states = self.row_states();
+        if states.contains(&RowState::Garbled) {
+            return None;
+        }
+        if states.first() != Some(&RowState::Populated) {
+            return None;
+        }
+        let populated: Vec<AdapterInfo> = entries
+            .iter()
+            .zip(&states)
+            .filter(|(_, state)| **state == RowState::Populated)
+            .map(|(entry, _)| *entry)
+            .collect();
+        if populated.is_empty() {
+            return None;
+        }
+        let mut indices: Vec<c_int> = populated.iter().map(|row| row.i_adapter_index).collect();
+        indices.sort_unstable();
+        indices.dedup();
+        if indices.len() != populated.len() {
+            return None;
+        }
+        Some(populated)
     }
 }
 
@@ -787,42 +934,108 @@ mod tests {
     }
 
     #[test]
-    fn a_row_the_driver_never_wrote_is_not_a_valid_empty_adapter() {
-        // Every arm of `looks_sane` is individually satisfied by the
-        // zero row `for_count` pre-fills the buffer with: `iSize` is 0
-        // (accepted), `iAdapterIndex` is 0 (in range), and each string
-        // field is a NUL at offset 0, which `adl_string` documents as
-        // the empty string rather than garbage. The blank check is the
-        // only thing standing between that and a table of "valid"
-        // adapters ADL never touched.
+    fn rows_classify_by_what_the_driver_did_to_them() {
+        // Poison intact: never written. The poison bytes are neither
+        // NUL nor printable, so order matters: an untouched row must
+        // not fall through to Garbled.
+        assert_eq!(AdapterInfo::poisoned().classify(), RowState::Untouched);
+
+        // All zero: memset but not populated. An all-zero row passes
+        // every `looks_sane` arm vacuously, so blankness must be
+        // decided before saneness.
         let blank = AdapterInfo::default();
         assert!(blank.is_blank());
-        assert!(!blank.looks_sane());
-        assert_eq!(adl_string(&blank.str_udid), Some(""));
+        assert!(blank.looks_sane());
+        assert_eq!(blank.classify(), RowState::Blank);
 
-        // And one written byte anywhere is enough to stop being blank.
+        // Written and consistent with the layout.
         let written = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
-        assert!(!written.is_blank());
-        assert!(written.looks_sane());
+        assert_eq!(written.classify(), RowState::Populated);
+
+        // Written bytes that contradict the layout.
+        let mut garbage = written;
+        garbage.str_pnp_string = [0xFF; ADL_MAX_PATH];
+        assert_eq!(garbage.classify(), RowState::Garbled);
     }
 
     #[test]
-    fn a_short_write_leaving_trailing_rows_blank_fails_verification() {
-        // The failure mode of transcribing a struct *larger* than the
-        // driver's: ADL derives its row count as `iInputSize / sizeof`,
-        // stops early, and leaves our tail untouched. Nothing garbles,
-        // so the per-row string checks alone would pass the table; the
-        // short write itself is the layout evidence.
+    fn a_trailing_untouched_run_is_accepted_and_dropped() {
+        // A declared size *smaller* than the driver's makes ADL derive
+        // a lower row count from iInputSize and stop early, leaving the
+        // tail poison. With row 0 populated that shape is accepted:
+        // the worst case is under-attribution of the missing cards,
+        // never mis-attribution, and it is indistinguishable from a
+        // driver that simply had less to say.
         let mut array = AdapterInfoArray::for_count(3);
         array.entries[0] = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
         array.entries[1] = sane_entry(1, r"PCI\VEN_1002&DEV_164E\4&FEDC&0&41");
-        // entries[2] is still the zero we handed the driver.
+        // entries[2] still carries the poison fill.
+        let accepted = array.validated().expect("trailing untouched run must pass");
+        assert_eq!(accepted.len(), 2);
+        assert_eq!(
+            array.row_states(),
+            vec![
+                RowState::Populated,
+                RowState::Populated,
+                RowState::Untouched
+            ]
+        );
+        // The doctor still gets every raw row to report.
+        assert_eq!(array.requested_entries().len(), 3);
+    }
+
+    #[test]
+    fn blank_rows_are_dropped_whether_trailing_or_interleaved() {
+        // Interleaved blanks are the signature of healthy iPresent
+        // filtering (AMD's own SDK sample zero-fills and then filters),
+        // so they must not reject the table; only the populated rows
+        // come back.
+        let mut array = AdapterInfoArray::for_count(3);
+        array.entries[0] = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        array.entries[1] = AdapterInfo::default();
+        array.entries[2] = sane_entry(2, r"PCI\VEN_1002&DEV_164E\4&FEDC&0&41");
+        let accepted = array.validated().expect("interleaved blanks must pass");
+        assert_eq!(accepted.len(), 2);
+        assert_eq!(accepted[0].i_adapter_index, 0);
+        assert_eq!(accepted[1].i_adapter_index, 2);
+
+        // Trailing blanks behave the same.
+        let mut array = AdapterInfoArray::for_count(2);
+        array.entries[0] = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        array.entries[1] = AdapterInfo::default();
+        assert_eq!(array.validated().map(|rows| rows.len()), Some(1));
+    }
+
+    #[test]
+    fn a_table_without_a_populated_first_row_is_rejected() {
+        // Row 0 blank: the driver memset the buffer but described no
+        // adapter, which a successful call never legitimately does.
+        let mut array = AdapterInfoArray::for_count(2);
+        array.entries[0] = AdapterInfo::default();
+        array.entries[1] = sane_entry(1, r"PCI\VEN_1002&DEV_164E\4&FEDC&0&41");
         assert!(array.validated().is_none());
 
-        // The doctor still gets the raw rows to report, blank ones
-        // included, since "ADL wrote two of the three rows we asked
-        // for" is exactly the evidence that names the error.
-        assert_eq!(array.requested_entries().len(), 3);
+        // Row 0 untouched: the call wrote nothing at all. This is also
+        // the shape the input_size() == 0 refusal produces, and the
+        // shape of a declared size so much smaller than the driver's
+        // that zero rows fit the byte budget.
+        let untouched = AdapterInfoArray::for_count(2);
+        assert_eq!(
+            untouched.row_states(),
+            vec![RowState::Untouched, RowState::Untouched]
+        );
+        assert!(untouched.validated().is_none());
+    }
+
+    #[test]
+    fn duplicate_adapter_indices_among_populated_rows_are_rejected() {
+        // A stride mismatch tends to repeat or scramble iAdapterIndex;
+        // two populated rows claiming the same index is cheap extra
+        // stride evidence, and no healthy enumeration produces it.
+        let mut array = AdapterInfoArray::for_count(2);
+        array.entries[0] = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        array.entries[1] = sane_entry(0, r"PCI\VEN_1002&DEV_164E\4&FEDC&0&41");
+        assert!(array.validated().is_none());
     }
 
     #[test]
@@ -831,11 +1044,11 @@ mod tests {
         array.entries[0] = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
         array.entries[1] = sane_entry(1, r"PCI\VEN_1002&DEV_164E\4&FEDC&0&41");
         assert!(array.validated().is_some());
-        assert_eq!(array.validated().unwrap().len(), 2);
+        assert_eq!(array.validated().map(|rows| rows.len()), Some(2));
 
         // A wrong stride leaves the first row parseable and garbles the
-        // second; that must reject everything, because a layout that is
-        // wrong for one row is wrong for all of them.
+        // second; that must reject everything, blanks or not, because a
+        // layout that is wrong for one row is wrong for all of them.
         array.entries[1].str_udid = [0xFF; ADL_MAX_PATH];
         assert!(array.validated().is_none());
     }

--- a/src/device/readers/amd_adl/ffi.rs
+++ b/src/device/readers/amd_adl/ffi.rs
@@ -351,6 +351,30 @@ impl AdapterInfo {
     /// it a short write reads as a table of valid rows whose strings
     /// are all legitimately empty, and the `amd.adl.adapters` doctor
     /// check would report PASS over a buffer the driver never touched.
+    ///
+    /// ## Open risk: this may be too strict for a real driver
+    ///
+    /// AMD's own ADL SDK sample zero-fills its `AdapterInfo` array
+    /// before calling `ADL2_Adapter_AdapterInfo_Get` and then filters
+    /// the result by `iPresent` / `ADL2_Adapter_Active_Get` rather than
+    /// assuming every requested row comes back populated. That implies
+    /// a real driver may legitimately leave some rows untouched even on
+    /// correctly enumerated, healthy hardware, in which case this check
+    /// would disable multi-GPU attribution on a host whose layout is
+    /// actually right.
+    ///
+    /// This must **not** be relaxed on that suspicion alone: tolerating
+    /// blank rows again reopens exactly the short-write detection hole
+    /// `is_blank` exists to close (see the module docs and the history
+    /// of this check). The evidence that would justify revisiting it is
+    /// specific: an `amd.adl.adapters` dump from real hardware showing
+    /// blank rows *interleaved with* otherwise legible, `looks_sane`-passing
+    /// rows in the same call. That pattern is the signature of a driver
+    /// that legitimately leaves some rows unused; a `sizeof` mismatch
+    /// instead produces a run of blank rows from some index onward with
+    /// nothing legible past it. Until that evidence exists, a blank row
+    /// is treated as a layout failure, not as a normal driver response,
+    /// and the fix belongs in the caller's requested count, not here.
     pub fn is_blank(&self) -> bool {
         *self == Self::default()
     }
@@ -370,6 +394,22 @@ impl AdapterInfo {
     ///   leave size fields untouched);
     /// - `iAdapterIndex` must be a plausible small index rather than,
     ///   say, the first four bytes of a string that landed there.
+    ///
+    /// Only 4 of the struct's 6 string fields are checked here:
+    /// `strUDID`, `strAdapterName`, `strDisplayName`, and
+    /// `strPNPString`. `strDriverPath` (offset 800) and
+    /// `strDriverPathExt` (offset 1056) are skipped deliberately, not
+    /// by oversight. They sit strictly between `strDisplayName` (536)
+    /// and `strPNPString` (1312), so `strPNPString` parsing correctly
+    /// already means the stride carried it through both skipped fields
+    /// intact; the marginal detection gain from checking them too is
+    /// small. Each additional strictness arm is also a new way for this
+    /// check to decline on real hardware nobody has tested yet, which
+    /// cuts against this module's stated bias toward declining rather
+    /// than guessing only when the alternative is *wrong* data, not
+    /// merely *unverified* code paths. Revisit once a real host has
+    /// produced a passing `amd.adl.adapters` dump to check the omitted
+    /// fields against.
     ///
     /// This is a *layout* check, not a data-quality check: plausibility
     /// of the PCI bus/device/function values is judged at grouping

--- a/src/device/readers/amd_adl/ffi.rs
+++ b/src/device/readers/amd_adl/ffi.rs
@@ -48,7 +48,8 @@
 //! device paths, a wrong one reads them as garbage.
 //! [`AdapterInfoArray::validated`] performs that check at runtime, per
 //! entry, so a wrong stride is caught on the second entry even when the
-//! first happens to parse. Whenever verification fails the reader
+//! first happens to parse, and a row ADL never wrote is a failure
+//! rather than an empty adapter. Whenever verification fails the reader
 //! declines multi-GPU attribution, leaving the DXGI and PDH baseline
 //! (the pre-#353 behavior, which a single-GPU machine keeps
 //! unconditionally), and the `amd.adl.adapters` doctor check dumps the
@@ -227,7 +228,7 @@ const _: () = assert!(
 /// the module docs), which is why nothing consumes an `AdapterInfo`
 /// without it first passing [`AdapterInfoArray::validated`].
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AdapterInfo {
     /// Size of the structure. Some ADL revisions fill it in, some leave
     /// the caller's zero; [`Self::looks_sane`] accepts either but
@@ -335,11 +336,33 @@ pub fn adl_string_lossy(bytes: &[u8]) -> String {
 }
 
 impl AdapterInfo {
+    /// Whether ADL left this row exactly as [`AdapterInfoArray::for_count`]
+    /// pre-filled it: every byte still zero.
+    ///
+    /// A row ADL actually wrote always carries something, a UDID, a
+    /// marketing name, a vendor id, so an untouched row means ADL
+    /// filled fewer rows than `iInputSize` asked for. That is what
+    /// happens when the real `sizeof(AdapterInfo)` is larger than the
+    /// one transcribed here: ADL derives its row count as
+    /// `iInputSize / sizeof` and stops early, leaving the tail blank.
+    /// Since that is precisely the transcription error the runtime
+    /// verification exists to catch, [`Self::looks_sane`] treats a
+    /// blank row as a failure rather than as an empty adapter. Without
+    /// it a short write reads as a table of valid rows whose strings
+    /// are all legitimately empty, and the `amd.adl.adapters` doctor
+    /// check would report PASS over a buffer the driver never touched.
+    pub fn is_blank(&self) -> bool {
+        *self == Self::default()
+    }
+
     /// Whether this entry is consistent with the layout declared above.
     ///
-    /// Three independent signals, all of which a correct layout passes
+    /// Four independent signals, all of which a correct layout passes
     /// trivially and a wrong one fails almost surely:
     ///
+    /// - the row must not be blank, i.e. ADL must have written it at
+    ///   all (see [`Self::is_blank`] for why a short write is a layout
+    ///   signal and not an empty adapter);
     /// - the four string fields must be NUL-terminated printable ASCII
     ///   (a shifted or misdeclared layout puts binary data there);
     /// - `iSize`, when the driver fills it in, must equal our
@@ -353,6 +376,9 @@ impl AdapterInfo {
     /// time, per entry, so one odd row cannot disable attribution for
     /// the whole machine.
     pub fn looks_sane(&self) -> bool {
+        if self.is_blank() {
+            return false;
+        }
         let size_ok = self.i_size == 0 || self.i_size as usize == std::mem::size_of::<Self>();
         let index_ok = (0..256).contains(&self.i_adapter_index);
         size_ok
@@ -420,7 +446,11 @@ impl AdapterInfoArray {
     /// *size* the first row still parses (offsets within it are right)
     /// and it is the second row onward that garbles, so on the
     /// multi-adapter machines this struct exists for, the later rows
-    /// are the stride check.
+    /// are the stride check. A size wrong in the other direction (ours
+    /// larger than the driver's) makes ADL write fewer rows than we
+    /// requested rather than garbled ones, so the later rows stay
+    /// blank; [`AdapterInfo::is_blank`] is what turns that into a
+    /// failure instead of a table of empty adapters.
     pub fn validated(&self) -> Option<&[AdapterInfo]> {
         let entries = self.requested_entries();
         entries
@@ -687,6 +717,45 @@ mod tests {
         // And the pointer handed to ADL must be the first entry.
         let base = array.as_mut_ptr() as usize;
         assert_eq!(base, array.entries.as_ptr() as usize);
+    }
+
+    #[test]
+    fn a_row_the_driver_never_wrote_is_not_a_valid_empty_adapter() {
+        // Every arm of `looks_sane` is individually satisfied by the
+        // zero row `for_count` pre-fills the buffer with: `iSize` is 0
+        // (accepted), `iAdapterIndex` is 0 (in range), and each string
+        // field is a NUL at offset 0, which `adl_string` documents as
+        // the empty string rather than garbage. The blank check is the
+        // only thing standing between that and a table of "valid"
+        // adapters ADL never touched.
+        let blank = AdapterInfo::default();
+        assert!(blank.is_blank());
+        assert!(!blank.looks_sane());
+        assert_eq!(adl_string(&blank.str_udid), Some(""));
+
+        // And one written byte anywhere is enough to stop being blank.
+        let written = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        assert!(!written.is_blank());
+        assert!(written.looks_sane());
+    }
+
+    #[test]
+    fn a_short_write_leaving_trailing_rows_blank_fails_verification() {
+        // The failure mode of transcribing a struct *larger* than the
+        // driver's: ADL derives its row count as `iInputSize / sizeof`,
+        // stops early, and leaves our tail untouched. Nothing garbles,
+        // so the per-row string checks alone would pass the table; the
+        // short write itself is the layout evidence.
+        let mut array = AdapterInfoArray::for_count(3);
+        array.entries[0] = sane_entry(0, r"PCI\VEN_1002&DEV_744C\6&ABCD&0&19");
+        array.entries[1] = sane_entry(1, r"PCI\VEN_1002&DEV_164E\4&FEDC&0&41");
+        // entries[2] is still the zero we handed the driver.
+        assert!(array.validated().is_none());
+
+        // The doctor still gets the raw rows to report, blank ones
+        // included, since "ADL wrote two of the three rows we asked
+        // for" is exactly the evidence that names the error.
+        assert_eq!(array.requested_entries().len(), 3);
     }
 
     #[test]

--- a/src/device/readers/amd_adl/ffi.rs
+++ b/src/device/readers/amd_adl/ffi.rs
@@ -400,9 +400,10 @@ impl AdapterInfo {
 /// by its own larger `sizeof` in disregard of `iInputSize` still lands
 /// inside our allocation instead of behind it.
 ///
-/// Callers must keep `requested` small enough that
-/// `requested * size_of::<AdapterInfo>()` fits a `c_int`; the loader
-/// bounds the adapter count long before this matters.
+/// A `requested` count whose byte size does not fit a `c_int`
+/// advertises 0 rather than wrapping, so the driver is never handed a
+/// plausible-looking size that exceeds the allocation; the loader
+/// bounds the adapter count long before that matters.
 pub struct AdapterInfoArray {
     entries: Vec<AdapterInfo>,
     requested: usize,
@@ -428,8 +429,20 @@ impl AdapterInfoArray {
     /// caller asked for, *not* the (larger) allocation. Reporting the
     /// true request keeps the driver's own bounds accounting honest;
     /// the headroom exists for drivers that ignore it.
+    ///
+    /// The conversion is checked rather than a truncating cast: this is
+    /// the one number here that, if it ever exceeded the allocation,
+    /// would be a buffer overflow inside a closed-source driver, so a
+    /// silent wrap must not be able to produce it. A request too large
+    /// to express in a `c_int` reports 0, which makes the driver write
+    /// nothing and leaves every row blank, which
+    /// [`AdapterInfo::looks_sane`] then rejects. The loader bounds the
+    /// adapter count long before this matters.
     pub fn input_size(&self) -> c_int {
-        (self.requested * std::mem::size_of::<AdapterInfo>()) as c_int
+        self.requested
+            .checked_mul(std::mem::size_of::<AdapterInfo>())
+            .and_then(|bytes| c_int::try_from(bytes).ok())
+            .unwrap_or(0)
     }
 
     /// The requested rows without any validation. For diagnostics only:
@@ -717,6 +730,20 @@ mod tests {
         // And the pointer handed to ADL must be the first entry.
         let base = array.as_mut_ptr() as usize;
         assert_eq!(base, array.entries.as_ptr() as usize);
+    }
+
+    #[test]
+    fn an_inexpressible_request_size_advertises_zero_rather_than_wrapping() {
+        // `input_size` is the number the driver writes against, so it
+        // must never exceed the allocation. A count large enough to
+        // overflow `c_int` reports 0 (the driver writes nothing and the
+        // untouched rows fail verification) instead of wrapping into a
+        // plausible-looking positive size.
+        let array = AdapterInfoArray {
+            entries: Vec::new(),
+            requested: usize::MAX / 8,
+        };
+        assert_eq!(array.input_size(), 0);
     }
 
     #[test]

--- a/src/device/readers/amd_adl/loader.rs
+++ b/src/device/readers/amd_adl/loader.rs
@@ -77,17 +77,6 @@ const MIN_OVERDRIVE_VERSION: c_int = 7;
 /// ADL exposes no staleness signal, so a slow retry stands in for one.
 const RESCAN_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Upper bound on the adapter count accepted from the driver.
-///
-/// A real machine has a handful of ADL rows (one per display output
-/// per card; a four-card workstation with six outputs each is 24).
-/// The bound keeps a garbage count from demanding an absurd
-/// `AdapterInfo` allocation, and it keeps
-/// `AdapterInfoArray::input_size` far away from `c_int` overflow. A
-/// count beyond it is treated as a failed call, which multi-GPU
-/// attribution answers by declining.
-const MAX_ADAPTER_ROWS: c_int = 64;
-
 /// Allocator handed to `ADL2_Main_Control_Create`.
 ///
 /// Allocates from the process heap rather than Rust's global allocator.
@@ -263,14 +252,10 @@ impl AdlRuntime {
         if unsafe { (self.number_of_adapters)(self.context, &mut count) } != ADL_OK || count <= 0 {
             return;
         }
-        // Bound the driver's count the way `probe_adapter_info` does.
-        // The loop below makes one `ADL2_Overdrive_Caps` call per index
-        // and may make one PMLog read per index, all while holding the
-        // process-wide runtime lock, so a garbage count would wedge the
-        // refresh loop rather than merely waste a little work. Clamping
-        // instead of rejecting keeps a machine with an implausibly long
-        // adapter list working on its first rows.
-        let count = count.min(MAX_ADAPTER_ROWS);
+        // Bound the driver's count the way `probe_adapter_info` does;
+        // see `adapters::clamp_scan_count` for why this clamps rather
+        // than rejects.
+        let count = adapters::clamp_scan_count(count);
 
         let mut preferred = Vec::new();
         let mut fallback = Vec::new();
@@ -363,7 +348,7 @@ impl AdlRuntime {
         let mut count: c_int = 0;
         // SAFETY: valid context and out pointer.
         if unsafe { (self.number_of_adapters)(self.context, &mut count) } != ADL_OK
-            || !(1..=MAX_ADAPTER_ROWS).contains(&count)
+            || !adapters::plausible_adapter_count(count)
         {
             return AdapterProbe::CallFailed;
         }

--- a/src/device/readers/amd_adl/loader.rs
+++ b/src/device/readers/amd_adl/loader.rs
@@ -352,12 +352,14 @@ impl AdlRuntime {
             return AdapterProbe::CallFailed;
         }
         let mut buffer = AdapterInfoArray::for_count(count as usize);
+        // Read before the pointer is taken so no borrow of `buffer` is
+        // created while the pointer ADL writes through is live.
+        let input_size = buffer.input_size();
         // SAFETY: `buffer` starts with at least `count` zeroed
         // `AdapterInfo` entries plus headroom (see `AdapterInfoArray`),
         // `input_size` reports the requested size, and the compile-time
         // assertions in `ffi` pin the layout the driver will write.
-        let status =
-            unsafe { adapter_info_get(self.context, buffer.as_mut_ptr(), buffer.input_size()) };
+        let status = unsafe { adapter_info_get(self.context, buffer.as_mut_ptr(), input_size) };
         if status != ADL_OK {
             return AdapterProbe::CallFailed;
         }

--- a/src/device/readers/amd_adl/loader.rs
+++ b/src/device/readers/amd_adl/loader.rs
@@ -263,6 +263,14 @@ impl AdlRuntime {
         if unsafe { (self.number_of_adapters)(self.context, &mut count) } != ADL_OK || count <= 0 {
             return;
         }
+        // Bound the driver's count the way `probe_adapter_info` does.
+        // The loop below makes one `ADL2_Overdrive_Caps` call per index
+        // and may make one PMLog read per index, all while holding the
+        // process-wide runtime lock, so a garbage count would wedge the
+        // refresh loop rather than merely waste a little work. Clamping
+        // instead of rejecting keeps a machine with an implausibly long
+        // adapter list working on its first rows.
+        let count = count.min(MAX_ADAPTER_ROWS);
 
         let mut preferred = Vec::new();
         let mut fallback = Vec::new();
@@ -302,10 +310,18 @@ impl AdlRuntime {
         // writes a larger table than this file declares cannot smash
         // the stack of a long-running daemon.
         let mut buffer = Box::<AdlPmLogDataBuffer>::default();
-        // SAFETY: `buffer.output` begins a correctly aligned allocation
-        // at least as large as ADLPMLogDataOutput, with headroom beyond
-        // it; the compile-time assertions in `ffi` pin the layout.
-        let status = unsafe { (self.query_pmlog)(self.context, index, &raw mut buffer.output) };
+        // The pointer is derived from the whole padded buffer and then
+        // narrowed by a cast, not from the `output` field: a pointer
+        // derived from the field alone is valid only for that field's
+        // 2052 bytes, which would put the headroom out of bounds for
+        // exactly the oversized write the headroom exists to absorb.
+        let output = (&raw mut *buffer).cast::<AdlPmLogDataOutput>();
+        // SAFETY: `output` addresses the start of a correctly aligned
+        // allocation at least as large as ADLPMLogDataOutput, with
+        // headroom beyond it. `AdlPmLogDataBuffer` is `#[repr(C)]` with
+        // `output` first, which the `ffi` tests pin, and the
+        // compile-time assertions in `ffi` pin the layout itself.
+        let status = unsafe { (self.query_pmlog)(self.context, index, output) };
         if status != ADL_OK {
             return None;
         }

--- a/src/device/readers/amd_adl/loader.rs
+++ b/src/device/readers/amd_adl/loader.rs
@@ -356,27 +356,32 @@ impl AdlRuntime {
         // Read before the pointer is taken so no borrow of `buffer` is
         // created while the pointer ADL writes through is live.
         let input_size = buffer.input_size();
-        // SAFETY: `buffer` starts with at least `count` zeroed
-        // `AdapterInfo` entries plus headroom (see `AdapterInfoArray`),
-        // `input_size` reports the requested size, and the compile-time
-        // assertions in `ffi` pin the layout the driver will write.
+        // SAFETY: `buffer` starts with at least `count` poison-filled
+        // `AdapterInfo` entries plus headroom (see `AdapterInfoArray`).
+        // `AdapterInfo` is all plain-old-data (ints and byte arrays, no
+        // padding, pinned by the `ffi` assertions), so the poison
+        // pattern is a valid value of the type and the buffer is fully
+        // initialized before the driver sees it. `input_size` reports
+        // the requested size, and the compile-time assertions in `ffi`
+        // pin the layout the driver will write.
         let status = unsafe { adapter_info_get(self.context, buffer.as_mut_ptr(), input_size) };
         if status != ADL_OK {
             return AdapterProbe::CallFailed;
         }
-        let layout_ok = buffer.validated().is_some();
+        let accepted = buffer.validated();
         AdapterProbe::Rows {
             rows: buffer.requested_entries().to_vec(),
-            layout_ok,
+            accepted,
         }
     }
 
     /// The validated adapter inventory, refreshed on the slow interval.
     ///
     /// `None` covers every way of not having one: the entry point is
-    /// missing, the call failed, or layout verification rejected the
-    /// rows. All of them mean multi-GPU attribution declines, which is
-    /// the designed failure mode.
+    /// missing, the call failed, or verification rejected the table.
+    /// All of them mean multi-GPU attribution declines, which is the
+    /// designed failure mode. On acceptance only the populated rows
+    /// are parsed; blank or untouched rows never enter the inventory.
     fn adapter_inventory(&mut self) -> Option<&[AdlAdapter]> {
         let due = match self.inventory_scanned_at {
             None => true,
@@ -386,9 +391,9 @@ impl AdlRuntime {
             self.inventory_scanned_at = Some(Instant::now());
             self.adapter_inventory = match self.probe_adapter_info() {
                 AdapterProbe::Rows {
-                    rows,
-                    layout_ok: true,
-                } => Some(adapters::parse_adapters(&rows)),
+                    accepted: Some(populated),
+                    ..
+                } => Some(adapters::parse_adapters(&populated)),
                 _ => None,
             };
         }
@@ -405,13 +410,15 @@ pub enum AdapterProbe {
     /// The count or info call returned an error, or the count was
     /// implausible.
     CallFailed,
-    /// The call succeeded. `layout_ok` reports whether every row passed
-    /// `AdapterInfo::looks_sane`; the rows are returned either way,
-    /// because when verification fails the raw bytes are exactly the
-    /// evidence the doctor exists to collect.
+    /// The call succeeded. `rows` is every requested row exactly as the
+    /// driver (or the poison pre-fill) left it, returned even on
+    /// verification failure because the raw bytes are exactly the
+    /// evidence the doctor exists to collect. `accepted` is the
+    /// populated subset when `AdapterInfoArray::validated` accepted the
+    /// table, `None` when it rejected it.
     Rows {
         rows: Vec<AdapterInfo>,
-        layout_ok: bool,
+        accepted: Option<Vec<AdapterInfo>>,
     },
 }
 

--- a/src/device/readers/amd_adl/loader.rs
+++ b/src/device/readers/amd_adl/loader.rs
@@ -35,13 +35,17 @@
 //!
 //! The DLL load and `ADL2_Main_Control_Create` happen once for the
 //! process. The capability scan that picks an adapter index happens once
-//! and is then cached. A steady-state poll is therefore a single
-//! `ADL2_New_QueryPMLogData_Get`, which reads the telemetry block the
-//! driver already maintains for its own overlay and submits no work to
-//! the GPU.
+//! and is then cached, as is the `AdapterInfo` inventory the multi-GPU
+//! path matches against (both on the same slow refresh interval). A
+//! steady-state poll is therefore one `ADL2_New_QueryPMLogData_Get` on
+//! a single-GPU host, and one per matched card on a multi-GPU host,
+//! each reading the telemetry block the driver already maintains for
+//! its own overlay; nothing submits work to the GPU.
 
+use super::adapters::{self, AdlAdapter};
 use super::ffi::{
-    ADL_OK, Adl2AdapterNumberOfAdaptersGet, Adl2MainControlCreate, Adl2NewQueryPmLogDataGet,
+    ADL_OK, AdapterInfo, AdapterInfoArray, Adl2AdapterAdapterInfoGet,
+    Adl2AdapterNumberOfAdaptersGet, Adl2MainControlCreate, Adl2NewQueryPmLogDataGet,
     Adl2OverdriveCaps, AdlContextHandle, AdlPmLogDataBuffer, AdlPmLogDataOutput,
 };
 use libloading::os::windows::LOAD_LIBRARY_SEARCH_SYSTEM32;
@@ -73,6 +77,17 @@ const MIN_OVERDRIVE_VERSION: c_int = 7;
 /// ADL exposes no staleness signal, so a slow retry stands in for one.
 const RESCAN_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Upper bound on the adapter count accepted from the driver.
+///
+/// A real machine has a handful of ADL rows (one per display output
+/// per card; a four-card workstation with six outputs each is 24).
+/// The bound keeps a garbage count from demanding an absurd
+/// `AdapterInfo` allocation, and it keeps
+/// `AdapterInfoArray::input_size` far away from `c_int` overflow. A
+/// count beyond it is treated as a failed call, which multi-GPU
+/// attribution answers by declining.
+const MAX_ADAPTER_ROWS: c_int = 64;
+
 /// Allocator handed to `ADL2_Main_Control_Create`.
 ///
 /// Allocates from the process heap rather than Rust's global allocator.
@@ -83,9 +98,11 @@ const RESCAN_INTERVAL: Duration = Duration::from_secs(60);
 /// the UCRT allocator is built on, so it stays compatible either way.
 ///
 /// ADL only invokes this for buffers it allocates on the caller's
-/// behalf, which is the `AdapterInfo` family this reader never calls, so
-/// in practice it should never run. It exists because
-/// `ADL2_Main_Control_Create` requires a non-null callback.
+/// behalf, such as `ADL2_Adapter_AdapterInfoX2_Get`. This reader calls
+/// none of those: even its `ADL2_Adapter_AdapterInfo_Get` use hands ADL
+/// a caller-allocated buffer, so in practice the callback should never
+/// run. It exists because `ADL2_Main_Control_Create` requires a
+/// non-null callback.
 ///
 /// # Safety
 ///
@@ -114,6 +131,12 @@ struct AdlRuntime {
     number_of_adapters: Adl2AdapterNumberOfAdaptersGet,
     overdrive_caps: Adl2OverdriveCaps,
     query_pmlog: Adl2NewQueryPmLogDataGet,
+    /// `ADL2_Adapter_AdapterInfo_Get`, or `None` when the installed
+    /// driver does not export it. Looked up leniently, unlike the
+    /// mandatory symbols above: a driver without it simply cannot
+    /// attribute on multi-GPU hosts, and must not lose the single-GPU
+    /// sensor path over that.
+    adapter_info_get: Option<Adl2AdapterAdapterInfoGet>,
     /// Adapter index chosen by the first capability scan.
     ///
     /// A single card exposes several ADL adapter indices, one per
@@ -128,6 +151,17 @@ struct AdlRuntime {
     /// disabling ADL for the life of the process. See the constant for
     /// why that matters.
     last_scan: Option<Instant>,
+    /// Validated adapter inventory, or `None` when the last fetch
+    /// failed (entry point missing, call error, or layout
+    /// verification rejecting the rows).
+    adapter_inventory: Option<Vec<AdlAdapter>>,
+    /// When the inventory was last fetched. Refreshed after
+    /// [`RESCAN_INTERVAL`] whether the fetch succeeded or not: adapter
+    /// topology changes (driver update, TDR reset, eGPU hotplug)
+    /// invalidate a success just as a service starting before the
+    /// driver invalidates a failure, and the refresh is one
+    /// registry-backed call per minute.
+    inventory_scanned_at: Option<Instant>,
 }
 
 // ADL context handles are plain opaque pointers rather than thread-affine
@@ -160,7 +194,7 @@ impl AdlRuntime {
         // SAFETY: symbol lookups against a successfully loaded library.
         // The signatures are transcribed from AMD's public headers; see
         // the `ffi` module.
-        let (create, number_of_adapters, overdrive_caps, query_pmlog) = unsafe {
+        let (create, number_of_adapters, overdrive_caps, query_pmlog, adapter_info_get) = unsafe {
             let create = *library
                 .get::<Adl2MainControlCreate>(b"ADL2_Main_Control_Create\0")
                 .ok()?;
@@ -173,7 +207,19 @@ impl AdlRuntime {
             let query_pmlog = *library
                 .get::<Adl2NewQueryPmLogDataGet>(b"ADL2_New_QueryPMLogData_Get\0")
                 .ok()?;
-            (create, number_of_adapters, overdrive_caps, query_pmlog)
+            // Optional: absent on drivers old enough, and only needed
+            // for multi-GPU attribution.
+            let adapter_info_get = library
+                .get::<Adl2AdapterAdapterInfoGet>(b"ADL2_Adapter_AdapterInfo_Get\0")
+                .ok()
+                .map(|symbol| *symbol);
+            (
+                create,
+                number_of_adapters,
+                overdrive_caps,
+                query_pmlog,
+                adapter_info_get,
+            )
         };
 
         let mut context: AdlContextHandle = std::ptr::null_mut();
@@ -191,8 +237,11 @@ impl AdlRuntime {
             number_of_adapters,
             overdrive_caps,
             query_pmlog,
+            adapter_info_get,
             chosen_index: None,
             last_scan: None,
+            adapter_inventory: None,
+            inventory_scanned_at: None,
         })
     }
 
@@ -289,6 +338,78 @@ impl AdlRuntime {
             }
         }
     }
+
+    /// One raw `AdapterInfo` fetch, uncached.
+    fn probe_adapter_info(&self) -> AdapterProbe {
+        let Some(adapter_info_get) = self.adapter_info_get else {
+            return AdapterProbe::NoEntryPoint;
+        };
+        let mut count: c_int = 0;
+        // SAFETY: valid context and out pointer.
+        if unsafe { (self.number_of_adapters)(self.context, &mut count) } != ADL_OK
+            || !(1..=MAX_ADAPTER_ROWS).contains(&count)
+        {
+            return AdapterProbe::CallFailed;
+        }
+        let mut buffer = AdapterInfoArray::for_count(count as usize);
+        // SAFETY: `buffer` starts with at least `count` zeroed
+        // `AdapterInfo` entries plus headroom (see `AdapterInfoArray`),
+        // `input_size` reports the requested size, and the compile-time
+        // assertions in `ffi` pin the layout the driver will write.
+        let status =
+            unsafe { adapter_info_get(self.context, buffer.as_mut_ptr(), buffer.input_size()) };
+        if status != ADL_OK {
+            return AdapterProbe::CallFailed;
+        }
+        let layout_ok = buffer.validated().is_some();
+        AdapterProbe::Rows {
+            rows: buffer.requested_entries().to_vec(),
+            layout_ok,
+        }
+    }
+
+    /// The validated adapter inventory, refreshed on the slow interval.
+    ///
+    /// `None` covers every way of not having one: the entry point is
+    /// missing, the call failed, or layout verification rejected the
+    /// rows. All of them mean multi-GPU attribution declines, which is
+    /// the designed failure mode.
+    fn adapter_inventory(&mut self) -> Option<&[AdlAdapter]> {
+        let due = match self.inventory_scanned_at {
+            None => true,
+            Some(at) => at.elapsed() >= RESCAN_INTERVAL,
+        };
+        if due {
+            self.inventory_scanned_at = Some(Instant::now());
+            self.adapter_inventory = match self.probe_adapter_info() {
+                AdapterProbe::Rows {
+                    rows,
+                    layout_ok: true,
+                } => Some(adapters::parse_adapters(&rows)),
+                _ => None,
+            };
+        }
+        self.adapter_inventory.as_deref()
+    }
+}
+
+/// Outcome of one raw `AdapterInfo` fetch, granular enough for the
+/// `amd.adl.adapters` doctor check to name the stage that failed.
+pub enum AdapterProbe {
+    /// The driver's `atiadlxx.dll` does not export
+    /// `ADL2_Adapter_AdapterInfo_Get`.
+    NoEntryPoint,
+    /// The count or info call returned an error, or the count was
+    /// implausible.
+    CallFailed,
+    /// The call succeeded. `layout_ok` reports whether every row passed
+    /// `AdapterInfo::looks_sane`; the rows are returned either way,
+    /// because when verification fails the raw bytes are exactly the
+    /// evidence the doctor exists to collect.
+    Rows {
+        rows: Vec<AdapterInfo>,
+        layout_ok: bool,
+    },
 }
 
 /// Process-wide runtime. `None` once loading has failed, so a machine
@@ -307,6 +428,43 @@ pub fn sample() -> Option<AdlPmLogDataOutput> {
         Err(poisoned) => poisoned.into_inner(),
     };
     guard.as_mut()?.sample()
+}
+
+/// Take one PMLog sample from a specific adapter index, bypassing the
+/// capability scan. Used by the multi-GPU path, where the index comes
+/// from `AdapterInfo`-based matching rather than from the scan.
+pub fn sample_adapter(index: i32) -> Option<AdlPmLogDataOutput> {
+    let guard = match runtime().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.as_ref()?.read_pmlog(index)
+}
+
+/// The validated adapter inventory, or `None` when it is unavailable
+/// for any reason (no library, no entry point, failed call, or failed
+/// layout verification). Cloned out so the runtime lock is not held
+/// across the caller's matching work.
+pub fn adapter_inventory() -> Option<Vec<AdlAdapter>> {
+    let mut guard = match runtime().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard
+        .as_mut()?
+        .adapter_inventory()
+        .map(<[AdlAdapter]>::to_vec)
+}
+
+/// One raw, uncached `AdapterInfo` fetch for the `amd.adl.adapters`
+/// doctor check. `None` when the library itself is unavailable (see
+/// [`library_available`] for separating that case).
+pub fn adapter_info_probe() -> Option<AdapterProbe> {
+    let guard = match runtime().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    Some(guard.as_ref()?.probe_adapter_info())
 }
 
 /// Whether `atiadlxx.dll` loaded and a context was created. Used by the

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -29,6 +29,7 @@ static CHECKS: &[&Check] = &[
     &BUILD_GATE,
     &ADL_LIBRARY,
     &ADL_SENSORS,
+    &ADL_ADAPTERS,
 ];
 
 pub fn checks() -> &'static [&'static Check] {
@@ -78,6 +79,84 @@ static ADL_SENSORS: Check = Check {
     severity_on_fail: Severity::Info,
     run: check_adl_sensors,
 };
+
+static ADL_ADAPTERS: Check = Check {
+    id: "amd.adl.adapters",
+    title: "AMD ADL adapter inventory",
+    severity_on_fail: Severity::Info,
+    run: check_adl_adapters,
+};
+
+/// Dump the raw `AdapterInfo` rows: index, PCI bus/device/function,
+/// `strAdapterName`, and `strPNPString` per adapter.
+///
+/// This is the field-verification path for the `AdapterInfo` layout in
+/// `device/readers/amd_adl/ffi.rs`, the same role `amd.adl.sensors`
+/// plays for the PMLog sensor index mapping: the layout is transcribed
+/// from AMD's public headers and nothing in CI can check it (no job
+/// compiles all-smi for Windows, no test can call the real library),
+/// so an operator on real hardware is the verifier. Legible device
+/// paths in the dump confirm the layout; garbage refutes it, which is
+/// why the rows are printed even, and especially, when runtime
+/// verification fails. The dump also shows the grouping and the PNP
+/// strings that multi-GPU attribution matches against the GPU uuids,
+/// so a wrong match can be diagnosed from the same output.
+fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
+    #[cfg(target_os = "windows")]
+    {
+        use crate::device::readers::amd_adl::loader::AdapterProbe;
+        use crate::device::readers::amd_adl::{adapters, loader};
+
+        let Some(probe) = loader::adapter_info_probe() else {
+            return CheckResult::Skip("ADL unavailable (see amd.adl.library)".to_string());
+        };
+        match probe {
+            AdapterProbe::NoEntryPoint => CheckResult::Skip(
+                "atiadlxx.dll does not export ADL2_Adapter_AdapterInfo_Get; multi-GPU \
+                 attribution is unavailable on this driver"
+                    .to_string(),
+            ),
+            AdapterProbe::CallFailed => CheckResult::Warn(
+                "ADL2_Adapter_AdapterInfo_Get failed or reported an implausible adapter count"
+                    .to_string(),
+                Some("single-GPU sensor augmentation is unaffected".to_string()),
+            ),
+            AdapterProbe::Rows { rows, layout_ok } => {
+                let dump = rows
+                    .iter()
+                    .enumerate()
+                    .map(|(slot, row)| adapters::describe_raw_entry(slot, row))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                if !layout_ok {
+                    return CheckResult::Warn(
+                        format!(
+                            "AdapterInfo layout verification FAILED; multi-GPU attribution is \
+                             disabled. raw rows: {dump}"
+                        ),
+                        Some(
+                            "this is what a wrong transcribed struct layout looks like; please \
+                             report the raw rows so the layout can be corrected"
+                                .to_string(),
+                        ),
+                    );
+                }
+                let parsed = adapters::parse_adapters(&rows);
+                let groups = adapters::group_by_card(&parsed);
+                CheckResult::Pass(format!(
+                    "{} adapter row(s) across {} physical card(s); {}",
+                    rows.len(),
+                    groups.len(),
+                    dump
+                ))
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        CheckResult::Skip("ADL is Windows-only".to_string())
+    }
+}
 
 /// Report whether `atiadlxx.dll` loaded and an ADL2 context was created.
 fn check_adl_library(_ctx: &CheckCtx) -> CheckResult {

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -159,11 +159,10 @@ fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
                 let parsed = adapters::parse_adapters(&populated);
                 let groups = adapters::group_by_card(&parsed);
                 CheckResult::Pass(format!(
-                    "{} adapter row(s), {} populated, across {} physical card(s); {}",
+                    "{} adapter row(s), {} populated, across {} physical card(s); {dump}",
                     rows.len(),
                     populated.len(),
                     groups.len(),
-                    dump
                 ))
             }
         }

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -98,9 +98,12 @@ static ADL_ADAPTERS: Check = Check {
 /// so an operator on real hardware is the verifier. Legible device
 /// paths in the dump confirm the layout; garbage refutes it, which is
 /// why the rows are printed even, and especially, when runtime
-/// verification fails. The dump also shows the grouping and the PNP
-/// strings that multi-GPU attribution matches against the GPU uuids,
-/// so a wrong match can be diagnosed from the same output.
+/// verification fails, and why each row carries its `RowState` tag:
+/// BLANK (driver memset, healthy filtering) versus UNTOUCHED (poison
+/// intact, short write) is exactly the distinction a real-hardware
+/// report needs to settle. The dump also shows the grouping and the
+/// PNP strings that multi-GPU attribution matches against the GPU
+/// uuids, so a wrong match can be diagnosed from the same output.
 fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
     #[cfg(target_os = "windows")]
     {
@@ -121,16 +124,22 @@ fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
                     .to_string(),
                 Some("single-GPU sensor augmentation is unaffected".to_string()),
             ),
-            AdapterProbe::Rows { rows, layout_ok } => {
+            AdapterProbe::Rows { rows, accepted } => {
+                // Every row renders with its RowState tag (POPULATED
+                // rows untagged, BLANK / UNTOUCHED / GARBLED named), so
+                // a real-hardware dump says decisively whether a
+                // non-populated row was memset by the driver or never
+                // written; that distinction is what the poison pre-fill
+                // exists for.
                 let dump = rows
                     .iter()
                     .enumerate()
                     .map(|(slot, row)| adapters::describe_raw_entry(slot, row))
                     .collect::<Vec<_>>()
                     .join("; ");
-                if !layout_ok {
-                    // The two failures point at opposite corrections, so
-                    // name which one was seen. See
+                let Some(populated) = accepted else {
+                    // The failure shapes point at different
+                    // corrections, so name the one seen. See
                     // `adapters::describe_layout_failure`, which is
                     // where this is tested: this whole function is
                     // Windows-gated and cannot run on the Linux runner.
@@ -146,12 +155,13 @@ fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
                                 .to_string(),
                         ),
                     );
-                }
-                let parsed = adapters::parse_adapters(&rows);
+                };
+                let parsed = adapters::parse_adapters(&populated);
                 let groups = adapters::group_by_card(&parsed);
                 CheckResult::Pass(format!(
-                    "{} adapter row(s) across {} physical card(s); {}",
+                    "{} adapter row(s), {} populated, across {} physical card(s); {}",
                     rows.len(),
+                    populated.len(),
                     groups.len(),
                     dump
                 ))

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -129,24 +129,12 @@ fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
                     .collect::<Vec<_>>()
                     .join("; ");
                 if !layout_ok {
-                    // The two failures point at opposite corrections,
-                    // so name which one was seen. A blank row means ADL
-                    // wrote fewer rows than `iInputSize` asked for,
-                    // which is what a declared AdapterInfo larger than
-                    // the driver's produces; garbled strings are the
-                    // other direction.
-                    let blank = rows.iter().filter(|row| row.is_blank()).count();
-                    let shape = if blank > 0 {
-                        format!(
-                            "the driver left {blank} of {} row(s) untouched, which is what a \
-                             declared AdapterInfo larger than the driver's produces",
-                            rows.len()
-                        )
-                    } else {
-                        "the rows were written but their string fields are not legible, which is \
-                         what a wrong field offset or stride produces"
-                            .to_string()
-                    };
+                    // The two failures point at opposite corrections, so
+                    // name which one was seen. See
+                    // `adapters::describe_layout_failure`, which is
+                    // where this is tested: this whole function is
+                    // Windows-gated and cannot run on the Linux runner.
+                    let shape = adapters::describe_layout_failure(&rows);
                     return CheckResult::Warn(
                         format!(
                             "AdapterInfo layout verification FAILED; multi-GPU attribution is \

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -129,14 +129,32 @@ fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
                     .collect::<Vec<_>>()
                     .join("; ");
                 if !layout_ok {
+                    // The two failures point at opposite corrections,
+                    // so name which one was seen. A blank row means ADL
+                    // wrote fewer rows than `iInputSize` asked for,
+                    // which is what a declared AdapterInfo larger than
+                    // the driver's produces; garbled strings are the
+                    // other direction.
+                    let blank = rows.iter().filter(|row| row.is_blank()).count();
+                    let shape = if blank > 0 {
+                        format!(
+                            "the driver left {blank} of {} row(s) untouched, which is what a \
+                             declared AdapterInfo larger than the driver's produces",
+                            rows.len()
+                        )
+                    } else {
+                        "the rows were written but their string fields are not legible, which is \
+                         what a wrong field offset or stride produces"
+                            .to_string()
+                    };
                     return CheckResult::Warn(
                         format!(
                             "AdapterInfo layout verification FAILED; multi-GPU attribution is \
-                             disabled. raw rows: {dump}"
+                             disabled. {shape}. raw rows: {dump}"
                         ),
                         Some(
-                            "this is what a wrong transcribed struct layout looks like; please \
-                             report the raw rows so the layout can be corrected"
+                            "please report the raw rows so the transcribed layout in \
+                             device/readers/amd_adl/ffi.rs can be corrected"
                                 .to_string(),
                         ),
                     );


### PR DESCRIPTION
## Status: layout CONFIRMED on real hardware, merging with the two-GPU observation tracked in #370

**This supersedes the "do not merge" header this PR originally carried.** That header existed because the `AdapterInfo` layout was transcribed blind from AMD's public `adl_structures.h`, and nothing in CI compiles all-smi for Windows. That risk is retired. On 2026-08-18 the branch ran on a real AMD host (Radeon(TM) 8060S Graphics, Strix Halo APU `DEV_1586`, driver 32.0.31035.1003, Windows 11 Pro 26200, native `x86_64-pc-windows-msvc`, rustc 1.97.1). The declared 1572-byte layout, its stride across five rows, and every load-bearing offset were evaluated under the real target ABI and confirmed against the live driver; `strPNPString` came back byte-identical to the WMI `PNPDeviceID`, so the exact join this PR rests on does resolve on real hardware. The run also surfaced a bug that would have made the feature dead on arrival on the very hosts it targets, fixed here by `0bebb9a`. Whole-workspace `cargo build --release` and 61 `--lib` tests passed natively. The two hardware comments below carry the full dumps.

What remains is an observation, not a code question: whether two *different physical* cards report *different* telemetry. No host with one AMD GPU can establish that, since `plan_attribution` takes its `SoleGpu` arm before the inventory is ever consulted. Holding validated code out of `main` indefinitely, waiting on hardware that may not appear, costs more than it protects here, because every failure path in this PR declines attribution and keeps the DXGI/PDH baseline rather than guessing. The remaining acceptance criterion is therefore split out to #370 as a `type:test` issue, the same way #309, #310, and #311 were split into #354, #355, #356, and #357.

**For whoever has a two-AMD-GPU Windows host:** the validation procedure, the expected output shape, and what to report all live in #370.

## Summary

The Windows ADL reader bailed out on any host with two or more AMD GPUs (`can_attribute(count) == (count == 1)`), because without `AdapterInfo` an ADL adapter index cannot be tied to a physical card, and one card exposes several indices (one per display output) reporting identical telemetry. This PR declares `AdapterInfo`, groups adapter indices per physical card, matches cards to the reader's GPUs exactly, and relaxes attribution to any number of AMD GPUs while keeping every failure path a decline. The motivating configuration is a Ryzen APU plus Radeon dGPU laptop, which presents two AMD rows and previously lost temperature, power, fan, and clocks entirely.

## Struct size: 1572 bytes, not the issue's 1568

The issue body computes 1568 via `4 + 256 + 4*4 + 256 + 256 + 4 + 4 + 256 + 256 + 256 + 4`, which drops one `int`: the formula goes straight from `iSize` to `strUDID` and omits `iAdapterIndex`. Derived field by field from `adl_structures.h` (Windows branch), the layout is: `iSize` at 0, `iAdapterIndex` at 4, `strUDID` at 8, `iBusNumber` 264, `iDeviceNumber` 268, `iFunctionNumber` 272, `iVendorID` 276, `strAdapterName` 280, `strDisplayName` 536, `iPresent` 792, then the `#if defined(_WIN32) || defined(_WIN64)` tail: `iExist` 796, `strDriverPath` 800, `strDriverPathExt` 1056, `strPNPString` 1312, `iOSDisplayIndex` 1568, total 1572. That is 9 ints (36 bytes) plus 6 char[256] arrays (1536 bytes) with no padding, since every field is naturally 4-aligned. The declaration is Windows-shaped and documented as such: the Linux variant has a different tail and size, and nothing outside `cfg(target_os = "windows")` calls the entry point. Compile-time assertions pin the 1572-byte size, the 4-byte alignment, and every load-bearing offset, and they run unconditionally so the Linux test runner checks them.

## Safety design (why declaring this struct became acceptable)

- `ffi.rs`'s original refusal reasoned that ADL sizes its write by its own `sizeof` with no length parameter. That is true of `ADL2_New_QueryPMLogData_Get` but not here: `ADL2_Adapter_AdapterInfo_Get` takes the buffer size as `iInputSize`, which this PR passes correctly (the size of the requested rows).
- The padded-buffer pattern proven on `AdlPmLogDataBuffer` is preserved anyway: `AdapterInfoArray` allocates twice the requested rows plus slack, so a driver that ignores `iInputSize` and writes by a larger `sizeof` still lands inside our allocation.
- The residual risk (reading fields at wrong offsets) is caught at runtime: the struct is self-verifying because `strUDID`, `strAdapterName`, `strDisplayName`, and `strPNPString` are 256-byte char arrays at known offsets that read as NUL-terminated legible ASCII only if the layout is right. The buffer is pre-filled with a `0xAA` poison pattern and `AdapterInfo::classify` sorts each returned row into `Untouched` (poison intact, the driver never wrote it), `Blank` (all zero, the driver memset without populating, which AMD's own SDK sample treats as normal `iPresent`-style filtering), `Populated` (passes the string, `iSize`, and `iAdapterIndex` checks), or `Garbled` (written bytes contradicting the layout). `AdapterInfoArray::validated` returns only the populated rows and rejects the table when any row is garbled, when row 0 is not populated, when nothing is populated, or when populated rows repeat an `iAdapterIndex`. The two stride errors point in opposite directions and both are covered: a declared size larger than the driver's makes the driver stride shorter, so our later rows read misaligned and classify garbled; a declared size smaller than the driver's makes it write fewer rows and leave a trailing untouched run, which is accepted and under-attributes the missing cards but can never mis-attribute, since the exact PNP join in `plan_attribution` is the real gate and a garbled read cannot produce a `strPNPString` equal to a WMI `PNPDeviceID` by accident.
- Verification failure, a missing entry point (old drivers are looked up leniently), a failed call, or a failed match all produce the same outcome: decline attribution and keep the DXGI/PDH baseline, matching the conclusion the #346 review reached for `match_adapter`. A single-GPU host never consults `AdapterInfo` at all and keeps the pre-#353 behavior unchanged, pinned by a regression test.

## Known gaps in the verification, deliberately left open for hardware evidence

- **Resolved: blank rows no longer veto the table.** An earlier revision rejected any all-zero row as short-write evidence, which would have disabled multi-GPU attribution on drivers that follow AMD's own SDK pattern (memset the array, populate present adapters, let the caller filter by `iPresent`), exactly the hosts the pending hardware validation needs to work on. The poison pre-fill now separates the two facts the zero fill conflated: an all-zero row proves the driver wrote zeros (`BLANK`, accepted and dropped), while a row still carrying the poison proves the driver never wrote it (`UNTOUCHED`, accepted only past a populated row 0). Interleaved blanks, the signature of healthy filtering, are deliberately not rejected; a stride mismatch produces garbled rows or a trailing untouched run instead. The worst case of accepting non-populated rows is under-attribution, never mis-attribution. What the hardware dump should now show: every row tagged with its state, ideally all rows populated or a mix of populated and `BLANK`; a run of `UNTOUCHED` rows after a populated row 0 would be the signature of a declared struct smaller than the driver's and should be reported. See `AdapterInfo::classify` and `AdapterInfoArray::validated` in `ffi.rs`.
- **Only 4 of the struct's 6 string fields are checked by `looks_sane`.** `strUDID`, `strAdapterName`, `strDisplayName`, and `strPNPString` are verified; `strDriverPath` (offset 800) and `strDriverPathExt` (offset 1056) are not. Both sit strictly between `strDisplayName` (536) and `strPNPString` (1312), so a `strPNPString` parse that succeeds already means the stride carried the two skipped fields through intact, and the marginal detection gain of checking them too is small. Each additional strictness arm is also a new way for this check to decline on real hardware nobody has tested yet. Revisit after a real host produces a passing dump. See the doc comment on `AdapterInfo::looks_sane` in `ffi.rs`.

## What changed

- `src/device/readers/amd_adl/ffi.rs`: `AdapterInfo` declared `#[repr(C)]` with compile-time size/align/offset assertions and offset tests; `adl_string` / `adl_string_lossy` helpers; `AdapterInfo::looks_sane` runtime layout check; `AdapterInfoArray` padded buffer with `validated()`; `Adl2AdapterAdapterInfoGet` entry point type (`extern "C"`, Windows-gated per file convention); module docs rewritten, since they previously explained at length why the struct was absent. The buffer is poison-filled (`AdapterInfo::poisoned`, `0xAA`) rather than zeroed, `AdapterInfo::classify` assigns each row a `RowState` (`Untouched` / `Blank` / `Populated` / `Garbled`), and `validated()` returns the populated rows only, rejecting on any garbled row, a non-populated row 0, an empty result, or repeated `iAdapterIndex` values; the remaining verification gap above is recorded on `looks_sane`.
- `src/device/readers/amd_adl/adapters.rs` (new, platform-independent like `windows_gpu_perf::ids`): `parse_adapters`, `group_by_card` (per-card grouping by bus/device/function with per-row BDF plausibility filtering, dropping a group whose rows carry two different non-empty PNP instance paths rather than merging them), `plan_attribution` (exact `strPNPString` join first, unambiguous PCI vendor+device fallback second, no ordinal or name guessing, injectivity enforced, `SoleGpu`/`PerCard`/`Decline`), and `describe_raw_entry` for the doctor dump. Reuses `parse_pnp_device_id` from `windows_gpu_perf::ids` rather than reimplementing PCI id parsing. Also now the platform-independent home for `MAX_ADAPTER_ROWS`, `plausible_adapter_count`, `clamp_scan_count`, and `describe_layout_failure`, moved out of the Windows-only `loader.rs` and `doctor/checks/amd.rs` so this arithmetic and message-shaping logic is unit-tested on the Linux runner instead of living entirely behind `cfg(target_os = "windows")` with zero coverage. `describe_raw_entry` now tags each dump line with the row's state, and `describe_layout_failure` names the four rejection shapes (garbled rows, a dead call with row 0 still poisoned, an empty memset, repeated adapter indices).
- `src/device/readers/amd_adl.rs`: `can_attribute` replaced by `adapters::plan_attribution`; `augment` attributes per matched card on multi-GPU hosts (trying each of a card's indices until one answers PMLog) and keeps the single-GPU path byte-identical, including not fetching the inventory at all; module docs updated.
- `src/device/readers/amd_adl/loader.rs`: lenient lookup of `ADL2_Adapter_AdapterInfo_Get`; `adapter_inventory()` cached on the existing 60-second rescan interval so topology changes self-heal; `sample_adapter(index)` for per-card PMLog reads; `adapter_info_probe()` returning every raw row plus the accepted populated subset (`AdapterProbe::Rows { rows, accepted }`) for the doctor, with the cached inventory parsing only the populated rows; `scan_for_capable_adapter` and `probe_adapter_info` now call into `adapters::clamp_scan_count` / `adapters::plausible_adapter_count` instead of inlining the bound.
- `src/doctor/checks/amd.rs`: new `amd.adl.adapters` check (template: `amd.adl.sensors`) dumping index, bus/device/function, `strAdapterName`, and `strPNPString` per adapter, printing the raw rows even, and especially, when layout verification fails, since garbage strings are the evidence a wrong transcription produces; each dump line now carries the row's state tag, and the failure-shape message comes from the tested `adapters::describe_layout_failure`.
- `README.md`: the `amd.*` doctor check-ID table now lists `amd.adl.library`, `amd.adl.sensors`, and `amd.adl.adapters` alongside the pre-existing Linux checks; it previously listed none of the three ADL checks.

## Test plan

- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test --lib device::readers::amd_adl` (61 passed: layout offsets, string sanity, padded array, row classification into untouched/blank/populated/garbled, trailing-untouched acceptance, interleaved-blank acceptance, non-populated-row-0 rejection, duplicate-index rejection, wrong-stride garble rejection, grouping with several indices per card and two cards, the BDF-disagreement group drop, APU+dGPU exact matching, PCI-id fallback, identical-cards decline, cross-vendor decline, failed-verification decline, single-GPU regression pin, the checked `input_size` conversion, the extracted adapter-count bound/clamp functions, and the four doctor failure-shape messages plus per-row state tags)
- [x] `cargo test --lib doctor` (25 passed)
- [x] `cargo test --lib device::readers::windows_gpu_perf` (31 passed)
- [x] Windows-target compile check of the ADL modules in isolation: `ffi.rs`, `adapters.rs`, and `loader.rs` copied into a throwaway crate with a six-line stub for `windows_gpu_perf::ids`, then `cargo check --target x86_64-pc-windows-gnu`. Passes; flipping the 1572 assertion to 1568 fails the build, so the layout assertions are demonstrably live under a Windows target. Re-run after the poison-fill change with byte-identical copies of the three modules plus a replica of the doctor arm: passes, and a negative control (renaming the `validated` call in the loader copy) fails the build, so the `cfg(windows)` code is demonstrably compiled
- [ ] `cargo check --target x86_64-pc-windows-gnu` on the whole workspace: fails on this host (`zstd-sys` needs `x86_64-w64-mingw32-gcc`, which is not installed), which is why the logic lives in unconditional modules wherever possible
- [ ] Confirmed on a real host with two or more AMD GPUs with doctor output attached: NOT DONE, awaiting hardware (see the status section above)

Closes #353
Refs #370


