### PR TITLE
fix: refresh service help backend text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,10 +105,10 @@ pub enum Commands {
     /// machine-wide; `--user` installs a per-user service with no
     /// elevation. Runtime settings stay in the environment file and the
     /// TOML config, so changing a port never requires reinstalling.
-    /// Linux (systemd) and Windows (Service Control Manager) are
-    /// supported today; the macOS launchd backend is tracked
-    /// separately. `--user` has no meaning on Windows, where the
-    /// Service Control Manager has no per-user scope.
+    /// Linux (systemd), macOS (launchd), and Windows (Service Control
+    /// Manager) are supported. `--user` applies to Linux and macOS but
+    /// has no meaning on Windows, where the Service Control Manager has
+    /// no per-user scope.
     /// See `all-smi service --help` for subcommands.
     Service(ServiceArgs),
 }
@@ -892,6 +892,28 @@ mod tests {
                 "`service status` must accept --{expected}"
             );
         }
+    }
+
+    #[test]
+    fn service_help_mentions_all_supported_backends_and_user_scope() {
+        let mut cmd = build_command_with_runtime_help();
+        let service = cmd
+            .find_subcommand_mut("service")
+            .expect("service subcommand");
+        let help = service.render_long_help().to_string();
+
+        assert!(
+            help.contains("Linux (systemd), macOS (launchd), and Windows (Service Control"),
+            "service help must list Linux, macOS, and Windows support, got:\n{help}"
+        );
+        assert!(
+            help.contains("`--user` applies to Linux and macOS"),
+            "service help must describe where --user applies, got:\n{help}"
+        );
+        assert!(
+            !help.contains("tracked separately"),
+            "service help must not claim launchd is still pending, got:\n{help}"
+        );
     }
 
     /// `config_help_block()` must annotate the resolved path with an

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,10 +101,11 @@ pub enum Commands {
     /// Install and control `all-smi api` as a supervised background
     /// service (issue #309).
     ///
-    /// The system scope requires root and registers the service
-    /// machine-wide; `--user` installs a per-user service with no
-    /// elevation. Runtime settings stay in the environment file and the
-    /// TOML config, so changing a port never requires reinstalling.
+    /// On Linux and macOS, the system scope requires root and registers
+    /// the service machine-wide; `--user` installs a per-user service
+    /// with no elevation. Runtime settings stay in the environment file
+    /// and the TOML config, so changing a port never requires
+    /// reinstalling.
     /// Linux (systemd), macOS (launchd), and Windows (Service Control
     /// Manager) are supported. `--user` applies to Linux and macOS but
     /// has no meaning on Windows, where the Service Control Manager has
@@ -905,6 +906,10 @@ mod tests {
         assert!(
             help.contains("Linux (systemd), macOS (launchd), and Windows (Service Control"),
             "service help must list Linux, macOS, and Windows support, got:\n{help}"
+        );
+        assert!(
+            help.contains("On Linux and macOS, the system scope requires root"),
+            "service help must keep root wording scoped to Linux and macOS, got:\n{help}"
         );
         assert!(
             help.contains("`--user` applies to Linux and macOS"),


### PR DESCRIPTION
## Summary

Refresh `all-smi service --help` so it matches the shipped backend set from PR #321 and keeps the `--user` scope wording accurate.

## What changed

- Update `src/cli.rs` service help text to name Linux systemd, macOS launchd, and Windows SCM as supported backends.
- Clarify in the same help text that `--user` applies to Linux and macOS, not Windows.
- Scope the system-level root requirement to Linux and macOS instead of implying that it also applies to Windows SCM.
- Add a focused `src/cli.rs` regression test that fails if the help text again claims launchd is tracked separately or omits macOS support.

## Homebrew verification context

- On August 23, 2026, the tap `service do` block and Homebrew-installed binary refusal path from #310 were manually verified outside this repo.
- The pre-service-block 0.25.0 Homebrew receipt upgrade path was explicitly left out of scope because the next release will carry the new metadata; this PR does not add a tap revision or compatibility workaround for existing receipts.

## Test plan

- [x] `cargo test --lib cli::tests`
- [x] `cargo fmt --check`
- [x] `cargo run --quiet --bin all-smi -- service --help`

Closes #355
