### PR TITLE
chore(ci): make the Windows checks an ordinary gate

### DIFF
--- a/.github/workflows/windows-selfhosted.yml
+++ b/.github/workflows/windows-selfhosted.yml
@@ -57,12 +57,22 @@ jobs:
   # #367 records four `clippy -D warnings` sites, both reported from a
   # developer machine rather than from a run anyone else can read.
   #
-  # `continue-on-error` on the three check steps is deliberate and
-  # temporary. The point of the first run is to produce the list, and a
-  # job that stops at `fmt` would hide whatever `clippy` and `test` have
-  # to say. The summary step at the end fails the job, so a red run is
-  # still red; it just reports all three first. Remove the flags once
-  # #366 and #367 are closed, and this becomes an ordinary gate.
+  # This is an ordinary gate: the first failing check fails the job.
+  #
+  # It did not start that way. The three checks carried
+  # `continue-on-error` and a summary step failed the job at the end, so
+  # that one run could report all three rather than stopping at `fmt` and
+  # hiding what the other two had to say. That mattered while #366 and
+  # #367 were open, and it earned its keep twice: both issues turned out
+  # to undercount, because nothing could see past the first thing that
+  # stopped the build. #366 reported four failing tests and had seven,
+  # and #367 reported four clippy sites and had nine.
+  #
+  # Both are closed and run 32726116136 on `main` reported all three
+  # green, so the scaffolding is gone. If a future run needs the same
+  # report-everything behaviour for a debugging session, it is a few
+  # lines of `continue-on-error` plus a summary step, and this comment is
+  # the record of what it looked like.
   # ───────────────────────────────────────────────────────────────
   windows-checks:
     name: Windows Checks
@@ -114,47 +124,30 @@ jobs:
             [Security.Principal.WindowsBuiltInRole]::Administrator)
 
       - name: cargo fmt --check
-        id: fmt
-        continue-on-error: true
         run: cargo fmt --all -- --check
 
       - name: cargo clippy
-        id: clippy
-        continue-on-error: true
         run: cargo clippy --all-targets -- -D warnings
 
       - name: cargo test --lib
-        id: test
-        continue-on-error: true
         run: cargo test --lib
 
       # Diagnostics, not a gate. It runs the binary this job just built
       # against the actual hardware, which is the only way #377 and #378
       # get evidence rather than inference.
+      #
+      # `if: always()` so it still runs after a failed check, which is
+      # when knowing what the host is matters most. It keeps
+      # `continue-on-error` for the same reason it always had it: a probe
+      # that cannot build is not a reason to fail a run whose checks
+      # passed.
       - name: all-smi doctor
+        if: always()
         continue-on-error: true
         run: |
           cargo run --bin all-smi -- doctor --verbose
           Write-Output "--- level_zero only, as json"
           cargo run --bin all-smi -- doctor --only level_zero --json
-
-      - name: Report
-        run: |
-          $results = [ordered]@{
-            'cargo fmt --check' = "${{ steps.fmt.outcome }}"
-            'cargo clippy'      = "${{ steps.clippy.outcome }}"
-            'cargo test --lib'  = "${{ steps.test.outcome }}"
-          }
-          $failed = @()
-          foreach ($k in $results.Keys) {
-            Write-Output ("{0,-18} {1}" -f $k, $results[$k])
-            if ($results[$k] -ne 'success') { $failed += $k }
-          }
-          if ($failed.Count -gt 0) {
-            Write-Output "::error::native Windows checks failed: $($failed -join ', '). See #366 and #367."
-            exit 1
-          }
-          Write-Output "All native Windows checks passed."
 
   # ═══════════════════════════════════════════════════════════════
   # Job: Windows Service Control Manager smoke test (issue #311)


### PR DESCRIPTION
## Summary

Removes the `continue-on-error` scaffolding from the three Windows checks, which #392 said to do once #366 and #367 closed. Both are closed, and run [32726116136](https://github.com/lablup/all-smi/actions/runs/32726116136) on `main` reported all three green with "All native Windows checks passed".

## What the scaffolding bought

It was there so one run could report `fmt`, `clippy` and `test` together rather than stopping at the first and hiding the rest. That earned its keep twice, and in the same way each time: **both issues undercounted, because nothing could see past the first thing that stopped the build.**

- **#366** reported four failing tests and had **seven**. It was written against `b92ea0a` with 1417 tests; the crate had grown to 1559 since, and three more carried the same Unix assumptions.
- **#367** reported four clippy sites and had **nine**. Clearing the four in the lib let clippy reach the bin for the first time, where five more were waiting.

Neither gap would have been visible in a job that halted at `fmt`.

## Why the summary step goes too

Without `continue-on-error`, the Report step's failure branch is unreachable: the job cannot get there with a failed check behind it. A step whose error handling can never run is the kind of thing this repository keeps deleting rather than keeping for later, and each check now fails the job at its own step with cargo's own output, which is a clearer signal than a table of outcomes.

The header comment records what the scaffolding looked like, so restoring it for a debugging session is a few lines rather than an archaeology exercise.

## One small improvement, not just a removal

The two diagnostic steps keep `continue-on-error`, because a probe that cannot build is not a reason to fail a run whose checks passed. `all-smi doctor` additionally gains `if: always()`, so it still runs after a failed check. That is exactly when knowing what the host is matters most, and previously a red check skipped it.

## Verified on the runner

Run [32726837830](https://github.com/lablup/all-smi/actions/runs/32726837830) against this branch, dispatched to the real Windows host:

```
success  cargo fmt --check
success  cargo clippy
success  cargo test --lib
success  all-smi doctor
```

Job conclusion `success`, with no Report step. The gate holds on green; the failing path is the ordinary GitHub Actions one.
