### PR TITLE
fix(release): give the promote job a repository, and stop it failing silently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,6 +596,14 @@ jobs:
       - name: Promote to full release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job checks out nothing, so `gh` has no git remote to infer the
+          # repository from and every call below fails with "not a git
+          # repository". That failure used to be indistinguishable from a
+          # promoted release: the command substitution returned empty, the
+          # `!= "true"` test passed, and the job exited 0 having done nothing
+          # while reporting success. GH_REPO is what actually fixes it; the
+          # explicit emptiness check below is what stops it being silent again.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
           ALL_ASSETS: ${{ needs.setup.outputs.all_assets }}
         run: |
@@ -606,9 +614,15 @@ jobs:
             exit 1
           fi
 
+          IS_PRERELEASE="$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)"
+          if [ -z "$IS_PRERELEASE" ]; then
+            echo "::error::could not read the release state for $TAG; refusing to guess whether it needs promoting"
+            exit 1
+          fi
+
           # Idempotent: re-running a dispatch against an already-promoted tag
           # is a normal thing to do while recovering, and must not fail.
-          if [ "$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)" != "true" ]; then
+          if [ "$IS_PRERELEASE" != "true" ]; then
             echo "$TAG is already a full release; nothing to promote"
             exit 0
           fi
@@ -619,6 +633,10 @@ jobs:
           # are not all there. Check the whole expected set, not just what was
           # built here.
           PRESENT="$(gh release view "$TAG" --json assets -q '.assets[].name')"
+          if [ -z "$PRESENT" ]; then
+            echo "::error::$TAG reports no assets at all; refusing to promote"
+            exit 1
+          fi
           MISSING=""
           while IFS= read -r want; do
             [ -n "$want" ] || continue


### PR DESCRIPTION
fix(release): give the promote job a repository, and stop it failing silently

The promote job added in #386 reported success while doing nothing. Run 32687874926 built and uploaded all fourteen artifacts, promotion ran, and v0.26.0 stayed a pre-release:

    failed to run git: fatal: not a git repository (or any of the parent
    directories): .git

    v0.26.0 is already a full release; nothing to promote

The job checks out no source, by design, so `gh` had no git remote to infer the repository from and every call failed. `GH_REPO` supplies it.

The second half is the part worth dwelling on. The failure was swallowed:

    if [ "$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)" != "true" ]

A failing command substitution inside a test yields an empty string, `set -e` does not fire there, and empty is not "true", so the guard concluded the release was already promoted and exited 0. A step that cannot read the state took the branch that means "nothing to do", which is the worst possible default: it looks identical to success.

So the state is now read into a variable, an unreadable state is a hard error rather than an assumption, and the asset listing gets the same treatment. Refusing to guess is the whole point; a release that silently stays a pre-release also silently stalls Homebrew, which resolves through `releases/latest` and never sees one.

Refs run 32687874926
