### PR TITLE
fix: report the pinned libamdgpu_top version and level_zero in doctor

### DIFF
--- a/src/doctor/bundle.rs
+++ b/src/doctor/bundle.rs
@@ -333,6 +333,15 @@ fn enabled_features() -> Vec<&'static str> {
     v.push("mock");
     #[cfg(feature = "furiosa")]
     v.push("furiosa");
+    // Recorded because this feature decides what the Intel GPU readers can
+    // collect at all: with it the readers dlopen the Level Zero loader and
+    // surface per-engine activity plus Sysman power, without it they fall
+    // back to the sysfs/WMI baseline. Omitting it hid the one fact that
+    // explains why two builds report different Intel GPU metrics (issue
+    // #362). Every feature declared in Cargo.toml except `default` must have
+    // an arm here; `bundle_covers_every_declared_feature` enforces that.
+    #[cfg(feature = "level_zero")]
+    v.push("level_zero");
     if v.is_empty() {
         v.push("none");
     }
@@ -459,6 +468,129 @@ fn macos_system_profiler_bytes(redact: &RedactOptions) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
     use crate::doctor::Summary;
+
+    /// Both sources are embedded at compile time. `Cargo.toml` is reached
+    /// through `CARGO_MANIFEST_DIR` and this module's own file through a
+    /// relative include, so neither depends on the working directory.
+    const MANIFEST: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
+    const BUNDLE_SOURCE: &str = include_str!("bundle.rs");
+
+    /// Feature names declared in the `[features]` table of `Cargo.toml`.
+    ///
+    /// Continuation lines of multi-line arrays carry no `=` and are skipped,
+    /// as are comments and blank lines. Keys that are not bare identifiers
+    /// are ignored so a stray quoted entry cannot be mistaken for a feature.
+    fn declared_features(manifest: &str) -> Vec<&str> {
+        let mut out = Vec::new();
+        let mut in_features = false;
+        for line in manifest.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') {
+                in_features = trimmed == "[features]";
+                continue;
+            }
+            if !in_features || trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            let Some((name, _)) = trimmed.split_once('=') else {
+                continue;
+            };
+            let name = name.trim();
+            if !name.is_empty()
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                out.push(name);
+            }
+        }
+        out
+    }
+
+    /// Source text of `enabled_features`, from its signature to the next
+    /// top-level `fn`. Restricting the scan to this span keeps unrelated
+    /// feature gates elsewhere in the file, and the literals in this test
+    /// module, from satisfying the coverage assertion.
+    fn enabled_features_body(source: &str) -> &str {
+        let start = source.find("fn enabled_features()").expect(
+            "fn enabled_features() not found in bundle.rs; if it was renamed or moved, update \
+             this test to point at the new location",
+        );
+        let rest = &source[start..];
+        let end = rest.find("\nfn ").unwrap_or(rest.len());
+        &rest[..end]
+    }
+
+    /// Feature names appearing in `#[cfg(feature = "...")]` attributes.
+    fn cfg_gated_features(body: &str) -> Vec<&str> {
+        const MARKER: &str = "#[cfg(feature = \"";
+        let mut out = Vec::new();
+        let mut rest = body;
+        while let Some(i) = rest.find(MARKER) {
+            rest = &rest[i + MARKER.len()..];
+            let Some((name, tail)) = rest.split_once('"') else {
+                break;
+            };
+            out.push(name);
+            rest = tail;
+        }
+        out
+    }
+
+    /// Every declared cargo feature must be representable in the bundle's
+    /// feature list.
+    ///
+    /// The arms are `#[cfg]`-gated, so a running test only observes the
+    /// features it was itself built with and cannot notice a missing arm for
+    /// a disabled one. Comparing the manifest against the source text is what
+    /// makes the check independent of the build configuration. This function
+    /// has already drifted twice (`amd` arrived late in #358, `level_zero` was
+    /// missing from the start, #362), which is what the assertion is for.
+    ///
+    /// `default` is excluded: it is an alias for other features rather than a
+    /// runtime capability of its own.
+    #[test]
+    fn bundle_covers_every_declared_feature() {
+        let declared = declared_features(MANIFEST);
+        assert!(
+            declared.contains(&"default") && declared.contains(&"cli"),
+            "parsing the [features] table of Cargo.toml looks broken, got {declared:?}"
+        );
+
+        let covered = cfg_gated_features(enabled_features_body(BUNDLE_SOURCE));
+        for feature in declared {
+            if feature == "default" {
+                continue;
+            }
+            assert!(
+                covered.contains(&feature),
+                "cargo feature `{feature}` is declared in Cargo.toml but enabled_features() has \
+                 no arm for it, so a build with it would understate itself in support bundles; \
+                 arms found: {covered:?}"
+            );
+        }
+    }
+
+    /// The reported list must match what the binary was actually built with,
+    /// in both directions: a compiled-in feature appears and a compiled-out
+    /// one does not.
+    #[test]
+    fn enabled_features_matches_build_configuration() {
+        let features = enabled_features();
+        for (name, compiled_in) in [
+            ("cli", cfg!(feature = "cli")),
+            ("amd", cfg!(feature = "amd")),
+            ("mock", cfg!(feature = "mock")),
+            ("furiosa", cfg!(feature = "furiosa")),
+            ("level_zero", cfg!(feature = "level_zero")),
+        ] {
+            assert_eq!(
+                features.contains(&name),
+                compiled_in,
+                "feature `{name}` compiled in: {compiled_in}, but reported list is {features:?}"
+            );
+        }
+    }
 
     #[test]
     fn bundle_writes_expected_entries() {

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -35,6 +35,27 @@ pub fn checks() -> &'static [&'static Check] {
     CHECKS
 }
 
+/// The exact `libamdgpu_top` version pinned in `Cargo.toml`.
+///
+/// Cargo hands the compiler no dependency versions, so `env!` cannot reach
+/// this and the value has to be transcribed. `check_libamdgpu_top` used to
+/// format `env!("CARGO_PKG_VERSION")` into the ABI string, which reported
+/// all-smi's own version as the dependency's (issue #362). The transcription
+/// is kept honest by `pinned_version_matches_cargo_toml`, which parses the `=`
+/// pin out of `Cargo.toml` and fails when the two disagree, so a pin bump that
+/// forgets this constant breaks a test instead of shipping a wrong ABI
+/// identifier.
+///
+/// The `test` arm of the `cfg` keeps the constant alive in configurations
+/// where the reporting arm below is compiled out (musl, non-Linux, or the
+/// `amd` feature off) so the guard test runs everywhere. Without it the
+/// constant would be dead code in exactly those builds.
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl"), feature = "amd"),
+    test
+))]
+const LIBAMDGPU_TOP_PINNED_VERSION: &str = "0.11.5";
+
 static ROCM_VERSION: Check = Check {
     id: "amd.rocm.version",
     title: "ROCm version",
@@ -236,10 +257,10 @@ fn check_libamdgpu_top(_ctx: &CheckCtx) -> CheckResult {
     {
         // The `libamdgpu_top` crate is linked at compile time; if this
         // binary was built with AMD support the dep is present. Surface
-        // the crate version as the ABI identifier.
+        // the dependency's pinned version as the ABI identifier, not
+        // all-smi's own version (issue #362).
         CheckResult::Pass(format!(
-            "linked libamdgpu_top {}",
-            env!("CARGO_PKG_VERSION")
+            "linked libamdgpu_top {LIBAMDGPU_TOP_PINNED_VERSION}"
         ))
     }
     #[cfg(all(target_os = "linux", not(target_env = "musl"), not(feature = "amd")))]
@@ -326,5 +347,68 @@ fn check_build_gate(_ctx: &CheckCtx) -> CheckResult {
     ))]
     {
         CheckResult::Pass("glibc or non-Linux target — AMD support available".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LIBAMDGPU_TOP_PINNED_VERSION;
+
+    /// `Cargo.toml` is embedded at compile time rather than read from a
+    /// runtime path so the test does not depend on the working directory,
+    /// and so editing the manifest forces a rebuild of this test.
+    const MANIFEST: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
+
+    /// Extract the exact version from the `libamdgpu_top` dependency line.
+    ///
+    /// Returns `None` when no dependency line is found or the version cannot
+    /// be read, which the caller turns into a failure: a manifest the parser
+    /// no longer understands must not quietly pass the guard. Comment lines
+    /// mentioning the crate are skipped because they start with `#`.
+    fn pinned_libamdgpu_top_version(manifest: &str) -> Option<&str> {
+        let line = manifest
+            .lines()
+            .map(str::trim)
+            .find(|l| l.starts_with("libamdgpu_top") && l.contains("version"))?;
+        let after_key = line.split_once("version")?.1;
+        let after_quote = after_key.split_once('"')?.1;
+        let value = after_quote.split_once('"')?.0;
+        Some(value.trim().trim_start_matches('=').trim())
+    }
+
+    /// The reported ABI identifier must be the pinned dependency version.
+    ///
+    /// This is the forcing function the `Cargo.toml` comment asks for by
+    /// hand: bumping the `=` pin without updating
+    /// [`LIBAMDGPU_TOP_PINNED_VERSION`] fails here rather than shipping a
+    /// wrong version to whoever is debugging an AMD ABI problem.
+    #[test]
+    fn pinned_version_matches_cargo_toml() {
+        let pinned = pinned_libamdgpu_top_version(MANIFEST).expect(
+            "could not parse the libamdgpu_top version out of Cargo.toml; if the dependency \
+             declaration moved or changed shape, update pinned_libamdgpu_top_version",
+        );
+        assert_eq!(
+            pinned, LIBAMDGPU_TOP_PINNED_VERSION,
+            "libamdgpu_top is pinned to {pinned} in Cargo.toml but amd.libamdgpu_top.abi reports \
+             {LIBAMDGPU_TOP_PINNED_VERSION}; update LIBAMDGPU_TOP_PINNED_VERSION to match the pin"
+        );
+    }
+
+    /// The pin must stay an exact `=` requirement. A caret or range would
+    /// let Cargo resolve a different version than the one reported, which
+    /// this guard could not detect.
+    #[test]
+    fn libamdgpu_top_is_pinned_exactly() {
+        let line = MANIFEST
+            .lines()
+            .map(str::trim)
+            .find(|l| l.starts_with("libamdgpu_top") && l.contains("version"))
+            .expect("libamdgpu_top dependency line not found in Cargo.toml");
+        assert!(
+            line.contains("\"="),
+            "libamdgpu_top must stay pinned with an exact `=` requirement so the reported ABI \
+             version is the resolved one, got: {line}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two reporting defects in the `doctor` module, both surfaced during review of #358 and left out of it to keep that PR scoped. Neither breaks execution; both make `doctor` state something false or incomplete, which matters here because the module exists to be trusted when something is already wrong.

`amd.libamdgpu_top.abi` formatted `env!("CARGO_PKG_VERSION")` into its message. That is all-smi's own version, not the dependency's, so a default build of 0.25.0 reported `linked libamdgpu_top 0.25.0` while the pin was `=0.11.5`. `enabled_features()` in the support-bundle packer had no arm for `level_zero`, so a build with that feature understated itself in every bundle it produced.

## Which option for defect 1, and why

**Option A** (a constant plus a guard test that parses `Cargo.toml`), not Option B (emit it from `build.rs`).

Option B is attractive because it derives the value rather than duplicating it, which makes drift impossible by construction. It was rejected on two grounds. First, the acceptance criterion asks that a pin bump without a matching update *fail a test*; under Option B there is nothing left to fail, because the reported value silently follows the pin. That sounds strictly better until the parser is what breaks: a `Cargo.toml` reshuffle that stops matching the build script yields either a build failure at best or a silently wrong compile-time value at worst, and no test exists to say so. Option A keeps a real assertion that can be watched failing, which is the difference between a guard and an assumption.

Second, Option B moves the parse into `build.rs`, where it runs on every build of every consumer, including ones that will never enable the `amd` feature, and where a failure surfaces as a build-script error rather than a test name. Option A confines the same parse to the test harness. The cost is one transcribed string, and the test is what makes that cost safe. The demonstration below shows the guard failing on a drifted pin before it passes on the correct one.

A second test, `libamdgpu_top_is_pinned_exactly`, asserts the requirement stays an exact `=`. Without it, relaxing the pin to a caret or range would let Cargo resolve a version that the constant no longer describes, and the first guard would still pass.

## Is a source-parsing test for defect 2 worth it

Yes, and it is the only thing that works. The arms in `enabled_features()` are `#[cfg]`-gated, so a runtime test observes only the features the test binary was itself built with. A missing arm for a feature that is off is invisible to it by definition, which is precisely how `level_zero` stayed missing from the day the feature landed and how `amd` went missing until #358. `bundle_covers_every_declared_feature` therefore parses the `[features]` table of `Cargo.toml` and compares it against the feature gates found in the source text of `enabled_features`, both embedded with `include_str!` so no path guessing is involved.

Brittleness was bounded rather than accepted. The scan is scoped to the span between `fn enabled_features()` and the next top-level `fn`, so gates elsewhere in the file, and the feature names appearing in the test module itself, cannot satisfy the assertion. Both the manifest parse and the function lookup fail loudly with an explanatory message instead of degrading to a vacuous pass, and a sanity assertion rejects an empty or malformed feature list before the loop runs. `enabled_features_matches_build_configuration` covers the runtime half in both directions: a compiled-in feature must appear, a compiled-out one must not.

## What changed

- `src/doctor/checks/amd.rs`: added `LIBAMDGPU_TOP_PINNED_VERSION` and used it in place of `env!("CARGO_PKG_VERSION")` in the ABI message. The constant is gated on the reporting arm's own cfg plus `test`, so it is absent from musl, non-Linux, and `amd`-off builds where nothing reads it, and never becomes dead code, while the guard test still runs in every configuration.
- `src/doctor/checks/amd.rs`: added `pinned_version_matches_cargo_toml` and `libamdgpu_top_is_pinned_exactly`.
- `src/doctor/bundle.rs`: added the missing `#[cfg(feature = "level_zero")]` arm to `enabled_features()`.
- `src/doctor/bundle.rs`: added `bundle_covers_every_declared_feature` and `enabled_features_matches_build_configuration`.

The three-state reporting introduced by #358 is untouched: linked, compiled out by the musl gate, compiled out by the `amd` feature. The other six legitimate `env!("CARGO_PKG_VERSION")` sites are untouched.

## Test plan

- [x] `cargo test --lib doctor`: 28 passed, 0 failed.
- [x] Defect 1 guard observed failing. Pin temporarily moved to `=0.11.4`, then `cargo test --lib doctor::checks::amd`: `pinned_version_matches_cargo_toml ... FAILED`, with `libamdgpu_top is pinned to 0.11.4 in Cargo.toml but amd.libamdgpu_top.abi reports 0.11.5`. Pin reverted, same command: `2 passed; 0 failed`. `git diff Cargo.toml` empty before committing.
- [x] Defect 2 guard observed failing. `level_zero` arm removed, then `cargo test --lib doctor::bundle`: `bundle_covers_every_declared_feature ... FAILED`, with `arms found: ["cli", "amd", "mock", "furiosa"]`, which is exactly the pre-fix state. Arm restored, same command: `7 passed; 0 failed`.
- [x] `cargo run --bin all-smi -- doctor` on aarch64 glibc Linux with default features prints `PASS amd.libamdgpu_top.abi            linked libamdgpu_top 0.11.5`, down from the 0.25.0 it reported before. `amd.build.target_env` still passes with its unchanged message, so the build-gate reporting is intact.
- [x] `cargo check --no-default-features --features cli` passes.
- [x] `cargo clippy --lib --tests -- -D warnings` clean for default features and for `--no-default-features --features cli`.
- [x] `cargo build --features level_zero` compiles, and a bundle produced from that build records `features: cli,amd,level_zero` in `version.txt`.
- [x] `cargo fmt --check` clean.

Not verified locally: the musl and non-Linux arms, since only `aarch64-unknown-linux-gnu` is installed on this host. Those arms are unchanged by this PR, and the new constant is compiled out of both by its cfg while the guard test still runs there under `test`.

Closes #362
