### PR TITLE
fix(release): let the recovery dispatch resolve actions and finish the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       includes: ${{ steps.resolve.outputs.includes }}
+      all_assets: ${{ steps.resolve.outputs.all_assets }}
     steps:
       - name: Resolve target platforms
         id: resolve
@@ -99,6 +100,13 @@ jobs:
           printf '%s' "$includes" | jq -r '.[] | "  - " + .target'
           echo "includes=$includes" >> "$GITHUB_OUTPUT"
 
+          # Every asset a complete release carries, from the UNFILTERED matrix.
+          # `promote-release` needs this: a dispatch may build one family, and
+          # promoting on the strength of that alone would publish a release
+          # missing the targets this run never touched.
+          all_assets="$(printf '%s' "$ALL" | jq -c '[ .[] | .asset_name + .archive_ext ]')"
+          echo "all_assets=$all_assets" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.target }}
     needs: setup
@@ -132,6 +140,27 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag || github.sha }}
+
+      # 1.2) The composite actions this workflow calls.
+      #
+      # Step 1 deliberately checks out the *tag's* source. But `uses: ./...`
+      # resolves against the workspace, not against the ref this workflow was
+      # loaded from, so a tag older than an action the workflow calls fails
+      # with "Can't find 'action.yml'". Recovering v0.26.0 hit exactly that:
+      # release.yml came from main and called an action main had just gained,
+      # while the workspace held v0.26.0, which did not.
+      #
+      # `github.sha` is the ref that supplied release.yml under both triggers
+      # (the dispatched branch, or the release's tag), so this keeps the
+      # workflow and the actions it calls from drifting apart, which is what
+      # the self-healing design was after in the first place.
+      - name: Checkout workflow actions
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          path: .workflow-actions
 
       # 1.5) Pin Cargo/rustup to persistent paths on the Windows self-hosted
       # runner so registry/git/target survive workspace cleanup between jobs.
@@ -193,7 +222,7 @@ jobs:
       # 6) Setup protoc (cached) - skip on Windows as TPU support is Linux-only
       - name: Setup protoc
         if: runner.os != 'Windows'
-        uses: ./.github/actions/setup-protoc
+        uses: ./.workflow-actions/.github/actions/setup-protoc
         with:
           version: ${{ env.PROTOC_VERSION }}
           platform: ${{ matrix.protoc_platform }}
@@ -229,7 +258,7 @@ jobs:
       # those signatures happily, because nothing ever checked the authority.
       - name: Prepare signing certificate and tools
         if: runner.os == 'macOS'
-        uses: ./.github/actions/macos-signing-setup
+        uses: ./.workflow-actions/.github/actions/macos-signing-setup
         with:
           certificate: ${{ secrets.DEV_ID_CERT_P12 }}
           certificate-password: ${{ secrets.DEV_ID_CERT_PASSWORD }}
@@ -541,14 +570,55 @@ jobs:
   promote-release:
     name: Promote pre-release to release
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'release' && github.event.release.prerelease
+    needs: [setup, build]
+    # A dispatch has to be able to finish a release too, not only build one.
+    # The recovery path this workflow documents (dispatch a fixed release.yml
+    # at an old tag) previously stopped at "artifacts uploaded": promotion ran
+    # only for `release` events, so a rescued release stayed a pre-release
+    # forever. That also silently stalls Homebrew, which resolves the version
+    # through `releases/latest` and therefore never sees a pre-release.
+    if: >-
+      (github.event_name == 'release' && github.event.release.prerelease) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '')
     steps:
       - name: Promote to full release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+          ALL_ASSETS: ${{ needs.setup.outputs.all_assets }}
         run: |
-          gh api repos/${{ github.repository }}/releases/${{ github.event.release.id }} \
-            --method PATCH \
-            -f prerelease=false \
-            -f make_latest=true
+          set -euo pipefail
+
+          if [ -z "$TAG" ]; then
+            echo "::error::no release tag to promote"
+            exit 1
+          fi
+
+          # Idempotent: re-running a dispatch against an already-promoted tag
+          # is a normal thing to do while recovering, and must not fail.
+          if [ "$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)" != "true" ]; then
+            echo "$TAG is already a full release; nothing to promote"
+            exit 0
+          fi
+
+          # A dispatch can build one family. Promoting on the strength of that
+          # would publish a release missing every target this run did not
+          # touch, and Homebrew would then resolve a version whose artifacts
+          # are not all there. Check the whole expected set, not just what was
+          # built here.
+          PRESENT="$(gh release view "$TAG" --json assets -q '.assets[].name')"
+          MISSING=""
+          while IFS= read -r want; do
+            [ -n "$want" ] || continue
+            if ! grep -qxF "$want" <<<"$PRESENT"; then
+              MISSING="${MISSING:+$MISSING, }$want"
+            fi
+          done < <(jq -r '.[]' <<<"$ALL_ASSETS")
+
+          if [ -n "$MISSING" ]; then
+            echo "::error::$TAG is missing release artifacts, so it stays a pre-release: $MISSING"
+            exit 1
+          fi
+
+          echo "All expected artifacts present on $TAG; promoting"
+          gh release edit "$TAG" --prerelease=false --latest


### PR DESCRIPTION
fix(release): let the recovery dispatch resolve actions and finish the release

Two defects in the same path, both found by actually running it. The macOS rebuild of v0.26.0 failed before it signed anything:

    Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
    '.../.github/actions/macos-signing-setup'.
    Did you forget to run actions/checkout before running your local action?

## 1. The self-healing design did not cover its own actions

Step 1 checks out the *tag's* source on purpose, so an old tag can be rebuilt by a fixed workflow. But `uses: ./...` resolves against the workspace, not against the ref the workflow was loaded from. Dispatching main's release.yml at v0.26.0 therefore ran a workflow that calls `macos-signing-setup` against a tree from before that action existed.

`.github/actions` is now checked out separately from `github.sha`, which is the ref that supplied release.yml under both triggers, into `.workflow-actions/`. Both local actions resolve from there, so the workflow and the actions it calls can no longer drift apart. `setup-protoc` moves too: it happens to exist in v0.26.0, so it worked by luck, and leaving it on the old path would leave the same trap set for the next action added.

## 2. A dispatched release could never stop being a pre-release

`promote-release` ran only for `release` events. The recovery path this workflow documents in its own header ends at "artifacts uploaded", so a release rescued by dispatch stays a pre-release forever.

That also stalls Homebrew silently. `update_homebrew_formula.yml` resolves the version through `repos/{}/releases/latest`, which excludes pre-releases, so it fires on the successful run and then updates the tap to the *previous* version. Nothing fails; the formula simply never advances.

Promotion now also runs for a dispatch that names a `release_tag`, resolves the tag from whichever trigger supplied it, and exits cleanly when the tag is already a full release, since re-running a dispatch is a normal thing to do while recovering.

## The guard that makes that safe

A dispatch can build one family. Promoting on the strength of that alone would publish a release missing every target the run never touched, and Homebrew would then resolve a version whose artifacts are not all there.

So `setup` now also emits the asset list from the UNFILTERED matrix, and promotion refuses unless every one of those is present on the tag, naming what is missing. The check is against the whole expected set, not against what this particular run produced.

## Verification

`actionlint` reports nothing new; the single SC2086 it flags is pre-existing on `main`. The behaviour itself is only observable on a real dispatch, which is what found these two in the first place, so the next run against v0.26.0 is the proof.

Refs the failed recovery run 32686049629
