### PR TITLE
fix(macos): cut Apple Silicon client construction from 1.4s to 0.28s

### DIFF
--- a/docs/LIB_mode.md
+++ b/docs/LIB_mode.md
@@ -1172,6 +1172,10 @@ fn bad_example() -> Result<()> {
 }
 ```
 
+Construction is not free, and on macOS it is the most expensive of the supported platforms: it opens an IOReport subscription, discovers the machine's SMC temperature sensors, and takes a first sample so the initial query returns real data instead of nothing. On an Apple M5 Max that is roughly 280 ms for the first instance in a process and roughly 135 ms for later ones, which reuse the sensor and channel discovery the first one paid for. Keep one instance for the life of the monitoring loop rather than building one per query.
+
+Several instances may be alive at once, and dropping one does not disturb the others. The platform state they share is reference counted, so it is released when the last instance holding it goes away.
+
 ### 4. Handle Platform Differences
 
 ```rust

--- a/src/client.rs
+++ b/src/client.rs
@@ -59,9 +59,7 @@ use crate::error::Result;
 use crate::storage::{StorageInfo, StorageReader, create_storage_reader};
 
 #[cfg(target_os = "macos")]
-use crate::device::macos_native::{
-    initialize_native_metrics_manager, shutdown_native_metrics_manager,
-};
+use crate::device::macos_native::{acquire_native_metrics_manager, release_native_metrics_manager};
 
 #[cfg(target_os = "linux")]
 use crate::device::hlsmi::{initialize_hlsmi_manager, shutdown_hlsmi_manager};
@@ -211,7 +209,7 @@ impl AllSmi {
         #[cfg(target_os = "macos")]
         let macos_initialized = {
             if crate::device::is_apple_silicon() {
-                match initialize_native_metrics_manager(config.sample_interval_ms) {
+                match acquire_native_metrics_manager(config.sample_interval_ms) {
                     Ok(()) => true,
                     Err(e) => {
                         // Log but don't fail - some metrics may still work
@@ -710,7 +708,7 @@ impl Drop for AllSmi {
         // Cleanup platform-specific managers
         #[cfg(target_os = "macos")]
         if self._macos_initialized {
-            shutdown_native_metrics_manager();
+            release_native_metrics_manager();
         }
 
         #[cfg(target_os = "linux")]

--- a/src/device/macos_native/ioreport.rs
+++ b/src/device/macos_native/ioreport.rs
@@ -112,6 +112,154 @@ fn get_cfstring_refs() -> &'static CFStringRefs {
     CFSTRING_REFS.get_or_init(CFStringRefs::new)
 }
 
+/// One `IOReportCopyChannelsInGroup` query, in a form that can cross a thread
+/// boundary.
+///
+/// SAFETY: both fields are `CFStringRef`s owned by [`CFStringRefs`], which
+/// retains them for the life of the process and never mutates them. The same
+/// reasoning that makes `CFStringRefs` `Sync` makes this `Send`.
+#[derive(Clone, Copy)]
+struct ChannelGroupQuery {
+    group: CFStringRef,
+    subgroup: CFStringRef,
+}
+
+unsafe impl Send for ChannelGroupQuery {}
+
+impl ChannelGroupQuery {
+    /// Run the query. Returns null when the group does not exist on this host.
+    fn copy_channels(self) -> CFDictionaryRef {
+        unsafe { IOReportCopyChannelsInGroup(self.group, self.subgroup, 0, 0, 0) }
+    }
+}
+
+/// Process-wide cache of the merged channel description used to open every
+/// IOReport subscription.
+///
+/// SAFETY: holds an owned (+1 retained) reference to an immutable
+/// CFDictionary that is never released and never mutated after publication.
+/// Immutable CF objects are safe to read concurrently, and the only consumer,
+/// [`IOReport::new`], reads it solely as the source of a
+/// `CFDictionaryCreateMutableCopy`.
+struct MergedChannels(CFDictionaryRef);
+
+unsafe impl Send for MergedChannels {}
+unsafe impl Sync for MergedChannels {}
+
+/// Cached result of enumerating and merging the three channel groups.
+///
+/// The set of channels a machine exposes is fixed by its hardware, so this is
+/// computed once per process. That matters because
+/// `IOReportCopyChannelsInGroup` is by far the most expensive part of opening
+/// a subscription, and a library consumer can construct and drop several
+/// clients over a process's life (issue #374).
+static MERGED_CHANNELS: OnceLock<MergedChannels> = OnceLock::new();
+
+/// Enumerate the three channel groups and merge them into one dictionary.
+///
+/// The three queries are independent reads that are only combined afterwards,
+/// so they run concurrently. Only the Energy Model group is required: the CPU
+/// and GPU stats groups are tolerated as absent, which is the same asymmetry
+/// the sequential version had.
+///
+/// Returns an owned (+1 retained) dictionary.
+fn build_merged_channels() -> Result<CFDictionaryRef, &'static str> {
+    let refs = get_cfstring_refs();
+
+    // Spawn all three before joining any, so they overlap.
+    let energy = spawn_channel_query(refs.energy_model, ptr::null());
+    let cpu = spawn_channel_query(refs.cpu_stats, refs.cpu_perf_states);
+    let gpu = spawn_channel_query(refs.gpu_stats, refs.gpu_perf_states);
+
+    // `Err` means that worker panicked, which is distinct from a group that
+    // simply does not exist on this host: the latter returns a null dictionary.
+    let energy_channels = energy.join();
+    let cpu_channels = cpu.join().unwrap_or(ptr::null());
+    let gpu_channels = gpu.join().unwrap_or(ptr::null());
+
+    let energy_channels = match energy_channels {
+        Ok(dict) if !dict.is_null() => dict,
+        outcome => {
+            // The optional groups may still have succeeded; do not leak them.
+            for dict in [cpu_channels, gpu_channels] {
+                if !dict.is_null() {
+                    unsafe { CFRelease(dict as *const c_void) };
+                }
+            }
+            return Err(match outcome {
+                Err(_) => "IOReport Energy Model channel enumeration panicked",
+                Ok(_) => "Failed to get Energy Model channels",
+            });
+        }
+    };
+
+    unsafe {
+        // Merge all channels into one dictionary
+        if !cpu_channels.is_null() {
+            IOReportMergeChannels(energy_channels, cpu_channels, ptr::null());
+            CFRelease(cpu_channels as *const c_void);
+        }
+        if !gpu_channels.is_null() {
+            IOReportMergeChannels(energy_channels, gpu_channels, ptr::null());
+            CFRelease(gpu_channels as *const c_void);
+        }
+    }
+
+    Ok(energy_channels)
+}
+
+/// A `CFDictionaryRef` that may cross a thread boundary.
+///
+/// SAFETY: used only to hand an owned dictionary back from the worker thread
+/// that created it to the thread that joins it. Ownership moves with the
+/// value, so no two threads ever hold it at once.
+struct OwnedDict(CFDictionaryRef);
+
+unsafe impl Send for OwnedDict {}
+
+/// A joinable handle over one in-flight channel-group query.
+struct ChannelQueryHandle(std::thread::JoinHandle<OwnedDict>);
+
+impl ChannelQueryHandle {
+    /// Wait for the query. `Err` means the worker panicked; `Ok(null)` means
+    /// the group does not exist on this host.
+    fn join(self) -> Result<CFDictionaryRef, ()> {
+        self.0.join().map(|OwnedDict(dict)| dict).map_err(|_| ())
+    }
+}
+
+/// Start one `IOReportCopyChannelsInGroup` query on its own thread.
+fn spawn_channel_query(group: CFStringRef, subgroup: CFStringRef) -> ChannelQueryHandle {
+    let query = ChannelGroupQuery { group, subgroup };
+    ChannelQueryHandle(std::thread::spawn(move || OwnedDict(query.copy_channels())))
+}
+
+/// Borrow the process-wide merged channel description, building it on first
+/// use.
+///
+/// The returned reference stays valid for the life of the process and must not
+/// be released by the caller.
+fn merged_channels() -> Result<CFDictionaryRef, &'static str> {
+    if let Some(cached) = MERGED_CHANNELS.get() {
+        return Ok(cached.0);
+    }
+
+    let built = build_merged_channels()?;
+
+    // Another thread may have published first; release the loser's copy rather
+    // than leaking it. Either way the cache now holds the reference to use.
+    if let Err(MergedChannels(duplicate)) = MERGED_CHANNELS.set(MergedChannels(built)) {
+        unsafe { CFRelease(duplicate as *const c_void) };
+    }
+
+    // Set above either published `built` or found a winner already there, so
+    // the cache is populated by now either way.
+    MERGED_CHANNELS
+        .get()
+        .map(|cached| cached.0)
+        .ok_or("IOReport channel cache was not published")
+}
+
 /// Opaque IOReport subscription reference
 #[repr(C)]
 struct IOReportSubscription {
@@ -717,41 +865,25 @@ pub struct IOReport {
 
 impl IOReport {
     /// Create a new IOReport subscription for the specified channel groups
+    ///
+    /// The channel description this subscribes to is enumerated once per
+    /// process and cached, so repeated construction (a library consumer
+    /// building more than one client over the process's life) pays only for
+    /// the subscription itself.
     pub fn new() -> Result<Self, &'static str> {
+        // Borrowed from the process-wide cache, which retains it. Not ours to
+        // release.
+        let merged = merged_channels()?;
+
         unsafe {
-            // Get static CFString refs to avoid use-after-free
-            let refs = get_cfstring_refs();
-
-            // Get channels for each group using static CFStrings
-            let energy_channels =
-                IOReportCopyChannelsInGroup(refs.energy_model, ptr::null(), 0, 0, 0);
-            let cpu_channels =
-                IOReportCopyChannelsInGroup(refs.cpu_stats, refs.cpu_perf_states, 0, 0, 0);
-            let gpu_channels =
-                IOReportCopyChannelsInGroup(refs.gpu_stats, refs.gpu_perf_states, 0, 0, 0);
-
-            if energy_channels.is_null() {
-                return Err("Failed to get Energy Model channels");
-            }
-
-            // Merge all channels into one dictionary
-            if !cpu_channels.is_null() {
-                IOReportMergeChannels(energy_channels, cpu_channels, ptr::null());
-                CFRelease(cpu_channels as *const c_void);
-            }
-            if !gpu_channels.is_null() {
-                IOReportMergeChannels(energy_channels, gpu_channels, ptr::null());
-                CFRelease(gpu_channels as *const c_void);
-            }
-
-            // Create mutable copy for subscription
-            let count = core_foundation::dictionary::CFDictionaryGetCount(energy_channels) as isize;
+            // Create mutable copy for subscription. The cached dictionary must
+            // stay pristine, so the subscription always gets its own copy.
+            let count = core_foundation::dictionary::CFDictionaryGetCount(merged) as isize;
             let channels = core_foundation::dictionary::CFDictionaryCreateMutableCopy(
                 core_foundation::base::kCFAllocatorDefault,
                 count,
-                energy_channels,
+                merged,
             );
-            CFRelease(energy_channels as *const c_void);
 
             if channels.is_null() {
                 return Err("Failed to create mutable channel dictionary");
@@ -1204,6 +1336,65 @@ impl IOReportMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Opening a second subscription must not re-enumerate the channel groups.
+    ///
+    /// Enumerating them is the expensive half of `IOReport::new`, and a library
+    /// consumer that constructs and drops several clients over a process's life
+    /// used to pay it every time (issue #374). Pointer identity is the direct
+    /// evidence that the second call reused the first call's work; a timing
+    /// assertion would prove the same thing less reliably.
+    ///
+    /// Skipped where IOReport is unavailable (an Intel Mac, a VM, a sandboxed
+    /// runner), which is not a failure.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn channel_enumeration_happens_once_per_process() {
+        let Ok(first) = merged_channels() else {
+            return;
+        };
+        let second = merged_channels().expect("a cached lookup cannot start failing");
+        assert_eq!(
+            first, second,
+            "the merged channel dictionary must be enumerated once and reused"
+        );
+    }
+
+    /// Every subscription gets its own mutable copy, so nothing a subscription
+    /// does can reach the cached description the next one is built from.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn each_subscription_copies_the_cached_channels() {
+        let Ok(cached) = merged_channels() else {
+            return;
+        };
+        let Ok(report) = IOReport::new() else {
+            return;
+        };
+        assert_ne!(
+            report.channels as CFDictionaryRef, cached,
+            "a subscription must not hold the cached dictionary itself"
+        );
+    }
+
+    /// Two subscriptions can be open at once, which is what a second client
+    /// constructed before the first is dropped amounts to.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn two_subscriptions_can_coexist() {
+        let Ok(first) = IOReport::new() else {
+            return;
+        };
+        let Ok(second) = IOReport::new() else {
+            return;
+        };
+        assert!(!first.channels.is_null());
+        assert!(!second.channels.is_null());
+        assert_ne!(
+            first.channels, second.channels,
+            "each subscription needs its own channel dictionary"
+        );
+    }
 
     #[test]
     fn test_calc_freq_from_residencies() {

--- a/src/device/macos_native/ioreport.rs
+++ b/src/device/macos_native/ioreport.rs
@@ -217,21 +217,42 @@ struct OwnedDict(CFDictionaryRef);
 
 unsafe impl Send for OwnedDict {}
 
-/// A joinable handle over one in-flight channel-group query.
-struct ChannelQueryHandle(std::thread::JoinHandle<OwnedDict>);
+/// One channel-group query, either already running on its own thread or
+/// waiting to run on the calling thread.
+enum ChannelQuery {
+    Spawned(std::thread::JoinHandle<OwnedDict>),
+    /// No thread was available, so the query runs inline when joined. That
+    /// makes the enumeration sequential again, which is exactly the behavior
+    /// this replaced, rather than a failure.
+    Inline(ChannelGroupQuery),
+}
 
-impl ChannelQueryHandle {
+impl ChannelQuery {
     /// Wait for the query. `Err` means the worker panicked; `Ok(null)` means
     /// the group does not exist on this host.
     fn join(self) -> Result<CFDictionaryRef, ()> {
-        self.0.join().map(|OwnedDict(dict)| dict).map_err(|_| ())
+        match self {
+            Self::Spawned(handle) => handle.join().map(|OwnedDict(dict)| dict).map_err(|_| ()),
+            Self::Inline(query) => Ok(query.copy_channels()),
+        }
     }
 }
 
 /// Start one `IOReportCopyChannelsInGroup` query on its own thread.
-fn spawn_channel_query(group: CFStringRef, subgroup: CFStringRef) -> ChannelQueryHandle {
+///
+/// Thread creation can fail under resource pressure, and `thread::spawn`
+/// panics when it does. This is reached from `AllSmi::with_config`, a library
+/// entry point that reports failure through `Result`, so a refused thread
+/// degrades to running the query inline instead of unwinding through it.
+fn spawn_channel_query(group: CFStringRef, subgroup: CFStringRef) -> ChannelQuery {
     let query = ChannelGroupQuery { group, subgroup };
-    ChannelQueryHandle(std::thread::spawn(move || OwnedDict(query.copy_channels())))
+    match std::thread::Builder::new()
+        .name("all-smi-ioreport".to_string())
+        .spawn(move || OwnedDict(query.copy_channels()))
+    {
+        Ok(handle) => ChannelQuery::Spawned(handle),
+        Err(_) => ChannelQuery::Inline(query),
+    }
 }
 
 /// Borrow the process-wide merged channel description, building it on first

--- a/src/device/macos_native/manager.rs
+++ b/src/device/macos_native/manager.rs
@@ -99,9 +99,23 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::Duration;
 
+/// The process-global manager together with the number of live handles that
+/// asked for it to be kept alive.
+#[derive(Default)]
+struct ManagerSlot {
+    manager: Option<Arc<NativeMetricsManager>>,
+    /// Outstanding [`acquire_native_metrics_manager`] calls not yet matched by
+    /// a [`release_native_metrics_manager`].
+    ///
+    /// Only owning handles participate. [`initialize_native_metrics_manager`]
+    /// deliberately does not, because the readers that call it have no
+    /// teardown point of their own and would pin the manager forever.
+    handles: usize,
+}
+
 /// Global singleton for NativeMetricsManager
-static NATIVE_METRICS_MANAGER: Lazy<Mutex<Option<Arc<NativeMetricsManager>>>> =
-    Lazy::new(|| Mutex::new(None));
+static NATIVE_METRICS_MANAGER: Lazy<Mutex<ManagerSlot>> =
+    Lazy::new(|| Mutex::new(ManagerSlot::default()));
 
 /// Track if first data has been received
 static FIRST_DATA_RECEIVED: AtomicBool = AtomicBool::new(false);
@@ -477,32 +491,97 @@ unsafe impl Sync for NativeMetricsManager {}
 pub fn initialize_native_metrics_manager(
     interval_ms: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut manager_guard = NATIVE_METRICS_MANAGER.lock().map_err(|_| "Lock poisoned")?;
+    let mut slot = NATIVE_METRICS_MANAGER.lock().map_err(|_| "Lock poisoned")?;
+    ensure_manager(&mut slot, interval_ms)
+}
 
-    if manager_guard.is_none() {
-        let manager = NativeMetricsManager::new(interval_ms)?;
+/// Initialize the manager if needed and register an owning handle.
+///
+/// Pairs with [`release_native_metrics_manager`]. Use this instead of
+/// [`initialize_native_metrics_manager`] wherever the caller has a defined
+/// lifetime and tears the manager down when it ends, so that one owner ending
+/// does not pull the manager out from under another that is still running
+/// (issue #374).
+///
+/// The handle is registered only when initialization succeeds, so a caller
+/// that treats an error as "no manager to release" stays balanced.
+///
+/// Unused by the binary, which owns the manager for the whole process and
+/// tears it down with [`shutdown_native_metrics_manager`] instead.
+#[allow(dead_code)]
+pub fn acquire_native_metrics_manager(interval_ms: u64) -> Result<(), Box<dyn std::error::Error>> {
+    let mut slot = NATIVE_METRICS_MANAGER.lock().map_err(|_| "Lock poisoned")?;
+    ensure_manager(&mut slot, interval_ms)?;
+    slot.handles += 1;
+    Ok(())
+}
 
-        // Pre-collect first data sample to warm up the cache
-        // This ensures all subsequent calls from readers use cached data
-        let _ = manager.collect_once();
+/// Release an owning handle taken by [`acquire_native_metrics_manager`],
+/// tearing the manager down once the last one is gone.
+#[allow(dead_code)]
+pub fn release_native_metrics_manager() {
+    let Ok(mut slot) = NATIVE_METRICS_MANAGER.lock() else {
+        return;
+    };
 
-        *manager_guard = Some(Arc::new(manager));
+    slot.handles = slot.handles.saturating_sub(1);
+    if slot.handles > 0 {
+        return;
     }
 
+    let manager = slot.manager.take();
+    drop(slot);
+    finish_shutdown(manager);
+}
+
+/// Create the manager into `slot` if it is not there yet.
+fn ensure_manager(
+    slot: &mut ManagerSlot,
+    interval_ms: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if slot.manager.is_some() {
+        return Ok(());
+    }
+
+    let manager = NativeMetricsManager::new(interval_ms)?;
+
+    // Pre-collect first data sample to warm up the cache
+    // This ensures all subsequent calls from readers use cached data
+    let _ = manager.collect_once();
+
+    slot.manager = Some(Arc::new(manager));
     Ok(())
 }
 
 /// Get the global native metrics manager instance
 pub fn get_native_metrics_manager() -> Option<Arc<NativeMetricsManager>> {
-    NATIVE_METRICS_MANAGER.lock().ok()?.clone()
+    NATIVE_METRICS_MANAGER.lock().ok()?.manager.clone()
 }
 
 /// Shutdown and cleanup the native metrics manager
+///
+/// Unconditional: it tears the manager down and forgets every outstanding
+/// handle, so it belongs at process exit rather than at the end of one owner's
+/// life. Owners with a defined lifetime should use
+/// [`acquire_native_metrics_manager`] / [`release_native_metrics_manager`].
 #[allow(dead_code)]
 pub fn shutdown_native_metrics_manager() {
-    if let Ok(mut guard) = NATIVE_METRICS_MANAGER.lock()
-        && let Some(manager) = guard.take()
-    {
+    let manager = match NATIVE_METRICS_MANAGER.lock() {
+        Ok(mut slot) => {
+            slot.handles = 0;
+            slot.manager.take()
+        }
+        Err(_) => None,
+    };
+    finish_shutdown(manager);
+}
+
+/// Stop `manager`, if there is one, with the singleton lock already released.
+///
+/// [`NativeMetricsManager::shutdown`] joins the collector thread, so it must
+/// not run under the lock that thread's collaborators may need.
+fn finish_shutdown(manager: Option<Arc<NativeMetricsManager>>) {
+    if let Some(manager) = manager {
         manager.shutdown();
     }
     FIRST_DATA_RECEIVED.store(false, Ordering::Relaxed);

--- a/src/device/macos_native/mod.rs
+++ b/src/device/macos_native/mod.rs
@@ -46,6 +46,7 @@ pub use thermal::get_thermal_state;
 // Re-export public types for use by apple_silicon_native reader and main
 #[allow(unused_imports)]
 pub use manager::{
-    NativeMetricsManager, get_native_metrics_manager, initialize_native_metrics_manager,
+    NativeMetricsManager, acquire_native_metrics_manager, get_native_metrics_manager,
+    initialize_native_metrics_manager, release_native_metrics_manager,
     shutdown_native_metrics_manager,
 };

--- a/src/device/macos_native/smc.rs
+++ b/src/device/macos_native/smc.rs
@@ -35,8 +35,25 @@
 use std::ffi::c_void;
 use std::sync::OnceLock;
 
-/// Maximum number of temperature keys to discover per category (similar to mactop's limit)
-const MAX_TEMP_KEYS: usize = 64;
+/// Upper bound on discovered CPU temperature keys (`Tp*`/`Te*` on Apple
+/// Silicon, `TC*` on Intel).
+///
+/// This is a runaway guard, not a sampling budget: it is sized so no shipping
+/// Mac reaches it, which keeps the reported average over the complete sensor
+/// set rather than over an arbitrary prefix of the key table. Measured counts:
+/// 23 on an M5 Max, single digits on Intel.
+const MAX_CPU_TEMP_KEYS: usize = 256;
+
+/// Upper bound on discovered GPU temperature keys (`Tg*` on Apple Silicon,
+/// `TG*` on Intel).
+///
+/// Separate from [`MAX_CPU_TEMP_KEYS`] because the two families have very
+/// different real counts: an M5 Max exposes 84 `Tg*` sensors against 23
+/// `Tp*`/`Te*` ones. The previous shared cap of 64 truncated that set, so the
+/// reported GPU temperature averaged whichever 64 sensors the key table
+/// happened to list first. Sized to leave headroom above the largest known
+/// part (an Ultra is roughly two Max dies) so truncation stays theoretical.
+const MAX_GPU_TEMP_KEYS: usize = 512;
 
 /// Maximum number of fans to probe. No Mac ships with more than a handful.
 const MAX_FANS: u32 = 8;
@@ -189,10 +206,10 @@ enum TempKeyCategory {
 /// Every discovered reading is still range-filtered by the callers, so a
 /// misclassified sensor cannot pull an average outside plausible temperatures.
 fn classify_temperature_key(key: &str, data_type: u32) -> Option<TempKeyCategory> {
-    let bytes = key.as_bytes();
-    if bytes.len() < 2 || bytes[0] != b'T' {
+    if !is_temperature_key_candidate(key) {
         return None;
     }
+    let bytes = key.as_bytes();
 
     match data_type {
         SMC_TYPE_FLT => match bytes[1] {
@@ -207,6 +224,55 @@ fn classify_temperature_key(key: &str, data_type: u32) -> Option<TempKeyCategory
         },
         _ => None,
     }
+}
+
+/// True when `key`'s *name alone* leaves any chance that
+/// [`classify_temperature_key`] accepts it.
+///
+/// Discovery learns a key's name and its data type through two separate IOKit
+/// round trips, and the name is the cheaper of the two. Every key whose name
+/// already rules out both sensor families can therefore skip the second round
+/// trip entirely. On an M5 Max that is 3,623 of 3,739 keys.
+///
+/// [`classify_temperature_key`] delegates its name test here so the two can
+/// never disagree: a name this rejects is a name the classifier rejects.
+fn is_temperature_key_candidate(key: &str) -> bool {
+    let bytes = key.as_bytes();
+    bytes.len() >= 2 && bytes[0] == b'T' && matches!(bytes[1], b'p' | b'e' | b'g' | b'C' | b'G')
+}
+
+/// FourCC of the lowest key name any temperature sensor can have (`T\0\0\0`).
+const TEMP_KEY_RANGE_START: u32 = u32::from_be_bytes([b'T', 0, 0, 0]);
+
+/// FourCC one past the highest key name any temperature sensor can have
+/// (`U\0\0\0`). Every candidate name starts with `T`, so the sorted key table
+/// confines them to `TEMP_KEY_RANGE_START..TEMP_KEY_RANGE_END`.
+const TEMP_KEY_RANGE_END: u32 = u32::from_be_bytes([b'U', 0, 0, 0]);
+
+/// Result of one pass over the SMC key table, including how much of the table
+/// the pass had to touch.
+///
+/// The counts exist so callers (and tests) can assert that discovery stops
+/// short of the whole table; they are not used to compute any metric.
+#[derive(Debug, Clone, Default)]
+pub struct TempKeyScan {
+    /// Discovered CPU sensor keys, in key-table order.
+    pub cpu_keys: Vec<String>,
+    /// Discovered GPU sensor keys, in key-table order.
+    pub gpu_keys: Vec<String>,
+    /// Key-table indices actually read, including binary-search probes.
+    pub scanned_keys: u32,
+    /// Total number of keys the SMC reports.
+    pub total_keys: u32,
+    /// Whether the sorted-table fast path produced this result. False means
+    /// the exhaustive fallback ran. Diagnostic only; no metric depends on it.
+    #[allow(dead_code)]
+    pub used_sorted_range: bool,
+}
+
+/// Convert a FourCC code back to its 4-character name.
+fn fourcc_to_string(key: u32) -> String {
+    String::from_utf8_lossy(&key.to_be_bytes()).to_string()
 }
 
 /// Convert FourCC string to u32
@@ -333,68 +399,214 @@ impl SMC {
         Ok(count)
     }
 
-    /// Get key name by index
+    /// Get the raw FourCC code of the key at `index`.
     ///
-    /// Based on mactop's SMCGetKeyFromIndex implementation
-    pub fn get_key_from_index(&self, index: u32) -> Result<String, &'static str> {
+    /// The undecoded `u32` is what the key table is ordered by, so range
+    /// queries compare these rather than the lossily-decoded names returned by
+    /// [`get_key_from_index`].
+    fn get_key_code_from_index(&self, index: u32) -> Result<u32, &'static str> {
         let input = KeyData {
             data8: SMC_CMD_READ_INDEX,
             data32: index,
             ..Default::default()
         };
 
-        let output = self.read(&input)?;
+        Ok(self.read(&input)?.key)
+    }
 
-        // Key is stored as u32 in big-endian format
-        let key = output.key;
-        let key_bytes = key.to_be_bytes();
-
-        // Convert to string (4-character FourCC code)
-        let key_str = String::from_utf8_lossy(&key_bytes).to_string();
-
-        Ok(key_str)
+    /// Get key name by index
+    ///
+    /// Based on mactop's SMCGetKeyFromIndex implementation
+    ///
+    /// Part of this module's public surface; discovery itself compares the
+    /// undecoded codes from [`get_key_code_from_index`](Self::get_key_code_from_index).
+    #[allow(dead_code)]
+    pub fn get_key_from_index(&self, index: u32) -> Result<String, &'static str> {
+        Ok(fourcc_to_string(self.get_key_code_from_index(index)?))
     }
 
     /// Discover all temperature keys dynamically
     ///
-    /// Iterates the whole SMC key space once and keeps the keys that
-    /// [`classify_temperature_key`] recognizes as CPU or GPU sensors.
+    /// Keeps the keys that [`classify_temperature_key`] recognizes as CPU or
+    /// GPU sensors, capped per category by [`MAX_CPU_TEMP_KEYS`] and
+    /// [`MAX_GPU_TEMP_KEYS`].
     ///
-    /// Returns at most MAX_TEMP_KEYS per category to prevent unbounded growth.
+    /// See [`scan_temperature_keys`](Self::scan_temperature_keys) for how much
+    /// of the key table this has to read.
     pub fn discover_temperature_keys(&self) -> (Vec<String>, Vec<String>) {
-        let mut cpu_keys = Vec::with_capacity(MAX_TEMP_KEYS);
-        let mut gpu_keys = Vec::with_capacity(MAX_TEMP_KEYS);
+        let scan = self.scan_temperature_keys();
+        (scan.cpu_keys, scan.gpu_keys)
+    }
 
-        let key_count = match self.get_key_count() {
+    /// Discover temperature keys and report how much of the key table was read.
+    ///
+    /// The SMC key table is ordered by FourCC, so every candidate name (all of
+    /// which start with `T`) lives in one contiguous span. This binary-searches
+    /// for the start of that span and walks only to its end, which on an M5 Max
+    /// touches 359 of 3,739 indices instead of all of them. Within the span,
+    /// [`is_temperature_key_candidate`] rejects most names outright so the
+    /// second round trip (`read_key_info`) is spent only on plausible keys.
+    ///
+    /// Ordering is checked, not assumed. Nothing short of reading the whole
+    /// table can prove it, so this takes the two cheap checks available and
+    /// backstops them: the indices the binary search already read must be
+    /// non-decreasing, the key below the span must sort below it, and a span
+    /// that yields no sensors at all is treated as a failed assumption rather
+    /// than as a machine with no sensors. Any of those falling through runs the
+    /// exhaustive scan that predates this, which is the authority on what the
+    /// table contains. The fallback also skips the second round trip for
+    /// non-candidate names, so it is cheaper than the original was.
+    pub fn scan_temperature_keys(&self) -> TempKeyScan {
+        let total_keys = match self.get_key_count() {
             Ok(count) => count,
-            Err(_) => return (cpu_keys, gpu_keys),
+            Err(_) => return TempKeyScan::default(),
         };
 
-        for i in 0..key_count {
-            // Stop early if we've found enough keys in both categories
-            if cpu_keys.len() >= MAX_TEMP_KEYS && gpu_keys.len() >= MAX_TEMP_KEYS {
-                break;
-            }
+        if let Some(scan) = self.scan_sorted_temperature_range(total_keys)
+            && !(scan.cpu_keys.is_empty() && scan.gpu_keys.is_empty())
+        {
+            return scan;
+        }
 
-            let key = match self.get_key_from_index(i) {
-                Ok(k) => k,
-                Err(_) => continue,
-            };
+        self.scan_all_keys(total_keys)
+    }
 
-            // Get key info to check data type
-            let key_info = match self.read_key_info(&key) {
-                Ok(info) => info,
-                Err(_) => continue,
-            };
+    /// Fast path: locate the `T*` span in a FourCC-ordered key table and read
+    /// only that span.
+    ///
+    /// Returns `None` when the table does not behave like a sorted one, which
+    /// hands the caller back to [`scan_all_keys`](Self::scan_all_keys).
+    fn scan_sorted_temperature_range(&self, total_keys: u32) -> Option<TempKeyScan> {
+        if total_keys == 0 {
+            return None;
+        }
 
-            match classify_temperature_key(&key, key_info.data_type) {
-                Some(TempKeyCategory::Cpu) if cpu_keys.len() < MAX_TEMP_KEYS => cpu_keys.push(key),
-                Some(TempKeyCategory::Gpu) if gpu_keys.len() < MAX_TEMP_KEYS => gpu_keys.push(key),
-                _ => {}
+        let mut scanned_keys = 0u32;
+        // Probes recorded as (index, code); used to verify the table really is
+        // ordered before its ordering is relied on.
+        let mut probes: Vec<(u32, u32)> = Vec::new();
+
+        // Lower bound: first index whose key is >= "T\0\0\0".
+        let (mut lo, mut hi) = (0u32, total_keys);
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            let code = self.get_key_code_from_index(mid).ok()?;
+            scanned_keys += 1;
+            probes.push((mid, code));
+
+            if code < TEMP_KEY_RANGE_START {
+                lo = mid + 1;
+            } else {
+                hi = mid;
             }
         }
 
-        (cpu_keys, gpu_keys)
+        // Confirm the lower edge: the key before the span must sort below it.
+        if lo > 0 {
+            let code = self.get_key_code_from_index(lo - 1).ok()?;
+            scanned_keys += 1;
+            probes.push((lo - 1, code));
+            if code >= TEMP_KEY_RANGE_START {
+                return None;
+            }
+        }
+
+        // The probes must be consistent with an ordered table. Sorting by index
+        // and requiring non-decreasing codes catches a table that is not
+        // ordered the way the search assumed.
+        probes.sort_unstable_by_key(|(index, _)| *index);
+        if probes.windows(2).any(|w| w[0].1 > w[1].1) {
+            return None;
+        }
+
+        let mut cpu_keys = Vec::new();
+        let mut gpu_keys = Vec::new();
+
+        for index in lo..total_keys {
+            let code = match self.get_key_code_from_index(index) {
+                Ok(code) => code,
+                // Tolerated the same way the exhaustive scan tolerates it.
+                // The span's end is decided by the next key that reads back,
+                // so a gap costs extra indices but cannot end the walk early.
+                Err(_) => {
+                    scanned_keys += 1;
+                    continue;
+                }
+            };
+            scanned_keys += 1;
+
+            if code >= TEMP_KEY_RANGE_END {
+                break;
+            }
+
+            self.classify_key_at(code, &mut cpu_keys, &mut gpu_keys);
+
+            if cpu_keys.len() >= MAX_CPU_TEMP_KEYS && gpu_keys.len() >= MAX_GPU_TEMP_KEYS {
+                break;
+            }
+        }
+
+        Some(TempKeyScan {
+            cpu_keys,
+            gpu_keys,
+            scanned_keys,
+            total_keys,
+            used_sorted_range: true,
+        })
+    }
+
+    /// Fallback: walk the whole key table, as this did before the span search.
+    fn scan_all_keys(&self, total_keys: u32) -> TempKeyScan {
+        let mut cpu_keys = Vec::new();
+        let mut gpu_keys = Vec::new();
+        let mut scanned_keys = 0u32;
+
+        for index in 0..total_keys {
+            // Nothing left that either category can accept.
+            if cpu_keys.len() >= MAX_CPU_TEMP_KEYS && gpu_keys.len() >= MAX_GPU_TEMP_KEYS {
+                break;
+            }
+
+            let code = match self.get_key_code_from_index(index) {
+                Ok(code) => code,
+                Err(_) => {
+                    scanned_keys += 1;
+                    continue;
+                }
+            };
+            scanned_keys += 1;
+
+            self.classify_key_at(code, &mut cpu_keys, &mut gpu_keys);
+        }
+
+        TempKeyScan {
+            cpu_keys,
+            gpu_keys,
+            scanned_keys,
+            total_keys,
+            used_sorted_range: false,
+        }
+    }
+
+    /// Read `code`'s data type and file it under the category it belongs to.
+    ///
+    /// Skips the `read_key_info` round trip for any name that cannot classify,
+    /// and honours the per-category caps.
+    fn classify_key_at(&self, code: u32, cpu_keys: &mut Vec<String>, gpu_keys: &mut Vec<String>) {
+        let key = fourcc_to_string(code);
+        if !is_temperature_key_candidate(&key) {
+            return;
+        }
+
+        let Ok(key_info) = self.read_key_info(&key) else {
+            return;
+        };
+
+        match classify_temperature_key(&key, key_info.data_type) {
+            Some(TempKeyCategory::Cpu) if cpu_keys.len() < MAX_CPU_TEMP_KEYS => cpu_keys.push(key),
+            Some(TempKeyCategory::Gpu) if gpu_keys.len() < MAX_GPU_TEMP_KEYS => gpu_keys.push(key),
+            _ => {}
+        }
     }
 
     /// Read a value from the SMC
@@ -777,6 +989,163 @@ impl SMCMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The name pre-filter is the classifier's own first gate, so anything the
+    /// classifier can accept must survive it. If these ever disagree,
+    /// discovery silently stops finding sensors it used to find.
+    #[test]
+    fn name_prefilter_accepts_everything_the_classifier_can() {
+        let names = [
+            "Tp01", "Tp0X", "Te05", "Tg0f", "Tg7L", "TC0P", "TC0D", "TG0P", "TG0D", "TB0T", "TW0P",
+            "Ts0P", "PSTR", "F0Ac", "#KEY", "Tp", "T", "",
+        ];
+        for name in names {
+            for data_type in [SMC_TYPE_FLT, SMC_TYPE_SP78, SMC_TYPE_UI8, SMC_TYPE_UI32] {
+                if classify_temperature_key(name, data_type).is_some() {
+                    assert!(
+                        is_temperature_key_candidate(name),
+                        "{name} classifies but the pre-filter would have skipped it"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Keys the pre-filter rejects are exactly the keys whose second IOKit
+    /// round trip discovery is allowed to skip.
+    #[test]
+    fn name_prefilter_rejects_non_temperature_names() {
+        for name in [
+            "PSTR", "F0Ac", "#KEY", "TB0T", "TW0P", "Ts0P", "VP0R", "T", "",
+        ] {
+            assert!(
+                !is_temperature_key_candidate(name),
+                "{name} should not cost a key-info round trip"
+            );
+        }
+        for name in ["Tp01", "Te05", "Tg0f", "TC0P", "TG0D"] {
+            assert!(is_temperature_key_candidate(name), "{name} must be probed");
+        }
+    }
+
+    /// The span search assumes every candidate name sorts inside
+    /// `TEMP_KEY_RANGE_START..TEMP_KEY_RANGE_END`. A candidate outside it would
+    /// be skipped without the fallback ever noticing.
+    #[test]
+    fn every_candidate_name_sorts_inside_the_scanned_span() {
+        for second in *b"pegCG" {
+            for low in [0x00u8, b'0', b'z', 0xFF] {
+                let code = u32::from_be_bytes([b'T', second, low, low]);
+                assert!(
+                    (TEMP_KEY_RANGE_START..TEMP_KEY_RANGE_END).contains(&code),
+                    "{code:#010x} falls outside the scanned span"
+                );
+            }
+        }
+        assert!(str_to_fourcc("Sxxx") < TEMP_KEY_RANGE_START);
+        assert!(str_to_fourcc("U000") >= TEMP_KEY_RANGE_END);
+    }
+
+    /// GPU and CPU sensors are capped independently. A shared cap of 64
+    /// truncated the 84 `Tg*` sensors an M5 Max exposes, which made the
+    /// reported GPU temperature an average over whichever ones the key table
+    /// listed first.
+    #[test]
+    fn gpu_key_cap_clears_real_sensor_counts() {
+        const {
+            assert!(
+                MAX_GPU_TEMP_KEYS > 84,
+                "an M5 Max exposes 84 Tg* sensors; the cap must not truncate them"
+            );
+            assert!(
+                MAX_CPU_TEMP_KEYS > 23,
+                "an M5 Max exposes 23 Tp*/Te* sensors"
+            );
+        }
+    }
+
+    #[test]
+    fn fourcc_round_trips_through_its_name() {
+        for name in ["Tp01", "Tg0f", "TC0P", "#KEY", "PSTR"] {
+            assert_eq!(fourcc_to_string(str_to_fourcc(name)), name);
+        }
+    }
+
+    /// Discovery must stop short of the whole key table.
+    ///
+    /// The early exit it used to rely on required both categories to saturate a
+    /// shared 64-key cap, which no real Mac does, so every discovery walked all
+    /// 3,739 keys of an M5 Max table twice over. Skipped where the SMC is not
+    /// reachable (a VM or a sandboxed runner), which is not a failure.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn discovery_stops_before_the_end_of_the_key_table() {
+        let Ok(smc) = SMC::new() else {
+            return;
+        };
+        let scan = smc.scan_temperature_keys();
+        if scan.total_keys == 0 {
+            return;
+        }
+
+        assert!(
+            scan.scanned_keys < scan.total_keys,
+            "scanned {} of {} keys; discovery walked the whole table",
+            scan.scanned_keys,
+            scan.total_keys
+        );
+    }
+
+    /// Whichever path discovery took, the keys it returns must be ones the
+    /// classifier actually accepts, and it must respect the per-category caps.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn discovered_keys_are_classifiable_and_capped() {
+        let Ok(smc) = SMC::new() else {
+            return;
+        };
+        let scan = smc.scan_temperature_keys();
+
+        assert!(scan.cpu_keys.len() <= MAX_CPU_TEMP_KEYS);
+        assert!(scan.gpu_keys.len() <= MAX_GPU_TEMP_KEYS);
+        for key in scan.cpu_keys.iter().chain(scan.gpu_keys.iter()) {
+            assert!(
+                is_temperature_key_candidate(key),
+                "{key} is not a temperature sensor name"
+            );
+        }
+    }
+
+    /// The span search and the exhaustive fallback must agree. They are two
+    /// implementations of one question, and only the slow one is obviously
+    /// correct, so the fast one is checked against it on real hardware.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn the_span_search_finds_what_the_full_scan_finds() {
+        let Ok(smc) = SMC::new() else {
+            return;
+        };
+        let total_keys = match smc.get_key_count() {
+            Ok(count) if count > 0 => count,
+            _ => return,
+        };
+
+        let Some(fast) = smc.scan_sorted_temperature_range(total_keys) else {
+            return;
+        };
+        let full = smc.scan_all_keys(total_keys);
+
+        assert!(fast.used_sorted_range, "the fast path must report itself");
+        assert!(!full.used_sorted_range, "the fallback must report itself");
+        assert_eq!(fast.cpu_keys, full.cpu_keys, "CPU keys disagree");
+        assert_eq!(fast.gpu_keys, full.gpu_keys, "GPU keys disagree");
+        assert!(
+            fast.scanned_keys < full.scanned_keys,
+            "the span search read {} keys against the full scan's {}",
+            fast.scanned_keys,
+            full.scanned_keys
+        );
+    }
 
     #[test]
     fn test_fourcc_conversion() {

--- a/tests/library_api_test.rs
+++ b/tests/library_api_test.rs
@@ -356,27 +356,53 @@ fn test_refresh_memory_in_place() {
 /// every live GPU field as unavailable, even though it was still in use
 /// (issue #374).
 ///
-/// The second client is deliberately left untouched until after the first is
+/// The survivor is deliberately left untouched until after the other client is
 /// dropped: a client whose readers already cached the manager kept working by
 /// accident, so warming it first would hide the regression this guards.
+///
+/// Both drop orders are checked, because the two clients are not symmetric in
+/// the code under test. One of them constructed the shared manager and the
+/// other merely found it already there, and it should not matter which of the
+/// two goes away first.
 #[test]
 #[cfg(target_os = "macos")]
 fn dropping_one_client_leaves_another_working() {
+    assert_survivor_still_reads(DropOrder::FirstBuilt);
+    assert_survivor_still_reads(DropOrder::SecondBuilt);
+}
+
+#[cfg(target_os = "macos")]
+enum DropOrder {
+    /// Drop the client that constructed the shared manager.
+    FirstBuilt,
+    /// Drop the client that found the manager already constructed.
+    SecondBuilt,
+}
+
+/// Build two clients, drop the one `order` names, and assert the other still
+/// reads the GPU.
+#[cfg(target_os = "macos")]
+fn assert_survivor_still_reads(order: DropOrder) {
     let first = AllSmi::new().expect("Failed to create first AllSmi");
     let second = AllSmi::new().expect("Failed to create second AllSmi");
+
+    let (dropped, survivor) = match order {
+        DropOrder::FirstBuilt => (first, second),
+        DropOrder::SecondBuilt => (second, first),
+    };
 
     // Establish what a working client reports on this host. Where the native
     // metrics manager is unavailable to begin with (Intel Mac, VM, sandboxed
     // CI runner) there is nothing to regress, so the test only asserts that
-    // the second client is no worse off than the first.
-    let baseline_has_readings = first
+    // the survivor is no worse off than the client that was dropped.
+    let baseline_has_readings = dropped
         .get_gpu_info()
         .first()
         .is_some_and(|gpu| gpu.utilization_reading().is_some());
 
-    drop(first);
+    drop(dropped);
 
-    let gpus = second.get_gpu_info();
+    let gpus = survivor.get_gpu_info();
     if !baseline_has_readings {
         return;
     }

--- a/tests/library_api_test.rs
+++ b/tests/library_api_test.rs
@@ -347,3 +347,78 @@ fn test_refresh_memory_in_place() {
         assert_eq!(first.index, original_index);
     }
 }
+
+/// Dropping one `AllSmi` must not disable another that is still alive.
+///
+/// On macOS the native metrics manager is a process-global singleton, and
+/// `AllSmi::drop` used to tear it down unconditionally. A second client that
+/// had not yet touched its readers therefore found no manager and reported
+/// every live GPU field as unavailable, even though it was still in use
+/// (issue #374).
+///
+/// The second client is deliberately left untouched until after the first is
+/// dropped: a client whose readers already cached the manager kept working by
+/// accident, so warming it first would hide the regression this guards.
+#[test]
+#[cfg(target_os = "macos")]
+fn dropping_one_client_leaves_another_working() {
+    let first = AllSmi::new().expect("Failed to create first AllSmi");
+    let second = AllSmi::new().expect("Failed to create second AllSmi");
+
+    // Establish what a working client reports on this host. Where the native
+    // metrics manager is unavailable to begin with (Intel Mac, VM, sandboxed
+    // CI runner) there is nothing to regress, so the test only asserts that
+    // the second client is no worse off than the first.
+    let baseline_has_readings = first
+        .get_gpu_info()
+        .first()
+        .is_some_and(|gpu| gpu.utilization_reading().is_some());
+
+    drop(first);
+
+    let gpus = second.get_gpu_info();
+    if !baseline_has_readings {
+        return;
+    }
+
+    let gpu = gpus
+        .first()
+        .expect("the surviving client must still enumerate the GPU");
+    assert!(
+        gpu.utilization_reading().is_some(),
+        "utilization must still be readable after the other client was dropped"
+    );
+    assert!(
+        gpu.power_consumption_reading().is_some(),
+        "power must still be readable after the other client was dropped"
+    );
+}
+
+/// A client built after every earlier one was dropped must still work.
+///
+/// This is the same singleton lifetime as
+/// `dropping_one_client_leaves_another_working`, taken from the other side:
+/// the last drop does tear the manager down, so the next construction has to
+/// rebuild it rather than inherit a torn-down one.
+#[test]
+#[cfg(target_os = "macos")]
+fn a_client_built_after_the_last_drop_still_works() {
+    let first = AllSmi::new().expect("Failed to create first AllSmi");
+    let baseline_has_readings = first
+        .get_gpu_info()
+        .first()
+        .is_some_and(|gpu| gpu.utilization_reading().is_some());
+    drop(first);
+
+    let second = AllSmi::new().expect("Failed to create AllSmi after the first was dropped");
+    let gpus = second.get_gpu_info();
+    if !baseline_has_readings {
+        return;
+    }
+
+    assert!(
+        gpus.first()
+            .is_some_and(|gpu| gpu.utilization_reading().is_some()),
+        "a client built after the previous one was dropped must still read the GPU"
+    );
+}


### PR DESCRIPTION
## Summary

`AllSmi::with_config` blocked for seconds on Apple Silicon before returning, and all of it was in `get_gpu_readers` -> `NativeMetricsManager::new`. Issue #374 identifies three independent causes; each is fixed independently here.

On an Apple M5 Max (Mac17,7, macOS 26.6.2 25G83) the first construction drops from **1.28-1.54s to 273-285ms**, and each subsequent one from **275-281ms to 131-136ms**.

## Changes

**SMC key discovery no longer walks the whole key table.** `discover_temperature_keys` scanned all 3,739 keys of an M5 Max table at two IOKit round trips each, because its early exit required *both* the CPU and the GPU category to saturate a shared 64-key cap, and no real Mac saturates both (measured: 23 CPU keys, 84 GPU keys against a cap of 64). The key table is ordered by FourCC, so every candidate name (all start with `T`) occupies one contiguous span: discovery now binary-searches for the start of that span and walks only to its end, and skips the second round trip (`read_key_info`) for any name that cannot possibly classify. That is **373 indices read instead of 3,739**, and **1.05s becomes 80ms**.

**Ordering is checked, not assumed.** Nothing short of reading the whole table proves it is sorted, so the fast path takes the two cheap checks available and backstops them: the indices the binary search already read must be non-decreasing, the key below the span must sort below it, and a span that yields no sensors at all is treated as a failed assumption rather than as a machine with no sensors. Any of those falling through runs the exhaustive scan, which remains the authority on what the table contains and is itself cheaper than before thanks to the name pre-filter. `the_span_search_finds_what_the_full_scan_finds` asserts on real hardware that the two paths return identical keys.

**Channel enumeration runs concurrently and once per process.** `IOReport::new` issued three `IOReportCopyChannelsInGroup` calls back to back and merged them. They are independent reads combined only afterwards, so they now run concurrently (137ms to 62ms measured here), and because the channel set a machine exposes is fixed by its hardware, the merged dictionary is cached process-wide. Each subscription takes its own `CFDictionaryCreateMutableCopy`, so the cached description stays pristine. The existing asymmetry is preserved deliberately: the Energy Model group stays fatal, CPU and GPU stats stay tolerable as absent. A panicking enumeration thread is now reported distinctly from a group that simply does not exist on the host, and a thread the OS refuses under resource pressure falls back to running that query inline rather than panicking out of `AllSmi::with_config`, whose contract is to report failure through `Result`.

**Dropping one client no longer disables the others.** `AllSmi::drop` called `shutdown_native_metrics_manager`, which took the process-global manager out of its slot regardless of who else held it. A second client that had not yet touched its readers then found no manager and reported every live GPU field as unavailable. Reproduced before the fix:

```
a:                                    util=Some(0.61) power=Some(0.0085)
b (first ever use, after a dropped):  util=Some(-1.0) power=Some(-1.0)   <- GPU_METRIC_UNAVAILABLE
```

The manager now counts owning handles: `AllSmi` acquires one and releases it on drop, and teardown happens when the last one goes. `shutdown_native_metrics_manager` keeps its unconditional process-exit semantics for the binary, which does not participate in the count. As a side fix, the collector-thread join now runs outside the singleton lock rather than under it.

**The GPU key cap becomes per-category and stops truncating.** An M5 Max exposes 84 `Tg*` sensors against 23 `Tp*`/`Te*` ones, so the old shared cap of 64 truncated the GPU set and averaged whichever 64 sensors the key table happened to list first. Both caps are now sized above real hardware and act as runaway guards, which makes the reported temperature a function of the sensors rather than of key ordering.

Note this is the opposite direction from the *smaller* `Tg*` cap the issue suggests. The issue's stated concern is that the value is "diluted across whatever happens to be enumerated", and an arbitrary first-N subset is what causes that: removing the truncation addresses the concern directly, while lowering the cap would keep the value order-dependent. Measured cost of covering all 84 sensors instead of 64 is about 0.3ms per read, and the reported value moves by less than the thermal drift over the measurement itself (see below).

**Library docs record the construction cost and the overlap guarantee.** `docs/LIB_mode.md` told consumers to reuse an instance without saying what reuse saves, and said nothing about whether instances may overlap. It now records the measured cost on this hardware and states that overlapping instances are safe.

## Measurements

Release build, `default-features = false`, on an Apple M5 Max (Mac17,7, macOS 26.6.2 25G83). `origin/main` and this branch were built into separate worktrees and run **interleaved in the same session**, three rounds, so thermal drift affects both sides equally.

| | before (`origin/main`) | after |
|---|---|---|
| first `AllSmi::with_config` | 1.280s / 1.518s / 1.536s | 273ms / 275ms / 285ms |
| subsequent `with_config` | 275-281ms | 131-136ms |
| `discover_temperature_keys` | 933ms / 953ms / 1.271s | 77ms / 80ms / 83ms |
| key-table indices read | 3,739 of 3,739 | 373 of 3,739 |
| `IOReportCopyChannelsInGroup` x3 | 137-169ms (sequential) | 62ms (concurrent), then cached |
| discovered `Tg*` sensors | 64 (truncated from 84) | 84 |
| **reported GPU temperature** | **53.73 / 53.56 / 53.38 C** | **53.63 / 53.45 / 53.34 C** |

The GPU temperature column is the acceptance criterion on the `Tg*` cap. The three readings fall monotonically on both sides because the machine was cooling across the run; the before/after gap at each step (0.10 / 0.11 / 0.04 C) is smaller than the drift between consecutive steps, so the cap change is not what moves it.

**The 9-11s baseline in the issue did not reproduce on this hardware.** Measured `IOReportCopyChannelsInGroup` here is ~45ms per call, not the ~2.5s the issue reports, so the same three calls cost 137ms rather than 7.5s. The components the issue identifies are real and are exactly what these numbers move, but the absolute starting point on this machine was 1.4s, not 9-11s. Worth confirming against the original reporting environment.

## Tests

- `dropping_one_client_leaves_another_working` - the two-live-clients regression above. The second client is deliberately left untouched until after the first is dropped, because a client whose readers already cached the manager kept working by accident and warming it first would hide the bug.
- `a_client_built_after_the_last_drop_still_works` - the same lifetime from the other side.
- `discovery_stops_before_the_end_of_the_key_table` - asserts the scanned-key count is below the table size.
- `the_span_search_finds_what_the_full_scan_finds` - the fast path and the exhaustive fallback must return identical keys on real hardware.
- `channel_enumeration_happens_once_per_process` - pointer identity across two `merged_channels()` calls, which is direct evidence rather than a timing assertion.
- `each_subscription_copies_the_cached_channels`, `two_subscriptions_can_coexist` - the cache is never handed to a subscription itself.
- `name_prefilter_accepts_everything_the_classifier_can`, `every_candidate_name_sorts_inside_the_scanned_span` - the two invariants the fast path rests on.

Hardware-dependent tests skip cleanly where the SMC or IOReport is unreachable (Intel Mac, VM, sandboxed runner).

## Validation

`cargo test` (3331 passing, 0 failing), `cargo clippy --lib --tests --all-features` (no new warnings; the pre-existing `src/doctor/bundle.rs` one is untouched), `cargo fmt --check` clean.

Linux and Windows targets were not cross-compiled locally, since this environment has no cross-linker. Every change sits inside a `#[cfg(target_os = "macos")]` module or block, and the two new integration tests are `#[cfg(target_os = "macos")]`, so non-macOS targets see no change. Note that `cargo test --lib --no-default-features` fails to compile on `main` as well, from test code in `apple_silicon_native.rs` referencing the `cli`-gated `crate::api`; that is pre-existing and out of scope here.

Closes #374


