### PR TITLE
feat(doctor): report Level Zero loader, init, and device visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,43 @@ jobs:
             exit 1
           fi
 
+      # The doctor checks are the operator-facing half of the same
+      # question, and they are reachable here for the same reason: the
+      # loader is installed above, and `level_zero.loader` is deliberately
+      # not gated on Intel GPU presence, so it reports a real result on a
+      # runner that has no Intel hardware.
+      #
+      # Expected shape on this runner: build PASS, loader PASS naming the
+      # library, init SKIP and devices SKIP (no GPU to initialise for), and
+      # exit 0, because a machine without an Intel GPU is not broken. A SKIP
+      # on either of the first two means the checks stopped being reachable
+      # in CI, which is the failure this step exists to catch.
+      - name: Level Zero doctor checks report runtime state
+        run: |
+          set -euo pipefail
+          out="${RUNNER_TEMP:-/tmp}/level-zero-doctor.json"
+          status=0
+          cargo run --quiet --bin all-smi -- doctor --only level_zero --json > "$out" || status=$?
+          cat "$out"
+          if [ "$status" -ne 0 ]; then
+            echo "::error::doctor exited $status on a host with no Intel GPU; nothing here should fail such a host"
+            exit 1
+          fi
+          build=$(jq -r '.checks[] | select(.id=="level_zero.build") | .status' "$out")
+          loader=$(jq -r '.checks[] | select(.id=="level_zero.loader") | .status' "$out")
+          message=$(jq -r '.checks[] | select(.id=="level_zero.loader") | .message' "$out")
+          if [ "$build" != "pass" ] || [ "$loader" != "pass" ]; then
+            echo "::error::expected level_zero.build and level_zero.loader to pass here, got build=$build loader=$loader"
+            exit 1
+          fi
+          case "$message" in
+            *libze_loader*) ;;
+            *)
+              echo "::error::level_zero.loader passed without naming the library it loaded: $message"
+              exit 1
+              ;;
+          esac
+
       # `cargo test` with no flags now covers the Level Zero backend:
       # build.rs turns `all_smi_level_zero` on for every Linux target, so
       # there is no configuration in which the module goes uncompiled and

--- a/README.md
+++ b/README.md
@@ -542,9 +542,18 @@ netsh advfirewall firewall delete rule name="all-smi"
 The `all-smi doctor` subcommand runs a read-only suite of environment checks and
 prints a PASS/WARN/FAIL report covering platform, privileges, container
 runtime, every supported hardware backend (NVIDIA, AMD, Apple, Gaudi, TPU,
-Tenstorrent, Rebellions, Furiosa, Windows), the relevant environment
-variables, and optional remote endpoint connectivity. Each check has a hard
-3-second timeout.
+Tenstorrent, Rebellions, Furiosa, Intel Level Zero, Windows), the relevant
+environment variables, and optional remote endpoint connectivity. Each check
+has a hard 3-second timeout.
+
+The `level_zero.*` checks report the four stages that decide whether Intel GPU
+temperature, power, and frequency are collectable at all, separately rather
+than as one verdict: whether the backend is compiled in, which loader library
+was found, whether the runtime initialised and by which Sysman route, and how
+many devices Sysman enumerated. None of them can FAIL, because an absent Level
+Zero runtime degrades to the sysfs or WMI baseline rather than breaking a run,
+and a host with no Intel GPU reports SKIP rather than complaining about
+hardware it does not have.
 
 ```bash
 # Human-readable report (default)

--- a/src/device/readers/intel_gpu_level_zero.rs
+++ b/src/device/readers/intel_gpu_level_zero.rs
@@ -62,6 +62,7 @@ pub use apply::{ApplyPlatform, apply_to_gpu_info};
 pub use loader::normalise_pci_bdf;
 pub use loader::prepare_sysman_env_for_legacy_runtime;
 pub(crate) use loader::with_runtime;
+pub use loader::{LevelZeroInit, LevelZeroProbe, SysmanRoute, probe};
 pub(crate) use point::{
     FanSample, FrequencySample, MemorySample, TemperatureSample, populate_point_samples,
     refresh_fan, refresh_frequency, refresh_memory, refresh_temperature,

--- a/src/device/readers/intel_gpu_level_zero/loader.rs
+++ b/src/device/readers/intel_gpu_level_zero/loader.rs
@@ -136,6 +136,95 @@ pub unsafe fn prepare_sysman_env_for_legacy_runtime() {
 /// loaded — the typical case on a host without the Intel L0 loader.
 static LZ_RUNTIME: OnceCell<Mutex<Option<LzRuntime>>> = OnceCell::new();
 
+/// Which stage of [`initialize_runtime`] the process actually reached.
+///
+/// Every one of these is a `None` from `with_runtime`'s point of view, and
+/// they have four different remedies. Collapsing them was fine while the
+/// only consumer was a metric that silently fell back to sysfs or WMI;
+/// `all-smi doctor` has to tell an operator which one happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LevelZeroInit {
+    /// No entry in [`LIBZE_PATHS`] loaded with every mandatory symbol.
+    LoaderMissing,
+    /// The loader exports no `zesInit` and `ZES_ENABLE_SYSMAN=1` was not
+    /// set before `zeInit`, so Sysman cannot be reached at all.
+    SysmanUnavailable,
+    /// `zeInit` returned the carried non-success `ze_result_t`.
+    ZeInitFailed(i32),
+    /// `zesInit` returned the carried non-success `ze_result_t`.
+    ZesInitFailed(i32),
+    /// Initialisation completed. Says nothing about how many devices were
+    /// found; see [`LevelZeroProbe::device_count`].
+    Ok,
+}
+
+/// How Sysman was enabled, recorded only when initialisation succeeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SysmanRoute {
+    /// Modern loader: `zesInit` resolved and returned success.
+    ZesInit,
+    /// Legacy loader: no `zesInit` symbol, `ZES_ENABLE_SYSMAN=1` was
+    /// already in the environment when `zeInit` ran.
+    LegacyEnvVar,
+}
+
+/// What one process learned about the Level Zero runtime, recorded as
+/// [`initialize_runtime`] ran rather than re-derived afterwards.
+#[derive(Debug, Clone)]
+pub struct LevelZeroProbe {
+    /// `cfg!(all_smi_level_zero)`. Always true where this type exists; the
+    /// field carries the answer to callers that are compiled either way.
+    pub compiled_in: bool,
+    /// Every candidate this target would try, in order.
+    pub searched_paths: &'static [&'static str],
+    /// The entry that loaded with all mandatory symbols resolved.
+    pub loaded_path: Option<&'static str>,
+    pub init: LevelZeroInit,
+    pub sysman_route: Option<SysmanRoute>,
+    pub device_count: usize,
+    /// Canonical BDFs, sorted. Same source as `enumerated_pci_bdfs`.
+    pub device_bdfs: Vec<String>,
+}
+
+/// Stages recorded during the one initialisation this process performs.
+///
+/// Written exactly once, from inside [`initialize_runtime`], because
+/// `LZ_RUNTIME` is a `OnceCell`: a diagnostic that ran its own `dlopen`
+/// and `zeInit` would be a second code path, free to drift from the one
+/// that actually decides whether metrics appear.
+static LZ_INIT_RECORD: OnceCell<(Option<&'static str>, LevelZeroInit, Option<SysmanRoute>)> =
+    OnceCell::new();
+
+fn record_init(loaded_path: Option<&'static str>, init: LevelZeroInit, route: Option<SysmanRoute>) {
+    // `set` fails only if something already recorded, which cannot happen
+    // twice for one `OnceCell`-guarded initialisation. Ignoring the error
+    // keeps this a pure side-channel that cannot alter the caller.
+    let _ = LZ_INIT_RECORD.set((loaded_path, init, route));
+}
+
+/// Initialise if it has not happened yet, then report what each stage did.
+///
+/// Triggering initialisation is deliberate: on a host that has not touched
+/// an Intel GPU this is the call that answers whether the runtime would
+/// work at all, which is the entire question a diagnostic is asked.
+pub fn probe() -> LevelZeroProbe {
+    let device_bdfs = super::enumerated_pci_bdfs();
+    let (loaded_path, init, sysman_route) =
+        LZ_INIT_RECORD
+            .get()
+            .copied()
+            .unwrap_or((None, LevelZeroInit::LoaderMissing, None));
+    LevelZeroProbe {
+        compiled_in: true,
+        searched_paths: LIBZE_PATHS,
+        loaded_path,
+        init,
+        sysman_route,
+        device_count: device_bdfs.len(),
+        device_bdfs,
+    }
+}
+
 /// Result of the first successful library load + `zeInit`.
 pub(crate) struct LzRuntime {
     /// Keep the `libloading::Library` alive for the lifetime of the
@@ -193,16 +282,21 @@ fn initialize_runtime() -> Option<LzRuntime> {
     // symbols. A failure here is the normal case on a host without the
     // L0 runtime — we log at debug, never warn or error.
     let mut loaded: Option<LoadedLibrary> = None;
+    let mut loaded_path: Option<&'static str> = None;
     for path in LIBZE_PATHS {
         // SAFETY: see `try_load_library`'s safety contract — we only
         // load canonical Level Zero loader paths.
         if let Some(lib) = unsafe { try_load_library(path) } {
             debug!("Level Zero: loaded {path}");
             loaded = Some(lib);
+            loaded_path = Some(path);
             break;
         }
     }
-    let loaded = loaded?;
+    let Some(loaded) = loaded else {
+        record_init(None, LevelZeroInit::LoaderMissing, None);
+        return None;
+    };
 
     let api = loaded.api;
     let sysman_env_enabled = std::env::var(SYSMAN_ENV_KEY)
@@ -212,6 +306,7 @@ fn initialize_runtime() -> Option<LzRuntime> {
         debug!(
             "Level Zero: loader does not expose zesInit and {SYSMAN_ENV_KEY}=1 was not set before zeInit; degrading"
         );
+        record_init(loaded_path, LevelZeroInit::SysmanUnavailable, None);
         return None;
     }
 
@@ -221,6 +316,7 @@ fn initialize_runtime() -> Option<LzRuntime> {
     let init_res = unsafe { (api.ze_init)(ffi::ZE_INIT_FLAG_DEFAULT) };
     if init_res != ffi::ZE_RESULT_SUCCESS {
         debug!("Level Zero: zeInit returned {init_res}; degrading");
+        record_init(loaded_path, LevelZeroInit::ZeInitFailed(init_res), None);
         return None;
     }
 
@@ -232,9 +328,19 @@ fn initialize_runtime() -> Option<LzRuntime> {
         let sysman_res = unsafe { (zes_init)(ffi::ZE_INIT_FLAG_DEFAULT) };
         if sysman_res != ffi::ZE_RESULT_SUCCESS {
             debug!("Level Zero: zesInit returned {sysman_res}; degrading");
+            record_init(loaded_path, LevelZeroInit::ZesInitFailed(sysman_res), None);
             return None;
         }
     }
+
+    // Which route got us here decides the remediation when a later
+    // upgrade removes the environment variable from the operator's setup.
+    let route = if api.zes_init.is_some() {
+        SysmanRoute::ZesInit
+    } else {
+        SysmanRoute::LegacyEnvVar
+    };
+    record_init(loaded_path, LevelZeroInit::Ok, Some(route));
 
     let devices_by_pci = enumerate_devices(&api);
     if devices_by_pci.is_empty() {

--- a/src/doctor/checks/level_zero.rs
+++ b/src/doctor/checks/level_zero.rs
@@ -1,0 +1,479 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `level_zero.*` checks: the Intel oneAPI Level Zero backend's build-time
+//! presence, loader library, runtime initialisation, and device visibility.
+//!
+//! The support bundle's `version.txt` already carries a `level_zero:` line,
+//! but that reports a compile-time cfg. It cannot say whether the loader was
+//! found, whether `zeInit` succeeded, or whether Sysman saw any device, and
+//! those three facts are what decide whether an operator gets GPU
+//! temperature, power, and frequency on Intel hardware. On Windows nothing
+//! else supplies those fields at all.
+//!
+//! Four distinct failures used to collapse into one silent fallback, each
+//! with a different remedy. Every stage is reported separately here.
+//!
+//! ## No check in this namespace fails
+//!
+//! An absent Level Zero runtime always degrades to sysfs, to WMI, or to an
+//! unavailable field. It never breaks a run, so the worst outcome is `Warn`,
+//! and a host with no Intel GPU reports `Skip` rather than complaining about
+//! hardware it does not have.
+
+use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
+
+static CHECKS: &[&Check] = &[&BUILD, &LOADER, &INIT, &DEVICES];
+
+pub fn checks() -> &'static [&'static Check] {
+    CHECKS
+}
+
+static BUILD: Check = Check {
+    id: "level_zero.build",
+    title: "Level Zero build-time availability",
+    severity_on_fail: Severity::Info,
+    run: check_build,
+};
+
+static LOADER: Check = Check {
+    id: "level_zero.loader",
+    title: "Level Zero loader library",
+    severity_on_fail: Severity::Warn,
+    run: check_loader,
+};
+
+static INIT: Check = Check {
+    id: "level_zero.init",
+    title: "Level Zero runtime initialisation",
+    severity_on_fail: Severity::Warn,
+    run: check_init,
+};
+
+static DEVICES: Check = Check {
+    id: "level_zero.devices",
+    title: "Level Zero device visibility",
+    severity_on_fail: Severity::Info,
+    run: check_devices,
+};
+
+/// Agrees with `bundle::level_zero_effective` by construction: both read the
+/// same cfg, and a second, differently-worded test could disagree with the
+/// `level_zero:` line sitting next to it in the same support bundle.
+fn check_build(_ctx: &CheckCtx) -> CheckResult {
+    if cfg!(all_smi_level_zero) {
+        CheckResult::Pass(format!(
+            "compiled in for {} (unconditional on this target, not the `level_zero` cargo feature)",
+            std::env::consts::OS
+        ))
+    } else {
+        CheckResult::Skip(format!(
+            "not compiled in for {}: no Level Zero runtime exists for this platform",
+            std::env::consts::OS
+        ))
+    }
+}
+
+#[cfg(all_smi_level_zero)]
+mod present {
+    use super::*;
+    use crate::device::has_intel_gpu;
+    use crate::device::readers::intel_gpu_level_zero as l0;
+
+    pub fn loader(_ctx: &CheckCtx) -> CheckResult {
+        loader_verdict(&l0::probe(), has_intel_gpu())
+    }
+
+    pub fn init(_ctx: &CheckCtx) -> CheckResult {
+        init_verdict(&l0::probe(), has_intel_gpu())
+    }
+
+    pub fn devices(ctx: &CheckCtx) -> CheckResult {
+        devices_verdict(&l0::probe(), has_intel_gpu(), ctx.verbose)
+    }
+
+    /// The package that ships the loader, which is not the same thing as the
+    /// GPU driver on Linux and is exactly the same thing on Windows.
+    fn install_hint() -> &'static str {
+        if cfg!(target_os = "windows") {
+            "install the Intel graphics driver, which ships ze_loader.dll"
+        } else {
+            "install the Level Zero loader package (Debian and Ubuntu: libze1; \
+             or Intel's oneAPI runtime)"
+        }
+    }
+
+    /// Whether the loader library itself was found.
+    ///
+    /// Deliberately **not** gated on Intel GPU presence. It is the one stage a
+    /// machine without the hardware can reach, so gating it would make the
+    /// whole namespace unreachable on a CI runner, and whether the runtime is
+    /// installed is worth knowing before the card arrives.
+    pub fn loader_verdict(probe: &l0::LevelZeroProbe, intel_gpu_present: bool) -> CheckResult {
+        match probe.loaded_path {
+            Some(path) => CheckResult::Pass(format!("loaded {path}")),
+            None if intel_gpu_present => CheckResult::Warn(
+                format!(
+                    "an Intel GPU is present but no Level Zero loader was found; tried {}",
+                    probe.searched_paths.join(", ")
+                ),
+                Some(format!(
+                    "{}. Without it, temperature, power, and frequency fall back to \
+                     whatever the OS baseline provides.",
+                    install_hint()
+                )),
+            ),
+            None => CheckResult::Skip(format!(
+                "no Level Zero loader found and no Intel GPU present; tried {}",
+                probe.searched_paths.join(", ")
+            )),
+        }
+    }
+
+    pub fn init_verdict(probe: &l0::LevelZeroProbe, intel_gpu_present: bool) -> CheckResult {
+        if probe.loaded_path.is_none() {
+            return CheckResult::Skip("no Level Zero loader to initialise".to_string());
+        }
+        if !intel_gpu_present {
+            return CheckResult::Skip(
+                "loader present but no Intel GPU on this host; nothing to initialise for"
+                    .to_string(),
+            );
+        }
+        match probe.init {
+            l0::LevelZeroInit::Ok => {
+                let route = match probe.sysman_route {
+                    Some(l0::SysmanRoute::ZesInit) => "zesInit",
+                    Some(l0::SysmanRoute::LegacyEnvVar) => "legacy ZES_ENABLE_SYSMAN=1",
+                    None => "unknown route",
+                };
+                CheckResult::Pass(format!("initialised, Sysman enabled via {route}"))
+            }
+            l0::LevelZeroInit::SysmanUnavailable => CheckResult::Warn(
+                "the loader exports no zesInit and ZES_ENABLE_SYSMAN was not 1 when zeInit ran, \
+                 so Sysman cannot be reached"
+                    .to_string(),
+                Some(
+                    "set ZES_ENABLE_SYSMAN=1 before the process starts, not from inside it: \
+                     the variable is read at zeInit and all-smi will not mutate its own \
+                     environment once threads exist. Upgrading the Level Zero runtime to one \
+                     that exports zesInit removes the requirement."
+                        .to_string(),
+                ),
+            ),
+            l0::LevelZeroInit::ZeInitFailed(code) => CheckResult::Warn(
+                format!("zeInit returned ze_result_t {code:#x}"),
+                Some(
+                    "the loader is installed but the driver rejected initialisation. Check that \
+                     the Intel GPU driver matches the runtime version and that the current user \
+                     may open the device."
+                        .to_string(),
+                ),
+            ),
+            l0::LevelZeroInit::ZesInitFailed(code) => CheckResult::Warn(
+                format!("zesInit returned ze_result_t {code:#x}"),
+                Some(
+                    "core initialisation succeeded but Sysman did not. This usually means the \
+                     driver lacks Sysman support or the process lacks the privilege it needs."
+                        .to_string(),
+                ),
+            ),
+            // Unreachable while `loaded_path` is set, since the loader stage
+            // is what produces this variant. Handled rather than
+            // `unreachable!` so a future recording change cannot panic doctor.
+            l0::LevelZeroInit::LoaderMissing => {
+                CheckResult::Skip("no Level Zero loader to initialise".to_string())
+            }
+        }
+    }
+
+    pub fn devices_verdict(
+        probe: &l0::LevelZeroProbe,
+        intel_gpu_present: bool,
+        verbose: bool,
+    ) -> CheckResult {
+        if probe.init != l0::LevelZeroInit::Ok {
+            return CheckResult::Skip("Level Zero did not initialise".to_string());
+        }
+        if !intel_gpu_present {
+            return CheckResult::Skip("no Intel GPU on this host".to_string());
+        }
+        if probe.device_count == 0 {
+            return CheckResult::Warn(
+                "Level Zero initialised but Sysman enumerated no devices".to_string(),
+                Some(
+                    "this is the state that produces empty temperature, power, and frequency \
+                     with no other symptom. Check that the Intel GPU driver is loaded and that \
+                     the runtime version matches it."
+                        .to_string(),
+                ),
+            );
+        }
+        // The count is always safe to print. The BDFs identify hardware, so
+        // they ride behind --verbose like other identifying detail.
+        let mut message = format!("{} device(s) visible to Sysman", probe.device_count);
+        if verbose {
+            message.push_str(&format!(" ({})", probe.device_bdfs.join(", ")));
+        }
+        CheckResult::Pass(message)
+    }
+}
+
+#[cfg(not(all_smi_level_zero))]
+mod present {
+    use super::*;
+
+    pub fn loader(_ctx: &CheckCtx) -> CheckResult {
+        CheckResult::Skip("Level Zero backend not compiled in".to_string())
+    }
+
+    pub fn init(_ctx: &CheckCtx) -> CheckResult {
+        CheckResult::Skip("Level Zero backend not compiled in".to_string())
+    }
+
+    pub fn devices(_ctx: &CheckCtx) -> CheckResult {
+        CheckResult::Skip("Level Zero backend not compiled in".to_string())
+    }
+}
+
+fn check_loader(ctx: &CheckCtx) -> CheckResult {
+    present::loader(ctx)
+}
+
+fn check_init(ctx: &CheckCtx) -> CheckResult {
+    present::init(ctx)
+}
+
+fn check_devices(ctx: &CheckCtx) -> CheckResult {
+    present::devices(ctx)
+}
+
+#[cfg(all(test, all_smi_level_zero))]
+mod tests {
+    use super::present::{devices_verdict, init_verdict, loader_verdict};
+    use crate::device::readers::intel_gpu_level_zero as l0;
+    use crate::doctor::types::CheckResult;
+
+    fn probe(
+        loaded_path: Option<&'static str>,
+        init: l0::LevelZeroInit,
+        route: Option<l0::SysmanRoute>,
+        bdfs: &[&str],
+    ) -> l0::LevelZeroProbe {
+        l0::LevelZeroProbe {
+            compiled_in: true,
+            searched_paths: &["libze_loader.so.1", "/usr/lib64/libze_loader.so.1"],
+            loaded_path,
+            init,
+            sysman_route: route,
+            device_count: bdfs.len(),
+            device_bdfs: bdfs.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn ready(bdfs: &[&str]) -> l0::LevelZeroProbe {
+        probe(
+            Some("libze_loader.so.1"),
+            l0::LevelZeroInit::Ok,
+            Some(l0::SysmanRoute::ZesInit),
+            bdfs,
+        )
+    }
+
+    // ---------- loader ----------
+
+    /// The CI runner's shape: loader installed, no Intel GPU. It must pass,
+    /// because this is the one stage a machine without the hardware reaches,
+    /// and a skip here would make the namespace unreachable in CI.
+    #[test]
+    fn a_loader_without_hardware_still_passes() {
+        let r = loader_verdict(&ready(&[]), false);
+        assert!(matches!(r, CheckResult::Pass(ref m) if m.contains("libze_loader.so.1")));
+    }
+
+    /// The case worth acting on: the card is here and the runtime is not.
+    #[test]
+    fn hardware_without_a_loader_warns_with_a_hint() {
+        let r = loader_verdict(
+            &probe(None, l0::LevelZeroInit::LoaderMissing, None, &[]),
+            true,
+        );
+        let CheckResult::Warn(message, fix) = r else {
+            panic!("expected Warn, got {r:?}");
+        };
+        // The searched paths belong in the message: "not found" is useless
+        // without saying where we looked.
+        assert!(message.contains("libze_loader.so.1"), "{message}");
+        assert!(fix.is_some_and(|f| !f.is_empty()));
+    }
+
+    /// No card and no runtime is an ordinary machine, not a problem.
+    #[test]
+    fn neither_hardware_nor_loader_is_a_skip() {
+        let r = loader_verdict(
+            &probe(None, l0::LevelZeroInit::LoaderMissing, None, &[]),
+            false,
+        );
+        assert!(matches!(r, CheckResult::Skip(_)), "{r:?}");
+    }
+
+    // ---------- init ----------
+
+    #[test]
+    fn a_successful_init_names_the_sysman_route() {
+        let modern = init_verdict(&ready(&["0000:03:00.0"]), true);
+        assert!(matches!(modern, CheckResult::Pass(ref m) if m.contains("zesInit")));
+
+        let legacy = init_verdict(
+            &probe(
+                Some("libze_loader.so.1"),
+                l0::LevelZeroInit::Ok,
+                Some(l0::SysmanRoute::LegacyEnvVar),
+                &["0000:03:00.0"],
+            ),
+            true,
+        );
+        assert!(matches!(legacy, CheckResult::Pass(ref m) if m.contains("ZES_ENABLE_SYSMAN")));
+    }
+
+    /// The three failure modes must not read alike: each has a different fix.
+    #[test]
+    fn each_init_failure_is_distinguishable() {
+        let sysman = init_verdict(
+            &probe(
+                Some("libze_loader.so.1"),
+                l0::LevelZeroInit::SysmanUnavailable,
+                None,
+                &[],
+            ),
+            true,
+        );
+        let CheckResult::Warn(sysman_msg, sysman_fix) = sysman else {
+            panic!("expected Warn");
+        };
+        assert!(sysman_msg.contains("zesInit"), "{sysman_msg}");
+        let sysman_fix = sysman_fix.expect("SysmanUnavailable must carry a fix");
+        assert!(sysman_fix.contains("ZES_ENABLE_SYSMAN=1"), "{sysman_fix}");
+        assert!(
+            sysman_fix.contains("before the process starts"),
+            "the fix must say when to set it, not only what to set: {sysman_fix}"
+        );
+
+        let ze = init_verdict(
+            &probe(
+                Some("libze_loader.so.1"),
+                l0::LevelZeroInit::ZeInitFailed(0x7800_0001u32 as i32),
+                None,
+                &[],
+            ),
+            true,
+        );
+        let CheckResult::Warn(ze_msg, _) = ze else {
+            panic!("expected Warn");
+        };
+        assert!(ze_msg.contains("zeInit"), "{ze_msg}");
+        assert_ne!(ze_msg, sysman_msg);
+
+        let zes = init_verdict(
+            &probe(
+                Some("libze_loader.so.1"),
+                l0::LevelZeroInit::ZesInitFailed(5),
+                None,
+                &[],
+            ),
+            true,
+        );
+        let CheckResult::Warn(zes_msg, _) = zes else {
+            panic!("expected Warn");
+        };
+        assert!(zes_msg.contains("zesInit"), "{zes_msg}");
+        assert_ne!(zes_msg, ze_msg);
+    }
+
+    /// The numeric result code is what an operator pastes into a search.
+    #[test]
+    fn an_init_failure_carries_the_result_code() {
+        let r = init_verdict(
+            &probe(
+                Some("libze_loader.so.1"),
+                l0::LevelZeroInit::ZeInitFailed(0x7800_0001u32 as i32),
+                None,
+                &[],
+            ),
+            true,
+        );
+        let CheckResult::Warn(message, _) = r else {
+            panic!("expected Warn");
+        };
+        assert!(message.contains("78000001"), "{message}");
+    }
+
+    #[test]
+    fn init_skips_without_a_loader_or_without_hardware() {
+        let no_loader = init_verdict(
+            &probe(None, l0::LevelZeroInit::LoaderMissing, None, &[]),
+            true,
+        );
+        assert!(matches!(no_loader, CheckResult::Skip(_)), "{no_loader:?}");
+
+        let no_gpu = init_verdict(&ready(&[]), false);
+        assert!(matches!(no_gpu, CheckResult::Skip(_)), "{no_gpu:?}");
+    }
+
+    // ---------- devices ----------
+
+    /// Initialised but empty is the silent failure this check exists for.
+    #[test]
+    fn zero_devices_after_a_successful_init_warns() {
+        let r = devices_verdict(&ready(&[]), true, false);
+        assert!(matches!(r, CheckResult::Warn(_, Some(_))), "{r:?}");
+    }
+
+    #[test]
+    fn devices_are_counted_and_listed_only_when_verbose() {
+        let two = ready(&["0000:03:00.0", "0000:04:00.0"]);
+
+        let quiet = devices_verdict(&two, true, false);
+        let CheckResult::Pass(message) = quiet else {
+            panic!("expected Pass");
+        };
+        assert!(message.contains('2'), "{message}");
+        assert!(
+            !message.contains("0000:03:00.0"),
+            "BDFs identify hardware and must stay behind --verbose: {message}"
+        );
+
+        let verbose = devices_verdict(&two, true, true);
+        let CheckResult::Pass(message) = verbose else {
+            panic!("expected Pass");
+        };
+        assert!(message.contains("0000:03:00.0"), "{message}");
+        assert!(message.contains("0000:04:00.0"), "{message}");
+    }
+
+    #[test]
+    fn devices_skips_when_init_did_not_succeed() {
+        let r = devices_verdict(
+            &probe(
+                Some("libze_loader.so.1"),
+                l0::LevelZeroInit::ZeInitFailed(1),
+                None,
+                &[],
+            ),
+            true,
+            false,
+        );
+        assert!(matches!(r, CheckResult::Skip(_)), "{r:?}");
+    }
+}

--- a/src/doctor/checks/mod.rs
+++ b/src/doctor/checks/mod.rs
@@ -26,6 +26,7 @@ pub mod container;
 pub mod env;
 pub mod furiosa;
 pub mod gaudi;
+pub mod level_zero;
 pub mod network;
 pub mod nvidia;
 pub mod platform;
@@ -50,6 +51,7 @@ pub fn all() -> Vec<&'static Check> {
     v.extend(tenstorrent::checks());
     v.extend(rebellions::checks());
     v.extend(furiosa::checks());
+    v.extend(level_zero::checks());
     v.extend(windows::checks());
     v.extend(env::checks());
     v.extend(network::checks());

--- a/src/doctor/redact.rs
+++ b/src/doctor/redact.rs
@@ -301,4 +301,28 @@ mod tests {
         let got = scrub("kernel 5.15.0-89-generic", &opts);
         assert!(!got.contains(REDACT_KPTR));
     }
+
+    /// A PCI BDF must survive redaction intact.
+    ///
+    /// `0000:03:00.0` is colon-separated hex, which is the shape both the
+    /// IPv6 and the MAC matcher hunt for. A mangled BDF would make the
+    /// `level_zero.devices` check useless in the exact situation it exists
+    /// for, since the operator would be told a device is visible but not
+    /// which one.
+    #[test]
+    fn a_pci_bdf_survives_redaction() {
+        let opts = RedactOptions {
+            hostname: None,
+            username: None,
+            ..Default::default()
+        };
+        for bdf in [
+            "0000:03:00.0",
+            "0000:00:02.0",
+            "10de:01:00.1",
+            "2 device(s) visible to Sysman (0000:03:00.0, 0000:04:00.0)",
+        ] {
+            assert_eq!(scrub(bdf, &opts), bdf, "redaction mangled {bdf:?}");
+        }
+    }
 }


### PR DESCRIPTION
feat(doctor): report Level Zero loader, init, and device visibility

`all-smi doctor` had no Intel check at all. #365 added a `level_zero:` line to the support bundle's version.txt, but that reports a compile-time cfg: it cannot say whether the loader was found, whether `zeInit` succeeded, or whether Sysman saw a device, and those three decide whether an operator gets GPU temperature, power, and frequency on Intel hardware. On Windows nothing else supplies those fields at all.

Four failures used to collapse into one silent fallback, each with a different remedy: no candidate path loaded, the loader exports no `zesInit` and `ZES_ENABLE_SYSMAN=1` was not set before `zeInit`, `zeInit` failed, or `zesInit` failed. A fifth state is worth reporting and was equally invisible: initialisation succeeded and Sysman enumerated nothing, which produces empty metrics with no other symptom.

## Recording, not re-deriving

`initialize_runtime` now writes which stage it reached into a `OnceCell` beside `LZ_RUNTIME`, and `probe()` reads it back. Doctor performs no `dlopen` and no `zeInit` of its own. That is the point rather than an optimisation: `LZ_RUNTIME` is initialised once per process, so a diagnostic with its own loading path would be a second implementation, free to drift from the one that actually decides whether metrics appear. The recording adds no library load, changes no return value, and promotes no log level.

## The checks

| id | worst outcome | reports |
|---|---|---|
| `level_zero.build` | Info | compiled in for this target |
| `level_zero.loader` | Warn | which `LIBZE_PATHS` entry loaded |
| `level_zero.init` | Warn | initialised, and by which Sysman route |
| `level_zero.devices` | Info | how many devices Sysman enumerated |

None can FAIL. An absent runtime degrades to the sysfs or WMI baseline rather than breaking a run, so the worst honest verdict is a warning.

`level_zero.init` and `level_zero.devices` skip when no Intel GPU is present, since such a host is not broken. `level_zero.loader` deliberately does not: it is the one stage a machine without the hardware can reach, whether the runtime is installed is worth knowing before the card arrives, and gating it would make the whole namespace unreachable in CI.

Device counts are always printed; the PCI BDFs identify hardware and ride behind `--verbose`.

## Verification

- 10 unit tests on pure verdict functions covering every branch: loader present without hardware, hardware without loader, neither, all three init failures kept textually distinct with the numeric `ze_result_t` in the message, zero devices after a successful init, and the verbose split.
- A test pins that a PCI BDF survives `doctor::redact`. `0000:03:00.0` is colon-separated hex, the shape both the IPv6 and the MAC matcher hunt for, and a mangled BDF makes the device check useless in the exact situation it exists for.
- A CI step on the Linux job runs `doctor --only level_zero --json` and asserts build PASS, loader PASS naming the library, and exit 0. The runner installs `libze1` and has no Intel GPU, which is precisely the loader-without-hardware case.
- 3448 tests on macOS across 23 binaries and 1641 lib tests through the scratch probe with the backend compiled in, 0 failures. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on both.

Not verified: no Intel GPU here, so the init and device stages are exercised only through their verdict functions, never against a live Sysman. Reaching those without hardware is #379.

Closes #380
