### PR TITLE
fix(ci): say when the tap is being left a version behind

### DIFF
--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -87,10 +87,45 @@ jobs:
           # workflow_dispatch input is free text and reaches exactly as far.
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$RELEASE_TAG_INPUT" ]; then
             echo "VERSION=$RELEASE_TAG_INPUT" >> "$GITHUB_ENV"
-          else
-            TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
-            echo "VERSION=$TAG" >> "$GITHUB_ENV"
+            exit 0
           fi
+
+          # `releases/latest` is deliberate rather than "the newest tag": it
+          # excludes prereleases and drafts, and `brew install` must not hand a
+          # user a prerelease. What it cannot do is notice when it has answered
+          # a stale question.
+          #
+          # This job triggers on the Release workflow completing, and the step
+          # that promotes a prerelease to a full release lives inside that same
+          # workflow. If that promotion does not run, or fails, or the release
+          # is a deliberate prerelease, `releases/latest` returns the previous
+          # version, the formula already matches it, and the push step exits 0
+          # with "nothing to push". A green run that moved nothing.
+          #
+          # That is not hypothetical: run 32688159260 resolved v0.25.0 while
+          # v0.26.0 sat published-as-prerelease, reported success, and left the
+          # tap a version behind. The promotion had failed silently, which
+          # #388 fixed, but the silence here is its own defect and outlives
+          # that one cause.
+          #
+          # So resolve as before, and then say out loud when a newer release
+          # exists that this job is declining to serve. A warning rather than an
+          # error: refusing to publish a prerelease to `brew` users is correct
+          # behaviour, and only the silence was wrong.
+          NEWEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=20" \
+            --jq '[.[] | select(.draft | not)] | sort_by(.published_at) | (last // {}) | .tag_name // empty')
+
+          if ! TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null); then
+            echo "::error::${GITHUB_REPOSITORY} has no full release. The tap serves only full releases, and the newest published one is ${NEWEST:-none}."
+            exit 1
+          fi
+
+          if [ -n "$NEWEST" ] && [ "$NEWEST" != "$TAG" ]; then
+            echo "::warning::${NEWEST} is published but is not a full release, so the tap stays at ${TAG}. Promote ${NEWEST} out of prerelease and re-run this workflow to publish it."
+          fi
+
+          echo "Resolved ${TAG} (newest published release: ${NEWEST:-none})."
+          echo "VERSION=$TAG" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
## Summary

`releases/latest` excludes prereleases and drafts, which is the right policy: `brew install` must not hand a user a prerelease. What it cannot do is notice that it has answered a stale question.

This job triggers on the Release workflow completing, and the step that promotes a prerelease to a full release lives inside that same workflow. If that promotion does not run, or fails, or the release is a deliberate prerelease, `releases/latest` returns the previous version, the formula already matches it, and the push step exits 0 with "nothing to push". A green run that moved nothing.

## Not hypothetical

Run [32688159260](https://github.com/lablup/all-smi/actions/runs/32688159260) resolved **v0.25.0** while v0.26.0 sat published-as-prerelease. It reported success and left the tap a version behind, with nothing in the log to say so:

```
VERSION: v0.25.0
Formula already up to date for v0.25.0, nothing to push.
```

The promotion had failed silently, which #388 fixed. But the silence here is its own defect and outlives that one cause: any deliberate prerelease produces the same green no-op.

## The change

Resolution is unchanged. Added:

- A **warning** naming both tags when a newer published release exists that this job is declining to serve.
- An **error**, rather than a raw 404 from `gh`, when there is no full release at all.
- A line stating what was resolved and what the newest published release is, so the log answers the question without a reader having to infer it.

A warning and not an error for the first case, because refusing to publish a prerelease to `brew` users is correct behaviour. Only the silence was wrong.

## Verification

Run against the live GitHub API on all four branches, by extracting the step's bash from the parsed workflow.

| Case | Repository used | Result |
|---|---|---|
| `workflow_dispatch` with an explicit tag | n/a | `VERSION=v9.9.9`, no API call |
| All releases are full | `lablup/all-smi` | `Resolved v0.26.0 (newest published release: v0.26.0).` no warning |
| **Newest published release is a prerelease** | `lablup/backend.ai-go` | `::warning::v1.13.0-beta.1 is published but is not a full release, so the tap stays at v1.12.1.` then `VERSION=v1.12.1` |
| No release at all | `lablup/homebrew-tap` | `::error::... has no full release.` exit 1 |

The third row is the case this PR exists for. The old code resolves `v1.12.1` there too, with no mention of `v1.13.0-beta.1` anywhere in the log.

## Test plan

- [x] Workflow parses as YAML; step list unchanged
- [x] All four branches exercised against the live API, as above
- [x] No change to the clone, the formula rewrite, the validation, the token handling, or the push