### PR TITLE
fix(windows): mark unsourced GPU metrics unavailable (#378)

### DIFF
--- a/src/api/metrics/gpu.rs
+++ b/src/api/metrics/gpu.rs
@@ -891,6 +891,33 @@ mod tests {
         assert!(output.contains("all_smi_gpu_memory_total_bytes{"));
     }
 
+    /// Issue #378: a Windows WMI baseline must keep an unsourced field
+    /// absent through Prometheus instead of turning it into a zero sample.
+    #[test]
+    fn exporter_omits_unsourced_windows_utilization_and_power() {
+        use crate::device::types::GPU_METRIC_UNAVAILABLE;
+
+        let mut gpu = make_nvidia_gpu();
+        gpu.name = "AMD Radeon Graphics".to_string();
+        gpu.utilization = GPU_METRIC_UNAVAILABLE;
+        gpu.power_consumption = GPU_METRIC_UNAVAILABLE;
+        gpu.detail
+            .insert("Source: Utilization".to_string(), "unavailable".to_string());
+        gpu.detail
+            .insert("Source: Power".to_string(), "unavailable".to_string());
+
+        let output = GpuMetricExporter::new(&[gpu]).export_metrics();
+
+        assert!(!output.contains("all_smi_gpu_utilization{"), "{output}");
+        assert!(
+            !output.contains("all_smi_gpu_power_consumption_watts{"),
+            "{output}"
+        );
+        assert!(output.contains("all_smi_gpu_info{"), "{output}");
+        assert!(output.contains("source__utilization=\"unavailable\""));
+        assert!(output.contains("source__power=\"unavailable\""));
+    }
+
     /// The other half of the contract: a real zero is still published, so
     /// omission unambiguously means "no data".
     #[test]

--- a/src/device/readers/amd_adl.rs
+++ b/src/device/readers/amd_adl.rs
@@ -249,6 +249,7 @@ pub fn augment(_gpus: &mut [GpuInfo]) {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::device::types::GPU_METRIC_UNAVAILABLE;
     use std::collections::HashMap;
 
     fn baseline_gpu() -> GpuInfo {
@@ -280,7 +281,7 @@ mod tests {
             used_memory: 1_073_741_824,
             total_memory: 25_769_803_776,
             frequency: 0,
-            power_consumption: 0.0,
+            power_consumption: GPU_METRIC_UNAVAILABLE,
             gpu_core_count: None,
             temperature_threshold_slowdown: None,
             temperature_threshold_shutdown: None,
@@ -319,6 +320,7 @@ mod tests {
 
         assert_eq!(gpu.temperature, 62);
         assert_eq!(gpu.power_consumption, 310.0);
+        assert_eq!(gpu.power_consumption_reading(), Some(310.0));
         assert_eq!(gpu.frequency, 2400);
         assert_eq!(gpu.detail["Hotspot Temperature"], "81 C");
         assert_eq!(gpu.detail["Memory Temperature"], "70 C");
@@ -432,7 +434,7 @@ mod tests {
         assert_eq!(gpu.utilization, 12.0);
         assert_eq!(gpu.detail["Source: Utilization"], "PDH");
         assert_eq!(gpu.detail["Source: Power"], "unavailable");
-        assert_eq!(gpu.power_consumption, 0.0);
+        assert_eq!(gpu.power_consumption_reading(), None);
         assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI + PDH + ADL");
     }
 

--- a/src/device/readers/amd_windows.rs
+++ b/src/device/readers/amd_windows.rs
@@ -26,7 +26,7 @@
 
 use crate::device::GpuReader;
 use crate::device::readers::windows_gpu_perf::{self, ids::AdapterLuid};
-use crate::device::types::{GpuInfo, ProcessInfo};
+use crate::device::types::{GPU_METRIC_UNAVAILABLE, GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
 use chrono::Local;
 use serde::Deserialize;
@@ -184,7 +184,13 @@ impl AmdWindowsGpuReader {
                     host_id: hostname.clone(),
                     hostname: hostname.clone(),
                     instance: hostname.clone(),
-                    utilization: 0.0, // Not available via WMI
+                    // WMI cannot source utilization or power. These f64
+                    // fields use the unavailable sentinel because zero is a
+                    // legitimate reading; PDH / ADL overwrite it when they
+                    // answer. ANE is not applicable off Apple, while the u32
+                    // temperature and frequency accessors deliberately use
+                    // zero as their unavailable marker.
+                    utilization: GPU_METRIC_UNAVAILABLE,
                     ane_utilization: 0.0,
                     dla_utilization: None,
                     tensorcore_utilization: None,
@@ -192,7 +198,7 @@ impl AmdWindowsGpuReader {
                     used_memory: 0, // Not available via WMI
                     total_memory,
                     frequency: 0,         // Not available via WMI
-                    power_consumption: 0.0, // Not available via WMI
+                    power_consumption: GPU_METRIC_UNAVAILABLE,
                     gpu_core_count: None,
                     // AMD-on-Windows surfaces nothing beyond the basic WMI
                     // query — NVML thermal thresholds / P-states and NVIDIA

--- a/src/device/readers/intel_gpu_windows.rs
+++ b/src/device/readers/intel_gpu_windows.rs
@@ -50,7 +50,7 @@ use crate::device::GpuReader;
 use crate::device::readers::intel_gpu_names::{
     classify_intel_architecture, classify_intel_variant,
 };
-use crate::device::types::{GpuInfo, ProcessInfo};
+use crate::device::types::{GPU_METRIC_UNAVAILABLE, GpuInfo, ProcessInfo};
 use crate::utils::get_hostname;
 use chrono::Local;
 use serde::Deserialize;
@@ -231,7 +231,13 @@ impl IntelWindowsGpuReader {
                         host_id: hostname.clone(),
                         hostname: hostname.clone(),
                         instance: hostname.clone(),
-                        utilization: 0.0,
+                        // WMI cannot source utilization or power. These f64
+                        // fields use the unavailable sentinel because zero is
+                        // a legitimate reading; PDH / Level Zero overwrite it
+                        // when they answer. ANE is not applicable off Apple,
+                        // while the u32 temperature and frequency accessors
+                        // deliberately use zero as their unavailable marker.
+                        utilization: GPU_METRIC_UNAVAILABLE,
                         ane_utilization: 0.0,
                         dla_utilization: None,
                         tensorcore_utilization: None,
@@ -239,7 +245,7 @@ impl IntelWindowsGpuReader {
                         used_memory: 0,
                         total_memory,
                         frequency: 0,
-                        power_consumption: 0.0,
+                        power_consumption: GPU_METRIC_UNAVAILABLE,
                         gpu_core_count: None,
                         // Intel-on-Windows surfaces nothing beyond the
                         // basic WMI query — NVML thermal thresholds /

--- a/src/device/readers/windows_gpu_perf.rs
+++ b/src/device/readers/windows_gpu_perf.rs
@@ -757,12 +757,13 @@ mod tests {
         let (_, shared_below) = resolve_adapter_memory(MIN_DISCRETE_DEDICATED_BYTES - 1, 32 * GIB);
         assert!(shared_below, "one byte below the floor is a carve-out");
     }
-    use crate::device::types::GpuInfo;
+    use crate::device::types::{GPU_METRIC_UNAVAILABLE, GpuInfo};
 
     fn blank_gpu() -> GpuInfo {
         let mut detail = HashMap::new();
         detail.insert("Metrics Source".to_string(), "WMI".to_string());
         detail.insert("Source: Utilization".to_string(), "unavailable".to_string());
+        detail.insert("Source: Power".to_string(), "unavailable".to_string());
         detail.insert("Source: Memory".to_string(), "WMI".to_string());
         GpuInfo {
             uuid: "PCI\\VEN_1002&DEV_744C".to_string(),
@@ -772,7 +773,7 @@ mod tests {
             host_id: String::new(),
             hostname: String::new(),
             instance: String::new(),
-            utilization: 0.0,
+            utilization: GPU_METRIC_UNAVAILABLE,
             ane_utilization: 0.0,
             dla_utilization: None,
             tensorcore_utilization: None,
@@ -780,7 +781,7 @@ mod tests {
             used_memory: 0,
             total_memory: 4_294_967_295,
             frequency: 0,
-            power_consumption: 0.0,
+            power_consumption: GPU_METRIC_UNAVAILABLE,
             gpu_core_count: None,
             temperature_threshold_slowdown: None,
             temperature_threshold_shutdown: None,
@@ -876,11 +877,12 @@ mod tests {
         // utilization stays at its baseline and is not falsely
         // attributed to PDH.
         let mut gpu = blank_gpu();
-        gpu.utilization = 0.0;
         apply_to_gpu_info(&mut gpu, &metrics(Some(1_073_741_824), None, None));
         assert_eq!(gpu.total_memory, 1_073_741_824);
-        assert_eq!(gpu.utilization, 0.0);
+        assert_eq!(gpu.utilization_reading(), None);
+        assert_eq!(gpu.power_consumption_reading(), None);
         assert_eq!(gpu.detail["Source: Utilization"], "unavailable");
+        assert_eq!(gpu.detail["Source: Power"], "unavailable");
         assert_eq!(gpu.detail["Metrics Source"], "WMI + DXGI");
     }
 

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -882,6 +882,24 @@ mod tests {
         assert!(!rendered.contains("0.0W"), "ANE gauge shows 0W: {rendered}");
     }
 
+    /// Issue #378: Windows readers use the same sentinel contract, so an
+    /// unsourced utilization or power field must render as N/A as well.
+    #[test]
+    fn unsourced_windows_fields_render_as_na_not_zero() {
+        let mut gpu = make_gpu(45);
+        gpu.name = "AMD Radeon Graphics".to_string();
+        gpu.utilization = crate::device::types::GPU_METRIC_UNAVAILABLE;
+        gpu.power_consumption = crate::device::types::GPU_METRIC_UNAVAILABLE;
+        gpu.frequency = 338;
+
+        let rendered = render_row(&gpu);
+
+        assert!(rendered.contains("Util:   N/A"), "{rendered}");
+        assert!(rendered.contains("Pwr:     N/A"), "{rendered}");
+        assert!(!rendered.contains("Util:  0.0%"), "{rendered}");
+        assert!(!rendered.contains("Pwr:      0W"), "{rendered}");
+    }
+
     /// The complement: a genuine zero reading renders as a zero, so N/A
     /// unambiguously means "no data" on screen too.
     #[test]


### PR DESCRIPTION
## Summary

Windows WMI does not supply GPU utilization or power, but the Intel and AMD readers initialized both fields to `0.0`. This changes their baselines to the existing `GPU_METRIC_UNAVAILABLE` sentinel so consumers can distinguish an unsourced metric from a real idle reading.

## What changed

- Initialize Intel and AMD Windows utilization and power fields with `GPU_METRIC_UNAVAILABLE`, while documenting why ANE, temperature, and frequency keep their established zero semantics.
- Preserve PDH, ADL, and Level Zero precedence so any sourced value, including a genuine zero, overwrites the sentinel and updates provenance normally.
- Update Linux-reachable Windows PDH and AMD ADL fixtures to assert unsourced accessors/provenance and sourced overwrite behavior.
- Add focused Prometheus and TUI regressions showing that an unsourced Windows field is omitted from exposition and rendered as `N/A` instead of zero.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --lib device::readers::windows_gpu_perf` (47 passed)
- [x] `cargo test --lib device::readers::amd_adl` (65 passed)
- [x] `cargo test --lib unsourced_windows` (2 passed)
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`

The repository's broader and native-Windows validation remains with CI and the auto-implementation orchestrator; this worker intentionally used narrow checks to avoid duplicate long-running suites.

Closes #378
