### PR TITLE
fix: load the AMD backend at runtime (#359)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,22 +1036,44 @@ jobs:
       - name: Build binary
         run: cargo build --release --bin all-smi
 
+      - name: Build AMD runtime plugin
+        run: cargo build --release --locked -p all-smi-amd-plugin
+
       - name: Build library-only (no default features)
         run: cargo build --no-default-features --lib
 
-      # Guards issue #345: with the `amd` feature off, `libamdgpu_top` must
-      # not be linked, so the binary must not carry libdrm as a NEEDED entry.
-      # `--no-default-features` also drops `cli` and therefore the binary, so
-      # the comparable artifact is built with `cli` re-enabled. This step
-      # overwrites target/release/all-smi from the step above; nothing later
-      # in this job consumes that artifact.
-      - name: Verify the AMD backend is droppable (no libdrm linkage)
+      # Guards issues #345 and #359: both feature configurations keep libdrm
+      # out of the main binary, while the companion owns that linkage and can
+      # be loaded through the versioned ABI. `--no-default-features` drops the
+      # CLI, so the downstream-like binary build explicitly re-enables it.
+      - name: Verify AMD runtime linkage and plugin contract
         run: |
+          set -euo pipefail
+          if objdump -p target/release/all-smi | grep -q 'NEEDED.*libdrm'; then
+            echo "::error::the default-feature binary inherits libdrm"
+            exit 1
+          fi
+          if ! objdump -p target/release/liball_smi_amd.so | grep -q 'NEEDED.*libdrm_amdgpu'; then
+            echo "::error::the AMD companion does not own libdrm_amdgpu linkage"
+            exit 1
+          fi
+
           cargo build --release --no-default-features --features cli --bin all-smi
-          echo "NEEDED entries without the amd feature:"
+          echo "NEEDED entries for a downstream-like feature configuration:"
           objdump -p target/release/all-smi | grep NEEDED || true
           if objdump -p target/release/all-smi | grep -q 'NEEDED.*libdrm'; then
-            echo "::error::libdrm is still linked with --no-default-features --features cli"
+            echo "::error::the downstream-like binary inherits libdrm"
+            exit 1
+          fi
+
+          report="${RUNNER_TEMP}/amd-plugin-doctor.json"
+          ALL_SMI_AMD_PLUGIN="$PWD/target/release/liball_smi_amd.so" \
+            target/release/all-smi doctor --only amd --json > "$report"
+          cat "$report"
+          status=$(jq -r '.checks[] | select(.id=="amd.libamdgpu_top.abi") | .status' "$report")
+          message=$(jq -r '.checks[] | select(.id=="amd.libamdgpu_top.abi") | .message' "$report")
+          if [ "$status" != pass ] || [[ "$message" != *"ABI v1"* ]]; then
+            echo "::error::doctor did not verify the AMD plugin ABI: status=$status message=$message"
             exit 1
           fi
 

--- a/.github/workflows/debian_build.yml
+++ b/.github/workflows/debian_build.yml
@@ -133,9 +133,20 @@ jobs:
           echo "Error: Binary not found after extraction"
           exit 1
         fi
+        if git cat-file -e "${{ steps.get_tag.outputs.tag }}:crates/all-smi-amd-plugin/Cargo.toml" 2>/dev/null; then
+          if [ ! -f "liball_smi_amd.so" ]; then
+            echo "Error: AMD runtime plugin not found after extraction"
+            exit 1
+          fi
+        elif [ ! -f "liball_smi_amd.so" ]; then
+          echo "The selected release predates the AMD runtime plugin; packaging the legacy binary only."
+        fi
         
-        # Make it executable
+        # Make the executable and loadable companion executable by the package.
         chmod +x all-smi
+        if [ -f "liball_smi_amd.so" ]; then
+          chmod +x liball_smi_amd.so
+        fi
       env:
         GH_TOKEN: ${{ github.token }}
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,34 @@ jobs:
 
       # 7) Build the release binary
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} --locked
+        run: cargo build --release --target ${{ matrix.target }} --locked -p all-smi
+
+      - name: Build and verify AMD runtime plugin (Linux glibc only)
+        if: runner.os == 'Linux' && !contains(matrix.target, 'musl')
+        run: |
+          set -euo pipefail
+          echo "AMD_PLUGIN_BUILT=false" >> "$GITHUB_ENV"
+          if [ ! -f crates/all-smi-amd-plugin/Cargo.toml ]; then
+            echo "::notice::The selected source tag predates the AMD companion crate; preserving the self-healing old-tag release path."
+            exit 0
+          fi
+          cargo build --release --target ${{ matrix.target }} --locked -p all-smi-amd-plugin
+          BIN="target/${{ matrix.target }}/release/${{ matrix.artifact_name }}"
+          PLUGIN="target/${{ matrix.target }}/release/liball_smi_amd.so"
+          test -f "$PLUGIN"
+          if objdump -p "$BIN" | grep -q 'NEEDED.*libdrm'; then
+            echo "::error::$BIN inherits libdrm even though AMD is runtime-loaded"
+            exit 1
+          fi
+          if ! objdump -p "$PLUGIN" | grep -q 'NEEDED.*libdrm_amdgpu'; then
+            echo "::error::$PLUGIN does not own the expected libdrm_amdgpu linkage"
+            exit 1
+          fi
+          report="${RUNNER_TEMP}/amd-plugin-doctor.json"
+          ALL_SMI_AMD_PLUGIN="$PWD/$PLUGIN" "$BIN" doctor --only amd --json > "$report"
+          cat "$report"
+          test "$(jq -r '.checks[] | select(.id=="amd.libamdgpu_top.abi") | .status' "$report")" = pass
+          echo "AMD_PLUGIN_BUILT=true" >> "$GITHUB_ENV"
 
       # 8) macOS code signing
       #
@@ -421,9 +448,13 @@ jobs:
       - name: Package Linux binary (tar.gz)
         if: runner.os == 'Linux'
         run: |
+          set -euo pipefail
           BIN_DIR=target/${{ matrix.target }}/release
           mkdir -p package
           cp "$BIN_DIR/${{ matrix.artifact_name }}" package/
+          if [ "${AMD_PLUGIN_BUILT:-false}" = true ]; then
+            cp "$BIN_DIR/liball_smi_amd.so" package/
+          fi
           cp docs/man/all-smi.1 package/
           tar -C package -czf ${{ matrix.asset_name }}.tar.gz .
 

--- a/.github/workflows/update_homebrew_formula.yml
+++ b/.github/workflows/update_homebrew_formula.yml
@@ -306,6 +306,18 @@ jobs:
           fetch linux_arm "${BASE}/all-smi-linux-aarch64.tar.gz" "${ARTIFACT_DIR}/linux-arm.tar.gz"
           fetch linux_x86 "${BASE}/all-smi-linux-x86_64.tar.gz"  "${ARTIFACT_DIR}/linux-x86.tar.gz"
 
+          tar -tzf "${ARTIFACT_DIR}/linux-arm.tar.gz" > "${ARTIFACT_DIR}/linux-arm.contents"
+          tar -tzf "${ARTIFACT_DIR}/linux-x86.tar.gz" > "${ARTIFACT_DIR}/linux-x86.contents"
+          arm_plugin=false
+          x86_plugin=false
+          grep -Eq '(^|/)liball_smi_amd\.so$' "${ARTIFACT_DIR}/linux-arm.contents" && arm_plugin=true
+          grep -Eq '(^|/)liball_smi_amd\.so$' "${ARTIFACT_DIR}/linux-x86.contents" && x86_plugin=true
+          if [ "$arm_plugin" != "$x86_plugin" ]; then
+            echo "::error::Linux release archives disagree about AMD plugin presence: arm=${arm_plugin}, x86=${x86_plugin}."
+            exit 1
+          fi
+          echo "amd_plugin_present=${arm_plugin}" >> "$GITHUB_ENV"
+
           # The Intel Mac zip only exists from the release that first built
           # x86_64-apple-darwin onwards (#306), so its absence is a normal state
           # for older tags rather than an error, and re-running this workflow
@@ -433,10 +445,42 @@ jobs:
             mv "${file}.new" "$file"
           }
 
+          sync_amd_plugin_install() {  # file present
+            local file="$1" n
+            n=$(grep -cF '(lib/"all-smi").install "liball_smi_amd.so" if OS.linux?' "$file" || true)
+            if [ "$n" -gt 1 ]; then
+              echo "::error::${file}: AMD plugin install line appears ${n} times."
+              exit 1
+            fi
+            if [ "$2" != "true" ]; then
+              if [ "$n" -eq 1 ]; then
+                gsed -i '\|(lib/"all-smi").install "liball_smi_amd.so" if OS.linux?|d' "$file"
+              fi
+              return
+            fi
+            if [ "$n" -eq 1 ]; then
+              return
+            fi
+            awk '
+              { print }
+              !inserted && /^[[:space:]]*bin\.install "all-smi"$/ {
+                print "    (lib/\"all-smi\").install \"liball_smi_amd.so\" if OS.linux?"
+                inserted = 1
+              }
+              END { exit(inserted ? 0 : 1) }
+            ' "$file" > "${file}.new" || {
+              echo "::error::${file}: could not locate bin.install \"all-smi\" to add the AMD plugin."
+              rm -f "${file}.new"
+              exit 1
+            }
+            mv "${file}.new" "$file"
+          }
+
           set_version  Formula/all-smi.rb "$VERSION"
           set_artifact Formula/all-smi.rb all-smi-macos-aarch64.zip    "$mac_url"       "$mac_sha"
           set_artifact Formula/all-smi.rb all-smi-linux-aarch64.tar.gz "$linux_arm_url" "$linux_arm_sha"
           set_artifact Formula/all-smi.rb all-smi-linux-x86_64.tar.gz  "$linux_x86_url" "$linux_x86_sha"
+          sync_amd_plugin_install Formula/all-smi.rb "${amd_plugin_present:-false}"
 
           # The Intel Mac artifact and the formula stanza that serves it arrive
           # independently: the asset appears in the first release built for
@@ -501,6 +545,16 @@ jobs:
 
           if ! grep -q "^[[:space:]]*version \"${VERSION}\"$" Formula/all-smi.rb; then
             echo "::error::Formula/all-smi.rb: version stanza is not ${VERSION}."
+            exit 1
+          fi
+
+          plugin_installs=$(grep -cF '(lib/"all-smi").install "liball_smi_amd.so" if OS.linux?' Formula/all-smi.rb || true)
+          expected_plugin_installs=0
+          if [ "${amd_plugin_present:-false}" = "true" ]; then
+            expected_plugin_installs=1
+          fi
+          if [ "$plugin_installs" -ne "$expected_plugin_installs" ]; then
+            echo "::error::Formula/all-smi.rb: expected ${expected_plugin_installs} Linux AMD plugin install line(s), found ${plugin_installs}."
             exit 1
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,6 @@ dependencies = [
  "futures-util",
  "hyper",
  "hyper-util",
- "libamdgpu_top",
  "libc",
  "libloading 0.9.0",
  "luwen-api",
@@ -108,6 +107,19 @@ dependencies = [
  "windows-service",
  "wmi",
  "zstd",
+]
+
+[[package]]
+name = "all-smi-amd-plugin"
+version = "0.26.1"
+dependencies = [
+ "all-smi",
+ "chrono",
+ "libamdgpu_top",
+ "libc",
+ "serde",
+ "serde_json",
+ "sysinfo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ categories = ["command-line-utilities"]
 edition = "2024"
 rust-version = "1.96"
 
+[workspace]
+members = [".", "crates/all-smi-amd-plugin"]
+resolver = "3"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -71,20 +75,6 @@ cgroups-rs = "0.5.0"
 # Dynamic library loading for tpu_pjrt
 libloading = "0.9"
 
-# AMD GPU support (glibc only, not compatible with musl static linking)
-[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
-# Pinned exactly: this crate has shipped semver-violating breaking changes in
-# patch releases (0.11.4 renamed get_all_proc_usage → update_proc_usage, #205).
-# 0.11.5 fixes a file-descriptor leak (#218). Re-evaluate the exact version on
-# each bump.
-#
-# Optional and gated behind the default-on `amd` feature (issue #345). It stays
-# a hard link, not a `dlopen`, because `libdrm_amdgpu_sys` links `libdrm.so.2`
-# and `libdrm_amdgpu.so.1` unconditionally, so every dependent inherits them as
-# `NEEDED` entries. Making the dep optional is what lets a downstream crate that
-# does not need AMD drop those entries; see the `amd` feature comment below.
-libamdgpu_top = { version = "=0.11.5", optional = true }
-
 # Windows-specific dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
 wmi = "0.18"
@@ -128,28 +118,12 @@ tonic-prost-build = "0.14"
 [features]
 default = ["cli", "amd"]
 cli = ["dep:clap", "dep:crossterm", "dep:axum", "dep:tower-http", "dep:anyhow", "dep:toml", "dep:dirs"]
-# AMD GPU backend via `libamdgpu_top`. Default ON, unlike `furiosa` and
-# `level_zero`, so every existing distribution path (the glibc release
-# binaries, `cargo install all-smi`, the Homebrew formula, a plain
-# `cargo build`) keeps AMD support with no packaging change.
-#
-# The reason it is a feature at all is that `libamdgpu_top` pulls in
-# `libdrm_amdgpu_sys`, which links `libdrm.so.2` and `libdrm_amdgpu.so.1`
-# unconditionally. Those become hard `NEEDED` entries on every binary that
-# depends on this crate, so a host with no AMD GPU (the common case) fails to
-# start with a loader error before `main` runs, and cannot degrade gracefully.
-# A downstream crate that declares `default-features = false` now stops
-# inheriting them. Note that `--no-default-features` also drops `cli`; a
-# consumer that wants the CLI but not AMD needs
-# `default-features = false, features = ["cli"]`.
-#
-# Disabling it compiles out `src/device/readers/amd.rs`, the `has_amd`
-# detector, and the AMD arm of `reader_factory`, which is the same shape the
-# musl release artifacts have always shipped. `all-smi doctor` reports the
-# feature-off state distinctly from the musl state via `amd.build.target_env`
-# and `amd.libamdgpu_top.abi`. Windows AMD support (`amd_adl` / WMI) is
-# unaffected: it never used `libamdgpu_top`.
-amd = ["dep:libamdgpu_top"]
+# Accepted no-op kept for downstream manifest compatibility. Linux AMD support
+# is now compiled into every glibc build as a runtime loader; the separately
+# built `all-smi-amd-plugin` owns `libamdgpu_top` and its libdrm linkage.
+# Consequently `default-features = false` no longer removes AMD detection from
+# the main crate, and neither feature state adds libdrm to a consumer binary.
+amd = []
 mock = ["cli", "dep:rand", "dep:hyper", "dep:hyper-util"]
 # Opt-in Furiosa NPU support. Surfaced by the `furiosa.*` doctor checks
 # (issue #188) and used by the Linux-target `furiosa-smi-rs` optional dep.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Download the latest release from the [GitHub releases page](https://github.com/l
 
 1. Go to https://github.com/lablup/all-smi/releases
 2. Download the appropriate binary for your platform
-3. Extract the archive and place the binary in your `$PATH`
+3. Extract the archive and place the binary in your `$PATH`. On glibc Linux, keep `liball_smi_amd.so` beside the binary or install it under `/usr/local/lib/all-smi`; the companion provides AMD monitoring without making the main binary depend on libdrm.
 
 > Release binaries are signed: macOS archives are notarized (so Gatekeeper does not block them as coming from an unidentified developer) and Windows binaries are Authenticode code-signed.
 
@@ -94,6 +94,8 @@ sudo dnf install pkg-config openssl-devel protobuf-compiler protobuf-devel
 ```
 
 After installation, the binary will be available in your `$PATH` as `all-smi`.
+
+`cargo install` installs Cargo binary targets only, so it does not install the Linux AMD companion library. The resulting binary still starts on every host and `all-smi doctor --only amd` reports the plugin as unavailable; use the release archive, Homebrew, PPA/Debian package, or the source-build instructions below when Linux AMD monitoring is required.
 
 ### Option 6: Build from Source
 
@@ -762,6 +764,8 @@ Stable check IDs (greppable across versions):
 - **Linux:**
   - NVIDIA GPUs via NVML and nvidia-smi (fallback)
   - AMD GPUs (Radeon and Instinct) via ROCm and libamdgpu_top library
+    - `libamdgpu_top` lives in the runtime-loaded `liball_smi_amd.so` companion, so the main binary and downstream Rust consumers carry no hard libdrm dependency
+    - Missing companion/native libraries degrade to no AMD reader and are diagnosed by `all-smi doctor --only amd`; they never prevent process startup
     - Real-time VRAM and GTT memory monitoring
     - GPU process detection with memory usage tracking
     - Temperature, power consumption, frequency, and fan speed metrics

--- a/crates/all-smi-amd-plugin/Cargo.toml
+++ b/crates/all-smi-amd-plugin/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "all-smi-amd-plugin"
+version = "0.26.1"
+description = "Runtime-loaded Linux AMD GPU backend for all-smi"
+authors = ["Jeongkyu Shin <inureyes@gmail.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/lablup/all-smi"
+edition = "2024"
+rust-version = "1.96"
+publish = false
+
+[lib]
+name = "all_smi_amd"
+crate-type = ["cdylib"]
+
+[dependencies]
+all-smi = { path = "../..", default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sysinfo = "0.39"
+
+[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
+chrono = "0.4.44"
+libc = "0.2"
+# Keep this exact pin synchronized with the plugin metadata and the guard test
+# in src/lib.rs. Upstream has shipped patch-level API breaks in the past.
+libamdgpu_top = "=0.11.5"

--- a/crates/all-smi-amd-plugin/src/lib.rs
+++ b/crates/all-smi-amd-plugin/src/lib.rs
@@ -1,0 +1,173 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(all(target_os = "linux", not(target_env = "musl")))]
+
+mod reader;
+
+use std::ffi::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use all_smi::device::GpuReader;
+use all_smi::device::readers::amd_plugin_api::{
+    AMD_PLUGIN_ABI_VERSION, AMD_PLUGIN_WIRE_FORMAT, AmdPluginApiV1, AmdPluginBuffer,
+};
+use serde::Serialize;
+
+use reader::AmdGpuReader;
+
+const LIBAMDGPU_TOP_VERSION: &str = "0.11.5";
+const STATUS_OK: i32 = 0;
+const STATUS_INVALID_ARGUMENT: i32 = -1;
+const STATUS_FAILED: i32 = -2;
+
+#[derive(Serialize)]
+struct PluginMetadata<'a> {
+    plugin_version: &'a str,
+    libamdgpu_top_version: &'a str,
+    wire_format: &'a str,
+}
+
+fn write_json<T: Serialize>(value: &T, out: *mut AmdPluginBuffer) -> i32 {
+    if out.is_null() {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    let Ok(mut bytes) = serde_json::to_vec(value) else {
+        return STATUS_FAILED;
+    };
+    let buffer = AmdPluginBuffer {
+        ptr: bytes.as_mut_ptr(),
+        len: bytes.len(),
+        capacity: bytes.capacity(),
+    };
+    std::mem::forget(bytes);
+    // SAFETY: `out` was checked for null and points to host-provided storage
+    // matching the versioned ABI table that exposed this function.
+    unsafe { out.write(buffer) };
+    STATUS_OK
+}
+
+extern "C" fn create_reader() -> *mut c_void {
+    catch_unwind(AssertUnwindSafe(|| {
+        Box::into_raw(Box::new(AmdGpuReader::new())).cast::<c_void>()
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+extern "C" fn destroy_reader(handle: *mut c_void) {
+    if handle.is_null() {
+        return;
+    }
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: the host obtained this handle from `create_reader` and the
+        // ABI contract requires exactly one matching destroy call.
+        unsafe { drop(Box::from_raw(handle.cast::<AmdGpuReader>())) };
+    }));
+}
+
+fn read_with(
+    handle: *mut c_void,
+    out: *mut AmdPluginBuffer,
+    collect: impl FnOnce(&AmdGpuReader, *mut AmdPluginBuffer) -> i32,
+) -> i32 {
+    if handle.is_null() || out.is_null() {
+        return STATUS_INVALID_ARGUMENT;
+    }
+    catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: the handle was created by this plugin and remains owned by
+        // the host for the duration of the call.
+        let reader = unsafe { &*handle.cast::<AmdGpuReader>() };
+        collect(reader, out)
+    }))
+    .unwrap_or(STATUS_FAILED)
+}
+
+extern "C" fn read_gpu_info_json(handle: *mut c_void, out: *mut AmdPluginBuffer) -> i32 {
+    read_with(handle, out, |reader, out| {
+        write_json(&reader.get_gpu_info(), out)
+    })
+}
+
+extern "C" fn read_process_info_json(handle: *mut c_void, out: *mut AmdPluginBuffer) -> i32 {
+    read_with(handle, out, |reader, out| {
+        write_json(&reader.get_process_info(), out)
+    })
+}
+
+extern "C" fn read_metadata_json(out: *mut AmdPluginBuffer) -> i32 {
+    let metadata = PluginMetadata {
+        plugin_version: env!("CARGO_PKG_VERSION"),
+        libamdgpu_top_version: LIBAMDGPU_TOP_VERSION,
+        wire_format: AMD_PLUGIN_WIRE_FORMAT,
+    };
+    write_json(&metadata, out)
+}
+
+extern "C" fn free_buffer(buffer: *mut AmdPluginBuffer) {
+    if buffer.is_null() {
+        return;
+    }
+    // SAFETY: the pointer was checked above and the ABI gives this function
+    // exclusive access to the descriptor for the duration of the call.
+    let buffer = unsafe { &mut *buffer };
+    if !buffer.ptr.is_null() && buffer.len <= buffer.capacity {
+        // SAFETY: `write_json` created this allocation from a Vec with exactly
+        // these pointer, length, and capacity values, then forgot it.
+        unsafe { drop(Vec::from_raw_parts(buffer.ptr, buffer.len, buffer.capacity)) };
+    }
+    *buffer = AmdPluginBuffer::default();
+}
+
+static API_V1: AmdPluginApiV1 = AmdPluginApiV1 {
+    abi_version: AMD_PLUGIN_ABI_VERSION,
+    struct_size: std::mem::size_of::<AmdPluginApiV1>(),
+    create_reader: Some(create_reader),
+    destroy_reader: Some(destroy_reader),
+    read_gpu_info_json: Some(read_gpu_info_json),
+    read_process_info_json: Some(read_process_info_json),
+    read_metadata_json: Some(read_metadata_json),
+    free_buffer: Some(free_buffer),
+};
+
+/// Return the immutable v1 function table.
+///
+/// A loader must validate both `abi_version` and `struct_size` before calling
+/// any pointer in the table.
+#[unsafe(no_mangle)]
+pub extern "C" fn all_smi_amd_plugin_entry_v1() -> *const AmdPluginApiV1 {
+    &raw const API_V1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LIBAMDGPU_TOP_VERSION, PluginMetadata};
+
+    const MANIFEST: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
+
+    #[test]
+    fn metadata_matches_exact_dependency_pin() {
+        let expected = format!("libamdgpu_top = \"={LIBAMDGPU_TOP_VERSION}\"");
+        assert!(
+            MANIFEST.lines().any(|line| line.trim() == expected),
+            "plugin metadata reports libamdgpu_top {LIBAMDGPU_TOP_VERSION}, but Cargo.toml has no matching exact pin"
+        );
+        let metadata = PluginMetadata {
+            plugin_version: env!("CARGO_PKG_VERSION"),
+            libamdgpu_top_version: LIBAMDGPU_TOP_VERSION,
+            wire_format: all_smi::device::readers::amd_plugin_api::AMD_PLUGIN_WIRE_FORMAT,
+        };
+        let json = serde_json::to_string(&metadata).expect("metadata serializes");
+        assert!(json.contains(LIBAMDGPU_TOP_VERSION));
+    }
+}

--- a/crates/all-smi-amd-plugin/src/reader.rs
+++ b/crates/all-smi-amd-plugin/src/reader.rs
@@ -1,0 +1,335 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use all_smi::device::GpuReader;
+use all_smi::device::readers::common_cache::{DetailBuilder, DeviceStaticInfo};
+use all_smi::device::types::{GpuInfo, MAX_GPU_FAN_RPM, ProcessInfo};
+use all_smi::utils::get_hostname;
+use chrono::Local;
+use libamdgpu_top::AMDGPU::{DeviceHandle, GPU_INFO, GpuMetrics, MetricsInfo};
+use libamdgpu_top::stat::{self, FdInfoStat, ProcInfo};
+use libamdgpu_top::{AppDeviceInfo, DevicePath, VramUsage};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+// GPU metric validation constants
+const MAX_GPU_UTILIZATION: f64 = 100.0; // Maximum utilization percentage
+const MAX_GPU_POWER_WATTS: f64 = 1000.0; // Maximum power consumption in watts
+const MAX_GPU_TEMP_CELSIUS: u32 = 125; // Maximum temperature in Celsius
+const MAX_GPU_FREQ_MHZ: u32 = 5000; // Maximum frequency in MHz
+const MAX_GPU_MEMORY_BYTES: u64 = 512 * 1024 * 1024 * 1024; // 512GB max memory
+
+// Driver version validation constant
+// Linux kernel versions typically don't exceed 999 for any component
+const MAX_VERSION_COMPONENT: i32 = 999;
+
+/// Cap a raw `sensors.fan_rpm` reading so a garbled `libamdgpu_top` sample
+/// can never propagate `u32::MAX` into `GpuInfo::fan_speed_rpm` or the `Fan
+/// Speed` detail string. Mirrors the same defence applied to temperature,
+/// frequency, power, and memory a few lines below, and shares its bound
+/// with the Windows ADL, Intel sysfs, and Intel Level Zero fan readings via
+/// [`all_smi::device::types::MAX_GPU_FAN_RPM`].
+fn clamp_fan_rpm(rpm: Option<u32>) -> Option<u32> {
+    rpm.map(|value| value.min(MAX_GPU_FAN_RPM))
+}
+
+/// Per-device state that needs to be cached
+///
+/// # Thread Safety
+///
+/// The `vram_usage` field is protected by a `Mutex` to ensure thread-safe access
+/// across multiple concurrent readers. The VramUsage struct from libamdgpu_top
+/// maintains internal state that must be updated atomically.
+///
+/// ## Synchronization Guarantees
+/// - All reads and writes to `vram_usage` are serialized through the mutex
+/// - The mutex ensures memory ordering: all writes before unlock are visible after lock
+/// - No data races can occur as long as all access goes through the mutex
+///
+/// ## Mutex Poisoning Recovery
+/// If a thread panics while holding the mutex lock, the mutex becomes "poisoned"
+/// to prevent other threads from observing potentially inconsistent state.
+/// We handle this by:
+/// 1. Detecting the poisoned state
+/// 2. Attempting to recover with fresh data from the driver
+/// 3. Using `catch_unwind` to handle potential panics during recovery
+/// 4. Skipping the device if recovery fails to maintain system stability
+///
+/// ## Performance Considerations
+/// - Mutex contention is minimal as updates are quick (microseconds)
+/// - Each device has its own mutex, preventing global bottlenecks
+/// - The lock is held only during the VramUsage update operations
+struct AmdGpuDevice {
+    device_path: DevicePath,
+    device_handle: DeviceHandle,
+    vram_usage: Mutex<VramUsage>, // Protected by mutex for thread-safe updates
+    static_info: OnceLock<DeviceStaticInfo>, // Cached static device information
+}
+
+pub struct AmdGpuReader {
+    devices: Vec<AmdGpuDevice>,
+    /// Cached ROCm version (fetched only once, shared across all devices)
+    rocm_version: OnceLock<Option<String>>,
+}
+
+impl Default for AmdGpuReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AmdGpuReader {
+    pub fn new() -> Self {
+        // Check if we have permission to access AMD GPU devices
+        // This prevents panic from libamdgpu_top when running without sudo
+        // If no permission, silently return empty device list
+        // The main program will handle showing sudo message before TUI starts
+        if !Self::check_amd_gpu_permissions() {
+            return Self {
+                devices: Vec::new(),
+                rocm_version: OnceLock::new(),
+            };
+        }
+
+        let device_path_list = DevicePath::get_device_path_list();
+        let mut devices = Vec::new();
+
+        // Add device count validation to prevent unbounded growth
+        const MAX_DEVICES: usize = 256;
+        let device_paths_to_process: Vec<_> =
+            device_path_list.into_iter().take(MAX_DEVICES).collect();
+
+        for device_path in device_paths_to_process {
+            match device_path.init() {
+                Ok(amdgpu_dev) => {
+                    // Get initial memory_info to create VramUsage
+                    match amdgpu_dev.memory_info() {
+                        Ok(memory_info) => {
+                            let vram_usage = VramUsage::new(&memory_info);
+                            devices.push(AmdGpuDevice {
+                                device_path: device_path.clone(),
+                                device_handle: amdgpu_dev,
+                                vram_usage: Mutex::new(vram_usage),
+                                static_info: OnceLock::new(),
+                            });
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "Warning: Failed to get memory info for AMD GPU {}: {e}",
+                                device_path.pci
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: Failed to initialize AMD GPU {}: {e}",
+                        device_path.pci
+                    );
+                }
+            }
+        }
+
+        Self {
+            devices,
+            rocm_version: OnceLock::new(),
+        }
+    }
+
+    /// Get cached ROCm version, initializing if needed
+    fn get_rocm_version(&self) -> Option<String> {
+        self.rocm_version
+            .get_or_init(libamdgpu_top::get_rocm_version)
+            .clone()
+    }
+
+    /// Get cached static device info for a device, initializing if needed
+    fn get_device_static_info<'a>(&self, device: &'a AmdGpuDevice) -> &'a DeviceStaticInfo {
+        device
+            .static_info
+            .get_or_init(|| {
+                // Fetch static device information once
+                let ext_info = device.device_handle.device_info().ok();
+                let memory_info = device.device_handle.memory_info().ok();
+
+                let (device_name, mut detail) = if let (Some(ext), Some(mem)) =
+                    (ext_info.as_ref(), memory_info.as_ref())
+                {
+                    let sensors = libamdgpu_top::stat::Sensors::new(
+                        &device.device_handle,
+                        &device.device_path.pci,
+                        ext,
+                    );
+
+                    let app_device_info = AppDeviceInfo::new(
+                        &device.device_handle,
+                        ext,
+                        mem,
+                        &sensors,
+                        &device.device_path,
+                    );
+
+                    let mut builder = DetailBuilder::new()
+                        .insert("Device Name", &app_device_info.marketing_name)
+                        .insert("PCI Bus", app_device_info.pci_bus.to_string());
+
+                    // Add ROCm version
+                    if let Some(ref ver) = self.get_rocm_version() {
+                        builder = builder
+                            .insert("ROCm Version", ver)
+                            .insert("lib_name", "ROCm")
+                            .insert("lib_version", ver);
+                    }
+
+                    let mut detail = builder.build();
+
+                    // Add device details
+                    detail.insert(
+                        "Device ID".to_string(),
+                        format!("{:#06x}", ext.device_id()),
+                    );
+                    detail.insert(
+                        "Revision ID".to_string(),
+                        format!("{:#04x}", ext.pci_rev_id()),
+                    );
+                    detail.insert(
+                        "ASIC Name".to_string(),
+                        app_device_info.asic_name.to_string(),
+                    );
+
+                    if let Some(ref vbios) = app_device_info.vbios {
+                        detail.insert("VBIOS Version".to_string(), vbios.ver.clone());
+                        detail.insert("VBIOS Date".to_string(), vbios.date.clone());
+                    }
+
+                    if let Some(ref cap) = app_device_info.power_cap {
+                        detail.insert("Power Cap".to_string(), format!("{} W", cap.current));
+                        detail.insert("Power Cap (Min)".to_string(), format!("{} W", cap.min));
+                        detail.insert("Power Cap (Max)".to_string(), format!("{} W", cap.max));
+                    }
+
+                    if let Some(link) = app_device_info.max_gpu_link {
+                        detail.insert(
+                            "Max GPU Link".to_string(),
+                            format!("Gen{} x{}", link.r#gen, link.width),
+                        );
+                    }
+
+                    if let Some(link) = app_device_info.max_system_link {
+                        detail.insert(
+                            "Max System Link".to_string(),
+                            format!("Gen{} x{}", link.r#gen, link.width),
+                        );
+                    }
+
+                    if let Some(min_dpm_link) = app_device_info.min_dpm_link {
+                        detail.insert(
+                            "Min DPM Link".to_string(),
+                            format!("Gen{} x{}", min_dpm_link.r#gen, min_dpm_link.width),
+                        );
+                    }
+
+                    if let Some(max_dpm_link) = app_device_info.max_dpm_link {
+                        detail.insert(
+                            "Max DPM Link".to_string(),
+                            format!("Gen{} x{}", max_dpm_link.r#gen, max_dpm_link.width),
+                        );
+                    }
+
+                    (app_device_info.marketing_name, detail)
+                } else {
+                    (String::from("Unknown GPU"), HashMap::new())
+                };
+
+                // Get driver version
+                match device.device_handle.get_drm_version_struct() {
+                    Ok(drm) => {
+                        if drm.version_major >= 0
+                            && drm.version_major <= MAX_VERSION_COMPONENT
+                            && drm.version_minor >= 0
+                            && drm.version_minor <= MAX_VERSION_COMPONENT
+                            && drm.version_patchlevel >= 0
+                            && drm.version_patchlevel <= MAX_VERSION_COMPONENT
+                        {
+                            let ver = format!(
+                                "{}.{}.{}",
+                                drm.version_major, drm.version_minor, drm.version_patchlevel
+                            );
+                            detail.insert("Driver Version".to_string(), ver);
+                        } else {
+                            eprintln!(
+                                "Warning: Invalid driver version components detected: {}.{}.{} for device {}",
+                                drm.version_major, drm.version_minor, drm.version_patchlevel,
+                                device.device_path.pci
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: Failed to get driver version for device {}: {e}",
+                            device.device_path.pci
+                        );
+                    }
+                };
+
+                DeviceStaticInfo::with_details(device_name, None, detail)
+            })
+    }
+
+    /// Check if we have permission to access AMD GPU devices
+    /// Returns false if /dev/dri devices are not accessible
+    fn check_amd_gpu_permissions() -> bool {
+        use std::fs;
+
+        // Check if /dev/dri directory exists and is accessible
+        let dri_path = std::path::Path::new("/dev/dri");
+        if !dri_path.exists() {
+            return false;
+        }
+
+        // Try to read the directory to check permissions
+        match fs::read_dir(dri_path) {
+            Ok(entries) => {
+                // Check if we can read at least one render or card device
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+                    // Check card or render devices
+                    if file_name.starts_with("card") || file_name.starts_with("render") {
+                        // Check if we have read/write permissions
+                        // For root: always has access
+                        // SAFETY: libc::geteuid() is always safe to call - it's a simple
+                        // system call that reads the effective user ID from the kernel.
+                        // It cannot fail and doesn't access any memory we provide.
+                        if unsafe { libc::geteuid() } == 0 {
+                            return true; // Root always has access
+                        }
+
+                        // For non-root, check if we can actually open the device
+                        if let Ok(_file) = fs::OpenOptions::new().read(true).write(true).open(&path)
+                        {
+                            return true; // We have access
+                        }
+                    }
+                }
+                false // No accessible devices found
+            }
+            Err(_) => false, // Cannot read /dev/dri directory
+        }
+    }
+}
+
+include!("reader/gpu_reader.rs");
+include!("reader/tests.rs");

--- a/crates/all-smi-amd-plugin/src/reader/gpu_reader.rs
+++ b/crates/all-smi-amd-plugin/src/reader/gpu_reader.rs
@@ -1,0 +1,352 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+impl GpuReader for AmdGpuReader {
+    fn get_gpu_info(&self) -> Vec<GpuInfo> {
+        let mut gpu_info = Vec::new();
+
+        for device in &self.devices {
+            // Get cached static device information (fetched only once)
+            let static_info = self.get_device_static_info(device);
+            let mut detail = static_info.detail.clone();
+            let device_name = static_info.name.clone();
+
+            // Get device info for dynamic metrics only
+            let ext_info = match device.device_handle.device_info() {
+                Ok(info) => info,
+                Err(e) => {
+                    eprintln!(
+                        "Warning: Failed to get device info for AMD GPU {}: {e}",
+                        device.device_path.pci
+                    );
+                    continue; // Skip this GPU if we can't get device info
+                }
+            };
+
+            // Update the VramUsage from the driver (following libamdgpu-top pattern)
+            // SAFETY: We handle mutex poisoning by recreating the VramUsage from fresh memory_info
+            let memory_info = {
+                let vram_usage_result = device.vram_usage.lock();
+
+                match vram_usage_result {
+                    Ok(mut vram_usage) => {
+                        // Normal path: update and read
+                        vram_usage.update_usage(&device.device_handle);
+                        vram_usage.update_usable_heap_size(&device.device_handle);
+                        vram_usage.0 // VramUsage is a tuple struct wrapping drm_amdgpu_memory_info
+                    }
+                    Err(poisoned) => {
+                        // Mutex was poisoned - recover by getting fresh memory info
+                        // This prevents denial of service from panics in other threads
+                        eprintln!(
+                            "Warning: VramUsage mutex was poisoned for device {}, recovering...",
+                            device.device_path.pci
+                        );
+
+                        // Try to get fresh memory info from the device
+                        match device.device_handle.memory_info() {
+                            Ok(fresh_memory_info) => {
+                                // Attempt to recover the poisoned mutex safely
+                                // into_inner() can theoretically panic if the mutex is in an
+                                // inconsistent state, though this is extremely rare with modern
+                                // standard library implementations
+                                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    poisoned.into_inner()
+                                })) {
+                                    Ok(mut guard) => {
+                                        // Successfully recovered the guard
+                                        *guard = VramUsage::new(&fresh_memory_info);
+                                        guard.update_usage(&device.device_handle);
+                                        guard.update_usable_heap_size(&device.device_handle);
+                                        guard.0
+                                    }
+                                    Err(_) => {
+                                        // Recovery failed - skip this GPU
+                                        eprintln!(
+                                            "Critical: Failed to recover poisoned mutex for device {}, skipping",
+                                            device.device_path.pci
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("Failed to get fresh memory info during recovery: {e}");
+                                continue; // Skip this GPU if we can't recover
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Get dynamic sensor information
+            let sensors = libamdgpu_top::stat::Sensors::new(
+                &device.device_handle,
+                &device.device_path.pci,
+                &ext_info,
+            );
+
+            // Add dynamic sensor data to details
+            //
+            // The tachometer reading is published twice on purpose: once as
+            // the typed `GpuInfo::fan_speed_rpm` field that the TUI and the
+            // Prometheus exporter read, and once as the `Fan Speed` detail
+            // string that snapshots and the cross-reader overwrite guard in
+            // `intel_gpu_level_zero::apply_fan` still depend on. Both come
+            // from the same `sensors.fan_rpm` value so they cannot disagree.
+            let mut fan_speed_rpm = None;
+            if let Some(ref sensors) = sensors {
+                if let Some(link) = sensors.current_link {
+                    detail.insert(
+                        "Current Link".to_string(),
+                        format!("Gen{} x{}", link.r#gen, link.width),
+                    );
+                }
+                if let Some(fan) = clamp_fan_rpm(sensors.fan_rpm) {
+                    fan_speed_rpm = Some(fan);
+                    detail.insert("Fan Speed".to_string(), format!("{fan} RPM"));
+                }
+                if let Some(mclk) = sensors.mclk {
+                    detail.insert("Memory Clock".to_string(), format!("{mclk} MHz"));
+                }
+            }
+
+            let mut utilization = 0.0;
+            let mut power_consumption = 0.0;
+            let mut temperature: u32 = 0;
+            let mut frequency: u32 = 0;
+
+            // Try to get metrics from GpuMetrics first with validation
+            if let Ok(metrics) = GpuMetrics::get_from_sysfs_path(&device.device_path.sysfs_path) {
+                if let Some(gfx_activity) = metrics.get_average_gfx_activity() {
+                    // Validate utilization is within reasonable bounds
+                    utilization = (gfx_activity as f64).clamp(0.0, MAX_GPU_UTILIZATION);
+                }
+                if let Some(power) = metrics.get_average_socket_power() {
+                    // Validate power consumption
+                    let watts = power as f64 / 1000.0; // Convert mW to W
+                    power_consumption = watts.clamp(0.0, MAX_GPU_POWER_WATTS);
+                }
+                if let Some(temp) = metrics.get_temperature_edge() {
+                    // Validate temperature
+                    temperature = (temp as u32).min(MAX_GPU_TEMP_CELSIUS);
+                }
+                if let Some(freq) = metrics.get_current_gfxclk() {
+                    // Validate frequency
+                    frequency = (freq as u32).min(MAX_GPU_FREQ_MHZ);
+                }
+            }
+
+            // Fallback to sensors if metrics failed or missing (with validation)
+            if let Some(ref s) = sensors {
+                if utilization == 0.0 {
+                    // Approximate utilization from load if available, or leave 0
+                    // libamdgpu_top doesn't expose a simple "gpu load" sensor easily without GpuMetrics or fdinfo
+                }
+                if power_consumption == 0.0 {
+                    if let Some(ref p) = s.average_power {
+                        let watts = p.value as f64 / 1000.0; // Convert mW to W
+                        power_consumption = watts.clamp(0.0, MAX_GPU_POWER_WATTS);
+                    } else if let Some(ref p) = s.input_power {
+                        let watts = p.value as f64 / 1000.0; // Convert mW to W
+                        power_consumption = watts.clamp(0.0, MAX_GPU_POWER_WATTS);
+                    }
+                }
+                if temperature == 0
+                    && let Some(ref t) = s.edge_temp
+                {
+                    temperature = (t.current as u32).min(MAX_GPU_TEMP_CELSIUS);
+                }
+                if frequency == 0
+                    && let Some(clk) = s.sclk
+                {
+                    frequency = clk.min(MAX_GPU_FREQ_MHZ);
+                }
+            }
+
+            // Use memory_info from VramUsage (already updated above)
+            // The update_usable_heap_size() call updates total_heap_size from vram_gtt_info()
+            // but we do it once per update cycle, not repeated queries
+
+            // Get VRAM size - try multiple sources in order with validation
+            // Current max is MI325X with 288GB, but we allow headroom for future models
+            // Use saturating operations to prevent any possibility of overflow
+            let total_memory = if memory_info.vram.total_heap_size > 0 {
+                memory_info.vram.total_heap_size.min(MAX_GPU_MEMORY_BYTES)
+            } else if memory_info.vram.usable_heap_size > 0 {
+                memory_info.vram.usable_heap_size.min(MAX_GPU_MEMORY_BYTES)
+            } else {
+                0
+            };
+
+            // Validate used memory doesn't exceed total - use saturating_sub to prevent underflow
+            // in case of driver reporting incorrect values
+            let used_memory = memory_info.vram.heap_usage.min(total_memory);
+
+            let info = GpuInfo {
+                uuid: format!("GPU-{}", device.device_path.pci), // AMD doesn't have UUIDs like NVIDIA, use PCI
+                time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+                name: device_name, // Use cached device name
+                device_type: "GPU".to_string(),
+                host_id: get_hostname(),
+                hostname: get_hostname(),
+                instance: get_hostname(),
+                utilization,
+                ane_utilization: 0.0,
+                dla_utilization: None,
+                tensorcore_utilization: None,
+                temperature,
+                used_memory,
+                total_memory,
+                frequency,
+                power_consumption,
+                gpu_core_count: None,
+                // AMD GPUs surface temperature through libamdgpu_top; NVML
+                // thermal-threshold and P-state APIs do not apply here.
+                temperature_threshold_slowdown: None,
+                temperature_threshold_shutdown: None,
+                temperature_threshold_max_operating: None,
+                temperature_threshold_acoustic: None,
+                performance_state: None,
+                fan_speed_rpm,
+                // NVIDIA-specific hardware details (NUMA, GSP firmware,
+                // NvLink, GPM) do not apply to AMD — leave them at the
+                // "unavailable" defaults so consumers render them as
+                // missing rather than zero.
+                numa_node_id: None,
+                gsp_firmware_mode: None,
+                gsp_firmware_version: None,
+                nvlink_remote_devices: Vec::new(),
+                gpm_metrics: None,
+                detail,
+            };
+            gpu_info.push(info);
+        }
+
+        gpu_info
+    }
+
+    fn get_process_info(&self) -> Vec<ProcessInfo> {
+        use std::collections::{HashMap, HashSet};
+
+        let mut process_info_list = Vec::new();
+
+        // Get process list once for fdinfo parsing
+        let proc_list = stat::get_process_list();
+
+        // Collect all GPU process data in a single pass
+        struct GpuProcessData {
+            device_id: usize,
+            device_uuid: String,
+            pid: u32,
+            name: String,
+            vram_usage_kib: u64,
+            gtt_usage_kib: u64,
+        }
+
+        let mut gpu_processes = Vec::new();
+        let mut gpu_pids = HashSet::new();
+
+        // Single pass: collect all GPU process data
+        for (device_idx, device) in self.devices.iter().enumerate() {
+            // Build process index for this device
+            let mut proc_index: Vec<ProcInfo> = Vec::new();
+            stat::update_index_by_all_proc(
+                &mut proc_index,
+                &[&device.device_path.render, &device.device_path.card],
+                &proc_list,
+            );
+
+            // Get fdinfo usage for all processes
+            let mut fdinfo = FdInfoStat::default();
+            fdinfo.update_proc_usage(&proc_index);
+
+            // Collect process data
+            for proc_usage in fdinfo.proc_usage {
+                let vram_usage_kib = proc_usage.usage.vram_usage;
+                let gtt_usage_kib = proc_usage.usage.gtt_usage;
+
+                // Include process if it uses VRAM or GTT (GPU memory)
+                if vram_usage_kib > 0 || gtt_usage_kib > 0 {
+                    let pid = proc_usage.pid as u32;
+                    gpu_pids.insert(pid);
+
+                    gpu_processes.push(GpuProcessData {
+                        device_id: device_idx,
+                        device_uuid: format!("GPU-{}", device.device_path.pci),
+                        pid,
+                        name: proc_usage.name,
+                        vram_usage_kib,
+                        gtt_usage_kib,
+                    });
+                }
+            }
+        }
+
+        // Get system process information once for all GPU processes
+        // OPTIMIZATION: Use minimal refresh instead of refresh_all() which is extremely expensive
+        // We only need CPU, memory, and basic process info for GPU processes
+        use all_smi::utils::with_global_system;
+        use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
+        let system_processes = with_global_system(|system| {
+            let refresh_kind = ProcessRefreshKind::nothing()
+                .with_cpu()
+                .with_memory()
+                .with_user(UpdateKind::OnlyIfNotSet);
+            system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+            all_smi::device::process_list::get_all_processes(system, &gpu_pids)
+        });
+        let process_map: HashMap<u32, _> = system_processes.iter().map(|p| (p.pid, p)).collect();
+
+        // Build final ProcessInfo list efficiently
+        for gpu_proc in gpu_processes {
+            // Convert to bytes and prioritize VRAM, fallback to GTT
+            let gpu_memory_bytes = if gpu_proc.vram_usage_kib > 0 {
+                gpu_proc.vram_usage_kib * 1024
+            } else {
+                gpu_proc.gtt_usage_kib * 1024
+            };
+
+            // Get system process info or use defaults
+            let sys_proc = process_map.get(&gpu_proc.pid);
+
+            let process_info = ProcessInfo {
+                device_id: gpu_proc.device_id,
+                device_uuid: gpu_proc.device_uuid,
+                pid: gpu_proc.pid,
+                process_name: gpu_proc.name,
+                used_memory: gpu_memory_bytes,
+                cpu_percent: sys_proc.map(|p| p.cpu_percent).unwrap_or(0.0),
+                memory_percent: sys_proc.map(|p| p.memory_percent).unwrap_or(0.0),
+                memory_rss: sys_proc.map(|p| p.memory_rss).unwrap_or(0),
+                memory_vms: sys_proc.map(|p| p.memory_vms).unwrap_or(0),
+                user: sys_proc.map(|p| p.user.clone()).unwrap_or_default(),
+                state: sys_proc.map(|p| p.state.clone()).unwrap_or_default(),
+                start_time: sys_proc.map(|p| p.start_time.clone()).unwrap_or_default(),
+                cpu_time: sys_proc.map(|p| p.cpu_time).unwrap_or(0),
+                command: sys_proc.map(|p| p.command.clone()).unwrap_or_default(),
+                ppid: sys_proc.map(|p| p.ppid).unwrap_or(0),
+                threads: sys_proc.map(|p| p.threads).unwrap_or(0),
+                uses_gpu: true,
+                priority: sys_proc.map(|p| p.priority).unwrap_or(0),
+                nice_value: sys_proc.map(|p| p.nice_value).unwrap_or(0),
+                gpu_utilization: 0.0, // fdinfo doesn't directly provide this per-process
+            };
+
+            process_info_list.push(process_info);
+        }
+
+        process_info_list
+    }
+}

--- a/crates/all-smi-amd-plugin/src/reader/tests.rs
+++ b/crates/all-smi-amd-plugin/src/reader/tests.rs
@@ -1,0 +1,147 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_version_component_validation() {
+        // Test that MAX_VERSION_COMPONENT is reasonable for Linux kernel versions
+        const {
+            assert!(
+                MAX_VERSION_COMPONENT >= 99,
+                "Should support two-digit version components"
+            );
+            assert!(
+                MAX_VERSION_COMPONENT <= 9999,
+                "Should not be excessively large"
+            );
+        }
+
+        // Common kernel version components should be valid
+        let common_versions = vec![
+            (6, 12, 0),      // Linux 6.12.0
+            (5, 15, 0),      // Linux 5.15.0 LTS
+            (30, 10, 1),     // AMD driver version
+            (999, 999, 999), // Maximum allowed
+        ];
+
+        for (major, minor, patch) in common_versions {
+            assert!(
+                major <= MAX_VERSION_COMPONENT,
+                "Major version {major} should be valid"
+            );
+            assert!(
+                minor <= MAX_VERSION_COMPONENT,
+                "Minor version {minor} should be valid"
+            );
+            assert!(
+                patch <= MAX_VERSION_COMPONENT,
+                "Patch version {patch} should be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn test_version_validation_rejects_invalid() {
+        // Test that we reject unreasonable version numbers
+        let invalid_versions = vec![
+            (1000, 0, 0), // Major too high
+            (0, 1000, 0), // Minor too high
+            (0, 0, 1000), // Patch too high
+            (-1, 0, 0),   // Negative major
+            (0, -1, 0),   // Negative minor
+            (0, 0, -1),   // Negative patch
+        ];
+
+        for (major, minor, patch) in invalid_versions {
+            let major_valid = (0..=MAX_VERSION_COMPONENT).contains(&major);
+            let minor_valid = (0..=MAX_VERSION_COMPONENT).contains(&minor);
+            let patch_valid = (0..=MAX_VERSION_COMPONENT).contains(&patch);
+
+            assert!(
+                !(major_valid && minor_valid && patch_valid),
+                "Version {major}.{minor}.{patch} should be invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn test_memory_validation_constants() {
+        // Test memory validation constants are reasonable
+        assert_eq!(
+            MAX_GPU_MEMORY_BYTES,
+            512 * 1024 * 1024 * 1024,
+            "Max GPU memory should be 512GB"
+        );
+
+        // Current largest AMD GPU is MI325X with 288GB, ensure we support it
+        let mi325x_memory: u64 = 288 * 1024 * 1024 * 1024;
+        assert!(
+            mi325x_memory < MAX_GPU_MEMORY_BYTES,
+            "Should support MI325X 288GB memory"
+        );
+
+        // Future-proof for potential 400GB models
+        let future_memory: u64 = 400 * 1024 * 1024 * 1024;
+        assert!(
+            future_memory < MAX_GPU_MEMORY_BYTES,
+            "Should have headroom for future GPUs"
+        );
+    }
+
+    #[test]
+    fn test_gpu_metric_validation_constants() {
+        // Test that validation constants are reasonable
+        assert_eq!(MAX_GPU_UTILIZATION, 100.0, "Max utilization should be 100%");
+        assert_eq!(
+            MAX_GPU_POWER_WATTS, 1000.0,
+            "Max power should support high-end GPUs"
+        );
+        assert_eq!(
+            MAX_GPU_TEMP_CELSIUS, 125,
+            "Max temp should be above thermal limits"
+        );
+        assert_eq!(
+            MAX_GPU_FREQ_MHZ, 5000,
+            "Max frequency should support boost clocks"
+        );
+
+        // Real-world values should be within limits
+        let mi300x_power = 750.0; // MI300X max TDP
+        assert!(
+            mi300x_power < MAX_GPU_POWER_WATTS,
+            "Should support MI300X power draw"
+        );
+
+        let typical_boost_freq = 2500; // Typical AMD GPU boost
+        assert!(
+            typical_boost_freq < MAX_GPU_FREQ_MHZ,
+            "Should support typical boost frequencies"
+        );
+    }
+
+    #[test]
+    fn clamp_fan_rpm_bounds_a_garbled_sensor_reading() {
+        // A corrupted or overflowed `libamdgpu_top` sample must never reach
+        // `GpuInfo::fan_speed_rpm` (and, from there, the exporter and the
+        // TUI) unclamped.
+        assert_eq!(clamp_fan_rpm(Some(u32::MAX)), Some(MAX_GPU_FAN_RPM));
+        // A real-world reading passes through unchanged.
+        assert_eq!(clamp_fan_rpm(Some(1450)), Some(1450));
+        // No tachometer stays `None`, not a clamped zero.
+        assert_eq!(clamp_fan_rpm(None), None);
+    }
+}

--- a/debian/rules
+++ b/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -D -m 0755 target/release/all-smi debian/all-smi/usr/bin/all-smi
+	install -D -m 0755 target/release/liball_smi_amd.so debian/all-smi/usr/lib/all-smi/liball_smi_amd.so
 	# /etc/default/all-smi is the operator-editable environment file read by
 	# the unit through `EnvironmentFile=-`. Installed from debian/ rather than
 	# packaging/ so the Launchpad job, which overlays only debian/ onto a

--- a/debian/rules.binary
+++ b/debian/rules.binary
@@ -14,6 +14,7 @@ override_dh_auto_install:
 	# Install the pre-built binary
 	# The binary should be extracted to the project root before building the package
 	install -D -m 0755 all-smi debian/all-smi/usr/bin/all-smi
+	if [ -f liball_smi_amd.so ]; then install -D -m 0755 liball_smi_amd.so debian/all-smi/usr/lib/all-smi/liball_smi_amd.so; fi
 	# Operator-editable environment file consumed by the unit's
 	# `EnvironmentFile=-/etc/default/all-smi` line.
 	install -D -m 0644 debian/all-smi.default debian/all-smi/etc/default/all-smi

--- a/debian/rules.launchpad
+++ b/debian/rules.launchpad
@@ -37,6 +37,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -D -m 0755 target/release/all-smi debian/all-smi/usr/bin/all-smi
+	install -D -m 0755 target/release/liball_smi_amd.so debian/all-smi/usr/lib/all-smi/liball_smi_amd.so
 
 override_dh_auto_test:
 	@echo "Skipping tests for PPA build"

--- a/debian/rules.launchpad-simple
+++ b/debian/rules.launchpad-simple
@@ -27,6 +27,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -D -m 0755 target/release/all-smi debian/all-smi/usr/bin/all-smi
+	install -D -m 0755 target/release/liball_smi_amd.so debian/all-smi/usr/lib/all-smi/liball_smi_amd.so
 
 override_dh_auto_test:
 	@echo "Skipping tests for PPA build"

--- a/debian/rules.source
+++ b/debian/rules.source
@@ -37,6 +37,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -D -m 0755 target/release/all-smi debian/all-smi/usr/bin/all-smi
+	install -D -m 0755 target/release/liball_smi_amd.so debian/all-smi/usr/lib/all-smi/liball_smi_amd.so
 	# /etc/default/all-smi is the operator-editable environment file read by
 	# the unit through `EnvironmentFile=-`. Installed from debian/ rather than
 	# packaging/ so the Launchpad job, which overlays only debian/ onto a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,6 +207,14 @@ pub trait MetricsExporter: Send + Sync {
 - DLA (Deep Learning Accelerator) support
 - Integrated memory architecture handling
 
+#### AMD Linux runtime plugin (`src/device/readers/amd.rs`, `crates/all-smi-amd-plugin/`)
+- The main crate contains hardware detection and a `libloading` adapter only; it never links `libamdgpu_top`, `libdrm.so.2`, or `libdrm_amdgpu.so.1`
+- The companion `liball_smi_amd.so` retains the existing `libamdgpu_top` reader and exposes an opaque reader handle plus JSON buffers through the versioned `AmdPluginApiV1` C function table
+- The host validates the ABI version, function-table size, and wire-format identifier before creating a reader; mismatches fail closed and appear in `amd.libamdgpu_top.abi`
+- Search order is an explicit absolute `ALL_SMI_AMD_PLUGIN` override, the executable directory, executable-relative `../lib/all-smi`, `/usr/local/lib/all-smi`, and `/usr/lib/all-smi`; no current-directory or bare-name lookup is allowed, and world-writable candidates are rejected
+- Missing plugins, missing native dependencies, and sampling/serialization failures degrade to an absent AMD reader without affecting startup or other backends
+- Release tarballs keep the companion beside the binary, Homebrew installs it to the formula's `lib/all-smi`, and Debian/PPA packages install it to `/usr/lib/all-smi`
+
 #### Intel Arc / Iris Xe client GPU (Linux: `src/device/readers/intel_gpu_linux.rs`, Windows: `src/device/readers/intel_gpu_windows.rs`)
 - Linux: sysfs discovery under `/sys/class/drm/card*`, vendor `0x8086`, driver `i915` or `xe`
 - Windows: WMI `Win32_VideoController` query filtered to Intel graphics adapter names
@@ -539,8 +547,8 @@ pub const MAX_HISTORY_SIZE: usize = 60;
 default = ["cli", "amd"]
 # CLI parsing, TUI, and the axum API server
 cli = ["dep:clap", "dep:crossterm", "dep:axum", "dep:tower-http", "dep:anyhow", "dep:toml", "dep:dirs"]
-# AMD GPU backend via libamdgpu_top (glibc Linux)
-amd = ["dep:libamdgpu_top"]
+# Accepted no-op; glibc Linux always contains the runtime loader
+amd = []
 # Enables the mock server binary
 mock = ["cli", "dep:rand", "dep:hyper", "dep:hyper-util"]
 # Furiosa NPU backend
@@ -551,7 +559,7 @@ furiosa = ["furiosa-smi-rs"]
 level_zero = []
 ```
 
-`amd` is the only backend feature that defaults to on. It exists because `libamdgpu_top` links `libdrm.so.2` and `libdrm_amdgpu.so.1` unconditionally, which every dependent binary inherits as `NEEDED` entries; a consumer that must run on hosts without those libraries builds with `default-features = false` (see `docs/LIB_mode.md`). Disabling it compiles out `src/device/readers/amd.rs`, `platform_detection::has_amd`, and the AMD arm of `reader_factory`, which is the same shape the musl artifacts already ship. Windows AMD support goes through `amd_adl`/WMI and is independent of this feature.
+`amd` remains in the default feature list only for downstream manifest compatibility and has no effect. Every glibc Linux build contains AMD PCI/sysfs detection and the runtime loader, while `libamdgpu_top` and libdrm live exclusively in the `all-smi-amd-plugin` workspace package. A `default-features = false` consumer therefore regains AMD monitoring whenever the matching companion is deployed, without inheriting native `NEEDED` entries. Musl omits the loader, and Windows AMD support remains independent through `amd_adl`/WMI.
 
 ### Binary Targets
 

--- a/docs/LIB_mode.md
+++ b/docs/LIB_mode.md
@@ -62,12 +62,14 @@ cargo add all-smi
 | Feature | Default | Effect on a library consumer |
 |---------|---------|------------------------------|
 | `cli` | on | CLI parsing, TUI, and the `axum` API server. A library-only consumer usually does not need it. |
-| `amd` | on | AMD GPU backend on glibc Linux via `libamdgpu_top`. Adds `libdrm.so.2` and `libdrm_amdgpu.so.1` as link-time requirements. |
+| `amd` | on, accepted no-op | Retained for manifest compatibility. Every glibc Linux build contains the runtime AMD loader; this feature adds no dependency or link requirement. |
 | `mock` | off | Builds the mock server binary. |
 | `furiosa` | off | Furiosa NPU backend. |
 | `level_zero` | accepted no-op | The Intel Level Zero (Sysman) backend it used to gate is compiled into every Linux and Windows build. It adds no dependency (the loader is `dlopen`ed) and opens nothing on a machine with no Intel GPU, so there is nothing to opt out of; `build.rs` emits the `all_smi_level_zero` cfg for those targets and the readers gate on that. |
 
-`amd` is on by default so that adding this crate keeps AMD GPU monitoring without extra configuration. The cost is that `libamdgpu_top` links `libdrm.so.2` and `libdrm_amdgpu.so.1` unconditionally, and those become hard `NEEDED` entries on your binary too. A host that does not have AMD's userspace DRM libraries then fails to start your program with a loader error before `main` runs, which no amount of runtime handling can catch. Turn the feature off if your binary must run on hosts without those libraries:
+Linux AMD support is runtime-loaded. The `all-smi` crate detects AMD hardware and looks for the separately built `liball_smi_amd.so`; only that companion links `libdrm.so.2` and `libdrm_amdgpu.so.1`. Your binary has no libdrm `NEEDED` entry in either feature configuration and starts normally when the companion or AMD userspace libraries are absent.
+
+A library-only consumer can therefore disable default features without losing AMD detection:
 
 ```toml
 [dependencies]
@@ -81,7 +83,17 @@ all-smi = { version = "0.25", default-features = false }
 all-smi = { version = "0.25", default-features = false, features = ["cli"] }
 ```
 
-Confirm the result on Linux with `objdump -p <your-binary> | grep NEEDED`; neither `libdrm.so.2` nor `libdrm_amdgpu.so.1` should be listed. Everything except the AMD GPU readers is unaffected: NVIDIA, Apple Silicon, Intel, Tenstorrent, Rebellions, Furiosa, TPU, CPU, and memory collection all behave the same, and `GpuInfo` simply never reports AMD devices. AMD support on Windows goes through ADL/WMI and does not depend on this feature. The prebuilt musl artifacts have never included the AMD backend, so they are already free of the `libdrm` linkage.
+To activate AMD monitoring, deploy a companion from the same all-smi version in one of these locations, in order: the absolute path named by `ALL_SMI_AMD_PLUGIN`, beside the current executable, `../lib/all-smi` relative to the executable, `/usr/local/lib/all-smi`, or `/usr/lib/all-smi`. The override must be absolute. The loader canonicalizes candidates and refuses a plugin file or ancestor directory that is world-writable; it never searches the current working directory or passes an unqualified name to `dlopen`. A missing native dependency, missing entry point, ABI mismatch, or wire-format mismatch yields an empty AMD reader and a precise `all-smi doctor --only amd` message.
+
+The repository workspace builds both artifacts with:
+
+```bash
+cargo build --release -p all-smi -p all-smi-amd-plugin
+```
+
+Copy `target/release/liball_smi_amd.so` beside the embedding executable or into one of the fixed library directories above. Release archives, Homebrew, and Debian/PPA packages already do this. `cargo install all-smi` cannot install a `cdylib`, so it intentionally degrades without Linux AMD support unless you install the companion separately.
+
+Confirm the isolation with `objdump -p <your-binary> | grep NEEDED`; neither `libdrm.so.2` nor `libdrm_amdgpu.so.1` should be listed. `objdump -p liball_smi_amd.so | grep NEEDED` should show the native DRM dependencies instead. AMD support on Windows continues through ADL/WMI, and musl builds continue to report the Linux AMD plugin as unavailable.
 
 ## Quick Start
 

--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -468,7 +468,10 @@ Quit the application
 Full support via nvidia-smi, including CUDA information, PCIe status, and performance states
 .TP
 .B AMD GPUs
-Support for Radeon and Instinct GPUs via ROCm/libamdgpu_top, including VRAM/GTT memory tracking and fdinfo-based process monitoring
+Support for Radeon and Instinct GPUs via ROCm/libamdgpu_top, including VRAM/GTT memory tracking and fdinfo-based process monitoring. On glibc Linux, libamdgpu_top is isolated in the runtime-loaded
+.I liball_smi_amd.so
+companion, so missing AMD userspace libraries never prevent the main program from starting. Release archives place the companion beside the executable; Debian packages install it in
+.IR /usr/lib/all-smi .
 .TP
 .B Intel Arc / Iris Xe / Xe client GPUs
 Support for Arc A/B-series discrete GPUs and Iris Xe/Xe-LPG integrated GPUs via i915/xe sysfs (Linux) and WMI (Windows), including architecture classification, SYCL/oneAPI capability detection, engine-busy utilization computed from sysfs per-engine monotonic counters (Linux; max of render and compute engines reported as primary utilization), and per-process GPU memory tracking via /proc fdinfo (Linux; dedupes shared DRM file descriptors by drm-client-id).
@@ -744,6 +747,9 @@ Sample-gap threshold in seconds (range
 above which the integrator switches from trapezoidal to hold-last
 integration. Default: 10.
 .SH ENVIRONMENT
+.TP
+.B ALL_SMI_AMD_PLUGIN
+Absolute path to the glibc Linux AMD companion library. When unset, all-smi searches beside the current executable, then ../lib/all-smi relative to it, then /usr/local/lib/all-smi and /usr/lib/all-smi. Relative overrides and world-writable plugin paths are refused; the current working directory is never searched.
 .TP
 .B RUST_LOG
 Set logging level (e.g., debug, info, warn, error)

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -115,12 +115,10 @@ fn detect_nvidia() -> bool {
 
 /// Check whether at least one AMD GPU is present.
 ///
-/// Only compiled on glibc Linux with the default-on `amd` cargo feature, which
-/// is where the `libamdgpu_top` dependency exists. Consumers that need a
-/// configuration-independent answer should use
-/// [`introspection::snapshot`], whose `amd` field is `false` whenever the
-/// backend is compiled out.
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+/// Compiled on every glibc Linux build. Detection uses PCI/sysfs only and does
+/// not load the optional AMD companion plugin, so downstream feature choices
+/// cannot remove the hardware signal.
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
 pub fn has_amd() -> bool {
     static CACHE: OnceLock<bool> = OnceLock::new();
     *CACHE.get_or_init(detect_amd)
@@ -161,7 +159,7 @@ fn detect_intel_gpu() -> bool {
     }
 }
 
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
 fn detect_amd() -> bool {
     // On Linux, check for AMD GPUs
     if std::env::consts::OS == "linux" {
@@ -669,10 +667,9 @@ pub mod introspection {
         pub os: &'static str,
         pub nvidia: bool,
         pub jetson: bool,
-        /// `true` on glibc Linux targets when AMD is detected; always
-        /// `false` on musl builds, and on builds with the default-on `amd`
-        /// cargo feature disabled, because the `libamdgpu_top` dep is
-        /// compiled out in both cases.
+        /// `true` on glibc Linux targets when AMD hardware is detected;
+        /// always `false` on musl and non-Linux builds. Plugin availability is
+        /// reported separately by `all-smi doctor`.
         pub amd: bool,
         pub apple_silicon: bool,
         pub gaudi: bool,
@@ -708,12 +705,12 @@ pub mod introspection {
     // compiled only where `super::has_amd` exists, the negative one
     // everywhere else. Any drift produces either a duplicate definition or a
     // missing `detect_amd`.
-    #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+    #[cfg(all(target_os = "linux", not(target_env = "musl")))]
     fn detect_amd() -> bool {
         super::has_amd()
     }
 
-    #[cfg(not(all(target_os = "linux", not(target_env = "musl"), feature = "amd")))]
+    #[cfg(not(all(target_os = "linux", not(target_env = "musl"))))]
     fn detect_amd() -> bool {
         false
     }

--- a/src/device/reader_factory.rs
+++ b/src/device/reader_factory.rs
@@ -47,10 +47,10 @@ use crate::device::readers::intel_gpu_linux;
 #[cfg(target_os = "windows")]
 use crate::device::readers::intel_gpu_windows;
 
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
 use crate::device::platform_detection::has_amd;
 
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
 use crate::device::readers::amd;
 
 pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
@@ -100,11 +100,14 @@ pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
                 readers.push(Box::new(google_tpu::GoogleTpuReader::new()));
             }
 
-            // Check for AMD GPU support (glibc only, not musl, and only when
-            // the default-on `amd` feature is enabled)
-            #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+            // AMD hardware detection is always present on glibc Linux. The
+            // native backend is optional at runtime and never prevents startup.
+            #[cfg(all(target_os = "linux", not(target_env = "musl")))]
             if has_amd() {
-                readers.push(Box::new(amd::AmdGpuReader::new()));
+                match amd::AmdGpuReader::try_new() {
+                    Ok(reader) => readers.push(Box::new(reader)),
+                    Err(error) => eprintln!("AMD backend unavailable: {error}"),
+                }
             }
 
             // Check for Intel client GPU (Arc / Iris / Xe). Unlike

--- a/src/device/readers/amd.rs
+++ b/src/device/readers/amd.rs
@@ -12,75 +12,388 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::device::GpuReader;
-use crate::device::readers::common_cache::{DetailBuilder, DeviceStaticInfo};
-use crate::device::types::{GpuInfo, MAX_GPU_FAN_RPM, ProcessInfo};
-use crate::utils::get_hostname;
-use chrono::Local;
-use libamdgpu_top::AMDGPU::{DeviceHandle, GPU_INFO, GpuMetrics, MetricsInfo};
-use libamdgpu_top::stat::{self, FdInfoStat, ProcInfo};
-use libamdgpu_top::{AppDeviceInfo, DevicePath, VramUsage};
-use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+//! Runtime loader for the Linux AMD companion backend.
+//!
+//! The main crate deliberately has no `libamdgpu_top` dependency. It loads a
+//! packaged `liball_smi_amd.so` through a versioned function table and treats
+//! every lookup, native-dependency, ABI, and sampling failure as backend
+//! unavailability rather than a process-startup failure.
 
-// GPU metric validation constants
-const MAX_GPU_UTILIZATION: f64 = 100.0; // Maximum utilization percentage
-const MAX_GPU_POWER_WATTS: f64 = 1000.0; // Maximum power consumption in watts
-const MAX_GPU_TEMP_CELSIUS: u32 = 125; // Maximum temperature in Celsius
-const MAX_GPU_FREQ_MHZ: u32 = 5000; // Maximum frequency in MHz
-const MAX_GPU_MEMORY_BYTES: u64 = 512 * 1024 * 1024 * 1024; // 512GB max memory
+use std::collections::HashSet;
+use std::ffi::c_void;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
 
-// Driver version validation constant
-// Linux kernel versions typically don't exceed 999 for any component
-const MAX_VERSION_COMPONENT: i32 = 999;
+use libloading::Library;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
-/// Cap a raw `sensors.fan_rpm` reading so a garbled `libamdgpu_top` sample
-/// can never propagate `u32::MAX` into `GpuInfo::fan_speed_rpm` or the `Fan
-/// Speed` detail string. Mirrors the same defence applied to temperature,
-/// frequency, power, and memory a few lines below, and shares its bound
-/// with the Windows ADL, Intel sysfs, and Intel Level Zero fan readings via
-/// [`crate::device::types::MAX_GPU_FAN_RPM`].
-fn clamp_fan_rpm(rpm: Option<u32>) -> Option<u32> {
-    rpm.map(|value| value.min(MAX_GPU_FAN_RPM))
+use crate::device::readers::amd_plugin_api::{
+    AMD_PLUGIN_ABI_VERSION, AMD_PLUGIN_ENTRY_SYMBOL, AMD_PLUGIN_WIRE_FORMAT, AmdPluginApiV1,
+    AmdPluginBuffer, ReadJsonFn,
+};
+use crate::device::{GpuInfo, GpuReader, ProcessInfo};
+
+pub const AMD_PLUGIN_ENV: &str = "ALL_SMI_AMD_PLUGIN";
+pub const AMD_PLUGIN_FILENAME: &str = "liball_smi_amd.so";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AmdBackendStatus {
+    Loaded {
+        path: PathBuf,
+        abi_version: u32,
+        plugin_version: String,
+        libamdgpu_top_version: String,
+    },
+    Unavailable {
+        reason: String,
+    },
 }
 
-/// Per-device state that needs to be cached
-///
-/// # Thread Safety
-///
-/// The `vram_usage` field is protected by a `Mutex` to ensure thread-safe access
-/// across multiple concurrent readers. The VramUsage struct from libamdgpu_top
-/// maintains internal state that must be updated atomically.
-///
-/// ## Synchronization Guarantees
-/// - All reads and writes to `vram_usage` are serialized through the mutex
-/// - The mutex ensures memory ordering: all writes before unlock are visible after lock
-/// - No data races can occur as long as all access goes through the mutex
-///
-/// ## Mutex Poisoning Recovery
-/// If a thread panics while holding the mutex lock, the mutex becomes "poisoned"
-/// to prevent other threads from observing potentially inconsistent state.
-/// We handle this by:
-/// 1. Detecting the poisoned state
-/// 2. Attempting to recover with fresh data from the driver
-/// 3. Using `catch_unwind` to handle potential panics during recovery
-/// 4. Skipping the device if recovery fails to maintain system stability
-///
-/// ## Performance Considerations
-/// - Mutex contention is minimal as updates are quick (microseconds)
-/// - Each device has its own mutex, preventing global bottlenecks
-/// - The lock is held only during the VramUsage update operations
-struct AmdGpuDevice {
-    device_path: DevicePath,
-    device_handle: DeviceHandle,
-    vram_usage: Mutex<VramUsage>, // Protected by mutex for thread-safe updates
-    static_info: OnceLock<DeviceStaticInfo>, // Cached static device information
+#[derive(Deserialize)]
+struct PluginMetadata {
+    plugin_version: String,
+    libamdgpu_top_version: String,
+    wire_format: String,
+}
+
+struct LoadedPlugin {
+    _library: Library,
+    api: AmdPluginApiV1,
+    path: PathBuf,
+    metadata: PluginMetadata,
+}
+
+static PLUGIN: OnceLock<Result<Arc<LoadedPlugin>, String>> = OnceLock::new();
+
+fn plugin() -> Result<Arc<LoadedPlugin>, String> {
+    PLUGIN.get_or_init(load_plugin).clone()
+}
+
+pub fn backend_status() -> AmdBackendStatus {
+    match plugin() {
+        Ok(plugin) => AmdBackendStatus::Loaded {
+            path: plugin.path.clone(),
+            abi_version: plugin.api.abi_version,
+            plugin_version: plugin.metadata.plugin_version.clone(),
+            libamdgpu_top_version: plugin.metadata.libamdgpu_top_version.clone(),
+        },
+        Err(reason) => AmdBackendStatus::Unavailable { reason },
+    }
+}
+
+fn load_plugin() -> Result<Arc<LoadedPlugin>, String> {
+    let candidates = configured_candidates()?;
+    let mut failures = Vec::new();
+
+    for candidate in candidates {
+        if !candidate.exists() {
+            failures.push(format!("{}: not found", candidate.display()));
+            continue;
+        }
+        let path = match validate_candidate(&candidate) {
+            Ok(path) => path,
+            Err(error) => {
+                failures.push(error);
+                continue;
+            }
+        };
+        match load_candidate(path.clone()) {
+            Ok(plugin) => return Ok(Arc::new(plugin)),
+            Err(error) => failures.push(format!("{}: {error}", path.display())),
+        }
+    }
+
+    Err(format!(
+        "AMD plugin unavailable; {}. Install {AMD_PLUGIN_FILENAME} beside the executable or in /usr/lib/all-smi, or set {AMD_PLUGIN_ENV} to a safe absolute path",
+        failures.join("; ")
+    ))
+}
+
+fn configured_candidates() -> Result<Vec<PathBuf>, String> {
+    if let Some(override_path) = std::env::var_os(AMD_PLUGIN_ENV) {
+        if override_path.is_empty() {
+            return Err(format!("{AMD_PLUGIN_ENV} is set but empty"));
+        }
+        let path = PathBuf::from(override_path);
+        if !path.is_absolute() {
+            return Err(format!(
+                "{AMD_PLUGIN_ENV} must be an absolute path, got {}",
+                path.display()
+            ));
+        }
+        return Ok(vec![path]);
+    }
+
+    let executable = std::env::current_exe().map_err(|error| {
+        format!("cannot resolve the current executable for AMD plugin lookup: {error}")
+    })?;
+    Ok(default_candidates(&executable))
+}
+
+fn default_candidates(executable: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(bin_dir) = executable.parent() {
+        candidates.push(bin_dir.join(AMD_PLUGIN_FILENAME));
+        candidates.push(
+            bin_dir
+                .join("..")
+                .join("lib")
+                .join("all-smi")
+                .join(AMD_PLUGIN_FILENAME),
+        );
+    }
+    candidates.push(PathBuf::from("/usr/local/lib/all-smi").join(AMD_PLUGIN_FILENAME));
+    candidates.push(PathBuf::from("/usr/lib/all-smi").join(AMD_PLUGIN_FILENAME));
+
+    let mut seen = HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|candidate| seen.insert(candidate.clone()))
+        .collect()
+}
+
+fn validate_candidate(candidate: &Path) -> Result<PathBuf, String> {
+    if !candidate.is_absolute() {
+        return Err(format!(
+            "{}: plugin path is not absolute",
+            candidate.display()
+        ));
+    }
+    let canonical = candidate.canonicalize().map_err(|error| {
+        format!(
+            "{}: cannot canonicalize plugin path: {error}",
+            candidate.display()
+        )
+    })?;
+    if !canonical.is_file() {
+        return Err(format!(
+            "{}: plugin path is not a regular file",
+            canonical.display()
+        ));
+    }
+    reject_world_writable_path(&canonical)?;
+    Ok(canonical)
+}
+
+#[cfg(unix)]
+fn reject_world_writable_path(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    for component in path.ancestors() {
+        let metadata = component.metadata().map_err(|error| {
+            format!(
+                "{}: cannot inspect permissions: {error}",
+                component.display()
+            )
+        })?;
+        if metadata.permissions().mode() & 0o002 != 0 {
+            return Err(format!(
+                "{}: refusing AMD plugin because {} is world-writable",
+                path.display(),
+                component.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_world_writable_path(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+type EntryV1 = unsafe extern "C" fn() -> *const AmdPluginApiV1;
+
+fn load_candidate(path: PathBuf) -> Result<LoadedPlugin, String> {
+    // SAFETY: the path is absolute, canonicalized, and checked for a
+    // world-writable file or ancestor. The library stays owned by
+    // `LoadedPlugin` for longer than every copied function pointer.
+    let library =
+        unsafe { Library::new(&path) }.map_err(|error| format!("dlopen failed: {error}"))?;
+    let api = {
+        // SAFETY: the symbol name is NUL-terminated and the versioned ABI
+        // contract defines this exact function signature.
+        let entry = unsafe { library.get::<EntryV1>(AMD_PLUGIN_ENTRY_SYMBOL) }
+            .map_err(|error| format!("missing v1 entry point: {error}"))?;
+        // SAFETY: calling the entry point has no arguments and only returns a
+        // pointer to immutable static storage owned by the loaded library.
+        let api = unsafe { entry() };
+        if api.is_null() {
+            return Err("v1 entry point returned a null function table".to_string());
+        }
+        // SAFETY: every versioned entry point begins with these two header
+        // fields. Read and validate them before copying the full v1 table, so
+        // a legitimately older/truncated table is rejected without an
+        // out-of-bounds read.
+        let abi_version = unsafe { std::ptr::addr_of!((*api).abi_version).read() };
+        let struct_size = unsafe { std::ptr::addr_of!((*api).struct_size).read() };
+        validate_api_header(abi_version, struct_size)?;
+        // SAFETY: the validated `struct_size` covers the complete v1 table.
+        unsafe { api.read() }
+    };
+    validate_api(&api)?;
+    let metadata: PluginMetadata = read_buffer(&api, |out| {
+        // SAFETY: `validate_api` accepted the table and `out` points to a
+        // live descriptor for this call.
+        unsafe { (api.read_metadata_json.expect("validated function pointer"))(out) }
+    })?;
+    validate_metadata(&metadata)?;
+    Ok(LoadedPlugin {
+        _library: library,
+        api,
+        path,
+        metadata,
+    })
+}
+
+fn validate_metadata(metadata: &PluginMetadata) -> Result<(), String> {
+    let host_version = env!("CARGO_PKG_VERSION");
+    if metadata.plugin_version != host_version {
+        return Err(format!(
+            "plugin version mismatch: host requires {host_version}, plugin reports {}",
+            metadata.plugin_version
+        ));
+    }
+    if metadata.wire_format != AMD_PLUGIN_WIRE_FORMAT {
+        return Err(format!(
+            "wire format mismatch: host requires {AMD_PLUGIN_WIRE_FORMAT}, plugin reports {}",
+            metadata.wire_format
+        ));
+    }
+    Ok(())
+}
+
+fn validate_api(api: &AmdPluginApiV1) -> Result<(), String> {
+    validate_api_header(api.abi_version, api.struct_size)?;
+    if api.create_reader.is_none()
+        || api.destroy_reader.is_none()
+        || api.read_gpu_info_json.is_none()
+        || api.read_process_info_json.is_none()
+        || api.read_metadata_json.is_none()
+        || api.free_buffer.is_none()
+    {
+        return Err("ABI v1 function table contains a null function pointer".to_string());
+    }
+    Ok(())
+}
+
+fn validate_api_header(abi_version: u32, struct_size: usize) -> Result<(), String> {
+    if abi_version != AMD_PLUGIN_ABI_VERSION {
+        return Err(format!(
+            "ABI mismatch: host requires v{AMD_PLUGIN_ABI_VERSION}, plugin reports v{abi_version}"
+        ));
+    }
+    let required = std::mem::size_of::<AmdPluginApiV1>();
+    if struct_size < required {
+        return Err(format!(
+            "ABI v{AMD_PLUGIN_ABI_VERSION} function table is truncated: host requires {required} bytes, plugin reports {struct_size}"
+        ));
+    }
+    Ok(())
+}
+
+fn read_buffer<T: DeserializeOwned>(
+    api: &AmdPluginApiV1,
+    invoke: impl FnOnce(*mut AmdPluginBuffer) -> i32,
+) -> Result<T, String> {
+    let mut buffer = AmdPluginBuffer::default();
+    let status = invoke(&mut buffer);
+    if status != 0 {
+        return Err(format!("plugin call failed with status {status}"));
+    }
+    if buffer.len > buffer.capacity || (buffer.ptr.is_null() && buffer.len != 0) {
+        return Err("plugin returned an invalid buffer descriptor".to_string());
+    }
+    let decoded = if buffer.len == 0 {
+        Err("plugin returned an empty JSON buffer".to_string())
+    } else {
+        // SAFETY: the validated descriptor is owned by the plugin and remains
+        // live until `free_buffer` below.
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.ptr, buffer.len) };
+        serde_json::from_slice(bytes).map_err(|error| format!("invalid plugin JSON: {error}"))
+    };
+    // SAFETY: this descriptor came from the same validated API table and is
+    // released exactly once, even when deserialization fails.
+    unsafe { (api.free_buffer.expect("validated function pointer"))(&mut buffer) };
+    decoded
 }
 
 pub struct AmdGpuReader {
-    devices: Vec<AmdGpuDevice>,
-    /// Cached ROCm version (fetched only once, shared across all devices)
-    rocm_version: OnceLock<Option<String>>,
+    plugin: Option<Arc<LoadedPlugin>>,
+    handle: Option<usize>,
+    calls: Mutex<()>,
+    reported_error: Mutex<Option<String>>,
+}
+
+impl AmdGpuReader {
+    pub fn try_new() -> Result<Self, String> {
+        let plugin = plugin()?;
+        // SAFETY: the API table was validated and the library remains loaded
+        // through the Arc stored in the returned reader.
+        let handle = unsafe {
+            (plugin
+                .api
+                .create_reader
+                .expect("validated function pointer"))()
+        };
+        if handle.is_null() {
+            return Err("AMD plugin could not create a reader".to_string());
+        }
+        Ok(Self {
+            plugin: Some(plugin),
+            handle: Some(handle as usize),
+            calls: Mutex::new(()),
+            reported_error: Mutex::new(None),
+        })
+    }
+
+    pub fn new() -> Self {
+        match Self::try_new() {
+            Ok(reader) => reader,
+            Err(error) => {
+                eprintln!("AMD backend unavailable: {error}");
+                Self {
+                    plugin: None,
+                    handle: None,
+                    calls: Mutex::new(()),
+                    reported_error: Mutex::new(Some(error)),
+                }
+            }
+        }
+    }
+
+    fn collect<T: DeserializeOwned>(&self, read: ReadJsonFn) -> Vec<T> {
+        let (Some(plugin), Some(handle)) = (&self.plugin, self.handle) else {
+            return Vec::new();
+        };
+        let _call = self
+            .calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match read_buffer(&plugin.api, |out| {
+            // SAFETY: the handle belongs to this plugin instance, calls are
+            // serialized, and `out` is live for the duration of the call.
+            unsafe { read(handle as *mut c_void, out) }
+        }) {
+            Ok(values) => values,
+            Err(error) => {
+                self.report_error(error);
+                Vec::new()
+            }
+        }
+    }
+
+    fn report_error(&self, error: String) {
+        let mut previous = self
+            .reported_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if previous.as_deref() != Some(&error) {
+            eprintln!("AMD plugin sampling failed: {error}");
+            *previous = Some(error);
+        }
+    }
 }
 
 impl Default for AmdGpuReader {
@@ -89,717 +402,47 @@ impl Default for AmdGpuReader {
     }
 }
 
-impl AmdGpuReader {
-    pub fn new() -> Self {
-        // Check if we have permission to access AMD GPU devices
-        // This prevents panic from libamdgpu_top when running without sudo
-        // If no permission, silently return empty device list
-        // The main program will handle showing sudo message before TUI starts
-        if !Self::check_amd_gpu_permissions() {
-            return Self {
-                devices: Vec::new(),
-                rocm_version: OnceLock::new(),
+impl Drop for AmdGpuReader {
+    fn drop(&mut self) {
+        if let (Some(plugin), Some(handle)) = (&self.plugin, self.handle.take()) {
+            // SAFETY: this is the one destroy call paired with create_reader;
+            // `&mut self` guarantees no sampling call is active.
+            unsafe {
+                (plugin
+                    .api
+                    .destroy_reader
+                    .expect("validated function pointer"))(handle as *mut c_void)
             };
-        }
-
-        let device_path_list = DevicePath::get_device_path_list();
-        let mut devices = Vec::new();
-
-        // Add device count validation to prevent unbounded growth
-        const MAX_DEVICES: usize = 256;
-        let device_paths_to_process: Vec<_> =
-            device_path_list.into_iter().take(MAX_DEVICES).collect();
-
-        for device_path in device_paths_to_process {
-            match device_path.init() {
-                Ok(amdgpu_dev) => {
-                    // Get initial memory_info to create VramUsage
-                    match amdgpu_dev.memory_info() {
-                        Ok(memory_info) => {
-                            let vram_usage = VramUsage::new(&memory_info);
-                            devices.push(AmdGpuDevice {
-                                device_path: device_path.clone(),
-                                device_handle: amdgpu_dev,
-                                vram_usage: Mutex::new(vram_usage),
-                                static_info: OnceLock::new(),
-                            });
-                        }
-                        Err(e) => {
-                            eprintln!(
-                                "Warning: Failed to get memory info for AMD GPU {}: {e}",
-                                device_path.pci
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to initialize AMD GPU {}: {e}",
-                        device_path.pci
-                    );
-                }
-            }
-        }
-
-        Self {
-            devices,
-            rocm_version: OnceLock::new(),
-        }
-    }
-
-    /// Get cached ROCm version, initializing if needed
-    fn get_rocm_version(&self) -> Option<String> {
-        self.rocm_version
-            .get_or_init(libamdgpu_top::get_rocm_version)
-            .clone()
-    }
-
-    /// Get cached static device info for a device, initializing if needed
-    fn get_device_static_info<'a>(&self, device: &'a AmdGpuDevice) -> &'a DeviceStaticInfo {
-        device
-            .static_info
-            .get_or_init(|| {
-                // Fetch static device information once
-                let ext_info = device.device_handle.device_info().ok();
-                let memory_info = device.device_handle.memory_info().ok();
-
-                let (device_name, mut detail) = if let (Some(ext), Some(mem)) =
-                    (ext_info.as_ref(), memory_info.as_ref())
-                {
-                    let sensors = libamdgpu_top::stat::Sensors::new(
-                        &device.device_handle,
-                        &device.device_path.pci,
-                        ext,
-                    );
-
-                    let app_device_info = AppDeviceInfo::new(
-                        &device.device_handle,
-                        ext,
-                        mem,
-                        &sensors,
-                        &device.device_path,
-                    );
-
-                    let mut builder = DetailBuilder::new()
-                        .insert("Device Name", &app_device_info.marketing_name)
-                        .insert("PCI Bus", app_device_info.pci_bus.to_string());
-
-                    // Add ROCm version
-                    if let Some(ref ver) = self.get_rocm_version() {
-                        builder = builder
-                            .insert("ROCm Version", ver)
-                            .insert("lib_name", "ROCm")
-                            .insert("lib_version", ver);
-                    }
-
-                    let mut detail = builder.build();
-
-                    // Add device details
-                    detail.insert(
-                        "Device ID".to_string(),
-                        format!("{:#06x}", ext.device_id()),
-                    );
-                    detail.insert(
-                        "Revision ID".to_string(),
-                        format!("{:#04x}", ext.pci_rev_id()),
-                    );
-                    detail.insert(
-                        "ASIC Name".to_string(),
-                        app_device_info.asic_name.to_string(),
-                    );
-
-                    if let Some(ref vbios) = app_device_info.vbios {
-                        detail.insert("VBIOS Version".to_string(), vbios.ver.clone());
-                        detail.insert("VBIOS Date".to_string(), vbios.date.clone());
-                    }
-
-                    if let Some(ref cap) = app_device_info.power_cap {
-                        detail.insert("Power Cap".to_string(), format!("{} W", cap.current));
-                        detail.insert("Power Cap (Min)".to_string(), format!("{} W", cap.min));
-                        detail.insert("Power Cap (Max)".to_string(), format!("{} W", cap.max));
-                    }
-
-                    if let Some(link) = app_device_info.max_gpu_link {
-                        detail.insert(
-                            "Max GPU Link".to_string(),
-                            format!("Gen{} x{}", link.r#gen, link.width),
-                        );
-                    }
-
-                    if let Some(link) = app_device_info.max_system_link {
-                        detail.insert(
-                            "Max System Link".to_string(),
-                            format!("Gen{} x{}", link.r#gen, link.width),
-                        );
-                    }
-
-                    if let Some(min_dpm_link) = app_device_info.min_dpm_link {
-                        detail.insert(
-                            "Min DPM Link".to_string(),
-                            format!("Gen{} x{}", min_dpm_link.r#gen, min_dpm_link.width),
-                        );
-                    }
-
-                    if let Some(max_dpm_link) = app_device_info.max_dpm_link {
-                        detail.insert(
-                            "Max DPM Link".to_string(),
-                            format!("Gen{} x{}", max_dpm_link.r#gen, max_dpm_link.width),
-                        );
-                    }
-
-                    (app_device_info.marketing_name, detail)
-                } else {
-                    (String::from("Unknown GPU"), HashMap::new())
-                };
-
-                // Get driver version
-                match device.device_handle.get_drm_version_struct() {
-                    Ok(drm) => {
-                        if drm.version_major >= 0
-                            && drm.version_major <= MAX_VERSION_COMPONENT
-                            && drm.version_minor >= 0
-                            && drm.version_minor <= MAX_VERSION_COMPONENT
-                            && drm.version_patchlevel >= 0
-                            && drm.version_patchlevel <= MAX_VERSION_COMPONENT
-                        {
-                            let ver = format!(
-                                "{}.{}.{}",
-                                drm.version_major, drm.version_minor, drm.version_patchlevel
-                            );
-                            detail.insert("Driver Version".to_string(), ver);
-                        } else {
-                            eprintln!(
-                                "Warning: Invalid driver version components detected: {}.{}.{} for device {}",
-                                drm.version_major, drm.version_minor, drm.version_patchlevel,
-                                device.device_path.pci
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "Warning: Failed to get driver version for device {}: {e}",
-                            device.device_path.pci
-                        );
-                    }
-                };
-
-                DeviceStaticInfo::with_details(device_name, None, detail)
-            })
-    }
-
-    /// Check if we have permission to access AMD GPU devices
-    /// Returns false if /dev/dri devices are not accessible
-    fn check_amd_gpu_permissions() -> bool {
-        use std::fs;
-
-        // Check if /dev/dri directory exists and is accessible
-        let dri_path = std::path::Path::new("/dev/dri");
-        if !dri_path.exists() {
-            return false;
-        }
-
-        // Try to read the directory to check permissions
-        match fs::read_dir(dri_path) {
-            Ok(entries) => {
-                // Check if we can read at least one render or card device
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-
-                    // Check card or render devices
-                    if file_name.starts_with("card") || file_name.starts_with("render") {
-                        // Check if we have read/write permissions
-                        // For root: always has access
-                        // SAFETY: libc::geteuid() is always safe to call - it's a simple
-                        // system call that reads the effective user ID from the kernel.
-                        // It cannot fail and doesn't access any memory we provide.
-                        if unsafe { libc::geteuid() } == 0 {
-                            return true; // Root always has access
-                        }
-
-                        // For non-root, check if we can actually open the device
-                        if let Ok(_file) = fs::OpenOptions::new().read(true).write(true).open(&path)
-                        {
-                            return true; // We have access
-                        }
-                    }
-                }
-                false // No accessible devices found
-            }
-            Err(_) => false, // Cannot read /dev/dri directory
         }
     }
 }
 
 impl GpuReader for AmdGpuReader {
     fn get_gpu_info(&self) -> Vec<GpuInfo> {
-        let mut gpu_info = Vec::new();
-
-        for device in &self.devices {
-            // Get cached static device information (fetched only once)
-            let static_info = self.get_device_static_info(device);
-            let mut detail = static_info.detail.clone();
-            let device_name = static_info.name.clone();
-
-            // Get device info for dynamic metrics only
-            let ext_info = match device.device_handle.device_info() {
-                Ok(info) => info,
-                Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to get device info for AMD GPU {}: {e}",
-                        device.device_path.pci
-                    );
-                    continue; // Skip this GPU if we can't get device info
-                }
-            };
-
-            // Update the VramUsage from the driver (following libamdgpu-top pattern)
-            // SAFETY: We handle mutex poisoning by recreating the VramUsage from fresh memory_info
-            let memory_info = {
-                let vram_usage_result = device.vram_usage.lock();
-
-                match vram_usage_result {
-                    Ok(mut vram_usage) => {
-                        // Normal path: update and read
-                        vram_usage.update_usage(&device.device_handle);
-                        vram_usage.update_usable_heap_size(&device.device_handle);
-                        vram_usage.0 // VramUsage is a tuple struct wrapping drm_amdgpu_memory_info
-                    }
-                    Err(poisoned) => {
-                        // Mutex was poisoned - recover by getting fresh memory info
-                        // This prevents denial of service from panics in other threads
-                        eprintln!(
-                            "Warning: VramUsage mutex was poisoned for device {}, recovering...",
-                            device.device_path.pci
-                        );
-
-                        // Try to get fresh memory info from the device
-                        match device.device_handle.memory_info() {
-                            Ok(fresh_memory_info) => {
-                                // Attempt to recover the poisoned mutex safely
-                                // into_inner() can theoretically panic if the mutex is in an
-                                // inconsistent state, though this is extremely rare with modern
-                                // standard library implementations
-                                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                    poisoned.into_inner()
-                                })) {
-                                    Ok(mut guard) => {
-                                        // Successfully recovered the guard
-                                        *guard = VramUsage::new(&fresh_memory_info);
-                                        guard.update_usage(&device.device_handle);
-                                        guard.update_usable_heap_size(&device.device_handle);
-                                        guard.0
-                                    }
-                                    Err(_) => {
-                                        // Recovery failed - skip this GPU
-                                        eprintln!(
-                                            "Critical: Failed to recover poisoned mutex for device {}, skipping",
-                                            device.device_path.pci
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                eprintln!("Failed to get fresh memory info during recovery: {e}");
-                                continue; // Skip this GPU if we can't recover
-                            }
-                        }
-                    }
-                }
-            };
-
-            // Get dynamic sensor information
-            let sensors = libamdgpu_top::stat::Sensors::new(
-                &device.device_handle,
-                &device.device_path.pci,
-                &ext_info,
-            );
-
-            // Add dynamic sensor data to details
-            //
-            // The tachometer reading is published twice on purpose: once as
-            // the typed `GpuInfo::fan_speed_rpm` field that the TUI and the
-            // Prometheus exporter read, and once as the `Fan Speed` detail
-            // string that snapshots and the cross-reader overwrite guard in
-            // `intel_gpu_level_zero::apply_fan` still depend on. Both come
-            // from the same `sensors.fan_rpm` value so they cannot disagree.
-            let mut fan_speed_rpm = None;
-            if let Some(ref sensors) = sensors {
-                if let Some(link) = sensors.current_link {
-                    detail.insert(
-                        "Current Link".to_string(),
-                        format!("Gen{} x{}", link.r#gen, link.width),
-                    );
-                }
-                if let Some(fan) = clamp_fan_rpm(sensors.fan_rpm) {
-                    fan_speed_rpm = Some(fan);
-                    detail.insert("Fan Speed".to_string(), format!("{fan} RPM"));
-                }
-                if let Some(mclk) = sensors.mclk {
-                    detail.insert("Memory Clock".to_string(), format!("{mclk} MHz"));
-                }
-            }
-
-            let mut utilization = 0.0;
-            let mut power_consumption = 0.0;
-            let mut temperature: u32 = 0;
-            let mut frequency: u32 = 0;
-
-            // Try to get metrics from GpuMetrics first with validation
-            if let Ok(metrics) = GpuMetrics::get_from_sysfs_path(&device.device_path.sysfs_path) {
-                if let Some(gfx_activity) = metrics.get_average_gfx_activity() {
-                    // Validate utilization is within reasonable bounds
-                    utilization = (gfx_activity as f64).clamp(0.0, MAX_GPU_UTILIZATION);
-                }
-                if let Some(power) = metrics.get_average_socket_power() {
-                    // Validate power consumption
-                    let watts = power as f64 / 1000.0; // Convert mW to W
-                    power_consumption = watts.clamp(0.0, MAX_GPU_POWER_WATTS);
-                }
-                if let Some(temp) = metrics.get_temperature_edge() {
-                    // Validate temperature
-                    temperature = (temp as u32).min(MAX_GPU_TEMP_CELSIUS);
-                }
-                if let Some(freq) = metrics.get_current_gfxclk() {
-                    // Validate frequency
-                    frequency = (freq as u32).min(MAX_GPU_FREQ_MHZ);
-                }
-            }
-
-            // Fallback to sensors if metrics failed or missing (with validation)
-            if let Some(ref s) = sensors {
-                if utilization == 0.0 {
-                    // Approximate utilization from load if available, or leave 0
-                    // libamdgpu_top doesn't expose a simple "gpu load" sensor easily without GpuMetrics or fdinfo
-                }
-                if power_consumption == 0.0 {
-                    if let Some(ref p) = s.average_power {
-                        let watts = p.value as f64 / 1000.0; // Convert mW to W
-                        power_consumption = watts.clamp(0.0, MAX_GPU_POWER_WATTS);
-                    } else if let Some(ref p) = s.input_power {
-                        let watts = p.value as f64 / 1000.0; // Convert mW to W
-                        power_consumption = watts.clamp(0.0, MAX_GPU_POWER_WATTS);
-                    }
-                }
-                if temperature == 0
-                    && let Some(ref t) = s.edge_temp
-                {
-                    temperature = (t.current as u32).min(MAX_GPU_TEMP_CELSIUS);
-                }
-                if frequency == 0
-                    && let Some(clk) = s.sclk
-                {
-                    frequency = clk.min(MAX_GPU_FREQ_MHZ);
-                }
-            }
-
-            // Use memory_info from VramUsage (already updated above)
-            // The update_usable_heap_size() call updates total_heap_size from vram_gtt_info()
-            // but we do it once per update cycle, not repeated queries
-
-            // Get VRAM size - try multiple sources in order with validation
-            // Current max is MI325X with 288GB, but we allow headroom for future models
-            // Use saturating operations to prevent any possibility of overflow
-            let total_memory = if memory_info.vram.total_heap_size > 0 {
-                memory_info.vram.total_heap_size.min(MAX_GPU_MEMORY_BYTES)
-            } else if memory_info.vram.usable_heap_size > 0 {
-                memory_info.vram.usable_heap_size.min(MAX_GPU_MEMORY_BYTES)
-            } else {
-                0
-            };
-
-            // Validate used memory doesn't exceed total - use saturating_sub to prevent underflow
-            // in case of driver reporting incorrect values
-            let used_memory = memory_info.vram.heap_usage.min(total_memory);
-
-            let info = GpuInfo {
-                uuid: format!("GPU-{}", device.device_path.pci), // AMD doesn't have UUIDs like NVIDIA, use PCI
-                time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
-                name: device_name, // Use cached device name
-                device_type: "GPU".to_string(),
-                host_id: get_hostname(),
-                hostname: get_hostname(),
-                instance: get_hostname(),
-                utilization,
-                ane_utilization: 0.0,
-                dla_utilization: None,
-                tensorcore_utilization: None,
-                temperature,
-                used_memory,
-                total_memory,
-                frequency,
-                power_consumption,
-                gpu_core_count: None,
-                // AMD GPUs surface temperature through libamdgpu_top; NVML
-                // thermal-threshold and P-state APIs do not apply here.
-                temperature_threshold_slowdown: None,
-                temperature_threshold_shutdown: None,
-                temperature_threshold_max_operating: None,
-                temperature_threshold_acoustic: None,
-                performance_state: None,
-                fan_speed_rpm,
-                // NVIDIA-specific hardware details (NUMA, GSP firmware,
-                // NvLink, GPM) do not apply to AMD — leave them at the
-                // "unavailable" defaults so consumers render them as
-                // missing rather than zero.
-                numa_node_id: None,
-                gsp_firmware_mode: None,
-                gsp_firmware_version: None,
-                nvlink_remote_devices: Vec::new(),
-                gpm_metrics: None,
-                detail,
-            };
-            gpu_info.push(info);
-        }
-
-        gpu_info
+        let Some(plugin) = &self.plugin else {
+            return Vec::new();
+        };
+        self.collect(
+            plugin
+                .api
+                .read_gpu_info_json
+                .expect("validated function pointer"),
+        )
     }
 
     fn get_process_info(&self) -> Vec<ProcessInfo> {
-        use std::collections::{HashMap, HashSet};
-
-        let mut process_info_list = Vec::new();
-
-        // Get process list once for fdinfo parsing
-        let proc_list = stat::get_process_list();
-
-        // Collect all GPU process data in a single pass
-        struct GpuProcessData {
-            device_id: usize,
-            device_uuid: String,
-            pid: u32,
-            name: String,
-            vram_usage_kib: u64,
-            gtt_usage_kib: u64,
-        }
-
-        let mut gpu_processes = Vec::new();
-        let mut gpu_pids = HashSet::new();
-
-        // Single pass: collect all GPU process data
-        for (device_idx, device) in self.devices.iter().enumerate() {
-            // Build process index for this device
-            let mut proc_index: Vec<ProcInfo> = Vec::new();
-            stat::update_index_by_all_proc(
-                &mut proc_index,
-                &[&device.device_path.render, &device.device_path.card],
-                &proc_list,
-            );
-
-            // Get fdinfo usage for all processes
-            let mut fdinfo = FdInfoStat::default();
-            fdinfo.update_proc_usage(&proc_index);
-
-            // Collect process data
-            for proc_usage in fdinfo.proc_usage {
-                let vram_usage_kib = proc_usage.usage.vram_usage;
-                let gtt_usage_kib = proc_usage.usage.gtt_usage;
-
-                // Include process if it uses VRAM or GTT (GPU memory)
-                if vram_usage_kib > 0 || gtt_usage_kib > 0 {
-                    let pid = proc_usage.pid as u32;
-                    gpu_pids.insert(pid);
-
-                    gpu_processes.push(GpuProcessData {
-                        device_id: device_idx,
-                        device_uuid: format!("GPU-{}", device.device_path.pci),
-                        pid,
-                        name: proc_usage.name,
-                        vram_usage_kib,
-                        gtt_usage_kib,
-                    });
-                }
-            }
-        }
-
-        // Get system process information once for all GPU processes
-        // OPTIMIZATION: Use minimal refresh instead of refresh_all() which is extremely expensive
-        // We only need CPU, memory, and basic process info for GPU processes
-        use crate::utils::with_global_system;
-        use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, UpdateKind};
-        let system_processes = with_global_system(|system| {
-            let refresh_kind = ProcessRefreshKind::nothing()
-                .with_cpu()
-                .with_memory()
-                .with_user(UpdateKind::OnlyIfNotSet);
-            system.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
-            crate::device::process_list::get_all_processes(system, &gpu_pids)
-        });
-        let process_map: HashMap<u32, _> = system_processes.iter().map(|p| (p.pid, p)).collect();
-
-        // Build final ProcessInfo list efficiently
-        for gpu_proc in gpu_processes {
-            // Convert to bytes and prioritize VRAM, fallback to GTT
-            let gpu_memory_bytes = if gpu_proc.vram_usage_kib > 0 {
-                gpu_proc.vram_usage_kib * 1024
-            } else {
-                gpu_proc.gtt_usage_kib * 1024
-            };
-
-            // Get system process info or use defaults
-            let sys_proc = process_map.get(&gpu_proc.pid);
-
-            let process_info = ProcessInfo {
-                device_id: gpu_proc.device_id,
-                device_uuid: gpu_proc.device_uuid,
-                pid: gpu_proc.pid,
-                process_name: gpu_proc.name,
-                used_memory: gpu_memory_bytes,
-                cpu_percent: sys_proc.map(|p| p.cpu_percent).unwrap_or(0.0),
-                memory_percent: sys_proc.map(|p| p.memory_percent).unwrap_or(0.0),
-                memory_rss: sys_proc.map(|p| p.memory_rss).unwrap_or(0),
-                memory_vms: sys_proc.map(|p| p.memory_vms).unwrap_or(0),
-                user: sys_proc.map(|p| p.user.clone()).unwrap_or_default(),
-                state: sys_proc.map(|p| p.state.clone()).unwrap_or_default(),
-                start_time: sys_proc.map(|p| p.start_time.clone()).unwrap_or_default(),
-                cpu_time: sys_proc.map(|p| p.cpu_time).unwrap_or(0),
-                command: sys_proc.map(|p| p.command.clone()).unwrap_or_default(),
-                ppid: sys_proc.map(|p| p.ppid).unwrap_or(0),
-                threads: sys_proc.map(|p| p.threads).unwrap_or(0),
-                uses_gpu: true,
-                priority: sys_proc.map(|p| p.priority).unwrap_or(0),
-                nice_value: sys_proc.map(|p| p.nice_value).unwrap_or(0),
-                gpu_utilization: 0.0, // fdinfo doesn't directly provide this per-process
-            };
-
-            process_info_list.push(process_info);
-        }
-
-        process_info_list
+        let Some(plugin) = &self.plugin else {
+            return Vec::new();
+        };
+        self.collect(
+            plugin
+                .api
+                .read_process_info_json
+                .expect("validated function pointer"),
+        )
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_max_version_component_validation() {
-        // Test that MAX_VERSION_COMPONENT is reasonable for Linux kernel versions
-        const {
-            assert!(
-                MAX_VERSION_COMPONENT >= 99,
-                "Should support two-digit version components"
-            );
-            assert!(
-                MAX_VERSION_COMPONENT <= 9999,
-                "Should not be excessively large"
-            );
-        }
-
-        // Common kernel version components should be valid
-        let common_versions = vec![
-            (6, 12, 0),      // Linux 6.12.0
-            (5, 15, 0),      // Linux 5.15.0 LTS
-            (30, 10, 1),     // AMD driver version
-            (999, 999, 999), // Maximum allowed
-        ];
-
-        for (major, minor, patch) in common_versions {
-            assert!(
-                major <= MAX_VERSION_COMPONENT,
-                "Major version {major} should be valid"
-            );
-            assert!(
-                minor <= MAX_VERSION_COMPONENT,
-                "Minor version {minor} should be valid"
-            );
-            assert!(
-                patch <= MAX_VERSION_COMPONENT,
-                "Patch version {patch} should be valid"
-            );
-        }
-    }
-
-    #[test]
-    fn test_version_validation_rejects_invalid() {
-        // Test that we reject unreasonable version numbers
-        let invalid_versions = vec![
-            (1000, 0, 0), // Major too high
-            (0, 1000, 0), // Minor too high
-            (0, 0, 1000), // Patch too high
-            (-1, 0, 0),   // Negative major
-            (0, -1, 0),   // Negative minor
-            (0, 0, -1),   // Negative patch
-        ];
-
-        for (major, minor, patch) in invalid_versions {
-            let major_valid = (0..=MAX_VERSION_COMPONENT).contains(&major);
-            let minor_valid = (0..=MAX_VERSION_COMPONENT).contains(&minor);
-            let patch_valid = (0..=MAX_VERSION_COMPONENT).contains(&patch);
-
-            assert!(
-                !(major_valid && minor_valid && patch_valid),
-                "Version {major}.{minor}.{patch} should be invalid"
-            );
-        }
-    }
-
-    #[test]
-    fn test_memory_validation_constants() {
-        // Test memory validation constants are reasonable
-        assert_eq!(
-            MAX_GPU_MEMORY_BYTES,
-            512 * 1024 * 1024 * 1024,
-            "Max GPU memory should be 512GB"
-        );
-
-        // Current largest AMD GPU is MI325X with 288GB, ensure we support it
-        let mi325x_memory: u64 = 288 * 1024 * 1024 * 1024;
-        assert!(
-            mi325x_memory < MAX_GPU_MEMORY_BYTES,
-            "Should support MI325X 288GB memory"
-        );
-
-        // Future-proof for potential 400GB models
-        let future_memory: u64 = 400 * 1024 * 1024 * 1024;
-        assert!(
-            future_memory < MAX_GPU_MEMORY_BYTES,
-            "Should have headroom for future GPUs"
-        );
-    }
-
-    #[test]
-    fn test_gpu_metric_validation_constants() {
-        // Test that validation constants are reasonable
-        assert_eq!(MAX_GPU_UTILIZATION, 100.0, "Max utilization should be 100%");
-        assert_eq!(
-            MAX_GPU_POWER_WATTS, 1000.0,
-            "Max power should support high-end GPUs"
-        );
-        assert_eq!(
-            MAX_GPU_TEMP_CELSIUS, 125,
-            "Max temp should be above thermal limits"
-        );
-        assert_eq!(
-            MAX_GPU_FREQ_MHZ, 5000,
-            "Max frequency should support boost clocks"
-        );
-
-        // Real-world values should be within limits
-        let mi300x_power = 750.0; // MI300X max TDP
-        assert!(
-            mi300x_power < MAX_GPU_POWER_WATTS,
-            "Should support MI300X power draw"
-        );
-
-        let typical_boost_freq = 2500; // Typical AMD GPU boost
-        assert!(
-            typical_boost_freq < MAX_GPU_FREQ_MHZ,
-            "Should support typical boost frequencies"
-        );
-    }
-
-    #[test]
-    fn clamp_fan_rpm_bounds_a_garbled_sensor_reading() {
-        // A corrupted or overflowed `libamdgpu_top` sample must never reach
-        // `GpuInfo::fan_speed_rpm` (and, from there, the exporter and the
-        // TUI) unclamped.
-        assert_eq!(clamp_fan_rpm(Some(u32::MAX)), Some(MAX_GPU_FAN_RPM));
-        // A real-world reading passes through unchanged.
-        assert_eq!(clamp_fan_rpm(Some(1450)), Some(1450));
-        // No tachometer stays `None`, not a clamped zero.
-        assert_eq!(clamp_fan_rpm(None), None);
-    }
-}
+#[path = "amd_tests.rs"]
+mod tests;

--- a/src/device/readers/amd_plugin_api.rs
+++ b/src/device/readers/amd_plugin_api.rs
@@ -1,0 +1,53 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Versioned C ABI shared by the Linux AMD runtime loader and its plugin.
+//!
+//! Rust values never cross this boundary. The plugin owns an opaque reader
+//! handle and returns JSON in a byte buffer that must be released through the
+//! same function table. Any incompatible table or wire-format change requires
+//! a new ABI version and entry-point symbol.
+
+use std::ffi::c_void;
+
+pub const AMD_PLUGIN_ABI_VERSION: u32 = 1;
+pub const AMD_PLUGIN_ENTRY_SYMBOL: &[u8] = b"all_smi_amd_plugin_entry_v1\0";
+pub const AMD_PLUGIN_WIRE_FORMAT: &str = "all-smi-json-v1";
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct AmdPluginBuffer {
+    pub ptr: *mut u8,
+    pub len: usize,
+    pub capacity: usize,
+}
+
+pub type CreateReaderFn = unsafe extern "C" fn() -> *mut c_void;
+pub type DestroyReaderFn = unsafe extern "C" fn(*mut c_void);
+pub type ReadJsonFn = unsafe extern "C" fn(*mut c_void, *mut AmdPluginBuffer) -> i32;
+pub type ReadMetadataFn = unsafe extern "C" fn(*mut AmdPluginBuffer) -> i32;
+pub type FreeBufferFn = unsafe extern "C" fn(*mut AmdPluginBuffer);
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct AmdPluginApiV1 {
+    pub abi_version: u32,
+    pub struct_size: usize,
+    pub create_reader: Option<CreateReaderFn>,
+    pub destroy_reader: Option<DestroyReaderFn>,
+    pub read_gpu_info_json: Option<ReadJsonFn>,
+    pub read_process_info_json: Option<ReadJsonFn>,
+    pub read_metadata_json: Option<ReadMetadataFn>,
+    pub free_buffer: Option<FreeBufferFn>,
+}

--- a/src/device/readers/amd_tests.rs
+++ b/src/device/readers/amd_tests.rs
@@ -1,0 +1,106 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::c_void;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use super::{
+    AMD_PLUGIN_ABI_VERSION, AMD_PLUGIN_FILENAME, AmdPluginApiV1, AmdPluginBuffer, PluginMetadata,
+    default_candidates, validate_api, validate_candidate, validate_metadata,
+};
+
+unsafe extern "C" fn create() -> *mut c_void {
+    std::ptr::null_mut()
+}
+unsafe extern "C" fn destroy(_handle: *mut c_void) {}
+unsafe extern "C" fn read(_handle: *mut c_void, _out: *mut AmdPluginBuffer) -> i32 {
+    0
+}
+unsafe extern "C" fn metadata(_out: *mut AmdPluginBuffer) -> i32 {
+    0
+}
+unsafe extern "C" fn free(_buffer: *mut AmdPluginBuffer) {}
+
+fn api(version: u32, struct_size: usize) -> AmdPluginApiV1 {
+    AmdPluginApiV1 {
+        abi_version: version,
+        struct_size,
+        create_reader: Some(create),
+        destroy_reader: Some(destroy),
+        read_gpu_info_json: Some(read),
+        read_process_info_json: Some(read),
+        read_metadata_json: Some(metadata),
+        free_buffer: Some(free),
+    }
+}
+
+#[test]
+fn search_paths_are_qualified_and_never_include_the_working_directory() {
+    let candidates = default_candidates(Path::new("/opt/all-smi/bin/all-smi"));
+    assert_eq!(
+        candidates[0],
+        PathBuf::from("/opt/all-smi/bin").join(AMD_PLUGIN_FILENAME)
+    );
+    assert!(candidates.iter().all(|path| path.is_absolute()));
+    assert!(
+        candidates
+            .iter()
+            .all(|path| path != Path::new(AMD_PLUGIN_FILENAME))
+    );
+}
+
+#[test]
+fn mismatched_or_truncated_abi_is_rejected_clearly() {
+    let size = std::mem::size_of::<AmdPluginApiV1>();
+    assert!(validate_api(&api(AMD_PLUGIN_ABI_VERSION, size)).is_ok());
+    let mismatch = validate_api(&api(AMD_PLUGIN_ABI_VERSION + 1, size)).unwrap_err();
+    assert!(mismatch.contains("ABI mismatch"));
+    let truncated = validate_api(&api(AMD_PLUGIN_ABI_VERSION, size - 1)).unwrap_err();
+    assert!(truncated.contains("truncated"));
+    let mut null_entry = api(AMD_PLUGIN_ABI_VERSION, size);
+    null_entry.create_reader = None;
+    let null_error = validate_api(&null_entry).unwrap_err();
+    assert!(null_error.contains("null function pointer"));
+}
+
+#[test]
+fn world_writable_plugin_locations_are_refused() {
+    let temp = tempfile::tempdir().expect("temporary directory");
+    let plugin_dir = temp.path().join("plugins");
+    fs::create_dir(&plugin_dir).expect("plugin directory");
+    fs::set_permissions(&plugin_dir, fs::Permissions::from_mode(0o777))
+        .expect("world-writable mode");
+    let plugin = plugin_dir.join(AMD_PLUGIN_FILENAME);
+    fs::write(&plugin, b"not a library").expect("plugin fixture");
+    let error = validate_candidate(&plugin).unwrap_err();
+    assert!(error.contains("world-writable"), "{error}");
+}
+
+#[test]
+fn mismatched_plugin_version_or_wire_format_is_rejected() {
+    let mut metadata = PluginMetadata {
+        plugin_version: "0.0.0".to_string(),
+        libamdgpu_top_version: "0.11.5".to_string(),
+        wire_format: super::AMD_PLUGIN_WIRE_FORMAT.to_string(),
+    };
+    let version_error = validate_metadata(&metadata).unwrap_err();
+    assert!(version_error.contains("plugin version mismatch"));
+
+    metadata.plugin_version = env!("CARGO_PKG_VERSION").to_string();
+    metadata.wire_format = "incompatible-wire-format".to_string();
+    let wire_error = validate_metadata(&metadata).unwrap_err();
+    assert!(wire_error.contains("wire format mismatch"));
+}

--- a/src/device/readers/mod.rs
+++ b/src/device/readers/mod.rs
@@ -51,11 +51,12 @@ pub mod tpu_sysfs;
 #[cfg(target_os = "linux")]
 pub mod tenstorrent;
 
-// Gated on glibc Linux plus the default-on `amd` cargo feature (issue #345).
-// Disabling the feature drops the `libamdgpu_top` dependency and with it the
-// `libdrm.so.2` / `libdrm_amdgpu.so.1` link-time requirements.
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+// The main crate owns only a runtime loader. The companion cdylib keeps
+// `libamdgpu_top` and its libdrm linkage out of every consumer binary.
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
 pub mod amd;
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+pub mod amd_plugin_api;
 
 #[cfg(target_os = "windows")]
 pub mod amd_windows;

--- a/src/doctor/bundle.rs
+++ b/src/doctor/bundle.rs
@@ -342,9 +342,9 @@ fn enabled_features() -> Vec<&'static str> {
     let mut v = vec![
         #[cfg(feature = "cli")]
         "cli",
-        // Recorded so a support bundle shows whether the AMD backend was compiled
-        // in; its absence here is the first thing to check when AMD GPUs are
-        // missing from a glibc build (issue #345).
+        // Retained as a cargo-feature record for compatibility. It is a no-op;
+        // `amd.libamdgpu_top.abi` in the doctor report carries effective plugin
+        // availability and the exact runtime failure reason.
         #[cfg(feature = "amd")]
         "amd",
         #[cfg(feature = "mock")]

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `amd.*` checks: ROCm, libamdgpu_top, DRI access, and build-time gating
-//! (the musl target gate and the default-on `amd` cargo feature).
+//! `amd.*` checks: ROCm, the runtime-loaded Linux AMD plugin, DRI access,
+//! the musl target gate, and Windows ADL diagnostics.
 
 #[cfg(target_os = "linux")]
 use std::time::Duration;
@@ -37,27 +37,6 @@ pub fn checks() -> &'static [&'static Check] {
     CHECKS
 }
 
-/// The exact `libamdgpu_top` version pinned in `Cargo.toml`.
-///
-/// Cargo hands the compiler no dependency versions, so `env!` cannot reach
-/// this and the value has to be transcribed. `check_libamdgpu_top` used to
-/// format `env!("CARGO_PKG_VERSION")` into the ABI string, which reported
-/// all-smi's own version as the dependency's (issue #362). The transcription
-/// is kept honest by `pinned_version_matches_cargo_toml`, which parses the `=`
-/// pin out of `Cargo.toml` and fails when the two disagree, so a pin bump that
-/// forgets this constant breaks a test instead of shipping a wrong ABI
-/// identifier.
-///
-/// The `test` arm of the `cfg` keeps the constant alive in configurations
-/// where the reporting arm below is compiled out (musl, non-Linux, or the
-/// `amd` feature off) so the guard test runs everywhere. Without it the
-/// constant would be dead code in exactly those builds.
-#[cfg(any(
-    all(target_os = "linux", not(target_env = "musl"), feature = "amd"),
-    test
-))]
-const LIBAMDGPU_TOP_PINNED_VERSION: &str = "0.11.5";
-
 static ROCM_VERSION: Check = Check {
     id: "amd.rocm.version",
     title: "ROCm version",
@@ -67,7 +46,7 @@ static ROCM_VERSION: Check = Check {
 
 static LIBAMDGPU_TOP_ABI: Check = Check {
     id: "amd.libamdgpu_top.abi",
-    title: "libamdgpu_top ABI",
+    title: "AMD runtime plugin",
     severity_on_fail: Severity::Warn,
     run: check_libamdgpu_top,
 };
@@ -80,7 +59,7 @@ static DRI_PERMS: Check = Check {
 };
 
 // The check id stays `amd.build.target_env` for compatibility with existing
-// bundles and docs even though it now reports the `amd` cargo feature as well.
+// bundles even though the cargo feature is now an accepted no-op.
 static BUILD_GATE: Check = Check {
     id: "amd.build.target_env",
     title: "AMD build-time availability",
@@ -536,31 +515,34 @@ fn check_rocm(_ctx: &CheckCtx) -> CheckResult {
 }
 
 fn check_libamdgpu_top(_ctx: &CheckCtx) -> CheckResult {
-    // Three distinct Linux outcomes, so a user never gets told the wrong
-    // reason for a missing AMD backend: linked, compiled out by the musl
-    // target gate, or compiled out by the `amd` cargo feature (issue #345).
-    #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+    #[cfg(all(target_os = "linux", not(target_env = "musl")))]
     {
-        // The `libamdgpu_top` crate is linked at compile time; if this
-        // binary was built with AMD support the dep is present. Surface
-        // the dependency's pinned version as the ABI identifier, not
-        // all-smi's own version (issue #362).
-        CheckResult::Pass(format!(
-            "linked libamdgpu_top {LIBAMDGPU_TOP_PINNED_VERSION}"
-        ))
-    }
-    #[cfg(all(target_os = "linux", not(target_env = "musl"), not(feature = "amd")))]
-    {
-        CheckResult::Skip(
-            "libamdgpu_top not linked: built without the `amd` cargo feature (see \
-             amd.build.target_env)"
-                .to_string(),
-        )
+        use crate::device::readers::amd::{self, AmdBackendStatus};
+
+        match amd::backend_status() {
+            AmdBackendStatus::Loaded {
+                path,
+                abi_version,
+                plugin_version,
+                libamdgpu_top_version,
+            } => CheckResult::Pass(format!(
+                "loaded {} (plugin {plugin_version}, ABI v{abi_version}, libamdgpu_top {libamdgpu_top_version})",
+                path.display()
+            )),
+            AmdBackendStatus::Unavailable { reason } => CheckResult::Warn(
+                reason,
+                Some(
+                    "install the packaged AMD companion library, then rerun doctor; missing libdrm dependencies are reported by dlopen in this check"
+                        .to_string(),
+                ),
+            ),
+        }
     }
     #[cfg(all(target_os = "linux", target_env = "musl"))]
     {
         CheckResult::Skip(
-            "libamdgpu_top not linked in musl builds (see amd.build.target_env)".to_string(),
+            "AMD runtime plugin is unavailable in musl builds (see amd.build.target_env)"
+                .to_string(),
         )
     }
     #[cfg(not(target_os = "linux"))]
@@ -601,102 +583,35 @@ fn check_dri_perms(_ctx: &CheckCtx) -> CheckResult {
     }
 }
 
-/// Report which build-time gate, if any, compiled the AMD backend out.
+/// Report whether this target can host the runtime AMD plugin.
 ///
-/// Two independent gates can remove it: the musl target gate, and the
-/// default-on `amd` cargo feature (issue #345). The three arms below are
-/// mutually exclusive and exhaustive, and each names the gate that actually
-/// applies so `all-smi doctor` never blames the wrong one.
+/// The legacy `amd` cargo feature is intentionally irrelevant here: it is a
+/// compatibility no-op, so `default-features = false` consumers get the same
+/// loader as default builds without inheriting libdrm linkage.
 fn check_build_gate(_ctx: &CheckCtx) -> CheckResult {
     #[cfg(target_env = "musl")]
     {
         CheckResult::Warn(
-            "musl build — AMD support compiled out".to_string(),
+            "musl build — AMD runtime plugin loader is unavailable".to_string(),
             Some("use a glibc build (x86_64-unknown-linux-gnu) for AMD GPU monitoring".to_string()),
         )
     }
-    #[cfg(all(target_os = "linux", not(target_env = "musl"), not(feature = "amd")))]
+    #[cfg(all(target_os = "linux", not(target_env = "musl")))]
     {
-        CheckResult::Warn(
-            "glibc build without the `amd` cargo feature: AMD support compiled out".to_string(),
-            Some(
-                "rebuild with the default features, or add `--features amd`, for AMD GPU \
-                 monitoring; the feature is off here because something disabled it (typically a \
-                 downstream `default-features = false`) to avoid linking libdrm"
-                    .to_string(),
-            ),
+        CheckResult::Pass(
+            "glibc Linux build — AMD runtime loader compiled in; the `amd` cargo feature does not gate it"
+                .to_string(),
         )
     }
-    #[cfg(all(
-        not(target_env = "musl"),
-        any(not(target_os = "linux"), feature = "amd")
-    ))]
+    #[cfg(all(not(target_env = "musl"), not(target_os = "linux")))]
     {
-        CheckResult::Pass("glibc or non-Linux target — AMD support available".to_string())
+        CheckResult::Pass("non-Linux target — Linux AMD runtime plugin not applicable".to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{LIBAMDGPU_TOP_PINNED_VERSION, per_card_verdict};
-
-    /// `Cargo.toml` is embedded at compile time rather than read from a
-    /// runtime path so the test does not depend on the working directory,
-    /// and so editing the manifest forces a rebuild of this test.
-    const MANIFEST: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
-
-    /// Extract the exact version from the `libamdgpu_top` dependency line.
-    ///
-    /// Returns `None` when no dependency line is found or the version cannot
-    /// be read, which the caller turns into a failure: a manifest the parser
-    /// no longer understands must not quietly pass the guard. Comment lines
-    /// mentioning the crate are skipped because they start with `#`.
-    fn pinned_libamdgpu_top_version(manifest: &str) -> Option<&str> {
-        let line = manifest
-            .lines()
-            .map(str::trim)
-            .find(|l| l.starts_with("libamdgpu_top") && l.contains("version"))?;
-        let after_key = line.split_once("version")?.1;
-        let after_quote = after_key.split_once('"')?.1;
-        let value = after_quote.split_once('"')?.0;
-        Some(value.trim().trim_start_matches('=').trim())
-    }
-
-    /// The reported ABI identifier must be the pinned dependency version.
-    ///
-    /// This is the forcing function the `Cargo.toml` comment asks for by
-    /// hand: bumping the `=` pin without updating
-    /// [`LIBAMDGPU_TOP_PINNED_VERSION`] fails here rather than shipping a
-    /// wrong version to whoever is debugging an AMD ABI problem.
-    #[test]
-    fn pinned_version_matches_cargo_toml() {
-        let pinned = pinned_libamdgpu_top_version(MANIFEST).expect(
-            "could not parse the libamdgpu_top version out of Cargo.toml; if the dependency \
-             declaration moved or changed shape, update pinned_libamdgpu_top_version",
-        );
-        assert_eq!(
-            pinned, LIBAMDGPU_TOP_PINNED_VERSION,
-            "libamdgpu_top is pinned to {pinned} in Cargo.toml but amd.libamdgpu_top.abi reports \
-             {LIBAMDGPU_TOP_PINNED_VERSION}; update LIBAMDGPU_TOP_PINNED_VERSION to match the pin"
-        );
-    }
-
-    /// The pin must stay an exact `=` requirement. A caret or range would
-    /// let Cargo resolve a different version than the one reported, which
-    /// this guard could not detect.
-    #[test]
-    fn libamdgpu_top_is_pinned_exactly() {
-        let line = MANIFEST
-            .lines()
-            .map(str::trim)
-            .find(|l| l.starts_with("libamdgpu_top") && l.contains("version"))
-            .expect("libamdgpu_top dependency line not found in Cargo.toml");
-        assert!(
-            line.contains("\"="),
-            "libamdgpu_top must stay pinned with an exact `=` requirement so the reported ABI \
-             version is the resolved one, got: {line}"
-        );
-    }
+    use super::per_card_verdict;
 
     fn readout(power_w: f64) -> Option<String> {
         Some(format!("power=Some({power_w})W"))

--- a/src/doctor/checks/platform.rs
+++ b/src/doctor/checks/platform.rs
@@ -114,24 +114,13 @@ fn check_runtime(_ctx: &CheckCtx) -> CheckResult {
         msg.push_str(&format!(" (env={env})"));
     }
 
-    // The AMD backend is gated on `not(target_env = "musl")` and on the
-    // default-on `amd` cargo feature; surface a warning naming whichever gate
-    // actually removed it so the reason is never misattributed (issue #345).
+    // The runtime AMD plugin cannot participate in a statically linked musl
+    // build. Cargo feature state is deliberately irrelevant now.
     #[cfg(target_env = "musl")]
     {
         return CheckResult::Warn(
             format!("{msg} — musl builds do not include AMD GPU support"),
             Some("rebuild with a glibc target (e.g. x86_64-unknown-linux-gnu) for AMD".to_string()),
-        );
-    }
-
-    #[cfg(all(target_os = "linux", not(target_env = "musl"), not(feature = "amd")))]
-    {
-        return CheckResult::Warn(
-            format!(
-                "{msg}, built without the `amd` cargo feature so AMD GPU support is compiled out"
-            ),
-            Some("rebuild with the default features, or add `--features amd`, for AMD".to_string()),
         );
     }
 

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -98,9 +98,9 @@ pub fn ensure_sudo_permissions() {
     if cfg!(target_os = "macos") {
         // macOS uses native APIs (IOReport, SMC) that don't require sudo
     } else if cfg!(target_os = "linux") {
-        // On Linux, check if we have AMD GPUs that require sudo (glibc only,
-        // and only when the default-on `amd` feature is enabled)
-        #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+        // On Linux, check if AMD hardware needs DRI privileges. Detection is
+        // feature-independent; the native backend itself is loaded later.
+        #[cfg(all(target_os = "linux", not(target_env = "musl")))]
         {
             use crate::device::platform_detection::has_amd;
 
@@ -172,9 +172,9 @@ pub fn ensure_sudo_permissions_with_fallback() -> bool {
         // macOS uses native APIs (IOReport, SMC) that don't require sudo
         true
     } else if cfg!(target_os = "linux") {
-        // On Linux, check if we have AMD GPUs that require sudo (glibc only,
-        // and only when the default-on `amd` feature is enabled)
-        #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "amd"))]
+        // On Linux, check if AMD hardware needs DRI privileges. Detection is
+        // feature-independent; the native backend itself is loaded later.
+        #[cfg(all(target_os = "linux", not(target_env = "musl")))]
         {
             use crate::device::platform_detection::has_amd;
 
@@ -190,8 +190,8 @@ pub fn ensure_sudo_permissions_with_fallback() -> bool {
                 return true;
             }
         }
-        // For musl builds, builds without the `amd` feature, or when no AMD
-        // GPU is detected, no sudo is needed
+        // For musl builds or when no AMD GPU is detected, no AMD-specific
+        // privilege escalation is needed.
         true
     } else {
         true

--- a/tests/homebrew-formula-workflow/cases-formula.sh
+++ b/tests/homebrew-formula-workflow/cases-formula.sh
@@ -82,6 +82,7 @@ case_state1_asset_and_stanza() {
 
     formula="$box/homebrew-tap/Formula/all-smi.rb"
     assert_file_has "version bumped" "$formula" "version \"${NEW_VERSION}\""
+    assert_file_has "Linux installs the AMD companion" "$formula" '(lib/"all-smi").install "liball_smi_amd.so" if OS.linux?'
     assert_eq "four sha256 stanzas" 4 "$(count_sha_stanzas "$formula")"
     assert_eq "aarch64 macOS url rewritten" "$mac_url" "$(url_of "$formula" all-smi-macos-aarch64.zip)"
     assert_eq "aarch64 macOS checksum is its own" "$SHA_MAC" "$(sha_after "$formula" all-smi-macos-aarch64.zip)"

--- a/tests/homebrew-formula-workflow/lib.sh
+++ b/tests/homebrew-formula-workflow/lib.sh
@@ -135,6 +135,7 @@ make_tap() {  # dir fixture
 # the axis the four asset/stanza states turn on.
 export_artifact_env() {  # mac_x86_present
     export VERSION_NO_V="$NEW_VERSION"
+    export amd_plugin_present=true
     export mac_url="${NEW_BASE}/all-smi-macos-aarch64.zip"
     export mac_sha="$SHA_MAC"
     export linux_arm_url="${NEW_BASE}/all-smi-linux-aarch64.tar.gz"


### PR DESCRIPTION
## Summary

- Restore Linux AMD detection for `default-features = false` consumers without adding libdrm `NEEDED` entries to the main executable or downstream binaries.
- Move the existing libamdgpu_top reader into a separately packaged `liball_smi_amd.so` companion and load it through a narrow versioned C ABI.

## Implementation

- Add safe absolute-path discovery, canonicalization, world-writable-path rejection, nullable function-table validation, exact host/plugin version checks, wire-format validation, serialized calls, and graceful load/sampling failure handling.
- Keep AMD PCI/sysfs detection and the loader enabled on every glibc Linux feature configuration while retaining `amd` as an accepted compatibility no-op.
- Report the loaded plugin path, plugin/ABI/libamdgpu_top versions, and exact unavailable reason through the existing `amd.libamdgpu_top.abi` doctor check, distinct from musl and cargo-feature state.
- Package the companion beside Linux release binaries, under Homebrew `lib/all-smi`, and under Debian `/usr/lib/all-smi`, with old-tag compatibility in self-healing release/package workflows.
- Document deployment, search order, Cargo-install limitations, architecture, and linkage verification.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p all-smi --lib --tests`
- `cargo check -p all-smi-amd-plugin --lib --tests`
- `cargo check -p all-smi --bin all-smi`
- `cargo check -p all-smi --no-default-features --lib`
- `cargo test -p all-smi --lib device::readers::amd::tests::`
- `cargo test -p all-smi --no-default-features --lib device::readers::amd::tests::`
- `cargo test -p all-smi-amd-plugin --lib tests::metadata_matches_exact_dependency_pin`
- `cargo test -p all-smi-amd-plugin --lib reader::tests::`
- `cargo clippy -p all-smi --lib --tests -- -D warnings`
- `cargo clippy -p all-smi-amd-plugin --lib --tests -- -D warnings`
- Debug builds plus `objdump -p`: the host lists no libdrm dependency; the companion lists `libdrm.so.2` and `libdrm_amdgpu.so.1`.
- `all-smi doctor --only amd --json`: explicit companion path passes with plugin 0.26.1 / ABI v1 / libamdgpu_top 0.11.5; a nonexistent path warns accurately and startup succeeds.
- Modified workflow YAML parses; modified Homebrew step bodies pass `bash -n`; root crate packaging succeeds.

## Review notes

- Correctness review verified every acceptance path, buffer ownership, version refusal, feature independence, package layout, and graceful fallback behavior.
- Security review verified no current-directory or bare-name lookup, canonical absolute loading, world-writable rejection, bounded ABI-header reads, null function-pointer rejection, and paired opaque-handle/buffer destruction.
- Performance review verified one-time plugin discovery/loading, one reader per detected AMD backend, serialized FFI access, cached static device data, and unchanged native sampling behavior inside the companion.
- The available Linux aarch64 runner exposes NVIDIA hardware rather than AMD hardware, so live AMD sampling could not be exercised locally; the existing libamdgpu_top reader was moved without behavioral changes and all loader/linkage/doctor paths were exercised.

Closes #359
