### PR TITLE
fix(windows): report the Arc B390 as an integrated Xe3 part

### DIFF
--- a/src/device/macos_native/smc.rs
+++ b/src/device/macos_native/smc.rs
@@ -261,8 +261,13 @@ pub struct TempKeyScan {
     /// Discovered GPU sensor keys, in key-table order.
     pub gpu_keys: Vec<String>,
     /// Key-table indices actually read, including binary-search probes.
+    ///
+    /// Diagnostic only, like the other two counters here: the binary
+    /// target never reads it, so it needs the same `dead_code` waiver.
+    #[allow(dead_code)]
     pub scanned_keys: u32,
     /// Total number of keys the SMC reports.
+    #[allow(dead_code)]
     pub total_keys: u32,
     /// Whether the sorted-table fast path produced this result. False means
     /// the exhaustive fallback ran. Diagnostic only; no metric depends on it.

--- a/src/device/readers/intel_gpu_names.rs
+++ b/src/device/readers/intel_gpu_names.rs
@@ -123,6 +123,12 @@ pub enum IntelArchitecture {
     XeLpg,
     /// Xe-LPG+ integrated (Lunar Lake / Core Ultra Series 2 / Arc 140V/130V).
     XeLpgPlus,
+    /// Xe3 integrated (Panther Lake / Core Ultra Series 3 / Arc B390).
+    ///
+    /// The first Intel iGPU generation sold under a discrete-looking model
+    /// number, which is what broke the naming assumptions this module used
+    /// to rely on (issue #364).
+    Xe3,
     /// Xe (Iris Xe on Tiger / Alder / Raptor Lake integrated graphics).
     IrisXe,
     /// Older integrated graphics — HD Graphics / UHD Graphics on pre-Xe
@@ -139,7 +145,12 @@ impl IntelArchitecture {
     pub fn is_sycl_capable(self) -> bool {
         matches!(
             self,
-            Self::Alchemist | Self::Battlemage | Self::XeLpg | Self::XeLpgPlus | Self::IrisXe,
+            Self::Alchemist
+                | Self::Battlemage
+                | Self::XeLpg
+                | Self::XeLpgPlus
+                | Self::Xe3
+                | Self::IrisXe,
         )
     }
 
@@ -150,6 +161,7 @@ impl IntelArchitecture {
             Self::Battlemage => "Battlemage (Xe2, B-series)",
             Self::XeLpg => "Xe-LPG (Meteor Lake)",
             Self::XeLpgPlus => "Xe-LPG+ (Lunar Lake)",
+            Self::Xe3 => "Xe3 (Panther Lake)",
             Self::IrisXe => "Iris Xe (Tiger/Alder/Raptor Lake)",
             Self::OlderIntegrated => "Pre-Xe (HD/UHD Graphics)",
             Self::Unknown => "Unknown",
@@ -237,15 +249,36 @@ pub fn classify_intel_architecture(name: &str) -> IntelArchitecture {
         return IntelArchitecture::XeLpgPlus;
     }
 
-    // 5. Xe-LPG (Meteor Lake). Either the explicit `xe-lpg`/`xe lpg`
-    //    family name, or any other Arc iGPU — by this point Alchemist and
-    //    Lunar Lake have been ruled out, so a residual `arc` + `graphics`
-    //    name (notably `Intel Arc Graphics`) is the Meteor Lake iGPU.
-    if (n.contains("xe") && n.contains("lpg")) || (n.contains("arc") && n.contains("graphics")) {
+    // 5. Xe3 (Panther Lake). Either an explicit family token, or Arc plus
+    //    a known Xe3 iGPU model number. Panther Lake is the first Intel
+    //    iGPU generation sold under a model number, so it has to be named
+    //    here: it is neither ruled in by the Battlemage SKU list above nor
+    //    ruled out by the residual-iGPU rule below, and without this arm
+    //    it silently reported as Meteor Lake (issue #364).
+    if n.contains("panther lake")
+        || n.contains("pantherlake")
+        || n.contains("xe3")
+        || (n.contains("arc") && XE3_INTEGRATED_MODELS.iter().any(|m| n.contains(m)))
+    {
+        return IntelArchitecture::Xe3;
+    }
+
+    // 6. Xe-LPG (Meteor Lake). Either the explicit `xe-lpg`/`xe lpg`
+    //    family name, or a residual unnumbered Arc iGPU. The unnumbered
+    //    part is load-bearing: `Intel Arc Graphics` with no model number
+    //    is the Meteor Lake iGPU, while every numbered Arc name has been
+    //    resolved by one of the arms above or is a part this table does
+    //    not know yet. Claiming Meteor Lake for an unknown numbered SKU is
+    //    what produced the B390 misreport, so numbered names fall through
+    //    to `Unknown` instead.
+    if n.contains("xe") && n.contains("lpg") {
+        return IntelArchitecture::XeLpg;
+    }
+    if n.contains("arc") && n.contains("graphics") && !contains_arc_model_number(&n) {
         return IntelArchitecture::XeLpg;
     }
 
-    // 6. Iris Xe (Tiger / Alder / Raptor Lake integrated).
+    // 7. Iris Xe (Tiger / Alder / Raptor Lake integrated).
     if n.contains("iris") && n.contains("xe") {
         return IntelArchitecture::IrisXe;
     }
@@ -253,9 +286,240 @@ pub fn classify_intel_architecture(name: &str) -> IntelArchitecture {
     IntelArchitecture::Unknown
 }
 
+// ---------------------------------------------------------------------
+// Discrete / integrated classification.
+//
+// Lives here rather than in `intel_gpu_windows` for two reasons. It is
+// pure string matching, like everything else in this module. And
+// `intel_gpu_windows` is `cfg(target_os = "windows")`, which means no
+// runner this project has ever compiles it, so the rule that produced the
+// B390 misreport was unreachable by every test job (issue #364, #368).
+// ---------------------------------------------------------------------
+
+/// Arc model numbers that belong to discrete cards.
+///
+/// An explicit table, not a pattern. Until Panther Lake, "an Arc name with
+/// a model number" was a sound proxy for "discrete", and the code relied on
+/// it. That proxy is dead: the integrated B390 and the discrete B380 differ
+/// by one digit, so no general rule over the name can separate them.
+///
+/// The entries are the SKUs this project already claimed as discrete before
+/// issue #364, kept exactly as they were so nothing regresses.
+const DISCRETE_ARC_MODELS: &[&str] = &[
+    // Alchemist (Xe-HPG) desktop
+    "a310", "a380", "a580", "a750", "a770", // Battlemage (Xe2) desktop
+    "b380", "b570", "b580",
+];
+
+/// Arc model numbers that belong to integrated parts.
+///
+/// The counterpart to [`DISCRETE_ARC_MODELS`]: numbered names that are
+/// iGPUs. Lunar Lake's `V` suffix used to escape the old heuristic by
+/// accident (`140v` is digits-then-letter, which failed its digits-only
+/// test); it is named explicitly here so the escape is deliberate.
+const INTEGRATED_ARC_MODELS: &[&str] = &["130v", "140v", "b390"];
+
+/// Panther Lake iGPU model numbers.
+///
+/// A subset of [`INTEGRATED_ARC_MODELS`]; kept separate because it also
+/// drives the architecture arm, where Lunar Lake's parts must not land.
+const XE3_INTEGRATED_MODELS: &[&str] = &["b390"];
+
+/// `true` when the lowercased name carries an Arc-style model number,
+/// whether or not this module knows which part it is.
+///
+/// A model number is a single letter in `a`..=`d` followed by three or more
+/// digits (`a770`, `b580`, `b390`), or three digits followed by `v`
+/// (`140v`). Used to tell "unnumbered, therefore the Meteor Lake iGPU" from
+/// "numbered, therefore a part that must be named explicitly".
+fn contains_arc_model_number(lower: &str) -> bool {
+    lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(is_arc_model_token)
+}
+
+/// `true` for one token that looks like an Arc model number.
+fn is_arc_model_token(token: &str) -> bool {
+    let bytes = token.as_bytes();
+    if bytes.len() < 4 {
+        return false;
+    }
+    // `a770`, `b580`, `b390`: letter then digits.
+    let letter_first =
+        matches!(bytes[0], b'a' | b'b' | b'c' | b'd') && bytes[1..].iter().all(u8::is_ascii_digit);
+    // `140v`, `130v`: digits then the Lunar Lake suffix.
+    let suffix_last =
+        bytes[bytes.len() - 1] == b'v' && bytes[..bytes.len() - 1].iter().all(u8::is_ascii_digit);
+    letter_first || suffix_last
+}
+
+/// Whether an Intel GPU marketing name denotes a discrete card.
+///
+/// `None` means "this name carries a model number this table does not
+/// know". That is a deliberate third answer rather than a guess: the caller
+/// leaves the field to the authoritative source (the DXGI memory layout)
+/// instead of asserting a variant it cannot support. Guessing here is
+/// exactly what reported the integrated B390 as `Discrete`.
+pub fn classify_intel_variant(name: &str) -> Option<&'static str> {
+    let lower = name.to_lowercase();
+    if !lower.contains("arc") {
+        // Iris / UHD / HD / Xe Graphics are always integrated.
+        return Some("Integrated");
+    }
+    if DISCRETE_ARC_MODELS.iter().any(|m| lower.contains(m)) {
+        return Some("Discrete");
+    }
+    if INTEGRATED_ARC_MODELS.iter().any(|m| lower.contains(m)) {
+        return Some("Integrated");
+    }
+    if contains_arc_model_number(&lower) {
+        // A numbered Arc part that predates this table's knowledge. Since
+        // Panther Lake, a number no longer implies discrete.
+        return None;
+    }
+    // Unnumbered Arc, e.g. `Intel(R) Arc(TM) Graphics` on Meteor Lake.
+    Some("Integrated")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---------- issue #364: Intel Arc B390 (Xe3 / Panther Lake) ----------
+
+    /// The reported defect: an integrated Xe3 part with a model number was
+    /// called `Discrete` because "Arc name with a model number" was taken
+    /// as a proxy for discrete.
+    #[test]
+    fn b390_is_integrated_not_discrete() {
+        assert_eq!(
+            classify_intel_variant("Intel(R) Arc(TM) B390 Graphics"),
+            Some("Integrated")
+        );
+    }
+
+    /// The second half of the same defect: with no Xe3 variant the B390
+    /// fell through to the residual-iGPU rule and reported as Meteor Lake.
+    #[test]
+    fn b390_classifies_as_xe3_not_meteor_lake() {
+        let arch = classify_intel_architecture("Intel(R) Arc(TM) B390 Graphics");
+        assert_eq!(arch, IntelArchitecture::Xe3);
+        assert_eq!(arch.label(), "Xe3 (Panther Lake)");
+        assert!(arch.is_sycl_capable());
+    }
+
+    /// B390 (integrated Xe3) and B380 (discrete Battlemage) differ by one
+    /// digit. This is the case that makes an explicit table necessary and
+    /// any general name pattern wrong.
+    #[test]
+    fn b380_and_b390_do_not_collide() {
+        assert_eq!(
+            classify_intel_variant("Intel(R) Arc(TM) B380 Graphics"),
+            Some("Discrete")
+        );
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) B380 Graphics"),
+            IntelArchitecture::Battlemage
+        );
+        assert_eq!(
+            classify_intel_variant("Intel(R) Arc(TM) B390 Graphics"),
+            Some("Integrated")
+        );
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) B390 Graphics"),
+            IntelArchitecture::Xe3
+        );
+    }
+
+    /// An Arc name carrying a model number this table does not know gets
+    /// no variant at all, so the caller can defer to DXGI. Guessing
+    /// `Discrete` here is the original bug.
+    #[test]
+    fn unknown_numbered_arc_defers_instead_of_guessing() {
+        assert_eq!(
+            classify_intel_variant("Intel(R) Arc(TM) C990 Graphics"),
+            None
+        );
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) C990 Graphics"),
+            IntelArchitecture::Unknown
+        );
+    }
+
+    // ---------- regression guards for the pre-#364 behaviour ----------
+
+    #[test]
+    fn known_discrete_arc_skus_stay_discrete() {
+        for name in [
+            "Intel(R) Arc(TM) A770 Graphics",
+            "Intel(R) Arc(TM) A750 Graphics",
+            "Intel(R) Arc(TM) A580 Graphics",
+            "Intel(R) Arc(TM) A380 Graphics",
+            "Intel(R) Arc(TM) A310 Graphics",
+            "Intel(R) Arc(TM) B580 Graphics",
+            "Intel(R) Arc(TM) B570 Graphics",
+        ] {
+            assert_eq!(
+                classify_intel_variant(name),
+                Some("Discrete"),
+                "{name} must stay discrete"
+            );
+        }
+    }
+
+    #[test]
+    fn integrated_families_stay_integrated() {
+        for name in [
+            "Intel(R) Iris(R) Xe Graphics",
+            "Intel(R) UHD Graphics 770",
+            "Intel(R) HD Graphics 620",
+            // Unnumbered Arc on Meteor Lake.
+            "Intel(R) Arc(TM) Graphics",
+            // Lunar Lake's numbered iGPUs.
+            "Intel(R) Arc(TM) 140V GPU",
+            "Intel(R) Arc(TM) 130V GPU",
+        ] {
+            assert_eq!(
+                classify_intel_variant(name),
+                Some("Integrated"),
+                "{name} must stay integrated"
+            );
+        }
+    }
+
+    /// The Meteor Lake residual rule still has to fire for the unnumbered
+    /// name it was written for, and Lunar Lake must not be swallowed by
+    /// the new Xe3 arm.
+    #[test]
+    fn neighbouring_architectures_do_not_regress() {
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) Graphics"),
+            IntelArchitecture::XeLpg
+        );
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) 140V GPU"),
+            IntelArchitecture::XeLpgPlus
+        );
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) A770 Graphics"),
+            IntelArchitecture::Alchemist
+        );
+        assert_eq!(
+            classify_intel_architecture("Intel(R) Arc(TM) B580 Graphics"),
+            IntelArchitecture::Battlemage
+        );
+    }
+
+    #[test]
+    fn arc_model_number_detection() {
+        assert!(contains_arc_model_number("intel(r) arc(tm) a770 graphics"));
+        assert!(contains_arc_model_number("intel(r) arc(tm) b390 graphics"));
+        assert!(contains_arc_model_number("intel(r) arc(tm) 140v gpu"));
+        assert!(!contains_arc_model_number("intel(r) arc(tm) graphics"));
+        assert!(!contains_arc_model_number("intel(r) iris(r) xe graphics"));
+        // A single letter followed by fewer than three digits is not a model.
+        assert!(!contains_arc_model_number("a77"));
+    }
 
     #[test]
     fn known_families_resolve() {

--- a/src/device/readers/intel_gpu_names.rs
+++ b/src/device/readers/intel_gpu_names.rs
@@ -305,6 +305,7 @@ pub fn classify_intel_architecture(name: &str) -> IntelArchitecture {
 ///
 /// The entries are the SKUs this project already claimed as discrete before
 /// issue #364, kept exactly as they were so nothing regresses.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 const DISCRETE_ARC_MODELS: &[&str] = &[
     // Alchemist (Xe-HPG) desktop
     "a310", "a380", "a580", "a750", "a770", // Battlemage (Xe2) desktop
@@ -317,6 +318,7 @@ const DISCRETE_ARC_MODELS: &[&str] = &[
 /// iGPUs. Lunar Lake's `V` suffix used to escape the old heuristic by
 /// accident (`140v` is digits-then-letter, which failed its digits-only
 /// test); it is named explicitly here so the escape is deliberate.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 const INTEGRATED_ARC_MODELS: &[&str] = &["130v", "140v", "b390"];
 
 /// Panther Lake iGPU model numbers.
@@ -360,6 +362,7 @@ fn is_arc_model_token(token: &str) -> bool {
 /// leaves the field to the authoritative source (the DXGI memory layout)
 /// instead of asserting a variant it cannot support. Guessing here is
 /// exactly what reported the integrated B390 as `Discrete`.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub fn classify_intel_variant(name: &str) -> Option<&'static str> {
     let lower = name.to_lowercase();
     if !lower.contains("arc") {

--- a/src/device/readers/intel_gpu_windows.rs
+++ b/src/device/readers/intel_gpu_windows.rs
@@ -36,7 +36,9 @@
 //! before — there is no regression for hosts that lack either.
 
 use crate::device::GpuReader;
-use crate::device::readers::intel_gpu_names::classify_intel_architecture;
+use crate::device::readers::intel_gpu_names::{
+    classify_intel_architecture, classify_intel_variant,
+};
 use crate::device::types::{GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
 use chrono::Local;
@@ -173,10 +175,14 @@ impl IntelWindowsGpuReader {
                     if let Some(ref dac_type) = controller.adapter_d_a_c_type {
                         detail.insert("DAC Type".to_string(), dac_type.clone());
                     }
-                    detail.insert(
-                        "Variant".to_string(),
-                        classify_intel_variant(&name).to_string(),
-                    );
+                    // `None` means the name carries a model number this
+                    // table does not know. Leave the field unset rather
+                    // than guessing: the DXGI memory layout fills it in
+                    // `windows_gpu_perf::apply_to_gpu_info`, and it knows
+                    // the answer for real (issue #364).
+                    if let Some(variant) = classify_intel_variant(&name) {
+                        detail.insert("Variant".to_string(), variant.to_string());
+                    }
                     // Architecture / SYCL classification — shared with
                     // the Linux reader via `intel_gpu_names::classify_*`
                     // so a single source of truth drives downstream
@@ -409,48 +415,6 @@ pub fn is_intel_gpu_name(name: &str) -> bool {
         "lunar lake",
     ];
     FAMILY_TOKENS.iter().any(|t| lower.contains(t))
-}
-
-/// Heuristic discrete-vs-integrated discriminator for Intel client
-/// GPUs on Windows. We can't introspect VRAM reliably via WMI (the 32-bit
-/// `AdapterRAM` field is unreliable, see above) so we fall back to a
-/// name-pattern check that the test suite locks in.
-///
-/// The discriminator looks for an Arc model number — discrete Arc cards
-/// always carry one (e.g. `A770`, `A750`, `B580`, `B570`), while the
-/// Meteor Lake / Core Ultra iGPU is sold as "Intel(R) Arc(TM) Graphics"
-/// with no number. Iris / UHD / HD Graphics / Xe Graphics are always
-/// integrated.
-fn classify_intel_variant(name: &str) -> &'static str {
-    let lower = name.to_lowercase();
-    if !lower.contains("arc") {
-        return "Integrated";
-    }
-    // Heuristic: discrete Arc names contain a token like "a770", "b580"
-    // etc. — a letter A/B/C followed by 3+ digits. Scan word boundaries.
-    let has_model_number = lower
-        .split(|c: char| !c.is_ascii_alphanumeric())
-        .any(is_arc_model_token);
-    if has_model_number {
-        "Discrete"
-    } else {
-        "Integrated"
-    }
-}
-
-/// `true` for tokens like `a770`, `a750`, `b580`, `c770` — a single
-/// letter (current Arc generations are A/B; reserve C/D for forward
-/// compatibility) followed by 3+ digits.
-fn is_arc_model_token(token: &str) -> bool {
-    let bytes = token.as_bytes();
-    if bytes.len() < 4 {
-        return false;
-    }
-    let first = bytes[0] as char;
-    if !matches!(first, 'a' | 'b' | 'c' | 'd') {
-        return false;
-    }
-    bytes[1..].iter().all(|b| b.is_ascii_digit())
 }
 
 #[cfg(test)]

--- a/src/device/readers/intel_gpu_windows/tests.rs
+++ b/src/device/readers/intel_gpu_windows/tests.rs
@@ -76,64 +76,6 @@ fn non_intel_excluded() {
     assert!(!is_intel_gpu_name("AMD Radeon RX 7900 XTX"));
 }
 
-#[test]
-fn classify_arc_discrete() {
-    assert_eq!(
-        classify_intel_variant("Intel(R) Arc(TM) A770 Graphics"),
-        "Discrete"
-    );
-    assert_eq!(
-        classify_intel_variant("Intel(R) Arc(TM) B580 Graphics"),
-        "Discrete"
-    );
-}
-
-#[test]
-fn classify_iris_integrated() {
-    assert_eq!(
-        classify_intel_variant("Intel(R) Iris(R) Xe Graphics"),
-        "Integrated"
-    );
-}
-
-#[test]
-fn classify_uhd_integrated() {
-    assert_eq!(
-        classify_intel_variant("Intel(R) UHD Graphics 770"),
-        "Integrated"
-    );
-}
-
-#[test]
-fn classify_meteor_lake_arc_igpu_as_integrated() {
-    // "Intel Arc Graphics" without a model number on Core Ultra is
-    // the iGPU and must NOT be classified as Discrete.
-    assert_eq!(
-        classify_intel_variant("Intel(R) Arc(TM) Graphics"),
-        "Integrated"
-    );
-}
-
-#[test]
-fn arc_model_token_recognises_known_skus() {
-    assert!(is_arc_model_token("a770"));
-    assert!(is_arc_model_token("a750"));
-    assert!(is_arc_model_token("a580"));
-    assert!(is_arc_model_token("a380"));
-    assert!(is_arc_model_token("b580"));
-    assert!(is_arc_model_token("b570"));
-}
-
-#[test]
-fn arc_model_token_rejects_non_models() {
-    assert!(!is_arc_model_token("arc"));
-    assert!(!is_arc_model_token("tm"));
-    assert!(!is_arc_model_token("graphics"));
-    assert!(!is_arc_model_token("a"));
-    // Single letter followed by <3 digits doesn't count as a model.
-    assert!(!is_arc_model_token("a77"));
-}
-
 // ---------- Marketing-name fixture parity with backend.ai-go ----------
 //
 // Every name the architecture classifier handles must also pass the

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -79,7 +79,14 @@ pub mod intel_gpu_gtidle;
 pub mod intel_gpu_level_zero;
 #[cfg(target_os = "linux")]
 pub mod intel_gpu_linux;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+// The `test` arm is load-bearing for the same reason it is on
+// `windows_gpu_perf` below. The discrete/integrated and architecture rules
+// live here, the Windows reader that consumes them is never compiled by any
+// runner this project has, and a wrong rule there is invisible until it
+// reaches a user's machine. That is how the B390 shipped misclassified
+// (issue #364). Compiling under `cfg(test)` everywhere puts the rules in
+// front of every test runner, including a macOS development host.
+#[cfg(any(target_os = "linux", target_os = "windows", test))]
 pub mod intel_gpu_names;
 // The helpers themselves only use portable filesystem APIs, so keep their unit
 // tests available on non-Linux development hosts as well.

--- a/src/device/readers/windows_gpu_perf.rs
+++ b/src/device/readers/windows_gpu_perf.rs
@@ -179,18 +179,10 @@ pub fn snapshot() -> Snapshot {
         .into_iter()
         .map(|adapter| {
             let luid = adapter.identity.luid;
-            // Integrated graphics report no dedicated pool at all and
-            // address system RAM instead, so falling back to
-            // `SharedSystemMemory` is the difference between a correct
-            // capacity and leaving the wrong 32-bit WMI value in place
-            // for every Intel iGPU.
-            let (total_memory, memory_is_shared) = if adapter.dedicated_video_memory > 0 {
-                (Some(adapter.dedicated_video_memory), false)
-            } else if adapter.shared_system_memory > 0 {
-                (Some(adapter.shared_system_memory), true)
-            } else {
-                (None, false)
-            };
+            let (total_memory, memory_is_shared) = resolve_adapter_memory(
+                adapter.dedicated_video_memory,
+                adapter.shared_system_memory,
+            );
             AdapterMetrics {
                 identity: adapter.identity,
                 total_memory,
@@ -322,6 +314,52 @@ pub fn note_metrics_source(detail: &mut HashMap<String, String>, source: &str) {
 /// shape of a GitHub-hosted Windows runner) upgrades VRAM and leaves
 /// utilization at the baseline rather than zeroing anything that was
 /// already known.
+/// Smallest dedicated pool that can plausibly be a discrete card's own
+/// VRAM.
+///
+/// The previous rule was "a non-zero dedicated pool means a discrete
+/// card", written from the premise that integrated graphics report no
+/// dedicated pool at all. That premise is false on current hardware:
+/// modern Intel and AMD integrated parts publish a small stolen-memory
+/// carve-out through DXGI, and 128 MiB is the classic value. The old rule
+/// therefore took the carve-out as the whole capacity, which is what
+/// reported an Arc B390 as a 128 MiB card (issue #364).
+///
+/// 1 GiB separates the two populations with room on both sides. No
+/// discrete card has ever shipped with less, and the stock carve-outs are
+/// 64/128/256/512 MiB. A machine whose firmware is configured for a large
+/// carve-out (some AMD APUs allow 2 GiB or more) lands above the floor and
+/// is reported at that size, which is the amount the operator actually
+/// set aside.
+const MIN_DISCRETE_DEDICATED_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Choose an adapter's total memory and say whether it is a shared
+/// aperture rather than a dedicated pool.
+///
+/// Split out of [`build_adapter_metrics`] so the decision is reachable by
+/// a test runner. It drives every Windows GPU this project reports:
+/// `intel_gpu_windows` and `amd_windows` both reach it through
+/// [`augment_gpus`], so a change here moves Radeon APUs as well as Intel
+/// iGPUs.
+fn resolve_adapter_memory(dedicated: u64, shared: u64) -> (Option<u64>, bool) {
+    if dedicated >= MIN_DISCRETE_DEDICATED_BYTES {
+        return (Some(dedicated), false);
+    }
+    if shared > 0 {
+        // Either a carve-out below the floor or no dedicated pool at all.
+        // The shared aperture is the memory the device can actually
+        // address, so it is the honest capacity.
+        return (Some(shared), true);
+    }
+    if dedicated > 0 {
+        // Below the floor with nothing shared to fall back to. Report
+        // what the adapter claims rather than nothing; a small pool is
+        // still better than an unknown one.
+        return (Some(dedicated), false);
+    }
+    (None, false)
+}
+
 pub fn apply_to_gpu_info(gpu: &mut GpuInfo, metrics: &AdapterMetrics) {
     let mut touched_dxgi = false;
     let mut touched_pdh = false;
@@ -337,6 +375,20 @@ pub fn apply_to_gpu_info(gpu: &mut GpuInfo, metrics: &AdapterMetrics) {
             }
             .to_string(),
         );
+        // Fill the discrete/integrated variant when the caller could not
+        // decide from the device name. Whether the adapter owns a
+        // dedicated pool or addresses a shared aperture is the definition
+        // of the distinction, so DXGI answers it directly rather than by
+        // inference from a marketing string. `or_insert_with` keeps a
+        // name-derived answer that the reader already trusted; only the
+        // "unknown numbered part" case reaches this (issue #364).
+        gpu.detail.entry("Variant".to_string()).or_insert_with(|| {
+            if metrics.memory_is_shared {
+                "Integrated".to_string()
+            } else {
+                "Discrete".to_string()
+            }
+        });
         touched_dxgi = true;
     }
 
@@ -559,6 +611,88 @@ pub fn gpu_process_row(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * MIB;
+
+    // ---------- issue #364: the dedicated-pool premise ----------
+
+    /// The reported defect. An Arc B390 publishes a 128 MiB DXGI
+    /// carve-out, the old rule took any non-zero dedicated pool as the
+    /// card's VRAM, and the device reported as a 128 MiB card.
+    #[test]
+    fn small_carve_out_reports_the_shared_aperture() {
+        let (total, shared) = resolve_adapter_memory(128 * MIB, 16 * GIB);
+        assert_eq!(total, Some(16 * GIB));
+        assert!(shared, "a carve-out below the floor is a shared aperture");
+    }
+
+    /// The same premise breaks on AMD: `amd_windows` reaches this through
+    /// `augment_gpus`, so every Radeon APU on Windows moves with it. The
+    /// issue calls this out as test-plan scope rather than a review
+    /// surprise.
+    #[test]
+    fn amd_apu_carve_out_reports_the_shared_aperture() {
+        for carve_out in [64 * MIB, 128 * MIB, 256 * MIB, 512 * MIB] {
+            let (total, shared) = resolve_adapter_memory(carve_out, 32 * GIB);
+            assert_eq!(total, Some(32 * GIB), "carve-out {carve_out} bytes");
+            assert!(shared, "carve-out {carve_out} bytes");
+        }
+    }
+
+    /// A discrete card keeps its dedicated pool. This is the behaviour the
+    /// old rule got right and the fix must not trade away.
+    #[test]
+    fn discrete_card_keeps_its_dedicated_pool() {
+        for vram in [2 * GIB, 8 * GIB, 12 * GIB, 24 * GIB] {
+            let (total, shared) = resolve_adapter_memory(vram, 16 * GIB);
+            assert_eq!(total, Some(vram), "vram {vram} bytes");
+            assert!(!shared, "vram {vram} bytes");
+        }
+    }
+
+    /// An integrated part that reports no dedicated pool at all: the case
+    /// the original rule was written for, unchanged.
+    #[test]
+    fn zero_dedicated_still_reports_the_shared_aperture() {
+        let (total, shared) = resolve_adapter_memory(0, 8 * GIB);
+        assert_eq!(total, Some(8 * GIB));
+        assert!(shared);
+    }
+
+    /// A firmware-configured carve-out at or above the floor is what the
+    /// operator set aside, so it is reported as dedicated rather than
+    /// silently replaced by the aperture.
+    #[test]
+    fn large_configured_carve_out_is_taken_at_face_value() {
+        let (total, shared) = resolve_adapter_memory(2 * GIB, 32 * GIB);
+        assert_eq!(total, Some(2 * GIB));
+        assert!(!shared);
+    }
+
+    /// Nothing shared to fall back to: report the small pool rather than
+    /// nothing at all.
+    #[test]
+    fn small_pool_with_no_aperture_is_reported_as_is() {
+        let (total, shared) = resolve_adapter_memory(128 * MIB, 0);
+        assert_eq!(total, Some(128 * MIB));
+        assert!(!shared);
+    }
+
+    #[test]
+    fn no_memory_information_reports_nothing() {
+        assert_eq!(resolve_adapter_memory(0, 0), (None, false));
+    }
+
+    /// The floor itself is inclusive, so the boundary is pinned rather
+    /// than left to drift with a future edit.
+    #[test]
+    fn the_discrete_floor_is_inclusive() {
+        let (_, shared_at) = resolve_adapter_memory(MIN_DISCRETE_DEDICATED_BYTES, 32 * GIB);
+        assert!(!shared_at, "exactly at the floor counts as dedicated");
+        let (_, shared_below) = resolve_adapter_memory(MIN_DISCRETE_DEDICATED_BYTES - 1, 32 * GIB);
+        assert!(shared_below, "one byte below the floor is a carve-out");
+    }
     use crate::device::types::GpuInfo;
 
     fn blank_gpu() -> GpuInfo {
@@ -614,6 +748,36 @@ mod tests {
             process_budget: None,
             process_current_usage: None,
         }
+    }
+
+    /// DXGI settles the discrete/integrated question when the device
+    /// name could not. Owning a dedicated pool versus addressing a shared
+    /// aperture is the distinction itself, so this is a direct answer
+    /// rather than an inference from a marketing string (issue #364).
+    #[test]
+    fn dxgi_fills_the_variant_the_name_could_not_decide() {
+        let mut shared = blank_gpu();
+        let mut shared_metrics = metrics(Some(16 * GIB), None, None);
+        shared_metrics.memory_is_shared = true;
+        apply_to_gpu_info(&mut shared, &shared_metrics);
+        assert_eq!(shared.detail["Variant"], "Integrated");
+
+        let mut dedicated = blank_gpu();
+        apply_to_gpu_info(&mut dedicated, &metrics(Some(8 * GIB), None, None));
+        assert_eq!(dedicated.detail["Variant"], "Discrete");
+    }
+
+    /// A variant the reader already decided from a known SKU wins. DXGI
+    /// only fills the gap; it does not overrule a curated answer.
+    #[test]
+    fn an_existing_variant_is_not_overwritten() {
+        let mut gpu = blank_gpu();
+        gpu.detail
+            .insert("Variant".to_string(), "Discrete".to_string());
+        let mut shared_metrics = metrics(Some(16 * GIB), None, None);
+        shared_metrics.memory_is_shared = true;
+        apply_to_gpu_info(&mut gpu, &shared_metrics);
+        assert_eq!(gpu.detail["Variant"], "Discrete");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

An Intel Arc B390 is an integrated Xe3 (Panther Lake) GPU. all-smi finds the device but attaches three wrong values to it: `Discrete`, `Xe-LPG (Meteor Lake)`, and a 128 MiB total memory. Each comes from a separate premise that was true when it was written and that current hardware has invalidated. All three are confirmed by reading the source, and all three are fixed here.

The memory defect lives in `windows_gpu_perf.rs`, which is new since v0.25.0 and has never shipped, so this is the difference between releasing it correct and releasing it wrong for the first time. It is also shared with `amd_windows.rs` through `augment_gpus`, so it moves every Radeon APU on Windows as well.

## The three defects

**Discrete/integrated.** The rule read "an Arc name with a model number" as "discrete card". That held until Panther Lake, the first Intel iGPU generation sold under a model number. It cannot be repaired as a pattern, because the integrated B390 and the discrete B380 differ by one digit. It is now an explicit table of the SKUs this project already claimed as discrete, plus a table of the numbered integrated parts (Lunar Lake's 140V/130V, which previously escaped the old test only by accident, and the B390). A name carrying a number that neither table knows returns **no answer at all** rather than guessing, and the DXGI memory layout fills it in instead. Owning a dedicated pool versus addressing a shared aperture is the definition of the distinction, so DXGI answers it directly rather than by inference from a marketing string.

**Architecture.** `IntelArchitecture` had no Xe3 variant, so the B390 fell through to a residual rule whose comment claimed any remaining `arc` + `graphics` name must be the Meteor Lake iGPU. Xe3 is now a variant, the residual rule is narrowed to unnumbered names only, and a numbered part the table does not recognize reports `Unknown` instead of being assigned to Meteor Lake by elimination.

**Memory.** The branch assumed integrated graphics report no dedicated pool at all, falling back to the shared aperture only when the dedicated pool was exactly zero. Modern Intel and AMD integrated parts publish a small stolen-memory carve-out through DXGI, and 128 MiB is the classic value, so the branch took the carve-out as the whole capacity. A pool below 1 GiB is now treated as a carve-out and the shared aperture is reported instead. No discrete card has ever shipped with less than that floor and the stock carve-outs are 64 to 512 MiB, so the two populations separate with room on both sides. A firmware-configured carve-out at or above the floor is still reported at face value, since that is the amount the operator set aside.

## Making the rules reachable by a test runner

Both name rules move into `intel_gpu_names`, which is pure string matching, and that module's gate gains a `test` arm. This is the substance of the fix rather than tidying.

The discrete/integrated rule lived in `intel_gpu_windows`, which is `cfg(target_os = "windows")`. No runner this project has ever compiled it, so the wrong rule was unreachable by every test job and could only be found by someone holding the hardware. `intel_gpu_sysfs`, `windows_gpu_perf` and `amd_adl` already carry the same `test` arm, and `mod.rs` states the reason next to each. This applies it to the module that just demonstrated why it matters.

## Verification, and its limits

No B390, no Windows host, and the self-hosted runners are down for maintenance. Everything claimed below was actually executed; nothing is inferred.

- **3406 tests pass**, 0 failures. 16 are new: the B390 itself, the one-digit B380/B390 collision, the deferral for unknown numbered parts, the AMD APU carve-out range (64/128/256/512 MiB), the discrete floor boundary, and regression guards pinning every SKU and architecture that was already classified correctly.
- `cargo clippy --lib --tests --all-features` produces no new warnings (the pre-existing `src/doctor/bundle.rs` one is untouched), and `cargo fmt --check` is clean.
- **The Windows-only reader was type-checked, linted, and its tests run**, using the probe technique this repository documents in `src/service_cmd/mod.rs`: a scratch worktree with a stubbed `wmi` crate and the module's gate widened, so the real `intel_gpu_windows.rs` compiles against the real `GpuInfo`, the real `windows_gpu_perf`, and the real classifier. `cargo check --target x86_64-pc-windows-msvc` still dies in `zstd-sys` for the reason #357 records, so this is the only route available. Probe reachability was proven rather than assumed: a deliberate type error injected at the changed line produced a compile error through the probe, and reverting it returned a clean check. All 22 of that module's own tests pass through it.

**What is not verified:** the B390's actual reported values. No one has run this against the device. The classification is verified against the name string the issue records, not against WMI output from the machine.

## One unrelated fix carried here

`cargo clippy -- -D warnings`, the command CI runs, fails on `main` today on a macOS host: `TempKeyScan::scanned_keys` and `total_keys` are diagnostic counters read only by tests, so they are dead behind the binary's module root exactly as `used_sorted_range` already was. It arrived with #375 and CI did not catch it, because `smc.rs` is macOS-only, the job that runs clippy runs on `ubuntu-latest`, and the one macOS job runs `cargo build --bin all-smi` alone with no clippy and no tests. That is the same blind spot #368 describes for Windows, one platform over.

It is fixed here rather than left for a separate PR because it is a one-line waiver on code this branch already had to lint past, and leaving `main` red under its own CI command is worse than the small scope bleed. Both items now carry the waiver that the neighbouring items in each file already use.

## Not addressed, deliberately

- **The missing-utilization symptom.** The issue frames it as a hypothesis needing the device and it cannot be settled from the source. `UTILIZATION_ENGINE_TYPES = ["3D", "Compute"]` in `windows_gpu_perf/ids.rs` is the candidate, and it is recorded in the follow-up rather than guessed at here.
- **Temperature.** An explicit non-goal: the part exposes no Sysman thermal sensor, so a criterion for it could never pass.
- **The two `intel_gpu_level_zero/apply.rs` sites** referenced by the archived original issue body. That analysis was lost with the draft and the module is behind `--features level_zero`, which no shipped artifact enables. The coordinates are recorded in the follow-up so they are not lost a second time.

Closes #364

