### PR TITLE
fix: keep Level Zero memory provenance in sync

### DIFF
--- a/src/device/readers/intel_gpu_level_zero/apply.rs
+++ b/src/device/readers/intel_gpu_level_zero/apply.rs
@@ -59,6 +59,7 @@ pub fn apply_to_gpu_info(
                 gpu_info.total_memory = memory.total_bytes;
                 gpu_info.used_memory = memory.used_bytes.min(memory.total_bytes);
                 set_source(gpu_info, "Memory", memory.source);
+                set_source(gpu_info, "Memory Used", memory.source);
                 gpu_info.detail.insert(
                     "VRAM Total".to_string(),
                     format!("{} bytes", memory.total_bytes),

--- a/src/device/readers/intel_gpu_level_zero/tests/apply.rs
+++ b/src/device/readers/intel_gpu_level_zero/tests/apply.rs
@@ -94,6 +94,10 @@ fn linux_fresh_sysman_overwrites_fields() {
     assert_eq!(gpu.used_memory, 4 * 1024 * 1024 * 1024);
     assert_eq!(gpu.total_memory, 12 * 1024 * 1024 * 1024);
     assert_eq!(
+        gpu.detail.get("Source: Memory Used").map(String::as_str),
+        Some("Level Zero Sysman")
+    );
+    assert_eq!(
         gpu.detail.get("Power (L0)").map(String::as_str),
         Some("120.50 W")
     );
@@ -325,11 +329,16 @@ fn no_data_keeps_baseline() {
 fn integrated_after_dxgi() -> GpuInfo {
     let mut gpu = make_baseline_gpu_info();
     gpu.name = "Intel(R) Arc(TM) B390 GPU".to_string();
+    gpu.used_memory = 6 * 1024 * 1024 * 1024;
     gpu.total_memory = 19_202_415_943;
     gpu.detail
         .insert("Metrics Source".to_string(), "WMI".to_string());
     gpu.detail
         .insert("Source: Memory".to_string(), "DXGI (shared)".to_string());
+    gpu.detail.insert(
+        "Source: Memory Used".to_string(),
+        "PDH (shared)".to_string(),
+    );
     crate::device::readers::detail_keys::note_metrics_source(&mut gpu.detail, "DXGI");
     crate::device::readers::detail_keys::note_metrics_source(&mut gpu.detail, "PDH");
     gpu
@@ -354,9 +363,14 @@ fn a_dedicated_carve_out_never_replaces_a_shared_aperture() {
     apply_to_gpu_info(&mut gpu, &readout, ApplyPlatform::Windows);
 
     assert_eq!(gpu.total_memory, 19_202_415_943);
+    assert_eq!(gpu.used_memory, 6 * 1024 * 1024 * 1024);
     assert_eq!(
         gpu.detail.get("Source: Memory").map(String::as_str),
         Some("DXGI (shared)")
+    );
+    assert_eq!(
+        gpu.detail.get("Source: Memory Used").map(String::as_str),
+        Some("PDH (shared)")
     );
     // Not discarded: the carve-out is real, it is just not the capacity.
     assert_eq!(
@@ -375,6 +389,8 @@ fn a_discrete_card_still_takes_its_sysman_total() {
     let mut gpu = make_baseline_gpu_info();
     gpu.detail
         .insert("Source: Memory".to_string(), "WMI".to_string());
+    gpu.detail
+        .insert("Source: Memory Used".to_string(), "PDH".to_string());
     let readout = LevelZeroReadout {
         memory: Some(LevelZeroMemoryReadout {
             used_bytes: 2 * 1024 * 1024 * 1024,
@@ -390,6 +406,10 @@ fn a_discrete_card_still_takes_its_sysman_total() {
     assert_eq!(gpu.used_memory, 2 * 1024 * 1024 * 1024);
     assert_eq!(
         gpu.detail.get("Source: Memory").map(String::as_str),
+        Some("Level Zero Sysman")
+    );
+    assert_eq!(
+        gpu.detail.get("Source: Memory Used").map(String::as_str),
         Some("Level Zero Sysman")
     );
 }


### PR DESCRIPTION
## Summary

Re-read the Level Zero apply layer against the Linux sysfs and Windows WMI/DXGI/PDH precedence contracts. The two archived defects were already fixed by #365: a Sysman dedicated carve-out no longer replaces a Windows shared aperture, and `Metrics Source` appends layers instead of erasing them. The fresh audit found one remaining provenance defect: when a dedicated Sysman sample replaced `used_memory`, `Source: Memory Used` still claimed the older PDH source.

## What changed

- Record `Level Zero Sysman` as the used-memory source whenever a fresh dedicated/local Sysman sample wins.
- Extend focused tests to prove Linux and discrete Windows samples update the used-memory provenance together with the value.
- Extend the integrated Windows regression shape to prove a DXGI shared aperture preserves both the PDH shared-usage value and its source when the Sysman dedicated pool is only a stolen-memory carve-out.

## Review findings

- Correctness: the source label now follows the exact overwrite branch that changes `used_memory`, while the shared-aperture branch remains untouched.
- Security: no input handling, unsafe code, FFI calls, or trust boundaries changed.
- Performance: the winning dedicated-memory path performs one additional detail-map update per refresh; no polling, allocation topology, or hardware query behavior changed.
- Finalization: focused regression coverage, formatting, compilation, and lint checks pass; no documentation change is needed for this correction to an existing detail-key contract.

## Test plan

- [x] `cargo test --lib device::readers::intel_gpu_level_zero::tests::apply::`
- [x] `cargo fmt --check`
- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings`

Closes #377
