### PR TITLE
fix(doctor): act on what real Windows hardware showed

### DIFF
--- a/.github/workflows/windows-selfhosted.yml
+++ b/.github/workflows/windows-selfhosted.yml
@@ -167,8 +167,15 @@ jobs:
   #
   # THIS JOB HAS NEVER EXECUTED. It was written alongside the backend on
   # a macOS host with no access to Windows or to the runner, so treat its
-  # first real run as part of the work, not as a regression signal. That
-  # first run is what settles issue #357.
+  # first real run as part of the work, not as a regression signal.
+  #
+  # It will not be this runner that runs it first. `windows-on-macmini02-x64`
+  # reports `elevated: False`, measured in run 32705270378, and the decision
+  # was to leave it that way: an elevated persistent runner executes whatever
+  # lands on main with Administrator rights, and a one-off check on a
+  # dedicated machine is the cheaper risk. Issue #357 records that, and the
+  # guard below states it rather than telling the next reader to go and
+  # elevate the box.
   #
   # The cleanup step is `if: always()` on purpose: a half-finished run
   # that left `all-smi` registered would poison every later run on a
@@ -203,9 +210,9 @@ jobs:
       # feature, so a plain build already includes the backend. Passing the
       # flag would compile the same thing while testing a configuration we
       # do not ship; leaving it off means this job builds exactly what the
-      # release artifact is. The job is opt-in via
-      # ENABLE_WINDOWS_SERVICE_SMOKE, so this is coverage when the runner
-      # is available rather than a guarantee.
+      # release artifact is. The job runs only when dispatched with
+      # `run_service_smoke`, so this is coverage when someone asks for it
+      # rather than a guarantee.
       - name: Build all-smi
         run: cargo build --bin all-smi
 
@@ -214,7 +221,7 @@ jobs:
           $id = [Security.Principal.WindowsIdentity]::GetCurrent()
           $principal = New-Object Security.Principal.WindowsPrincipal($id)
           if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-            Write-Output "::error::the runner service is not elevated; every mutating Service Control Manager action needs Administrator rights. Reconfigure the runner to run as an administrator, or unset ENABLE_WINDOWS_SERVICE_SMOKE."
+            Write-Output "::error::the runner service is not elevated, so every mutating Service Control Manager action here would fail. This is expected on windows-on-macmini02-x64 and is not a defect to work around: elevating a shared persistent runner was considered and declined (see #357). Run this on a dedicated Windows machine instead."
             exit 1
           }
 

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -210,10 +210,20 @@ fn check_adl_adapters(_ctx: &CheckCtx) -> CheckResult {
 /// so the formatting lives here rather than at each call site.
 #[cfg(target_os = "windows")]
 fn describe_readout(readout: &crate::device::readers::amd_adl::sensors::AdlReadout) -> String {
+    // `temperature_gfx_c` is printed because it is the second link in
+    // `primary_temperature_c`'s chain (edge, then gfx, then hotspot), and
+    // omitting it made this dump contradict the reading all-smi actually
+    // publishes. A Strix Halo APU reports none of edge, mem or hotspot and
+    // does report gfx, so the summary said `edge=None hotspot=None mem=None`
+    // while the TUI correctly showed 41 C from the gfx sensor. The raw table
+    // below carried the answer at index 28 all along, which is the opposite
+    // of what a field-verification dump is for: it should not take reading
+    // the source to reconcile the interpreted line with the product.
     format!(
-        "edge={:?}C hotspot={:?}C mem={:?}C power={:?}W fan={:?}rpm gfx={:?}MHz \
-         mclk={:?}MHz activity={:?}%",
+        "edge={:?}C gfx={:?}C hotspot={:?}C mem={:?}C power={:?}W fan={:?}rpm \
+         gfxclk={:?}MHz mclk={:?}MHz activity={:?}%",
         readout.temperature_edge_c,
+        readout.temperature_gfx_c,
         readout.temperature_hotspot_c,
         readout.temperature_mem_c,
         readout.power_w,

--- a/src/doctor/checks/nvidia.rs
+++ b/src/doctor/checks/nvidia.rs
@@ -17,6 +17,7 @@
 
 use std::time::Duration;
 
+use crate::device::platform_detection::has_nvidia;
 use crate::doctor::exec::{try_exec, which};
 use crate::doctor::types::{Check, CheckCtx, CheckResult, Severity};
 
@@ -67,7 +68,41 @@ static MIG_MODE: Check = Check {
     run: check_mig,
 };
 
+/// Why the NVIDIA checks stand down, phrased so it does not overclaim.
+///
+/// [`has_nvidia`] asks `nvidia-smi -L` on Windows and macOS, so a false
+/// answer covers three states this function cannot separate: no NVIDIA
+/// hardware at all, hardware whose driver cannot be reached, and on
+/// Windows an unelevated shell, where `nvidia-smi` refuses with a
+/// permission error before it ever reaches the driver. Naming all three
+/// beats asserting the first, and the middle one is the reason this is a
+/// skip rather than a pass.
+fn nvidia_absent_reason() -> String {
+    "no NVIDIA GPU visible to `nvidia-smi -L`; on Windows the same answer comes from an \
+     unelevated shell or from an external GPU that is currently detached. Re-run elevated, \
+     or with the GPU attached, if one is expected"
+        .to_string()
+}
+
 fn check_nvml_loadable(_ctx: &CheckCtx) -> CheckResult {
+    // A host with no NVIDIA GPU is not a broken host, and NVML failing to
+    // initialise on one is not a defect worth an Error. `level_zero.init`
+    // and `level_zero.devices` already take that position for Intel; this
+    // brings NVIDIA into line, for the same reason given there: an absent
+    // vendor stack degrades to reporting no device of that vendor rather
+    // than breaking a run, so the worst honest verdict is not a failure.
+    //
+    // The state that forced the question: a machine whose only NVIDIA GPU
+    // is external and currently detached, with the driver still installed.
+    // Every NVML error became `Fail`, so `doctor` exited 2 on a healthy
+    // host, and the error it printed was `NVML_ERROR_NO_PERMISSION`, which
+    // sent the operator looking for an elevation problem that did not
+    // exist. Elevated, the same machine reports the real condition: the
+    // driver cannot be reached because there is no GPU behind it.
+    if !has_nvidia() {
+        return CheckResult::Skip(nvidia_absent_reason());
+    }
+
     // The `nvml-wrapper` crate loads libnvidia-ml via dlopen on first
     // Nvml::init(). Attempting the init is the cheapest authoritative test:
     // if the library is missing or the driver isn't usable, init() fails
@@ -104,6 +139,18 @@ fn check_smi(_ctx: &CheckCtx) -> CheckResult {
             );
         }
     };
+
+    // The binary being installed says nothing about a GPU being present:
+    // an NVIDIA driver survives its hardware being unplugged, which is the
+    // ordinary state of a machine whose NVIDIA GPU is external. Report that
+    // as a skip rather than running a command whose failure would be
+    // reported as the host's fault.
+    if !has_nvidia() {
+        return CheckResult::Skip(format!(
+            "{path} is installed but {}",
+            nvidia_absent_reason()
+        ));
+    }
 
     match try_exec("nvidia-smi", &["--version"], Duration::from_millis(2_000)) {
         Some(out) if out.success() => {

--- a/src/doctor/checks/windows.rs
+++ b/src/doctor/checks/windows.rs
@@ -127,7 +127,19 @@ fn check_gpu_perf_counters(_ctx: &CheckCtx) -> CheckResult {
                     Some(value) => format!("{value:.1}%"),
                     None => "unavailable".to_string(),
                 };
-                format!("{description} ({total_gib:.1} GiB, utilization {utilization})")
+                // Which pool the figure came from, not just its size. The
+                // number alone is ambiguous: `resolve_adapter_memory` reports
+                // the dedicated pool when it clears the 1 GiB floor and the
+                // shared aperture otherwise, and those are different
+                // quantities. Reading a capacity off this check without
+                // knowing which one it is invites the wrong conclusion, which
+                // is what happened on the first Windows run (#378).
+                let pool = if adapter.memory_is_shared {
+                    "shared aperture"
+                } else {
+                    "dedicated"
+                };
+                format!("{description} ({total_gib:.1} GiB {pool}, utilization {utilization})")
             })
             .collect();
 


### PR DESCRIPTION
## Summary

Four corrections that came out of running `all-smi` on real Windows hardware: first the CI runner (a VMware VM), then a Ryzen AI MAX+ 395 with a Radeon 8060S and a detached NVIDIA eGPU. Three of the four are the same defect in different places: **a check held the value that answered the question and did not print it.**

## 1. The elevation guard gave the wrong advice

The service smoke test told the reader to reconfigure the runner as an administrator. `windows-on-macmini02-x64` reports `elevated: False`, and the decision was to leave it that way: an elevated persistent runner executes whatever lands on `main` with Administrator rights, and a one-off check on a dedicated machine is the cheaper risk. #357 carries that decision; the workflow now agrees with it. Also drops two references to `ENABLE_WINDOWS_SERVICE_SMOKE`, gone since #392.

## 2. The Windows capacity did not say which pool it came from

`resolve_adapter_memory` returns the dedicated pool above a 1 GiB floor and the shared aperture otherwise. `windows.gpu.perf_counters` printed the number without the distinction, and I misread the VM's output as a result. It now prints `95.8 GiB dedicated` or `... shared aperture`.

For the record, the question that ambiguity blocked is now settled by the AMD host, with nothing left to interpret:

| Source | Same adapter, same moment |
|---|---|
| WMI `Win32_VideoController.AdapterRAM` | `4293918720` (3.999 GiB) |
| DXGI, via this check | **95.8 GiB** |
| Firmware carve-out, confirmed by the operator | 96 GB of 128 GB |

`4293918720` is `0xFFF00000`, the largest MiB-aligned value below `2^32`. The identical number appeared on the VM's 8 GiB adapter, which is what shows it to be a saturation artifact rather than a configured size. A `uint32` cannot carry 96 GB, so the WMI baseline was wrong by a factor of 24 on this machine. That is the defect #348 replaced.

## 3. The ADL readout hid the temperature it actually used

`describe_readout` printed edge, hotspot and mem and left out gfx, which is the second link in `primary_temperature_c`'s chain. A Strix Halo APU reports none of edge, mem or hotspot and does report gfx, so `amd.adl.sensors` said

```
edge=NoneC hotspot=NoneC mem=NoneC
```

while the TUI correctly showed **41 C**, taken from the gfx sensor at raw index 28. A field-verification dump should not need the source read to reconcile it with the product. The clock keeps its value under `gfxclk` so the two `gfx` quantities stay apart. Nothing string-matches this format.

## 4. A host with no NVIDIA GPU was reported as failing

`check_nvml_loadable` turned every `Nvml::init()` error into `Fail` with no branch for the commonest cause, and `check_smi` had the same shape once the binary was found. A driver survives its hardware being unplugged, so finding `nvidia-smi` says nothing about a device being present.

A machine whose only NVIDIA GPU is external and detached reported two failures and exited 2 while healthy. Unelevated it printed `NVML_ERROR_NO_PERMISSION`, sending the operator after an elevation problem that does not exist; elevated, the same host reports the real condition, that it cannot reach the driver.

Both checks now stand down when `has_nvidia()` is false, which is the position `level_zero.init` and `level_zero.devices` already take for Intel, for the reason #381 records. The skip message does not assert "no GPU": `has_nvidia()` asks `nvidia-smi -L`, so a false answer covers no hardware, an unreachable driver, and an unelevated Windows shell. It names all three.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --lib -- -D warnings`, `cargo check --lib` clean
- [x] `cargo test --lib doctor`: 47 passed
- [x] The NVIDIA gate does not suppress the positive path: on a Linux host that has an NVIDIA GPU, all five `nvidia.*` checks still pass and `doctor --only nvidia` exits 0
- [x] Workflow parses; jobs and step count unchanged
- [ ] The two Windows-gated changes (2 and 3) are not compiled locally: this host has no `x86_64-pc-windows-msvc` toolchain and both sit behind `cfg(target_os = "windows")` with no `test` arm. Field accesses were verified against the struct definitions. The `windows-checks` job from #392 compiles them on merge.
