### PR TITLE
fix: clear the clippy denials on native Windows

### DIFF
--- a/src/api/shutdown.rs
+++ b/src/api/shutdown.rs
@@ -102,7 +102,13 @@ pub async fn wait_until_serving() {
 }
 
 /// Whether at least one listener has been bound.
-#[cfg_attr(not(windows), allow(dead_code))]
+///
+/// Unlike [`wait_until_serving`], which the Windows service host awaits,
+/// this has no caller outside the tests. The attribute below therefore
+/// keys on `test` rather than on the platform: it was copied from the
+/// sibling above, and `not(windows)` silenced every target except the one
+/// where the item is genuinely dead.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn is_serving() -> bool {
     serving_latch().is_triggered()
 }

--- a/src/device/cpu_windows.rs
+++ b/src/device/cpu_windows.rs
@@ -46,11 +46,12 @@ thread_local! {
 fn with_cimv2_connection<T, F: FnOnce(&WMIConnection) -> T>(f: F) -> Option<T> {
     WMI_CIMV2_CONNECTION.with(|cell| {
         let mut conn_ref = cell.borrow_mut();
-        if conn_ref.is_none() {
-            if let Ok(wmi_con) = WMIConnection::new() {
-                *conn_ref = Some(wmi_con);
-            }
-            // Silently fail if connection cannot be created
+        // A failed connection is left as `None` on purpose: the caller
+        // gets `None` back and degrades, and the next call retries.
+        if conn_ref.is_none()
+            && let Ok(wmi_con) = WMIConnection::new()
+        {
+            *conn_ref = Some(wmi_con);
         }
         conn_ref.as_ref().map(f)
     })
@@ -60,11 +61,11 @@ fn with_cimv2_connection<T, F: FnOnce(&WMIConnection) -> T>(f: F) -> Option<T> {
 fn with_root_wmi_connection<T, F: FnOnce(&WMIConnection) -> T>(f: F) -> Option<T> {
     WMI_ROOT_WMI_CONNECTION.with(|cell| {
         let mut conn_ref = cell.borrow_mut();
-        if conn_ref.is_none() {
-            if let Ok(wmi_con) = WMIConnection::with_namespace_path("root\\WMI") {
-                *conn_ref = Some(wmi_con);
-            }
-            // Silently fail if connection cannot be created
+        // Same as above: a failed connection stays `None` and is retried.
+        if conn_ref.is_none()
+            && let Ok(wmi_con) = WMIConnection::with_namespace_path("root\\WMI")
+        {
+            *conn_ref = Some(wmi_con);
         }
         conn_ref.as_ref().map(f)
     })

--- a/src/device/readers/windows_gpu_perf.rs
+++ b/src/device/readers/windows_gpu_perf.rs
@@ -125,6 +125,12 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+    /// Test-only today. This module is gated `cfg(any(target_os =
+    /// "windows", test))`, so off Windows it exists only under `test`,
+    /// where this is used and nothing is reported. A non-test Windows
+    /// build compiles it with no caller, which is the one configuration
+    /// that sees it as dead.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn is_empty(&self) -> bool {
         self.adapters.is_empty() && self.processes.is_empty()
     }

--- a/src/device/readers/windows_gpu_perf/ids.rs
+++ b/src/device/readers/windows_gpu_perf/ids.rs
@@ -49,6 +49,11 @@ pub struct AdapterLuid {
 }
 
 impl AdapterLuid {
+    /// Test-only today: production code builds this with a struct literal
+    /// from the DXGI descriptor, and every caller here is an assertion.
+    /// Dead only in a non-test Windows build, for the reason given on
+    /// `Snapshot::is_empty`.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn new(high: i32, low: u32) -> Self {
         Self { high, low }
     }

--- a/src/device/windows_temp/amd_ryzen.rs
+++ b/src/device/windows_temp/amd_ryzen.rs
@@ -225,17 +225,20 @@ impl AmdRyzenSource {
 impl Drop for AmdRyzenSource {
     fn drop(&mut self) {
         // Clean up the AMD library
-        if let Some(state) = write_lock(&self.library_state).take() {
-            if state.initialized {
-                // SAFETY: We're calling PlatformUninit to clean up resources.
-                let uninit_fn: Result<Symbol<PlatformUninitFn>, _> =
-                    unsafe { state.library.get(b"PlatformUninit\0") };
+        // `take()` runs either way, so the lock is cleared even when the
+        // library was never initialised; only the uninit call is
+        // conditional. Collapsing preserves that order.
+        if let Some(state) = write_lock(&self.library_state).take()
+            && state.initialized
+        {
+            // SAFETY: We're calling PlatformUninit to clean up resources.
+            let uninit_fn: Result<Symbol<PlatformUninitFn>, _> =
+                unsafe { state.library.get(b"PlatformUninit\0") };
 
-                if let Ok(uninit) = uninit_fn {
-                    // SAFETY: Calling the documented cleanup function.
-                    unsafe {
-                        uninit();
-                    }
+            if let Ok(uninit) = uninit_fn {
+                // SAFETY: Calling the documented cleanup function.
+                unsafe {
+                    uninit();
                 }
             }
             // Library is dropped when state goes out of scope

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,11 @@ mod view;
 use api::run_api_mode;
 use clap::FromArgMatches;
 use cli::{Cli, Commands, LocalArgs};
-use common::config_file::{self, Settings, SocketSetting};
+use common::config_file::{self, Settings};
+// Only read inside the `#[cfg(unix)]` block that resolves the socket
+// setting, so importing it unconditionally leaves it unused on Windows.
+#[cfg(unix)]
+use common::config_file::SocketSetting;
 use tokio::signal;
 use utils::{RuntimeEnvironment, ensure_sudo_permissions_for_api};
 
@@ -321,6 +325,12 @@ async fn run_command(cli: Cli, settings: Settings) {
                 }
             }
 
+            // Consumed only by the macOS and Linux initialisers below, both
+            // cfg-gated, so on Windows this binding had no reader. Gating the
+            // binding rather than allowing the warning means a future consumer
+            // on another target fails to compile instead of silently
+            // reintroducing the dead binding.
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             let interval = args.interval.unwrap_or(3);
 
             // Initialize native metrics manager (no sudo required)

--- a/src/utils/command_timeout.rs
+++ b/src/utils/command_timeout.rs
@@ -185,7 +185,19 @@ fn check_cgroup_container() -> bool {
     }
 }
 
-#[cfg(test)]
+// Both tests here drive Unix programs (`yes`, `printf`) to exercise the
+// output cap, so the module is gated rather than the import inside it.
+// Gating only `use super::*` would leave
+// `output_cap_leaves_small_outputs_alone` compiled on Windows with its
+// entire body behind `#[cfg(unix)]`, which is a test that reports `ok`
+// while asserting nothing. An empty pass is a worse signal than an
+// absent test.
+//
+// The cap itself is cross-platform product code and now has no Windows
+// coverage. Giving it some needs a Windows program that emits an
+// unbounded stream, which is a test to write rather than a lint to
+// silence, so it is left for its own change.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/src/view/data_collection/ssh_strategy.rs
+++ b/src/view/data_collection/ssh_strategy.rs
@@ -268,6 +268,12 @@ impl DataCollectionStrategy for SshStrategy {
 /// Per-host collection driver. Returns `Ok((gpus, status))` on success
 /// (status `is_connected = true`); returns `Err((status,))` when the
 /// host failed — the status carries the error chip the UI renders.
+// Measured rather than assumed: see `boxing_the_error_would_not_shrink_the_result`
+// below. `ConnectionStatus` is 184 bytes, so the `Err` variant trips the lint's
+// 128-byte threshold, but the `Ok` variant carries the same struct plus a `Vec`
+// and is 208. The whole `Result` is 208 either way, so boxing the `Err` buys
+// nothing and costs an allocation on every failed host.
+#[allow(clippy::result_large_err)]
 async fn collect_one_host(
     hosts: Arc<Mutex<HashMap<String, HostState>>>,
     semaphore: Arc<Semaphore>,
@@ -409,6 +415,8 @@ async fn probe_simple(session: &SshSession, cmd: &str) -> ProbeResult {
     }
 }
 
+// Same signature, same measurement; see `collect_one_host` above.
+#[allow(clippy::result_large_err)]
 async fn exec_and_parse(
     hosts: &Arc<Mutex<HashMap<String, HostState>>>,
     target: &SshTarget,
@@ -607,5 +615,36 @@ mod tests {
             Err(other) => panic!("expected Other err, got {other:?}"),
             Ok(_) => panic!("expected err, got Ok"),
         }
+    }
+}
+
+#[cfg(test)]
+mod result_size {
+    use super::*;
+
+    /// Pins the fact the two `#[allow(clippy::result_large_err)]` above rest on.
+    ///
+    /// The conventional fix for that lint is to box the `Err`, and here it would
+    /// not shrink the type by one byte, because the `Ok` variant carries the same
+    /// `ConnectionStatus` plus a `Vec` and therefore dominates the enum. Suppressing
+    /// a lint on a claim about sizes is only honest if the claim is checked, so
+    /// check it. A failure here means the `Ok` variant got smaller and boxing the
+    /// `Err` may finally be worth its allocation.
+    #[test]
+    fn boxing_the_error_would_not_shrink_the_result() {
+        use std::mem::size_of;
+
+        type Collected = Result<(Vec<GpuInfo>, ConnectionStatus), (ConnectionStatus,)>;
+        type BoxedErr = Result<(Vec<GpuInfo>, ConnectionStatus), Box<ConnectionStatus>>;
+
+        assert_eq!(
+            size_of::<Collected>(),
+            size_of::<BoxedErr>(),
+            "boxing the Err changed the Result size, so the allow is no longer justified"
+        );
+        assert!(
+            size_of::<(Vec<GpuInfo>, ConnectionStatus)>() > size_of::<(ConnectionStatus,)>(),
+            "the Ok variant no longer dominates, so the Err is now worth shrinking"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Makes `cargo clippy --all-targets -- -D warnings` pass on native Windows. Two commits, because clearing the four sites this issue names turned out not to be sufficient.

Closes #367

## The four sites (first commit)

All confirmed still present on `ecc60a4` by run [32716362643](https://github.com/lablup/all-smi/actions/runs/32716362643), the first CI run ever to lint this code.

Three are `clippy::collapsible_if`, each collapsing to a let-chain, which this crate already uses elsewhere and edition 2024 supports at the pinned MSRV. The `amd_ryzen.rs` one is worth a note: `take()` runs whether or not the second condition holds, so the lock is cleared even when the library was never initialised and only the uninit call is conditional. A let-chain preserves that order exactly. The two comments explaining why a failed WMI connection is deliberately left as `None` moved above their `if` rather than disappearing with the nesting.

The fourth is the unused `use super::*` in `command_timeout.rs`'s test module. **Deleting it breaks Linux**, where it is used, so the fix has to be a gate. The module is now `#[cfg(all(test, unix))]` rather than gating the import alone: both tests drive Unix programs (`yes`, `printf`), and gating only the import would leave `output_cap_leaves_small_outputs_alone` compiled on Windows with its entire body behind `#[cfg(unix)]`. That is a test reporting `ok` while asserting nothing, and an empty pass is a worse signal than an absent test. Windows loses one vacuous test as a result.

That does leave the output cap, which is cross-platform product code, with no Windows coverage. Restoring it needs a Windows program that emits an unbounded stream, which is a test to write rather than a lint to silence, so it is left for its own change. Both constants it uses are consumed by product code, so gating the module orphans nothing.

## Why a second commit was needed

The Windows run stopped at the lib, so **the bin was never linted**. Its log shows only `could not compile all-smi (lib)` and `(lib test)`. `src/view/data_collection/ssh_strategy.rs` lives in the bin, so as soon as the lib compiles, clippy reaches it and raises `result_large_err` on the two collector signatures. Fixing only the four sites would have moved the failure rather than removed it.

The conventional fix for that lint is to box the `Err`. Here it shrinks nothing:

```
ConnectionStatus                                184
Ok  variant (Vec<GpuInfo>, ConnectionStatus)    208
Err variant (ConnectionStatus,)                 184
Result                                          208
Result with a boxed Err                         208
```

The `Ok` variant carries the same `ConnectionStatus` plus a `Vec`, so it dominates the enum and the `Result` is 208 bytes either way. Boxing would add a heap allocation on every failed host and remove zero bytes.

So both functions take `#[allow(clippy::result_large_err)]` carrying that measurement, and a new test pins it. Suppressing a lint on a claim about sizes is only honest if the claim is checked. If someone later shrinks the `Ok` side, `boxing_the_error_would_not_shrink_the_result` fails and the suppression stops being justified, which is exactly when boxing would become worth its allocation.

These two findings are pre-existing on `main` (confirmed by stashing this branch and re-running clippy) and were recorded once before in PR #382 as a rustc 1.98 difference the CI toolchain did not reproduce.

## Validation

On Linux, rustc 1.98.0:

- `cargo clippy --all-targets -- -D warnings` passes with **no findings at all**, where `main` has two
- `cargo fmt --check` clean
- `cargo test --lib` 1684 passed, `cargo test --bin all-smi` 1861 passed

Not verified on Windows from here. The `windows-checks` job has no `pull_request` trigger by design, so verification is either `gh workflow run "Windows Self-Hosted" --ref fix/issue-367-windows-clippy` or a build on a Windows host.

Note for whoever runs it: the job's Report step fails while #366 is open, because `cargo test --lib` still has its seven failures. The signal to read is the per-step line, which should now say `cargo clippy  success`.
