### PR TITLE
fix(release): sign macOS binaries with rcodesign instead of the keychain

### DIFF
--- a/.github/actions/macos-signing-setup/action.yml
+++ b/.github/actions/macos-signing-setup/action.yml
@@ -1,0 +1,250 @@
+name: "macOS signing setup"
+description: >-
+  Extract the Developer ID Application signing certificate to a PEM, verify it
+  really is a Developer ID certificate, and install rcodesign, exporting
+  PEM_FILE and SIGNING_READY for the rest of the job.
+
+  Mirrored from lablup/bssh, which adopted this procedure after an "Apple
+  Distribution" certificate shipped in its releases and was later revoked.
+  Keep the two in sync when either changes.
+
+inputs:
+  certificate:
+    description: "Base64-encoded Developer ID Application .p12 (the APPLE_CERTIFICATE secret)."
+    required: true
+  certificate-password:
+    description: "Password for the .p12 (the APPLE_CERTIFICATE_PASSWORD secret)."
+    required: true
+  required:
+    description: >-
+      'true' fails the job when the certificate secrets are missing or unusable.
+      'false' emits a warning, sets SIGNING_READY=false, and lets the job carry
+      on producing unsigned artifacts.
+    required: false
+    default: "true"
+
+# secrets.* is not readable from inside a composite action, so every secret this
+# action needs is passed in by the caller as an input.
+runs:
+  using: composite
+  steps:
+    - name: Prepare signing certificate (rcodesign)
+      shell: bash
+      env:
+        APPLE_CERTIFICATE: ${{ inputs.certificate }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ inputs.certificate-password }}
+        CERTIFICATE_REQUIRED: ${{ inputs.required }}
+      run: |
+        # Use rcodesign instead of Apple's codesign. rcodesign reads the p12
+        # file directly: no keychain, no SecurityAgent, no GUI session required,
+        # and no ambiguous substring matching against whatever identities happen
+        # to be in the keychain.
+
+        echo "=== Checking certificate availability ==="
+        MISSING=""
+        if [ -z "$APPLE_CERTIFICATE" ]; then
+          MISSING="APPLE_CERTIFICATE"
+        fi
+        if [ -z "$APPLE_CERTIFICATE_PASSWORD" ]; then
+          MISSING="${MISSING:+$MISSING, }APPLE_CERTIFICATE_PASSWORD"
+        fi
+
+        if [ -n "$MISSING" ]; then
+          if [ "$CERTIFICATE_REQUIRED" = "true" ]; then
+            echo "::error::signing certificate secrets are not set or empty: $MISSING"
+            exit 1
+          fi
+          echo "::warning::signing certificate secrets are not set or empty ($MISSING); continuing without a Developer ID signature"
+          echo "SIGNING_READY=false" >> "$GITHUB_ENV"
+          exit 0
+        fi
+
+        echo "=== Decoding certificate ==="
+        echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/original.p12"
+
+        # Apple's exported p12 uses RC2-40-CBC, which only OpenSSL's legacy
+        # provider reads, so the extraction needs `openssl pkcs12 -legacy`.
+        # rcodesign's own p12 parser cannot read it either, which is why it is
+        # handed a PEM instead.
+        #
+        # Do NOT let PATH decide which openssl runs. Apple's /usr/bin/openssl is
+        # LibreSSL, which has no -legacy option at all and exits 1 on it.
+        # Installing a Homebrew openssl does not make the bare name safe either:
+        # the versioned formulae are keg-only, so they are never symlinked into
+        # the prefix bin.
+        #
+        # Select by capability rather than by version. Whichever binary
+        # advertises -legacy is by definition the one that can do this, which
+        # keeps working on a future openssl@5 and rejects LibreSSL for the
+        # reason that matters.
+        echo "=== Selecting an OpenSSL with legacy provider support ==="
+        # Probe through a variable rather than `cmd | grep -q`. A composite
+        # action's `shell: bash` runs with `-o pipefail`. `grep -q` exits as soon
+        # as it matches, so the writer on the left can take a SIGPIPE on a later
+        # line and pipefail would report the probe as failed even though
+        # `-legacy` was present. A here-string has no writer process, so it
+        # cannot.
+        supports_legacy() {
+          local help_output
+          help_output="$("$1" pkcs12 -help 2>&1 || true)"
+          grep -q -- '-legacy' <<<"$help_output"
+        }
+
+        OPENSSL_BIN=""
+        for FORMULA in openssl@4 openssl@3 openssl; do
+          PREFIX="$(brew --prefix "$FORMULA" 2>/dev/null || true)"
+          [ -n "$PREFIX" ] || continue
+          CANDIDATE="$PREFIX/bin/openssl"
+          if [ -x "$CANDIDATE" ] && supports_legacy "$CANDIDATE"; then
+            OPENSSL_BIN="$CANDIDATE"
+            break
+          fi
+        done
+        if [ -z "$OPENSSL_BIN" ]; then
+          CANDIDATE="$(command -v openssl || true)"
+          if [ -n "$CANDIDATE" ] && supports_legacy "$CANDIDATE"; then
+            OPENSSL_BIN="$CANDIDATE"
+          fi
+        fi
+
+        if [ -z "$OPENSSL_BIN" ]; then
+          echo "::error::No openssl on this runner supports 'pkcs12 -legacy', which is required to read the RC2-40-CBC signing certificate. Install one with: brew install openssl@3"
+          echo "openssl resolved from PATH: $(command -v openssl || echo none)"
+          command -v openssl >/dev/null 2>&1 && openssl version || true
+          rm -f "$RUNNER_TEMP/original.p12"
+          exit 1
+        fi
+        echo "Using $OPENSSL_BIN ($("$OPENSSL_BIN" version))"
+
+        echo "=== Extracting certificate to PEM ==="
+        # stderr is deliberately kept. openssl writes diagnostics here, not key
+        # material, and without them a failure surfaces only as "exit code 1".
+        if ! "$OPENSSL_BIN" pkcs12 -in "$RUNNER_TEMP/original.p12" \
+          -passin "pass:$APPLE_CERTIFICATE_PASSWORD" \
+          -legacy -nodes -out "$RUNNER_TEMP/signing.pem"; then
+          echo "::error::openssl could not extract the signing certificate from the p12"
+          rm -f "$RUNNER_TEMP/original.p12" "$RUNNER_TEMP/signing.pem"
+          exit 1
+        fi
+
+        rm -f "$RUNNER_TEMP/original.p12"
+
+        if [ ! -s "$RUNNER_TEMP/signing.pem" ]; then
+          echo "::error::Extraction reported success but produced an empty PEM"
+          exit 1
+        fi
+
+        echo "Certificate extracted successfully"
+
+        echo "=== Certificate details ==="
+        "$OPENSSL_BIN" x509 -in "$RUNNER_TEMP/signing.pem" \
+          -noout -subject -issuer -dates || echo "::warning::Could not read certificate details"
+
+        # Gate on the certificate TYPE, not just its presence.
+        #
+        # Releases up to v2.4.1 shipped signed with "Apple Distribution: Lablup
+        # Inc.", an App Store / TestFlight submission certificate. Its leaf
+        # carries 1.2.840.113635.100.6.1.7 but not 1.2.840.113635.100.6.1.13, so
+        # Gatekeeper refused every quarantined download even though `codesign`
+        # itself verified the signature happily; when that certificate was later
+        # revoked, macOS started killing installed binaries on launch and
+        # deleting them as malware. Only a "Developer ID Application"
+        # certificate satisfies the Developer ID policy.
+        #
+        # Check the whole PEM, not only the first block: `pkcs12 -nodes` emits
+        # the private key and the full chain, and the bag order that puts the
+        # leaf first is a convention rather than a guarantee.
+        echo "=== Verifying this is a Developer ID Application certificate ==="
+        # crl2pkcs7 | pkcs7 -print_certs lists every certificate in the PEM in
+        # one pass and ignores the private key block. Assigned into a variable
+        # with `|| true` so a pipefail-visible SIGPIPE cannot fail the step.
+        CERT_SUBJECTS="$("$OPENSSL_BIN" crl2pkcs7 -nocrl -certfile "$RUNNER_TEMP/signing.pem" 2>/dev/null \
+          | "$OPENSSL_BIN" pkcs7 -print_certs -noout 2>/dev/null || true)"
+        if [ -z "$CERT_SUBJECTS" ]; then
+          CERT_SUBJECTS="$("$OPENSSL_BIN" x509 -in "$RUNNER_TEMP/signing.pem" -noout -subject 2>/dev/null || true)"
+        fi
+        echo "$CERT_SUBJECTS"
+
+        if ! grep -q "Developer ID Application" <<<"$CERT_SUBJECTS"; then
+          echo "::error::the p12 in APPLE_CERTIFICATE contains no 'Developer ID Application' certificate, so anything signed with it is rejected by Gatekeeper on download. Issue a Developer ID Application certificate in the Apple Developer portal (Account Holder role required), export it as a .p12, and replace the secret."
+          if grep -qE "Apple Distribution|Apple Development|iPhone Distribution" <<<"$CERT_SUBJECTS"; then
+            echo "::error::the certificate present is an App Store / development certificate, which is only valid for submissions through App Store Connect"
+          fi
+          rm -f "$RUNNER_TEMP/signing.pem"
+          exit 1
+        fi
+        echo "Developer ID Application certificate confirmed"
+
+        echo "PEM_FILE=$RUNNER_TEMP/signing.pem" >> "$GITHUB_ENV"
+        echo "SIGNING_READY=true" >> "$GITHUB_ENV"
+
+    - name: Install rcodesign
+      shell: bash
+      run: |
+        if [ "${SIGNING_READY:-}" != "true" ]; then
+          echo "Signing is not ready; skipping rcodesign installation"
+          exit 0
+        fi
+
+        # rcodesign is a keychain-free Apple code signing tool. That is the
+        # property this repository needs. The keychain-based pipeline this
+        # replaces failed on the self-hosted Intel Mac with "unable to build
+        # chain to self-signed root" and errSecInternalComponent, while the
+        # same certificate signed cleanly on a GitHub-hosted runner: codesign
+        # depends on host keychain and SecurityAgent state that a headless
+        # runner does not reliably have.
+        RCODESIGN_VERSION="0.29.0"
+        RCODESIGN_DIR="$HOME/.rcodesign"
+        RCODESIGN_BIN="$RCODESIGN_DIR/rcodesign"
+
+        case "$(uname -m)" in
+          arm64|aarch64) RCODESIGN_ARCH="aarch64" ;;
+          x86_64)        RCODESIGN_ARCH="x86_64" ;;
+          *)
+            echo "::error::no rcodesign release build for $(uname -m)"
+            exit 1
+            ;;
+        esac
+
+        # Read the version into a variable and match that, so a SIGPIPE on the
+        # writer cannot be mistaken for a version mismatch under pipefail. -F
+        # because the version is a literal, not a regex whose dots match any
+        # character.
+        INSTALLED_VERSION=""
+        if [ -x "$RCODESIGN_BIN" ]; then
+          INSTALLED_VERSION="$("$RCODESIGN_BIN" --version 2>/dev/null || true)"
+        fi
+
+        if grep -qF "$RCODESIGN_VERSION" <<<"$INSTALLED_VERSION"; then
+          echo "rcodesign $RCODESIGN_VERSION already installed"
+        else
+          echo "Installing rcodesign $RCODESIGN_VERSION for $RCODESIGN_ARCH..."
+          mkdir -p "$RCODESIGN_DIR"
+          curl -fsSL "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-${RCODESIGN_ARCH}-apple-darwin.tar.gz" \
+            | tar xz -C "$RCODESIGN_DIR" --strip-components=1
+          echo "Installed: $("$RCODESIGN_BIN" --version)"
+        fi
+
+        echo "$RCODESIGN_DIR" >> "$GITHUB_PATH"
+
+    - name: Verify signing tools
+      shell: bash
+      run: |
+        if [ "${SIGNING_READY:-}" != "true" ]; then
+          echo "Signing is not ready; skipping signing tool verification"
+          exit 0
+        fi
+
+        # $GITHUB_PATH from the previous step does not apply until the next step
+        # boundary, which this is, so rcodesign resolves by bare name here.
+        echo "rcodesign: $(rcodesign --version)"
+
+        # The trailing `|| true` is load-bearing. A composite action's
+        # `shell: bash` runs `bash --noprofile --norc -eo pipefail`. `head -20`
+        # closes the pipe as soon as it has its 20 lines, so rcodesign
+        # (line-buffered stdout, well over 20 lines of output) can take a
+        # SIGPIPE on a later line. Without this, pipefail would surface that as
+        # exit 141 and a purely informational step would fail the release job.
+        echo "=== Verifying PEM readability ==="
+        rcodesign analyze-certificate --pem-file "$PEM_FILE" 2>&1 | head -20 || true
+        echo "rcodesign can read the signing certificate"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,49 +203,105 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --locked
 
       # 8) macOS code signing
-      # The Developer ID key goes into a keychain named after this run. That
-      # matters on the self-hosted Intel Mac, which is persistent: with the
-      # action's default fixed name (`signing_temp`) two runs would collide and
-      # every run would append another certificate to the same keychain.
       #
-      # Cleanup is the import action's own post step, which runs
-      # `security delete-keychain` at the end of the job on success, failure,
-      # and cancellation. Do NOT add a step that deletes this keychain: the
-      # post step would then fail with "The specified keychain could not be
-      # found" and fail the whole job after the artifacts were uploaded, which
-      # also skips the notify-teams and promote-release jobs.
-      - name: Remove stale signing keychains
+      # rcodesign, not Apple's codesign, and therefore no keychain at all.
+      #
+      # The keychain route this replaces worked on GitHub-hosted macOS and
+      # failed on the self-hosted Intel Mac, with the same certificate and the
+      # same command:
+      #
+      #   Warning: unable to build chain to self-signed root for signer
+      #            "Developer ID Application: Lablup Inc. (NVWJ7XZ6BY)"
+      #   all-smi: errSecInternalComponent
+      #
+      # That is codesign asking the Security framework to complete a trust
+      # chain out of host keychain state, on a machine with no logged-in GUI
+      # session. rcodesign reads the certificate from a PEM and builds the
+      # signature itself, so the whole failure class is gone rather than
+      # worked around, and it no longer matters which identities happen to be
+      # in the runner's keychain.
+      #
+      # Mirrored from lablup/bssh. The certificate-type gate inside the action
+      # is the reason that pipeline exists: bssh shipped releases signed by an
+      # "Apple Distribution" certificate, an App Store submission identity
+      # that Gatekeeper rejects for downloads, and when it was revoked macOS
+      # began deleting installed binaries as malware. codesign had verified
+      # those signatures happily, because nothing ever checked the authority.
+      - name: Prepare signing certificate and tools
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/macos-signing-setup
+        with:
+          certificate: ${{ secrets.DEV_ID_CERT_P12 }}
+          certificate-password: ${{ secrets.DEV_ID_CERT_PASSWORD }}
+          # Release artifacts must never ship unsigned, so a missing or wrong
+          # certificate fails the job rather than degrading quietly.
+          required: "true"
+
+      # Sign into `package/` rather than in place. `target/` is restored from
+      # actions/cache across runs, so signing the build output there would put
+      # a signed binary into the cache; every later step reads the staged copy
+      # instead, and the packaging step below zips this same directory.
+      - name: Sign macOS binary
         if: runner.os == 'macOS'
         run: |
-          # Safety net for the persistent runner, reachable only when an
-          # earlier run was hard-killed before its post step could delete its
-          # keychain. Scoped to this workflow's own name prefix and to files
-          # older than a day, so it can never remove a keychain this workflow
-          # did not create nor one belonging to a run still in flight.
-          STALE=$(find "$HOME/Library/Keychains" -maxdepth 1 -name 'all-smi-signing-*' -mtime +0 2>/dev/null || true)
-          if [ -n "$STALE" ]; then
-            echo "$STALE" | while IFS= read -r kc; do
-              echo "Removing stale signing keychain: $kc"
-              security delete-keychain "$kc" || true
-            done
-          else
-            echo "No stale signing keychains"
+          set -euo pipefail
+
+          BIN="target/${{ matrix.target }}/release/${{ matrix.artifact_name }}"
+          if [ ! -f "$BIN" ]; then
+            echo "::error::binary to sign not found: $BIN"
+            exit 1
           fi
 
-      - name: Import Developer ID certificate
-        if: runner.os == 'macOS'
-        uses: apple-actions/import-codesign-certs@v6
-        with:
-          p12-file-base64: ${{ secrets.DEV_ID_CERT_P12 }}
-          p12-password: ${{ secrets.DEV_ID_CERT_PASSWORD }}
-          keychain: all-smi-signing-${{ github.run_id }}-${{ github.run_attempt }}
+          mkdir -p package
+          STAGED="package/${{ matrix.artifact_name }}"
+          cp "$BIN" "$STAGED"
+          chmod +x "$STAGED"
 
-      - name: Code sign macOS binary
-        if: runner.os == 'macOS'
-        run: |
-          BIN=target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
-          codesign --force --timestamp --options runtime \
-                   --sign "Developer ID Application" "$BIN"
+          # A composite action cannot enforce `required` on its inputs at
+          # runtime, and an empty identifier would make rcodesign fall back to
+          # the bare file name. Pin it, or the sealed identifier drifts with
+          # the artifact name.
+          if [ -z "${BUNDLE_ID:-}" ]; then
+            echo "::error::BUNDLE_ID is not set on the packaging environment; set it to a reverse-DNS identifier such as com.lablup.all-smi"
+            exit 1
+          fi
+
+          # rcodesign requests a secure timestamp from Apple by default, which
+          # notarization requires. No entitlements: all-smi is a self-contained
+          # Rust CLI that links no third-party dylib, so the hardened runtime
+          # applies with Apple's defaults.
+          rcodesign sign \
+            --pem-file "$PEM_FILE" \
+            --code-signature-flags runtime \
+            --binary-identifier "$BUNDLE_ID" \
+            "$STAGED"
+
+          echo "=== Verifying signature ==="
+          # `|| true` so a codesign failure surfaces as the named assertions
+          # below rather than as a bare non-zero exit under `set -e`.
+          CODESIGN_OUTPUT="$(codesign -dv --verbose=4 "$STAGED" 2>&1 || true)"
+          echo "$CODESIGN_OUTPUT"
+
+          # Matched from here-strings, not `echo | grep`: this runs under
+          # pipefail, where `grep -q` closing the pipe early can surface as a
+          # failed pipeline whether or not the pattern matched.
+          #
+          # This is the assertion that would have caught bssh's defect.
+          if ! grep -q "Authority=Developer ID Application" <<<"$CODESIGN_OUTPUT"; then
+            echo "::error::the binary is not signed by a Developer ID Application authority, so Gatekeeper will refuse it on download"
+            exit 1
+          fi
+          # By flag name, not by a literal hex value: other code signature
+          # flags combine into the same field.
+          if ! grep -Eq 'flags=0x[0-9a-f]+\(.*runtime.*\)' <<<"$CODESIGN_OUTPUT"; then
+            echo "::error::the binary is missing the hardened runtime flag, which notarization requires"
+            exit 1
+          fi
+          if ! grep -qxF "Identifier=$BUNDLE_ID" <<<"$CODESIGN_OUTPUT"; then
+            echo "::error::the binary was signed with a code signature identifier other than the requested $BUNDLE_ID"
+            exit 1
+          fi
+          echo "Signed as $BUNDLE_ID with a Developer ID Application authority and the hardened runtime"
 
       # 8.5) macOS notarization via App Store Connect API key
       # We submit a temporary zip wrapping the already-codesigned binary
@@ -262,7 +318,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          BIN="target/${{ matrix.target }}/release/${{ matrix.artifact_name }}"
+          # The staged copy the signing step produced. Notarizing the build
+          # output in target/ would submit an unsigned binary, which
+          # notarytool rejects.
+          BIN="package/${{ matrix.artifact_name }}"
           NOTARIZE_ZIP="${RUNNER_TEMP}/notarize.zip"
           KEY_FILE="${RUNNER_TEMP}/AuthKey.p8"
 
@@ -273,9 +332,8 @@ jobs:
           trap cleanup EXIT
 
           # The AC_API_PRIVATE_KEY_P8 secret stores the App Store Connect .p8
-          # key base64-encoded (same convention as DEV_ID_CERT_P12, which the
-          # import-codesign-certs action consumes as base64). Decode it back to
-          # PEM here. Also tolerate a raw .p8 pasted verbatim, and strip CR so a
+          # key base64-encoded, the same convention DEV_ID_CERT_P12 follows for
+          # the signing certificate. Decode it back to PEM here. Also tolerate a raw .p8 pasted verbatim, and strip CR so a
           # CRLF-mangled paste still parses. Writing the secret verbatim without
           # decoding makes notarytool fail with the opaque "Error: invalidAsn1".
           if [ -z "${AC_API_PRIVATE_KEY_P8:-}" ]; then
@@ -340,14 +398,30 @@ jobs:
           cp docs/man/all-smi.1 package/
           tar -C package -czf ${{ matrix.asset_name }}.tar.gz .
 
+      # `package/` already holds the signed binary, staged and sealed by the
+      # signing step above. Copying it again from target/ here would replace it
+      # with the unsigned build output and ship an unsigned, notarization-less
+      # artifact whose zip still looked correct.
       - name: Package macOS binary (zip)
         if: runner.os == 'macOS'
         run: |
-          BIN="target/${{ matrix.target }}/release/${{ matrix.artifact_name }}"
+          set -euo pipefail
+
           ASSET="${{ matrix.asset_name }}.zip"
-          mkdir -p package
-          cp "$BIN" package/
+          STAGED="package/${{ matrix.artifact_name }}"
+
+          if [ ! -f "$STAGED" ]; then
+            echo "::error::signed binary not found at $STAGED; the signing step must run before packaging"
+            exit 1
+          fi
+          # Cheap guard against a future edit reintroducing the overwrite.
+          if ! codesign -dv "$STAGED" 2>&1 | grep -q "Authority=Developer ID Application"; then
+            echo "::error::$STAGED lost its Developer ID signature between signing and packaging"
+            exit 1
+          fi
+
           cp docs/man/all-smi.1 package/
+          # ditto preserves the exec bit and the embedded signature.
           ditto -c -k --sequesterRsrc package "$ASSET"
 
       # Sign the Windows binary before packaging so the .zip artifact contains


### PR DESCRIPTION
fix(release): sign macOS binaries with rcodesign instead of the keychain

The v0.26.0 release failed. Six of seven targets built; `x86_64-apple-darwin` died at `Code sign macOS binary` on the self-hosted Intel Mac:

    Warning: unable to build chain to self-signed root for signer
             "Developer ID Application: Lablup Inc. (NVWJ7XZ6BY)"
    target/x86_64-apple-darwin/release/all-smi: errSecInternalComponent

The same certificate, the same `import-codesign-certs` step, and the same `codesign` command signed cleanly on the GitHub-hosted arm64 runner in the same run. So it is neither the certificate nor the workflow: it is codesign asking the Security framework to complete a trust chain out of host keychain state, on a machine with no logged-in GUI session. That machine had just come back from maintenance.

Adding the Apple intermediate back to that Mac would fix this run. It would not stop the next reimage, or a locked keychain, or a second identity in the search path from doing it again, because the release would still depend on host state nobody versions.

## What this does instead

Mirrors lablup/bssh, which solved this by not using a keychain at all. `rcodesign` reads the certificate from a PEM and builds the signature itself: no keychain, no SecurityAgent, no GUI session, and no substring matching against whatever identities happen to be installed. The whole failure class goes away rather than being worked around.

`.github/actions/macos-signing-setup` is ported from bssh essentially verbatim, because its comments encode findings that are expensive to rediscover: Apple's p12 export uses RC2-40-CBC so extraction needs OpenSSL's legacy provider; `/usr/bin/openssl` is LibreSSL and has no `-legacy` at all; Homebrew's versioned formulae are keg-only so the bare name is not safe either, hence selecting an openssl by capability rather than by version; and several `grep -q` calls are fed from here-strings because a composite action runs under `pipefail`, where an early pipe close reads as a failed pipeline.

## The guard that matters most

The action refuses to sign with anything that is not a Developer ID Application certificate.

That gate is the reason bssh's pipeline exists. bssh shipped releases signed by "Apple Distribution", an App Store submission identity whose leaf carries no Developer ID extension. Gatekeeper rejected every quarantined download, and when that certificate was revoked macOS escalated to killing installed binaries on launch and deleting them as malware. `codesign` had verified those signatures happily throughout, because nothing ever looked at the authority.

So the signature is now asserted after the fact as well: the authority must be Developer ID Application, the hardened runtime flag must be set, and the sealed identifier must equal the requested BUNDLE_ID. Any of the three failing fails the release rather than shipping quietly.

## Staged signing

The binary is signed into `package/` rather than in place. `target/` is restored from actions/cache across runs, so signing the build output there writes a signed binary into the cache. Notarization and packaging now read that staged copy, and packaging asserts the signature is still present, which guards against a future edit reintroducing the `cp` from `target/` that would have shipped an unsigned artifact inside a correct-looking zip.

## Deliberately unchanged

Notarization keeps the App Store Connect API key (`AC_API_*`). bssh uses an Apple ID with an app-specific password; the API key needs no personal Apple ID, is independently revocable, and already works here. Porting bssh's credential shape would have meant new secrets for no gain, so only the signing half is adopted. Existing secret names `DEV_ID_CERT_P12` and `DEV_ID_CERT_PASSWORD` are kept and wired into the action's inputs, so no secret has to be re-entered.

## Verification

- `actionlint` reports nothing in the changed region; the one SC2086 it flags is pre-existing on `main` at line 50.
- The openssl capability probe was run on a macOS host with the action's exact logic: it selected `openssl@4` over the LibreSSL on PATH, which is the case the version-ordered fallback exists for.
- The composite action parses, declares a shell on every step, and exposes the three inputs the caller passes.

Not verified here: the signing itself needs the `packaging` environment secrets and a macOS runner, so the first real proof is a release run. A `workflow_dispatch` against this branch is the intended way to get it, since the workflow builds the tag's source under the current workflow definition.

Refs the failed run 32682663676
