### PR TITLE
feat(ci): drive the Level Zero backend against a stub loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,69 @@ jobs:
               exit 1
               ;;
           esac
+      # Everything past `try_load_library` needs a driver to answer, and no
+      # runner has an Intel GPU. A synthetic loader supplies the answers so
+      # the rest of the backend runs here: device enumeration, the
+      # count-then-buffer idiom and its clamp, the BDF mapping, the delta
+      # arithmetic, and above all the struct layouts.
+      #
+      # The headers are the point. The stub is compiled against the vendor's
+      # own `ze_api.h` and `zes_api.h`, so a value that survives into an
+      # all-smi `#[repr(C)]` field proves the two layouts agree field by
+      # field. The size assertions we already have compare our struct to our
+      # own transcription of the spec, which cannot catch a field-order swap
+      # or an offset error that preserves the total.
+      - name: Install the Level Zero headers
+        run: sudo apt-get install -y libze-dev || sudo apt-get install -y level-zero-dev
+
+      # Built into its own directory so LD_LIBRARY_PATH ordering is
+      # unambiguous against the real libze1 installed above, which the
+      # previous step still needs.
+      - name: Build the stub Level Zero loader
+        run: |
+          set -euo pipefail
+          mkdir -p target/lz-stub
+          cc -shared -fPIC -Wall -Wextra -Werror \
+             -Wl,-soname,libze_loader.so.1 \
+             -o target/lz-stub/libze_loader.so.1 \
+             tests/fixtures/level_zero/stub_ze_loader.c
+          # Every symbol the backend resolves must be exported, or the test
+          # below fails later and less clearly.
+          for sym in zeInit zesInit zeDriverGet zeDeviceGet \
+                     zesDevicePciGetProperties zesDeviceEnumEngineGroups \
+                     zesEngineGetProperties zesEngineGetActivity \
+                     zesDeviceEnumPowerDomains zesPowerGetEnergyCounter \
+                     zesDeviceEnumTemperatureSensors zesTemperatureGetProperties \
+                     zesTemperatureGetState zesDeviceEnumMemoryModules \
+                     zesMemoryGetProperties zesMemoryGetState \
+                     zesDeviceEnumFrequencyDomains zesFrequencyGetProperties \
+                     zesFrequencyGetState zesDeviceEnumFans \
+                     zesFanGetProperties zesFanGetState; do
+            if ! nm -D --defined-only target/lz-stub/libze_loader.so.1 | grep -q " $sym\$"; then
+              echo "::error::the stub does not export $sym"
+              exit 1
+            fi
+          done
+
+      # `LIBZE_PATHS[0]` is the bare SONAME, and dlopen searches
+      # LD_LIBRARY_PATH before the default paths, so the stub wins here
+      # without any production code knowing it exists. The variable is set
+      # on this step alone, so every other step still sees the real loader.
+      #
+      # Its own test binary, therefore its own process: `LZ_RUNTIME` is a
+      # process-wide OnceCell and the library's unit tests already latch it.
+      - name: Drive the backend against the stub loader
+        env:
+          ALL_SMI_LEVEL_ZERO_STUB: "1"
+        run: |
+          set -euo pipefail
+          log="${RUNNER_TEMP:-/tmp}/level-zero-stub.log"
+          LD_LIBRARY_PATH="$PWD/target/lz-stub:${LD_LIBRARY_PATH:-}" \
+            cargo test --test level_zero_stub -- --nocapture | tee "$log"
+          if ! grep -q 'all-smi: level-zero-stub-assertions-ran' "$log"; then
+            echo "::error::the stub tests did not assert. Either ALL_SMI_LEVEL_ZERO_STUB no longer reaches them, or the LD_LIBRARY_PATH binding stopped working and every test returned early."
+            exit 1
+          fi
 
       # `cargo test` with no flags now covers the Level Zero backend:
       # build.rs turns `all_smi_level_zero` on for every Linux target, so

--- a/tests/fixtures/level_zero/stub_ze_loader.c
+++ b/tests/fixtures/level_zero/stub_ze_loader.c
@@ -476,11 +476,8 @@ zesFrequencyGetState(zes_freq_handle_t hFrequency, zes_freq_state_t *pState) {
     pState->currentVoltage = 1.05;
     pState->request = 2200.0;
     pState->tdp = 2300.0;
-    /* REACHABILITY PROOF, reverted in the next commit: `actual` and
-     * `efficient` swapped. This is exactly the defect class the size
-     * assertions cannot see, so the test must go red. */
-    pState->efficient = STUB_FREQ_ACTUAL_MHZ;
-    pState->actual = 1200.0;
+    pState->efficient = 1200.0;
+    pState->actual = STUB_FREQ_ACTUAL_MHZ;
     pState->throttleReasons = 0;
     return ZE_RESULT_SUCCESS;
 }

--- a/tests/fixtures/level_zero/stub_ze_loader.c
+++ b/tests/fixtures/level_zero/stub_ze_loader.c
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2025 Lablup Inc. and Jeongkyu Shin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * A synthetic Level Zero loader, built and used only by CI.
+ *
+ * ## Why it exists
+ *
+ * Every runner this project has lacks an Intel GPU, so `zeInit` has no
+ * driver to return and everything past `try_load_library` goes unexercised:
+ * device enumeration, the count-then-buffer idiom, the BDF mapping, the
+ * delta arithmetic, and the struct layouts the driver writes into. This
+ * library plays the driver's part so that code runs on an ordinary runner.
+ *
+ * ## What it verifies
+ *
+ * It is compiled against the **vendor headers**, not against all-smi's own
+ * transcription of them. That is the entire point. The existing size
+ * assertions in `tests/ffi_layout.rs` compare our struct to our own reading
+ * of the spec, which catches a mis-sized field but not two same-typed
+ * fields in the wrong order, nor a wrong offset that preserves the total,
+ * nor a spec value transcribed wrong in both places. Here the vendor's own
+ * struct definition is filled in on the C side and read back through
+ * all-smi's `#[repr(C)]` type on the Rust side, so a value arriving intact
+ * proves the two layouts agree field by field.
+ *
+ * Types verified this way, all in `src/device/readers/intel_gpu_level_zero`:
+ *   ffi.rs         zes_pci_address_t, zes_pci_speed_t, zes_pci_properties_t,
+ *                  zes_engine_properties_t, zes_engine_stats_t,
+ *                  zes_power_energy_counter_t
+ *   ffi/sysman.rs  zes_temp_properties_t, zes_mem_properties_t,
+ *                  zes_mem_state_t, zes_freq_properties_t,
+ *                  zes_freq_state_t, zes_fan_properties_t
+ *
+ * ## What it does NOT verify
+ *
+ * Real driver behaviour, plausible value ranges, error paths a real driver
+ * would take, Windows and `ze_loader.dll` (out of scope, see the issue),
+ * and any Sysman domain not implemented below. A green run here means the
+ * plumbing and the layouts are right, not that an Intel GPU would report
+ * anything in particular.
+ *
+ * ## Determinism
+ *
+ * No clock reads and no randomness. Counters advance by a fixed step per
+ * call so the derived percentages and watts are exact constants that the
+ * test asserts on directly, never ranges.
+ */
+
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
+
+#include <stdint.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ *
+ * Handles
+ *
+ * Every handle is the address of a distinct static object, so a handle
+ * mixed up between calls dereferences to visibly wrong data rather than
+ * to a plausible neighbour.
+ * ------------------------------------------------------------------ */
+
+static int stub_driver;
+
+/* Two devices at addresses that exercise a non-trivial bus byte and a
+ * sort order: 0xaf sorts after 0x03 numerically and as a string. */
+static int stub_device_a;
+static int stub_device_b;
+
+static int stub_engine_compute;
+static int stub_engine_render;
+static int stub_power;
+static int stub_temp;
+static int stub_mem;
+static int stub_freq;
+static int stub_fan;
+
+/* Device B owns nothing but its PCI address. It exists to prove that a
+ * second device is enumerated and sorted, and to exercise the two count
+ * edge cases below without disturbing device A's exact values. */
+
+/* ------------------------------------------------------------------ *
+ * Fixed per-call steps
+ *
+ * The backend derives engine busy from delta(activeTime)/delta(timestamp)
+ * and power from delta(energy in microjoules)/delta(timestamp in
+ * microseconds), which is microjoules per microsecond, that is watts. With
+ * the steps below the second refresh must produce exactly 25.00% compute,
+ * 10.00% render, and 45.00 W.
+ * ------------------------------------------------------------------ */
+
+#define STUB_TICK_US            1000000ULL
+#define STUB_COMPUTE_ACTIVE_US   250000ULL   /* 25.00% of a tick */
+#define STUB_RENDER_ACTIVE_US    100000ULL   /* 10.00% of a tick */
+#define STUB_ENERGY_UJ         45000000ULL   /* 45.00 W over a tick */
+
+static uint64_t compute_calls;
+static uint64_t render_calls;
+static uint64_t power_calls;
+
+/* Point-in-time values. Each is unique within its struct so a field read
+ * at the wrong offset yields an obviously wrong number. */
+#define STUB_TEMP_C            61.0
+#define STUB_MEM_SIZE      12884901888ULL   /* 12 GiB */
+#define STUB_MEM_FREE       4294967296ULL   /*  4 GiB, so 8 GiB used */
+#define STUB_FREQ_ACTUAL_MHZ    2100.0
+#define STUB_FREQ_MIN_MHZ        300.0
+#define STUB_FREQ_MAX_MHZ       2400.0
+#define STUB_FAN_RPM            1800
+
+/* ------------------------------------------------------------------ *
+ * Count-then-buffer helper
+ *
+ * The real API contract, which `enumerate_devices` and every `populate_*`
+ * helper depend on: a non-null count pointer with a null buffer means
+ * "report how many", and a second call fills that many.
+ * ------------------------------------------------------------------ */
+static ze_result_t stub_enumerate(uint32_t *pCount, void **buffer,
+                                  void **items, uint32_t available) {
+    if (pCount == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (buffer == NULL) {
+        *pCount = available;
+        return ZE_RESULT_SUCCESS;
+    }
+    uint32_t n = *pCount < available ? *pCount : available;
+    for (uint32_t i = 0; i < n; i++) {
+        buffer[i] = items[i];
+    }
+    *pCount = n;
+    return ZE_RESULT_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ *
+ * Core
+ * ------------------------------------------------------------------ */
+
+ZE_APIEXPORT ze_result_t ZE_APICALL zeInit(ze_init_flags_t flags) {
+    (void)flags;
+    return ZE_RESULT_SUCCESS;
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL zesInit(zes_init_flags_t flags) {
+    (void)flags;
+    return ZE_RESULT_SUCCESS;
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL zeDriverGet(uint32_t *pCount,
+                                                ze_driver_handle_t *phDrivers) {
+    void *items[] = {&stub_driver};
+    return stub_enumerate(pCount, (void **)phDrivers, items, 1);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL zeDeviceGet(ze_driver_handle_t hDriver,
+                                                uint32_t *pCount,
+                                                ze_device_handle_t *phDevices) {
+    if (hDriver != (ze_driver_handle_t)&stub_driver) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    void *items[] = {&stub_device_a, &stub_device_b};
+    return stub_enumerate(pCount, (void **)phDevices, items, 2);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDevicePciGetProperties(zes_device_handle_t hDevice,
+                          zes_pci_properties_t *pProperties) {
+    if (pProperties == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    memset(pProperties, 0, sizeof(*pProperties));
+    pProperties->stype = ZES_STRUCTURE_TYPE_PCI_PROPERTIES;
+    pProperties->pNext = NULL;
+
+    if (hDevice == (zes_device_handle_t)&stub_device_a) {
+        pProperties->address.domain = 0x0000;
+        pProperties->address.bus = 0x03;
+        pProperties->address.device = 0x00;
+        pProperties->address.function = 0x0;
+    } else if (hDevice == (zes_device_handle_t)&stub_device_b) {
+        pProperties->address.domain = 0x0000;
+        pProperties->address.bus = 0xaf;
+        pProperties->address.device = 0x00;
+        pProperties->address.function = 0x0;
+    } else {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    /* Filled so a wrong offset in the trailing fields is observable as a
+     * changed address rather than as silent garbage. */
+    pProperties->maxSpeed.gen = 4;
+    pProperties->maxSpeed.width = 16;
+    pProperties->maxSpeed.maxBandwidth = 31504000000LL;
+    pProperties->haveBandwidthCounters = 1;
+    pProperties->havePacketCounters = 0;
+    pProperties->haveReplayCounters = 1;
+    return ZE_RESULT_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ *
+ * Engines
+ * ------------------------------------------------------------------ */
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumEngineGroups(zes_device_handle_t hDevice, uint32_t *pCount,
+                          zes_engine_handle_t *phEngine) {
+    if (hDevice == (zes_device_handle_t)&stub_device_b) {
+        /* Edge case: report more than MAX_L0_HANDLES so `cap_handle_count`
+         * has something to clamp, then fill fewer than requested so the
+         * `truncate` after the fill call has something to trim. */
+        if (pCount == NULL) {
+            return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+        if (phEngine == NULL) {
+            *pCount = 4096;
+            return ZE_RESULT_SUCCESS;
+        }
+        phEngine[0] = (zes_engine_handle_t)&stub_engine_render;
+        *pCount = 1;
+        return ZE_RESULT_SUCCESS;
+    }
+    if (hDevice != (zes_device_handle_t)&stub_device_a) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    void *items[] = {&stub_engine_compute, &stub_engine_render};
+    return stub_enumerate(pCount, (void **)phEngine, items, 2);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesEngineGetProperties(zes_engine_handle_t hEngine,
+                       zes_engine_properties_t *pProperties) {
+    if (pProperties == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    memset(pProperties, 0, sizeof(*pProperties));
+    pProperties->stype = ZES_STRUCTURE_TYPE_ENGINE_PROPERTIES;
+    pProperties->pNext = NULL;
+    pProperties->onSubdevice = 0;
+    pProperties->subdeviceId = 0;
+    if (hEngine == (zes_engine_handle_t)&stub_engine_compute) {
+        pProperties->type = ZES_ENGINE_GROUP_COMPUTE_SINGLE;
+    } else if (hEngine == (zes_engine_handle_t)&stub_engine_render) {
+        pProperties->type = ZES_ENGINE_GROUP_RENDER_SINGLE;
+    } else {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    return ZE_RESULT_SUCCESS;
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesEngineGetActivity(zes_engine_handle_t hEngine, zes_engine_stats_t *pStats) {
+    if (pStats == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    memset(pStats, 0, sizeof(*pStats));
+    if (hEngine == (zes_engine_handle_t)&stub_engine_compute) {
+        compute_calls++;
+        pStats->activeTime = compute_calls * STUB_COMPUTE_ACTIVE_US;
+        pStats->timestamp = compute_calls * STUB_TICK_US;
+    } else if (hEngine == (zes_engine_handle_t)&stub_engine_render) {
+        render_calls++;
+        pStats->activeTime = render_calls * STUB_RENDER_ACTIVE_US;
+        pStats->timestamp = render_calls * STUB_TICK_US;
+    } else {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    return ZE_RESULT_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ *
+ * Power
+ * ------------------------------------------------------------------ */
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumPowerDomains(zes_device_handle_t hDevice, uint32_t *pCount,
+                          zes_pwr_handle_t *phPower) {
+    if (hDevice != (zes_device_handle_t)&stub_device_a) {
+        if (pCount != NULL && phPower == NULL) {
+            *pCount = 0;
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+    void *items[] = {&stub_power};
+    return stub_enumerate(pCount, (void **)phPower, items, 1);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesPowerGetEnergyCounter(zes_pwr_handle_t hPower,
+                         zes_power_energy_counter_t *pEnergy) {
+    if (pEnergy == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hPower != (zes_pwr_handle_t)&stub_power) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    memset(pEnergy, 0, sizeof(*pEnergy));
+    power_calls++;
+    pEnergy->energy = power_calls * STUB_ENERGY_UJ;
+    pEnergy->timestamp = power_calls * STUB_TICK_US;
+    return ZE_RESULT_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ *
+ * Temperature
+ * ------------------------------------------------------------------ */
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumTemperatureSensors(zes_device_handle_t hDevice, uint32_t *pCount,
+                                zes_temp_handle_t *phTemperature) {
+    if (hDevice != (zes_device_handle_t)&stub_device_a) {
+        if (pCount != NULL && phTemperature == NULL) {
+            *pCount = 0;
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+    void *items[] = {&stub_temp};
+    return stub_enumerate(pCount, (void **)phTemperature, items, 1);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesTemperatureGetProperties(zes_temp_handle_t hTemperature,
+                            zes_temp_properties_t *pProperties) {
+    if (pProperties == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hTemperature != (zes_temp_handle_t)&stub_temp) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    memset(pProperties, 0, sizeof(*pProperties));
+    pProperties->stype = ZES_STRUCTURE_TYPE_TEMP_PROPERTIES;
+    pProperties->pNext = NULL;
+    pProperties->type = ZES_TEMP_SENSORS_GPU;
+    pProperties->onSubdevice = 0;
+    pProperties->subdeviceId = 0;
+    pProperties->maxTemperature = 105.0;
+    pProperties->isCriticalTempSupported = 1;
+    pProperties->isThreshold1Supported = 0;
+    pProperties->isThreshold2Supported = 0;
+    return ZE_RESULT_SUCCESS;
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesTemperatureGetState(zes_temp_handle_t hTemperature, double *pTemperature) {
+    if (pTemperature == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hTemperature != (zes_temp_handle_t)&stub_temp) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    *pTemperature = STUB_TEMP_C;
+    return ZE_RESULT_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ *
+ * Memory
+ * ------------------------------------------------------------------ */
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumMemoryModules(zes_device_handle_t hDevice, uint32_t *pCount,
+                           zes_mem_handle_t *phMemory) {
+    if (hDevice != (zes_device_handle_t)&stub_device_a) {
+        if (pCount != NULL && phMemory == NULL) {
+            *pCount = 0;
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+    void *items[] = {&stub_mem};
+    return stub_enumerate(pCount, (void **)phMemory, items, 1);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesMemoryGetProperties(zes_mem_handle_t hMemory,
+                       zes_mem_properties_t *pProperties) {
+    if (pProperties == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hMemory != (zes_mem_handle_t)&stub_mem) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    memset(pProperties, 0, sizeof(*pProperties));
+    pProperties->stype = ZES_STRUCTURE_TYPE_MEM_PROPERTIES;
+    pProperties->pNext = NULL;
+    pProperties->type = ZES_MEM_TYPE_HBM;
+    pProperties->onSubdevice = 0;
+    pProperties->subdeviceId = 0;
+    pProperties->location = ZES_MEM_LOC_DEVICE;
+    pProperties->physicalSize = STUB_MEM_SIZE;
+    pProperties->busWidth = 256;
+    pProperties->numChannels = 8;
+    return ZE_RESULT_SUCCESS;
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesMemoryGetState(zes_mem_handle_t hMemory, zes_mem_state_t *pState) {
+    if (pState == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hMemory != (zes_mem_handle_t)&stub_mem) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    memset(pState, 0, sizeof(*pState));
+    pState->stype = ZES_STRUCTURE_TYPE_MEM_STATE;
+    pState->pNext = NULL;
+    pState->health = ZES_MEM_HEALTH_OK;
+    pState->free = STUB_MEM_FREE;
+    pState->size = STUB_MEM_SIZE;
+    return ZE_RESULT_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ *
+ * Frequency
+ * ------------------------------------------------------------------ */
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumFrequencyDomains(zes_device_handle_t hDevice, uint32_t *pCount,
+                              zes_freq_handle_t *phFrequency) {
+    if (hDevice != (zes_device_handle_t)&stub_device_a) {
+        if (pCount != NULL && phFrequency == NULL) {
+            *pCount = 0;
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+    void *items[] = {&stub_freq};
+    return stub_enumerate(pCount, (void **)phFrequency, items, 1);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyGetProperties(zes_freq_handle_t hFrequency,
+                          zes_freq_properties_t *pProperties) {
+    if (pProperties == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hFrequency != (zes_freq_handle_t)&stub_freq) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    memset(pProperties, 0, sizeof(*pProperties));
+    pProperties->stype = ZES_STRUCTURE_TYPE_FREQ_PROPERTIES;
+    pProperties->pNext = NULL;
+    pProperties->type = ZES_FREQ_DOMAIN_GPU;
+    pProperties->onSubdevice = 0;
+    pProperties->subdeviceId = 0;
+    pProperties->canControl = 1;
+    pProperties->isThrottleEventSupported = 0;
+    pProperties->min = STUB_FREQ_MIN_MHZ;
+    pProperties->max = STUB_FREQ_MAX_MHZ;
+    return ZE_RESULT_SUCCESS;
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFrequencyGetState(zes_freq_handle_t hFrequency, zes_freq_state_t *pState) {
+    if (pState == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hFrequency != (zes_freq_handle_t)&stub_freq) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    memset(pState, 0, sizeof(*pState));
+    pState->stype = ZES_STRUCTURE_TYPE_FREQ_STATE;
+    pState->pNext = NULL;
+    /* Each field a different number: `actual` read at the offset of any
+     * neighbour produces a visibly wrong frequency. */
+    pState->currentVoltage = 1.05;
+    pState->request = 2200.0;
+    pState->tdp = 2300.0;
+    pState->efficient = 1200.0;
+    pState->actual = STUB_FREQ_ACTUAL_MHZ;
+    pState->throttleReasons = 0;
+    return ZE_RESULT_SUCCESS;
+}
+
+/* ------------------------------------------------------------------ *
+ * Fan
+ * ------------------------------------------------------------------ */
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesDeviceEnumFans(zes_device_handle_t hDevice, uint32_t *pCount,
+                  zes_fan_handle_t *phFan) {
+    if (hDevice != (zes_device_handle_t)&stub_device_a) {
+        if (pCount != NULL && phFan == NULL) {
+            *pCount = 0;
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+    void *items[] = {&stub_fan};
+    return stub_enumerate(pCount, (void **)phFan, items, 1);
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanGetProperties(zes_fan_handle_t hFan, zes_fan_properties_t *pProperties) {
+    if (pProperties == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hFan != (zes_fan_handle_t)&stub_fan) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    memset(pProperties, 0, sizeof(*pProperties));
+    pProperties->stype = ZES_STRUCTURE_TYPE_FAN_PROPERTIES;
+    pProperties->pNext = NULL;
+    pProperties->onSubdevice = 0;
+    pProperties->subdeviceId = 0;
+    pProperties->canControl = 1;
+    pProperties->supportedModes = 0;
+    /* RPM only. The percent path must stay unreported, which is what
+     * proves `fan_unit_supported` is consulted rather than assumed. */
+    pProperties->supportedUnits = 1u << ZES_FAN_SPEED_UNITS_RPM;
+    pProperties->maxRPM = 4000;
+    pProperties->maxPoints = 0;
+    return ZE_RESULT_SUCCESS;
+}
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zesFanGetState(zes_fan_handle_t hFan, zes_fan_speed_units_t units,
+               int32_t *pSpeed) {
+    if (pSpeed == NULL) {
+        return ZE_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+    if (hFan != (zes_fan_handle_t)&stub_fan) {
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    if (units != ZES_FAN_SPEED_UNITS_RPM) {
+        /* Unsupported unit degrades that reading only, which is the
+         * per-family independence the module header promises. */
+        return ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+    *pSpeed = STUB_FAN_RPM;
+    return ZE_RESULT_SUCCESS;
+}

--- a/tests/fixtures/level_zero/stub_ze_loader.c
+++ b/tests/fixtures/level_zero/stub_ze_loader.c
@@ -476,8 +476,11 @@ zesFrequencyGetState(zes_freq_handle_t hFrequency, zes_freq_state_t *pState) {
     pState->currentVoltage = 1.05;
     pState->request = 2200.0;
     pState->tdp = 2300.0;
-    pState->efficient = 1200.0;
-    pState->actual = STUB_FREQ_ACTUAL_MHZ;
+    /* REACHABILITY PROOF, reverted in the next commit: `actual` and
+     * `efficient` swapped. This is exactly the defect class the size
+     * assertions cannot see, so the test must go red. */
+    pState->efficient = STUB_FREQ_ACTUAL_MHZ;
+    pState->actual = 1200.0;
     pState->throttleReasons = 0;
     return ZE_RESULT_SUCCESS;
 }

--- a/tests/fixtures/level_zero/stub_ze_loader.c
+++ b/tests/fixtures/level_zero/stub_ze_loader.c
@@ -63,6 +63,7 @@
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
 
+#include <stdatomic.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -89,9 +90,10 @@ static int stub_mem;
 static int stub_freq;
 static int stub_fan;
 
-/* Device B owns nothing but its PCI address. It exists to prove that a
- * second device is enumerated and sorted, and to exercise the two count
- * edge cases below without disturbing device A's exact values. */
+/* Device B owns one render engine and deliberately rejects power-domain
+ * enumeration. It exists to prove that a second device is enumerated and
+ * sorted, to exercise the count edge cases below, and to verify that one
+ * failing Sysman family does not suppress the others. */
 
 /* ------------------------------------------------------------------ *
  * Fixed per-call steps
@@ -108,9 +110,18 @@ static int stub_fan;
 #define STUB_RENDER_ACTIVE_US    100000ULL   /* 10.00% of a tick */
 #define STUB_ENERGY_UJ         45000000ULL   /* 45.00 W over a tick */
 
-static uint64_t compute_calls;
-static uint64_t render_calls;
-static uint64_t power_calls;
+/* Rust's test harness runs independent tests concurrently. These counters
+ * are shared by every test through the one process-wide stub library, so
+ * plain increments would be a C data race. Relaxed atomics are sufficient:
+ * callers need a unique monotonically increasing sample number, not an
+ * ordering relationship with any other state. */
+static _Atomic uint64_t compute_calls;
+static _Atomic uint64_t render_calls;
+static _Atomic uint64_t power_calls;
+
+static uint64_t next_call(_Atomic uint64_t *counter) {
+    return atomic_fetch_add_explicit(counter, 1, memory_order_relaxed) + 1;
+}
 
 /* Point-in-time values. Each is unique within its struct so a field read
  * at the wrong offset yields an obviously wrong number. */
@@ -268,13 +279,13 @@ zesEngineGetActivity(zes_engine_handle_t hEngine, zes_engine_stats_t *pStats) {
     }
     memset(pStats, 0, sizeof(*pStats));
     if (hEngine == (zes_engine_handle_t)&stub_engine_compute) {
-        compute_calls++;
-        pStats->activeTime = compute_calls * STUB_COMPUTE_ACTIVE_US;
-        pStats->timestamp = compute_calls * STUB_TICK_US;
+        uint64_t call = next_call(&compute_calls);
+        pStats->activeTime = call * STUB_COMPUTE_ACTIVE_US;
+        pStats->timestamp = call * STUB_TICK_US;
     } else if (hEngine == (zes_engine_handle_t)&stub_engine_render) {
-        render_calls++;
-        pStats->activeTime = render_calls * STUB_RENDER_ACTIVE_US;
-        pStats->timestamp = render_calls * STUB_TICK_US;
+        uint64_t call = next_call(&render_calls);
+        pStats->activeTime = call * STUB_RENDER_ACTIVE_US;
+        pStats->timestamp = call * STUB_TICK_US;
     } else {
         return ZE_RESULT_ERROR_INVALID_ARGUMENT;
     }
@@ -288,11 +299,11 @@ zesEngineGetActivity(zes_engine_handle_t hEngine, zes_engine_stats_t *pStats) {
 ZE_APIEXPORT ze_result_t ZE_APICALL
 zesDeviceEnumPowerDomains(zes_device_handle_t hDevice, uint32_t *pCount,
                           zes_pwr_handle_t *phPower) {
+    if (hDevice == (zes_device_handle_t)&stub_device_b) {
+        return ZE_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
     if (hDevice != (zes_device_handle_t)&stub_device_a) {
-        if (pCount != NULL && phPower == NULL) {
-            *pCount = 0;
-        }
-        return ZE_RESULT_SUCCESS;
+        return ZE_RESULT_ERROR_INVALID_ARGUMENT;
     }
     void *items[] = {&stub_power};
     return stub_enumerate(pCount, (void **)phPower, items, 1);
@@ -308,9 +319,9 @@ zesPowerGetEnergyCounter(zes_pwr_handle_t hPower,
         return ZE_RESULT_ERROR_INVALID_ARGUMENT;
     }
     memset(pEnergy, 0, sizeof(*pEnergy));
-    power_calls++;
-    pEnergy->energy = power_calls * STUB_ENERGY_UJ;
-    pEnergy->timestamp = power_calls * STUB_TICK_US;
+    uint64_t call = next_call(&power_calls);
+    pEnergy->energy = call * STUB_ENERGY_UJ;
+    pEnergy->timestamp = call * STUB_TICK_US;
     return ZE_RESULT_SUCCESS;
 }
 

--- a/tests/level_zero_stub.rs
+++ b/tests/level_zero_stub.rs
@@ -210,25 +210,32 @@ fn the_point_in_time_families_land_in_gpu_info() {
 }
 
 /// Device B advertises 4096 engines, above the `MAX_L0_HANDLES` cap of 256,
-/// then fills fewer than requested. Both the clamp and the post-fill
-/// truncate have to hold or this panics or reads past the buffer.
+/// then fills fewer than requested. It also returns a non-success result for
+/// power enumeration. The engine family must remain fresh while power alone
+/// degrades, in addition to surviving both the clamp and post-fill truncate.
 #[test]
-fn an_over_cap_count_and_a_short_fill_are_survived() {
+fn count_edges_and_a_failing_family_are_isolated() {
     if !armed() {
         return;
     }
     let mut state = l0::LevelZeroState::empty();
-    let readout = l0::refresh(&mut state, BDF_B).expect("device B must still bind");
+    let first = l0::refresh(&mut state, BDF_B).expect("device B must still bind");
     assert!(
         l0::is_bound(&state),
         "device B must bind even though its enumerator misbehaves"
     );
     // One engine survived the clamp and the truncate.
     assert_eq!(l0::engine_count(&state), 1);
-    // Device B has no power domain, and a family the driver does not offer
-    // must degrade only itself.
+    // The failing power family must degrade only itself.
     assert_eq!(l0::power_domain_count(&state), 0);
-    assert!(readout.power_watts.is_none());
+    assert!(first.power_watts.is_none());
+
+    let second = l0::refresh(&mut state, BDF_B).expect("the engine family must stay fresh");
+    let engine = second
+        .primary_engine_utilization
+        .expect("a power enumeration failure must not suppress engine data");
+    assert!((engine.value - 10.0).abs() < 1e-9);
+    assert!(second.power_watts.is_none());
     println!("{MARKER}");
 }
 

--- a/tests/level_zero_stub.rs
+++ b/tests/level_zero_stub.rs
@@ -1,0 +1,246 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The backend does not exist on targets `build.rs` does not emit the cfg
+// for, macOS among them, so this whole binary compiles away there rather
+// than failing to resolve the module.
+#![cfg(all_smi_level_zero)]
+
+//! Drive the Level Zero backend against the synthetic loader in
+//! `tests/fixtures/level_zero/stub_ze_loader.c`.
+//!
+//! ## Why this is a separate test binary
+//!
+//! `LZ_RUNTIME` is a process-wide `OnceCell`, latched by whichever caller
+//! reaches `ensure_runtime` first, and two unit tests in the library's own
+//! test binary already latch it. Whoever wins decides which loader the whole
+//! binary sees, so a stub test living beside them would be a race. Cargo
+//! compiles each file under `tests/` into its own binary, hence its own
+//! process, which is what makes the `LD_LIBRARY_PATH` binding deterministic.
+//!
+//! ## How the stub is bound
+//!
+//! `LIBZE_PATHS[0]` is the bare SONAME `libze_loader.so.1`, and `dlopen` on
+//! a bare SONAME searches `LD_LIBRARY_PATH` before the default paths. A
+//! stub built under that name, in a directory placed first, therefore wins
+//! over the real loader the CI job also installs. No production code knows
+//! this file exists: no path was added to `LIBZE_PATHS`, no environment
+//! override was added to the loader, and nothing here is compiled into the
+//! `all-smi` binary.
+//!
+//! ## Failing loudly
+//!
+//! Every test returns early unless `ALL_SMI_LEVEL_ZERO_STUB=1`, so a
+//! developer without the stub is not bothered. That makes a green run
+//! ambiguous on its own, which is the same trap the real-loader check in
+//! #365 had, so the same three-part answer applies: the env key arms the
+//! assertions, a marker is printed only after they pass, and the CI step
+//! greps for the marker.
+
+use all_smi::device::readers::intel_gpu_level_zero as l0;
+use all_smi::device::types::GpuInfo;
+use std::collections::HashMap;
+
+/// Set by CI once the stub is built and `LD_LIBRARY_PATH` points at it.
+const STUB_ENV: &str = "ALL_SMI_LEVEL_ZERO_STUB";
+
+/// Printed only after a test has actually asserted. See the module note.
+const MARKER: &str = "all-smi: level-zero-stub-assertions-ran";
+
+/// The addresses `stub_ze_loader.c` reports, in the order
+/// `enumerated_pci_bdfs` must sort them.
+const BDF_A: &str = "0000:03:00.0";
+const BDF_B: &str = "0000:af:00.0";
+
+fn armed() -> bool {
+    std::env::var_os(STUB_ENV).is_some()
+}
+
+fn blank_gpu_info() -> GpuInfo {
+    GpuInfo {
+        uuid: "stub-0".to_string(),
+        time: "2026-01-01 00:00:00".to_string(),
+        name: "Stub Intel GPU".to_string(),
+        device_type: "GPU".to_string(),
+        host_id: "stub-host".to_string(),
+        hostname: "stub-host".to_string(),
+        instance: "stub-host".to_string(),
+        utilization: 0.0,
+        ane_utilization: 0.0,
+        dla_utilization: None,
+        tensorcore_utilization: None,
+        temperature: 0,
+        used_memory: 0,
+        total_memory: 0,
+        frequency: 0,
+        power_consumption: 0.0,
+        gpu_core_count: None,
+        temperature_threshold_slowdown: None,
+        temperature_threshold_shutdown: None,
+        temperature_threshold_max_operating: None,
+        temperature_threshold_acoustic: None,
+        performance_state: None,
+        fan_speed_rpm: None,
+        numa_node_id: None,
+        gsp_firmware_mode: None,
+        gsp_firmware_version: None,
+        nvlink_remote_devices: Vec::new(),
+        gpm_metrics: None,
+        detail: HashMap::new(),
+    }
+}
+
+/// Take the two samples the delta families need, and return the second
+/// readout. The first is only a seed by design.
+fn second_readout(bdf: &str) -> l0::LevelZeroReadout {
+    let mut state = l0::LevelZeroState::empty();
+    let first = l0::refresh(&mut state, bdf)
+        .unwrap_or_else(|| panic!("{STUB_ENV} is set but the stub produced no readout for {bdf}"));
+    // Seeded, not fresh: a delta needs two samples.
+    assert!(
+        first.primary_engine_utilization.is_none(),
+        "the first refresh must only seed the delta counters, got {:?}",
+        first.primary_engine_utilization
+    );
+    l0::refresh(&mut state, bdf).expect("second refresh must produce a readout")
+}
+
+/// The full chain `zeDriverGet` then `zeDeviceGet` then
+/// `zesDevicePciGetProperties` then `format_pci_bdf`, end to end. Nothing
+/// short of a real driver has exercised it before.
+#[test]
+fn the_stub_devices_enumerate_in_sorted_bdf_order() {
+    if !armed() {
+        return;
+    }
+    let bdfs = l0::enumerated_pci_bdfs();
+    assert_eq!(
+        bdfs,
+        vec![BDF_A.to_string(), BDF_B.to_string()],
+        "the stub reports bus 0x03 and 0xaf; a wrong offset in zes_pci_address_t \
+         changes these strings"
+    );
+    println!("{MARKER}");
+}
+
+/// Exact constants, not ranges. The stub advances `activeTime` by 250000 and
+/// `timestamp` by 1000000 microseconds per call, so the second sample is
+/// 25.00% by construction, and energy by 45000000 microjoules over the same
+/// tick, which is 45.00 W.
+#[test]
+fn the_delta_families_produce_the_exact_synthetic_values() {
+    if !armed() {
+        return;
+    }
+    let readout = second_readout(BDF_A);
+
+    let engine = readout
+        .primary_engine_utilization
+        .expect("engine activity must be fresh on the second sample");
+    assert!(
+        (engine.value - 25.0).abs() < 1e-9,
+        "expected exactly 25.00% compute busy, got {}",
+        engine.value
+    );
+
+    let power = readout
+        .power_watts
+        .expect("power must be fresh on the second sample");
+    assert!(
+        (power.value - 45.0).abs() < 1e-9,
+        "expected exactly 45.00 W, got {}",
+        power.value
+    );
+
+    // Both engines are tracked, and the primary is the larger of the two.
+    let render = readout
+        .engines
+        .iter()
+        .find(|(label, _)| *label == "render")
+        .map(|(_, pct)| *pct)
+        .expect("the render engine must appear in the per-engine list");
+    assert!(
+        (render - 10.0).abs() < 1e-9,
+        "expected exactly 10.00% render, got {render}"
+    );
+    println!("{MARKER}");
+}
+
+/// Point-in-time families, and the reason the stub is compiled against the
+/// vendor headers: each value below is read back through a different
+/// `#[repr(C)]` struct, so a field at the wrong offset changes an
+/// observable number rather than passing silently.
+#[test]
+fn the_point_in_time_families_land_in_gpu_info() {
+    if !armed() {
+        return;
+    }
+    let readout = second_readout(BDF_A);
+    let mut gpu = blank_gpu_info();
+    l0::apply_to_gpu_info(&mut gpu, &readout, l0::ApplyPlatform::Linux);
+
+    // zes_temp_properties_t + zesTemperatureGetState
+    assert_eq!(gpu.temperature, 61, "temperature came back wrong");
+    // zes_freq_state_t: `actual` sits after four other f64 fields, so a
+    // one-field slip reports 1200, 2200, 2300, or a voltage as a frequency.
+    assert_eq!(gpu.frequency, 2100, "frequency came back wrong");
+    // zes_mem_state_t: 12 GiB total, 4 GiB free, so 8 GiB used.
+    assert_eq!(gpu.total_memory, 12 * 1024 * 1024 * 1024);
+    assert_eq!(gpu.used_memory, 8 * 1024 * 1024 * 1024);
+    // zes_fan_properties_t: RPM is the only advertised unit, so the
+    // percent reading must be absent rather than invented.
+    assert_eq!(gpu.fan_speed_rpm, Some(1800));
+    assert_eq!(
+        gpu.detail.get("Fan Speed").map(String::as_str),
+        Some("1800 RPM"),
+        "a percent reading must not appear: the stub advertises RPM only"
+    );
+    println!("{MARKER}");
+}
+
+/// Device B advertises 4096 engines, above the `MAX_L0_HANDLES` cap of 256,
+/// then fills fewer than requested. Both the clamp and the post-fill
+/// truncate have to hold or this panics or reads past the buffer.
+#[test]
+fn an_over_cap_count_and_a_short_fill_are_survived() {
+    if !armed() {
+        return;
+    }
+    let mut state = l0::LevelZeroState::empty();
+    let readout = l0::refresh(&mut state, BDF_B).expect("device B must still bind");
+    assert!(
+        l0::is_bound(&state),
+        "device B must bind even though its enumerator misbehaves"
+    );
+    // One engine survived the clamp and the truncate.
+    assert_eq!(l0::engine_count(&state), 1);
+    // Device B has no power domain, and a family the driver does not offer
+    // must degrade only itself.
+    assert_eq!(l0::power_domain_count(&state), 0);
+    assert!(readout.power_watts.is_none());
+    println!("{MARKER}");
+}
+
+/// A BDF the stub does not know must produce nothing, which is the same
+/// contract that holds when no runtime is present at all.
+#[test]
+fn an_unknown_bdf_binds_to_nothing() {
+    if !armed() {
+        return;
+    }
+    let mut state = l0::LevelZeroState::empty();
+    assert!(l0::refresh(&mut state, "0000:ff:00.0").is_none());
+    assert!(!l0::is_bound(&state));
+    println!("{MARKER}");
+}


### PR DESCRIPTION
feat(ci): drive the Level Zero backend against a stub loader

The loader check from #365 stops at `dlopen` plus symbol resolution, and deliberately so: a runner with no Intel GPU has no driver for the loader to return, so `zeInit` failing there is correct rather than a defect. The consequence is that everything past `try_load_library` is unexercised by any runner this project has. Device enumeration, the count-then-buffer idiom and its clamp, the BDF mapping, the delta arithmetic, and the metric refresh all ship on the strength of review alone.

The struct layouts are the sharpest edge. The coverage that exists compares our `#[repr(C)]` struct against our own transcription of the spec, which catches a mis-sized field and did once: `zes_pci_properties_t` declared three `ze_bool_t` fields as `u32`, inflating it from 56 to 64 bytes. It cannot catch two same-typed fields in the wrong order, a wrong offset that preserves the total, or a spec value transcribed wrong in both the struct and its assertion.

## The stub

`tests/fixtures/level_zero/stub_ze_loader.c` plays the driver's part, exporting all 23 symbols the backend resolves: the four mandatory ones, plus `zesInit` so initialisation takes the modern Sysman route, plus the engine, power, temperature, memory, frequency, and fan families.

It is compiled against the **vendor headers**, not against our transcription. That is the whole point: the vendor's own struct is filled on the C side and read back through our type on the Rust side, so a value arriving intact is evidence the two layouts agree field by field. A hand-written stub using our definitions would only prove our definitions agree with themselves.

Values are chosen to be individually identifiable. `zes_freq_state_t` carries five `f64` fields; the stub gives each a different number, so `actual` read one field early reports 1200, 2200, or 2300 rather than a plausible 2100. Counters advance by a fixed step per call, no clock reads and no randomness, so the second refresh is exactly 25.00% compute, 10.00% render, and 45.00 W, asserted as constants rather than ranges.

## How it binds, and why nothing shipped can reach it

`LIBZE_PATHS[0]` is the bare SONAME `libze_loader.so.1`, and `dlopen` on a bare SONAME searches `LD_LIBRARY_PATH` before the default paths. A stub built under that name in a directory placed first therefore wins over the real `libze1` the same job installs, with no new branch in the loader.

The rejected alternative was an `ALL_SMI_LEVEL_ZERO_LIBRARY` path override, which would have put a "load this arbitrary shared object" switch into every released binary in exchange for nothing this route does not provide. So: `LIBZE_PATHS` is unchanged, no environment override exists in production code, and the stub is neither compiled into the `all-smi` binary nor into any release artifact. `LD_LIBRARY_PATH` is set on one workflow step, so every other step still sees the real loader.

## The tests

`tests/level_zero_stub.rs` is its own integration binary, therefore its own process, because `LZ_RUNTIME` is a process-wide `OnceCell` and the library's unit tests already latch it. Whoever ran first would otherwise decide which loader the entire binary sees.

Five tests, driving only the public API: sorted BDF enumeration end to end; the exact delta-derived percentages and watts; the point-in-time families landing in a real `GpuInfo`; a device whose enumerator reports 4096 handles and then fills one, exercising both the `MAX_L0_HANDLES` clamp and the post-fill truncate; and an unknown BDF binding to nothing.

They fail loudly rather than skipping, in the same three-part shape as #365: an env key arms the assertions, a marker prints only after they pass, and the CI step greps for it.

## Verification

- The C stub cannot be compiled from this macOS host: it needs the vendor headers, which have no macOS package. CI is the compile check, and the build step also asserts with `nm` that all 23 symbols are exported.
- Rust side verified locally: the integration binary compiles both with the backend on (through the scratch probe) and off (macOS, where the file compiles away), and runs green unarmed.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

Reachability proof and the full CI evidence follow in a PR comment once the first run reports.

Closes #379
