### PR TITLE
fix: make the Windows-hostile unit tests portable

### DIFF
--- a/src/device/common/command_executor.rs
+++ b/src/device/common/command_executor.rs
@@ -115,9 +115,26 @@ pub fn execute_command_default(command: &str, args: &[&str]) -> DeviceResult<Com
 mod tests {
     use super::*;
 
+    // `echo` and `false` are shell builtins on Windows rather than
+    // executables on PATH, so `Command::new` cannot spawn them and both
+    // tests failed with `NotFound` there. Gating them to Unix would have
+    // been easier and wrong: `execute_command` runs on Windows in
+    // production (nvidia-smi, wmic), so it is worth testing there. Each
+    // platform therefore names a program it actually has.
+    #[cfg(unix)]
+    const ECHO: (&str, &[&str]) = ("echo", &["hello"]);
+    #[cfg(windows)]
+    const ECHO: (&str, &[&str]) = ("cmd", &["/C", "echo", "hello"]);
+
+    #[cfg(unix)]
+    const FAILS: (&str, &[&str]) = ("false", &[]);
+    #[cfg(windows)]
+    const FAILS: (&str, &[&str]) = ("cmd", &["/C", "exit", "1"]);
+
     #[test]
     fn test_execute_command_default_success() {
-        let out = execute_command_default("echo", &["hello"]).expect("echo should succeed");
+        let (cmd, args) = ECHO;
+        let out = execute_command_default(cmd, args).expect("echo should succeed");
         assert_eq!(out.status, 0);
         assert!(out.stdout.contains("hello"));
     }
@@ -128,8 +145,8 @@ mod tests {
             timeout: Some(Duration::from_secs(2)),
             check_status: true,
         };
-        // Use `false` which returns non-zero status on Unix
-        let err = execute_command("false", &[], &opts).unwrap_err();
+        let (cmd, args) = FAILS;
+        let err = execute_command(cmd, args, &opts).unwrap_err();
         match err {
             DeviceError::CommandFailed { .. } => {}
             _ => panic!("Expected CommandFailed error"),

--- a/src/device/common/validation.rs
+++ b/src/device/common/validation.rs
@@ -136,11 +136,25 @@ mod tests {
     fn test_validate_command_path() {
         use std::path::PathBuf;
 
+        // Absoluteness is spelled differently per platform: a leading
+        // slash carries no drive letter, so `/bin/ls` is not absolute on
+        // Windows and was rejected for the wrong reason. The traversal
+        // case is per-platform for the same reason: a Unix-shaped path
+        // would be refused on Windows before the `..` check is reached,
+        // so the branch this test exists for would go unexercised.
+        #[cfg(unix)]
+        let (valid, traversal) = ("/bin/ls", "/usr/../etc/passwd");
+        #[cfg(windows)]
+        let (valid, traversal) = (
+            r"C:\Windows\System32\cmd.exe",
+            r"C:\Windows\..\Windows\System32\cmd.exe",
+        );
+
         // Valid paths
-        assert!(validate_command_path(&PathBuf::from("/bin/ls")));
+        assert!(validate_command_path(&PathBuf::from(valid)));
 
         // Invalid paths
         assert!(!validate_command_path(&PathBuf::from("relative/path")));
-        assert!(!validate_command_path(&PathBuf::from("/usr/../etc/passwd")));
+        assert!(!validate_command_path(&PathBuf::from(traversal)));
     }
 }

--- a/src/doctor/bundle.rs
+++ b/src/doctor/bundle.rs
@@ -618,7 +618,14 @@ mod tests {
 
     #[test]
     fn bundle_writes_expected_entries() {
-        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        // A `NamedTempFile` stays open at the path it owns, and
+        // `write_bundle` creates or replaces a file at that same path.
+        // Windows refuses that while the handle is alive (os error 32);
+        // Unix permits it, which is why this passed everywhere else. Hand
+        // the writer a path inside a temp directory instead, so nothing
+        // else holds it open.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundle = dir.path().join("bundle.tar.gz");
         let report = Report {
             schema: 1,
             version: "0.99.9".to_string(),
@@ -634,15 +641,15 @@ mod tests {
         let opts = DoctorOptions {
             json: false,
             verbose: false,
-            bundle_path: Some(tmp.path().to_path_buf()),
+            bundle_path: Some(bundle.clone()),
             include_identifiers: true,
             remote_checks: vec![],
             skip: vec![],
             only: vec![],
             use_color: false,
         };
-        write_bundle(tmp.path(), &report, &opts).expect("bundle ok");
-        let bytes = std::fs::read(tmp.path()).expect("read bundle");
+        write_bundle(&bundle, &report, &opts).expect("bundle ok");
+        let bytes = std::fs::read(&bundle).expect("read bundle");
         // Cheap sanity check: the gzip header magic should be present.
         assert!(bytes.len() > 2);
         assert_eq!(bytes[0], 0x1f);

--- a/src/metrics/energy_wal.rs
+++ b/src/metrics/energy_wal.rs
@@ -766,6 +766,11 @@ mod tests {
         let truncated = (RECORD_LEN + 12) as u64;
         let f = OpenOptions::new().write(true).open(&path).unwrap();
         f.set_len(truncated).unwrap();
+        // Windows refuses the reopen below while this handle is alive
+        // (os error 32). Unix does not, which is why the leak went
+        // unnoticed. Close it before replaying rather than relying on
+        // end-of-scope.
+        drop(f);
 
         let mut integ = PowerIntegrator::default();
         let index = replay_from_path(&path, &mut integ).unwrap();
@@ -928,27 +933,20 @@ mod tests {
 
     #[test]
     fn expand_tilde_replaces_home_prefix() {
-        // Rust 2024 flags env mutations as unsafe because they can
-        // race with concurrent reads. We accept the risk in this
-        // single-threaded unit test and isolate by explicitly
-        // restoring the HOME variable at the end.
-        let original = std::env::var("HOME").ok();
-        unsafe {
-            std::env::set_var("HOME", "/tmp/fake-home");
-        }
+        // Compares against `dirs::home_dir()` rather than forcing `HOME`,
+        // which is both portable and safe. `expand_tilde` resolves through
+        // `dirs::home_dir()`, and that reads `USERPROFILE` on Windows, so
+        // overriding `HOME` changed nothing there and the assertion saw the
+        // real profile directory. Dropping the override also removes the
+        // `unsafe` env mutation the old comment admitted was a race. This is
+        // the shape `common::paths`'s own tilde tests already use.
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
         let expanded = expand_tilde(Path::new("~/.cache/all-smi/energy-wal.bin"));
-        assert_eq!(
-            expanded,
-            PathBuf::from("/tmp/fake-home/.cache/all-smi/energy-wal.bin")
-        );
+        assert_eq!(expanded, home.join(".cache/all-smi/energy-wal.bin"));
         let unchanged = expand_tilde(Path::new("/absolute/path"));
         assert_eq!(unchanged, PathBuf::from("/absolute/path"));
-        unsafe {
-            match original {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
     }
 
     /// Verify that `WalFlushHandle::shutdown()` terminates the background

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -562,8 +562,10 @@ mod tests {
 
     #[test]
     fn write_output_atomic_creates_file_and_contents_match() {
+        // `/tmp` is a Unix path and does not exist on Windows; the write
+        // failed there before it could test anything.
         let pid = std::process::id();
-        let path = std::path::PathBuf::from(format!("/tmp/all-smi-atomic-test-{pid}.json"));
+        let path = std::env::temp_dir().join(format!("all-smi-atomic-test-{pid}.json"));
         let _ = std::fs::remove_file(&path);
         let contents = r#"{"test":true}"#;
         write_output_atomic(&path, contents).expect("atomic write should succeed");


### PR DESCRIPTION
## Summary

Makes `cargo test --lib` pass on native Windows. All seven failures are test-harness portability, not product defects, which is what the issue already concluded for the four it names.

Closes #366

## The issue undercounts: seven, not four

The issue was written against `b92ea0a` with 1417 tests. Run [32716362643](https://github.com/lablup/all-smi/actions/runs/32716362643) on `ecc60a4` has 1559 and fails seven. The crate grew in between and three more tests carried the same kind of assumption. The title and the acceptance criteria should be read as covering all seven.

| Test | Panic on Windows |
|---|---|
| `command_executor::test_execute_command_default_success` | `echo should succeed: Io(NotFound, "program not found")` |
| `command_executor::test_execute_command_with_status_check` | `Expected CommandFailed error` |
| `validation::test_validate_command_path` | `assertion failed: validate_command_path("/bin/ls")` |
| `snapshot::write_output_atomic_creates_file_and_contents_match` | `failed to create snapshot temp file /tmp/all-smi-...` |
| `energy_wal::expand_tilde_replaces_home_prefix` | `left: "C:\Users\...\.cache/..."` |
| `energy_wal::torn_final_record_is_discarded` | os error 32, file in use |
| `doctor::bundle::bundle_writes_expected_entries` | `failed to create bundle file "...\.tmpynzaPj"` |

The last three are the ones the issue does not list.

## Unix programs that Windows does not have

`echo` and `false` are shell builtins on Windows rather than executables on PATH, so `Command::new` cannot spawn either. **Gating those two to Unix would have been easier and wrong**: `execute_command` runs on Windows in production against nvidia-smi and wmic, so it is worth testing there. Each platform now names a program it actually has, `cmd /C echo` and `cmd /C exit 1`, and both keep their coverage.

## Path shapes

`/bin/ls` carries no drive letter, so it is not absolute on Windows and was rejected before reaching the check the test is about. The traversal case became a per-platform literal for the same reason: a Unix-shaped path is refused for absoluteness first, which would leave the `..` branch unexercised on Windows.

`/tmp` does not exist on Windows, so the atomic-write test failed before it could assert anything. It now uses `std::env::temp_dir()`.

## The tilde test was testing nothing on Windows

It forced `HOME`, but `expand_tilde` resolves through `dirs::home_dir()`, which reads `USERPROFILE` on Windows. The override changed nothing and the assertion compared against the real profile directory. It now compares against `dirs::home_dir()` directly, which is the shape `common::paths`'s own tilde tests already use, and that also removes the `unsafe` env mutation whose own comment admitted it was accepting a data race.

## Two instances of one Windows rule

Windows refuses to open a path that another live handle owns. The WAL test kept its write handle open across the replay; the bundle test handed `write_bundle` the path of a still-open `NamedTempFile`. The first drops the handle explicitly, the second writes into a `tempdir` so nothing else holds the target. Unix permits both, which is why neither was noticed.

## One trap deliberately avoided

Nothing here matches on OS error text. The runner reported error 32 **in Korean**, so its locale is ko-KR, and any assertion on the message string would pass in one locale and fail in another. The fixes address the cause instead.

## Validation

On Linux: `cargo fmt --check` clean, `cargo test --lib` 1684 passed, `cargo test --bin all-smi` 1860 passed. `cargo clippy --all-targets` reports nothing in any changed file. It does report two `result_large_err` findings in `src/view/data_collection/ssh_strategy.rs`; those are pre-existing on `main`, untouched here, and fixed in #394.

Not verified on Windows from here. The `windows-checks` job has no `pull_request` trigger by design, so verification is `gh workflow run "Windows Self-Hosted" --ref fix/issue-366-windows-tests` or a build on a Windows host.

Note for whoever runs it: the job's Report step will still fail while #367 is open, because `cargo clippy` has its own four failures. The signal to read is the per-step line, which should now say `cargo test --lib  success`.
