### PR TITLE
fix(release): give the packaging signature guard the flag it needs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,8 +444,20 @@ jobs:
             exit 1
           fi
           # Cheap guard against a future edit reintroducing the overwrite.
-          if ! codesign -dv "$STAGED" 2>&1 | grep -q "Authority=Developer ID Application"; then
+          #
+          # `--verbose=4` is required, not cosmetic: plain `codesign -dv`
+          # prints the identifier, format, and hashes but no `Authority=`
+          # lines at all, so the grep below could never match and the guard
+          # failed every run regardless of the signature. Same invocation as
+          # the assertions in the signing step, for the same reason.
+          #
+          # Read into a variable rather than piping into `grep -q`. This step
+          # runs under pipefail, where grep closing the pipe early can surface
+          # as a failed pipeline whether or not the pattern matched.
+          SIGNATURE="$(codesign -dv --verbose=4 "$STAGED" 2>&1 || true)"
+          if ! grep -q "Authority=Developer ID Application" <<<"$SIGNATURE"; then
             echo "::error::$STAGED lost its Developer ID signature between signing and packaging"
+            echo "$SIGNATURE"
             exit 1
           fi
 


### PR DESCRIPTION
fix(release): give the packaging signature guard the flag it needs

The guard I added in #385 could never pass. Plain `codesign -dv` prints the identifier, format, and hashes, but no `Authority=` lines at all, so grepping its output for `Authority=Developer ID Application` matched nothing no matter how the binary was signed. `--verbose=4` is what emits them, which is why the assertions in the signing step, using that flag, passed in the same run.

Caught by the arm64 job of run 32687283050, where the substance worked: `Prepare signing certificate and tools`, `Sign macOS binary`, and `Notarize macOS binary` all succeeded through rcodesign, and then packaging refused the binary notarytool had just accepted.

Also reads the output into a variable rather than piping into `grep -q`. The step runs under pipefail, where grep closing the pipe early can surface as a failed pipeline whether or not the pattern matched, and the composite action this work mirrors calls that out in several places. The guard now prints the signature it saw when it does fail, so the next person does not have to guess which half was wrong.

Refs run 32687283050
