### PR TITLE
fix: make local TUI layout responsive

### DIFF
--- a/src/ui/buffer.rs
+++ b/src/ui/buffer.rs
@@ -19,6 +19,8 @@ use crossterm::{
 };
 use std::io::{Write, stdout};
 
+use crate::ui::text::truncate_ansi_to_width;
+
 pub struct BufferWriter {
     buffer: String,
     line_count: usize,
@@ -146,11 +148,20 @@ impl DifferentialRenderer {
         // Process lines directly from iterator, updating previous_lines in-place.
         // Per-line string comparison is the authoritative change-detection mechanism.
         // Rust's String `!=` checks length first, so identical lines are O(1).
-        for (line_num, current_line) in content.lines().enumerate() {
+        for (line_num, raw_line) in content.lines().enumerate() {
             if line_num >= self.screen_height {
                 break;
             }
             current_line_count = line_num + 1;
+
+            // A terminal wraps a line before the differential renderer can
+            // move to the next logical row. Clamp every row at this final
+            // boundary so an unexpectedly long device value can never
+            // overwrite the rows below it. Semantic renderers still choose
+            // which fields to show; this is the invariant-preserving safety
+            // net for unusual driver strings and future fields.
+            let current_line = truncate_ansi_to_width(raw_line, self.screen_width);
+            let current_line = current_line.as_ref();
 
             // Check if this line has changed (cheap pointer + length comparison first)
             if self.previous_lines[line_num] != current_line {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -32,15 +32,17 @@ impl LayoutCalculator {
     /// so their line contributions are excluded here.  This keeps the content
     /// area (process list, GPU rows) from being unnecessarily clipped and
     /// preserves the "reserved space for function keys" regression fix.
-    pub fn calculate_header_lines(state: &AppState) -> u16 {
+    pub fn calculate_header_lines(state: &AppState, cols: u16) -> u16 {
         let mut lines = 0u16;
 
         // Basic header (title line)
         lines += 1;
 
         if state.is_local_mode {
-            // Local mode shows the two-line host summary bar (identity + sparklines)
-            lines += 2;
+            // Local mode shows an identity row plus responsive metrics. The
+            // metrics intentionally occupy two rows below 40 columns rather
+            // than relying on terminal auto-wrap.
+            lines += crate::ui::local_header::local_header_line_count(cols);
         } else {
             // "Cluster Overview" label line
             lines += 1;
@@ -62,7 +64,7 @@ impl LayoutCalculator {
 
     /// Calculate available content area
     pub fn calculate_content_area(state: &AppState, cols: u16, rows: u16) -> ContentArea {
-        let header_lines = Self::calculate_header_lines(state);
+        let header_lines = Self::calculate_header_lines(state, cols);
         let function_keys_lines = 1; // Reserve space for function keys
 
         // In local mode, the Activity panel (CPU left + GPU right) consumes
@@ -139,7 +141,16 @@ impl LayoutCalculator {
         // mixed pages may under-fill by one row, which is acceptable —
         // overshooting would clip the gauges off-screen and corrupt the
         // scroll math.
-        let lines_per_gpu = max_gpu_lines_for_tab(state).max(2);
+        let full_gpu_lines = max_gpu_lines_for_tab(state);
+        let lines_per_gpu = if is_remote {
+            full_gpu_lines.max(2)
+        } else {
+            // Local mode replaces the duplicated live-value header + gauge
+            // pair with one inventory row, while preserving every optional
+            // diagnostic/vGPU/MIG row. The general renderer's count therefore
+            // differs by exactly one base row.
+            full_gpu_lines.saturating_sub(1).max(1)
+        };
         let max_gpu_items = gpu_display_rows / lines_per_gpu;
 
         GpuDisplayParams {
@@ -411,7 +422,7 @@ mod tests {
             is_local_mode: true,
             ..AppState::default()
         };
-        let local_lines = LayoutCalculator::calculate_header_lines(&local_state);
+        let local_lines = LayoutCalculator::calculate_header_lines(&local_state, 120);
 
         // Remote mode without history: title + "Cluster Overview" label +
         // dashboard card rows + tabs row.
@@ -419,7 +430,7 @@ mod tests {
             is_local_mode: false,
             ..AppState::default()
         };
-        let remote_lines_no_history = LayoutCalculator::calculate_header_lines(&remote_state);
+        let remote_lines_no_history = LayoutCalculator::calculate_header_lines(&remote_state, 120);
 
         assert!(
             local_lines < remote_lines_no_history,
@@ -428,11 +439,29 @@ mod tests {
 
         // Remote mode with non-empty utilization history adds more lines.
         remote_state.utilization_history.push_back(42.0);
-        let remote_lines_with_history = LayoutCalculator::calculate_header_lines(&remote_state);
+        let remote_lines_with_history =
+            LayoutCalculator::calculate_header_lines(&remote_state, 120);
 
         assert!(
             remote_lines_no_history < remote_lines_with_history,
             "remote mode with history ({remote_lines_with_history}) should use more header lines than without ({remote_lines_no_history})"
+        );
+    }
+
+    #[test]
+    fn narrow_local_header_reserves_its_intentional_second_metric_row() {
+        let local_state = AppState {
+            is_local_mode: true,
+            ..AppState::default()
+        };
+
+        assert_eq!(
+            LayoutCalculator::calculate_header_lines(&local_state, 39),
+            4
+        );
+        assert_eq!(
+            LayoutCalculator::calculate_header_lines(&local_state, 40),
+            3
         );
     }
 
@@ -480,7 +509,7 @@ mod tests {
             time: String::new(),
         });
 
-        let header = LayoutCalculator::calculate_header_lines(&state);
+        let header = LayoutCalculator::calculate_header_lines(&state, 120);
 
         // Short terminal -> fallback: CPU 5 rows, GPU 6 rows -> panel 6.
         let short = LayoutCalculator::calculate_content_area(&state, 120, 24);

--- a/src/ui/local_details.rs
+++ b/src/ui/local_details.rs
@@ -1,0 +1,466 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Non-repeating local-mode hardware details.
+//!
+//! The local header owns live CPU/GPU/RAM/power/temperature values and the
+//! Activity panel owns their history. These rows therefore contain only
+//! identity, topology, frequency, runtime, and pressure details that add new
+//! information instead of echoing the same sample in another gauge.
+
+use std::io::Write;
+
+use crossterm::{queue, style::Color, style::Print};
+
+use crate::device::{ChassisInfo, CpuInfo, GpuInfo, MemoryInfo};
+use crate::ui::text::{display_width, print_colored_text, truncate_to_width};
+
+const SEPARATOR: &str = "  ";
+
+/// Render the local CPU inventory row.
+pub fn print_cpu_details<W: Write>(stdout: &mut W, info: &CpuInfo, width: usize) {
+    let mut used = print_identity(stdout, "CPU", Color::Cyan, &info.cpu_model, width);
+
+    push_field(
+        stdout,
+        &mut used,
+        width,
+        "Cores ",
+        Color::Green,
+        &format_cpu_cores(info),
+    );
+    if let Some(frequency) = format_cpu_frequency(info) {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "Freq ",
+            Color::Magenta,
+            &frequency,
+        );
+    }
+    push_field(
+        stdout,
+        &mut used,
+        width,
+        "Arch ",
+        Color::Yellow,
+        &info.architecture,
+    );
+    if info.socket_count > 1 {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "Sockets ",
+            Color::Yellow,
+            &info.socket_count.to_string(),
+        );
+    }
+    if let Some(cache) = format_cpu_cache(info) {
+        push_field(stdout, &mut used, width, "Cache ", Color::Red, &cache);
+    }
+
+    queue!(stdout, Print("\r\n")).unwrap();
+}
+
+/// Render the local GPU/NPU inventory row without the live values already
+/// present in the summary and Activity panel.
+pub fn print_gpu_details<W: Write>(stdout: &mut W, info: &GpuInfo, width: usize) {
+    let mut used = print_identity(stdout, &info.device_type, Color::Cyan, &info.name, width);
+
+    if let Some(cores) = info.gpu_core_count {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "Cores ",
+            Color::Green,
+            &cores.to_string(),
+        );
+    }
+    if let Some(frequency) = info.frequency_reading() {
+        let display = if frequency >= 1000 {
+            format!("{:.2}GHz", frequency as f64 / 1000.0)
+        } else {
+            format!("{frequency}MHz")
+        };
+        push_field(stdout, &mut used, width, "Freq ", Color::Magenta, &display);
+    }
+
+    if let (Some(name), Some(version)) =
+        (info.detail.get("lib_name"), info.detail.get("lib_version"))
+    {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            &format!("{name} "),
+            Color::Green,
+            version,
+        );
+    } else if let Some(version) = info.detail.get("CUDA Version") {
+        push_field(stdout, &mut used, width, "CUDA ", Color::Green, version);
+    } else if let Some(version) = info.detail.get("ROCm Version") {
+        push_field(stdout, &mut used, width, "ROCm ", Color::Green, version);
+    }
+
+    if let Some(version) = info.detail.get("Driver Version") {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "Driver ",
+            Color::DarkGreen,
+            version,
+        );
+    }
+
+    queue!(stdout, Print("\r\n")).unwrap();
+}
+
+/// Render chassis-only details that are not already represented by the local
+/// summary. Returns whether a row was emitted.
+pub fn print_chassis_details<W: Write>(stdout: &mut W, info: &ChassisInfo, width: usize) -> bool {
+    let cpu_power = detail_number(info, "cpu_power_watts");
+    let gpu_power = detail_number(info, "gpu_power_watts");
+    let ane_power = detail_number(info, "ane_power_watts");
+    if info.thermal_pressure.is_none()
+        && cpu_power.is_none()
+        && gpu_power.is_none()
+        && ane_power.is_none()
+        && info.fan_speeds.is_empty()
+        && info.psu_status.is_empty()
+    {
+        return false;
+    }
+
+    let mut used = print_label(stdout, "System", Color::Yellow, width);
+    if let Some(pressure) = &info.thermal_pressure {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "Thermal ",
+            Color::Magenta,
+            pressure,
+        );
+    }
+    if let Some(power) = cpu_power {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "CPU ",
+            Color::Cyan,
+            &format!("{power:.1}W"),
+        );
+    }
+    if let Some(power) = gpu_power {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "GPU ",
+            Color::Green,
+            &format!("{power:.1}W"),
+        );
+    }
+    if let Some(power) = ane_power {
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "ANE ",
+            Color::Blue,
+            &format!("{power:.1}W"),
+        );
+    }
+    if !info.fan_speeds.is_empty() {
+        let average = info.fan_speeds.iter().map(|fan| fan.speed_rpm).sum::<u32>()
+            / info.fan_speeds.len() as u32;
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "Fans ",
+            Color::Cyan,
+            &format!("{average}RPM"),
+        );
+    }
+    if !info.psu_status.is_empty() {
+        let healthy = info
+            .psu_status
+            .iter()
+            .filter(|psu| psu.status == crate::device::PsuStatus::Ok)
+            .count();
+        push_field(
+            stdout,
+            &mut used,
+            width,
+            "PSU ",
+            Color::Yellow,
+            &format!("{healthy}/{}", info.psu_status.len()),
+        );
+    }
+
+    queue!(stdout, Print("\r\n")).unwrap();
+    true
+}
+
+/// Swap is not represented in the top RAM summary, so surface it only when a
+/// swap device actually exists. A compact ratio is enough; repeating another
+/// full-width memory gauge would recreate the visual redundancy this module
+/// exists to remove.
+pub fn print_memory_details<W: Write>(stdout: &mut W, info: &MemoryInfo, width: usize) {
+    if info.swap_total_bytes == 0 {
+        return;
+    }
+
+    let gib = 1024.0 * 1024.0 * 1024.0;
+    let used_gb = info.swap_used_bytes as f64 / gib;
+    let total_gb = info.swap_total_bytes as f64 / gib;
+    let utilization = info.swap_used_bytes as f64 / info.swap_total_bytes as f64 * 100.0;
+    let mut used = print_label(stdout, "Swap", Color::Magenta, width);
+    push_field(
+        stdout,
+        &mut used,
+        width,
+        "Used ",
+        Color::Red,
+        &format!("{used_gb:.1}/{total_gb:.1}GB"),
+    );
+    push_field(
+        stdout,
+        &mut used,
+        width,
+        "Util ",
+        Color::Magenta,
+        &format!("{utilization:.1}%"),
+    );
+    queue!(stdout, Print("\r\n")).unwrap();
+}
+
+fn print_identity<W: Write>(
+    stdout: &mut W,
+    label: &str,
+    color: Color,
+    name: &str,
+    width: usize,
+) -> usize {
+    let mut used = print_label(stdout, label, color, width);
+    if used >= width {
+        return used;
+    }
+
+    print_colored_text(stdout, " ", Color::White, None, None);
+    used += 1;
+    let name_budget = width.saturating_sub(used).min(24);
+    let display = truncate_to_width(name, name_budget);
+    print_colored_text(stdout, &display, Color::White, None, None);
+    used + display_width(&display)
+}
+
+fn print_label<W: Write>(stdout: &mut W, label: &str, color: Color, width: usize) -> usize {
+    let display = truncate_to_width(label, width);
+    print_colored_text(stdout, &display, color, None, None);
+    display_width(&display)
+}
+
+fn push_field<W: Write>(
+    stdout: &mut W,
+    used: &mut usize,
+    width: usize,
+    label: &str,
+    color: Color,
+    value: &str,
+) {
+    let required = display_width(SEPARATOR) + display_width(label) + display_width(value);
+    if used.saturating_add(required) > width {
+        return;
+    }
+
+    print_colored_text(stdout, SEPARATOR, Color::DarkGrey, None, None);
+    print_colored_text(stdout, label, color, None, None);
+    print_colored_text(stdout, value, Color::White, None, None);
+    *used += required;
+}
+
+fn format_cpu_cores(info: &CpuInfo) -> String {
+    if let Some(apple) = &info.apple_silicon_info {
+        if apple.s_core_count > 0 {
+            format!("{}S+{}P", apple.s_core_count, apple.p_core_count)
+        } else {
+            format!("{}P+{}E", apple.p_core_count, apple.e_core_count)
+        }
+    } else {
+        info.total_cores.to_string()
+    }
+}
+
+fn format_cpu_frequency(info: &CpuInfo) -> Option<String> {
+    if let Some(apple) = &info.apple_silicon_info {
+        let (high, low) = if apple.s_core_count > 0 {
+            (apple.s_cluster_frequency_mhz, apple.p_cluster_frequency_mhz)
+        } else {
+            (apple.p_cluster_frequency_mhz, apple.e_cluster_frequency_mhz)
+        };
+        if let (Some(high), Some(low)) = (high, low) {
+            return Some(format_frequency_pair(high, low));
+        }
+    }
+
+    (info.max_frequency_mhz > 0)
+        .then(|| format!("{:.1}GHz", info.max_frequency_mhz as f64 / 1000.0))
+}
+
+fn format_frequency_pair(high: u32, low: u32) -> String {
+    let format_one = |mhz: u32| {
+        if mhz >= 1000 {
+            format!("{:.2}GHz", mhz as f64 / 1000.0)
+        } else {
+            format!("{mhz}MHz")
+        }
+    };
+    format!("{}+{}", format_one(high), format_one(low))
+}
+
+fn format_cpu_cache(info: &CpuInfo) -> Option<String> {
+    if let Some(apple) = &info.apple_silicon_info {
+        let (high, low) = if apple.s_core_count > 0 {
+            (apple.s_core_l2_cache_mb, apple.p_core_l2_cache_mb)
+        } else {
+            (apple.p_core_l2_cache_mb, apple.e_core_l2_cache_mb)
+        };
+        if let (Some(high), Some(low)) = (high, low) {
+            return Some(format!("L2 {high}+{low}MB"));
+        }
+    }
+
+    (info.cache_size_mb > 0).then(|| format!("{}MB", info.cache_size_mb))
+}
+
+fn detail_number(info: &ChassisInfo, key: &str) -> Option<f64> {
+    info.detail.get(key).and_then(|value| value.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::device::{CpuPlatformType, GPU_METRIC_UNAVAILABLE};
+    use crate::ui::text::ansi_display_width;
+
+    fn gpu() -> GpuInfo {
+        GpuInfo {
+            uuid: "gpu-0".to_string(),
+            time: String::new(),
+            name: "A GPU With An Extremely Long Product Name".to_string(),
+            device_type: "GPU".to_string(),
+            host_id: "localhost".to_string(),
+            hostname: "localhost".to_string(),
+            instance: "localhost".to_string(),
+            utilization: 50.0,
+            ane_utilization: GPU_METRIC_UNAVAILABLE,
+            dla_utilization: None,
+            tensorcore_utilization: None,
+            temperature: 55,
+            used_memory: 8,
+            total_memory: 16,
+            frequency: 1500,
+            power_consumption: 100.0,
+            gpu_core_count: Some(80),
+            temperature_threshold_slowdown: None,
+            temperature_threshold_shutdown: None,
+            temperature_threshold_max_operating: None,
+            temperature_threshold_acoustic: None,
+            performance_state: None,
+            fan_speed_rpm: None,
+            numa_node_id: None,
+            gsp_firmware_mode: None,
+            gsp_firmware_version: None,
+            nvlink_remote_devices: Vec::new(),
+            gpm_metrics: None,
+            detail: HashMap::from([
+                ("lib_name".to_string(), "CUDA".to_string()),
+                ("lib_version".to_string(), "13.0".to_string()),
+            ]),
+        }
+    }
+
+    fn cpu() -> CpuInfo {
+        CpuInfo {
+            index: 0,
+            host_id: "localhost".to_string(),
+            hostname: "localhost".to_string(),
+            instance: "localhost".to_string(),
+            cpu_model: "A CPU With An Extremely Long Product Name".to_string(),
+            architecture: "aarch64".to_string(),
+            platform_type: CpuPlatformType::AppleSilicon,
+            socket_count: 1,
+            total_cores: 32,
+            total_threads: 32,
+            base_frequency_mhz: 0,
+            max_frequency_mhz: 3500,
+            cache_size_mb: 16,
+            utilization: 50.0,
+            temperature: Some(55),
+            power_consumption: Some(20.0),
+            per_socket_info: Vec::new(),
+            apple_silicon_info: None,
+            per_core_utilization: Vec::new(),
+            time: String::new(),
+        }
+    }
+
+    fn visible_lines(rendered: &[u8]) -> Vec<String> {
+        String::from_utf8_lossy(rendered)
+            .split("\r\n")
+            .filter(|line| !line.is_empty())
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn detail_rows_never_exceed_their_width() {
+        for width in [20, 40, 80, 120] {
+            let mut rendered = Vec::new();
+            print_cpu_details(&mut rendered, &cpu(), width);
+            print_gpu_details(&mut rendered, &gpu(), width);
+            for line in visible_lines(&rendered) {
+                assert!(
+                    ansi_display_width(&line) <= width,
+                    "line exceeded width {width}: {line:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn local_gpu_details_omit_summary_metrics() {
+        let mut rendered = Vec::new();
+        print_gpu_details(&mut rendered, &gpu(), 120);
+        let visible = String::from_utf8_lossy(&rendered);
+
+        assert!(visible.contains("Freq"));
+        assert!(visible.contains("CUDA"));
+        for repeated in ["Util:", "VRAM:", "Temp:", "Pwr:"] {
+            assert!(
+                !visible.contains(repeated),
+                "unexpected {repeated}: {visible}"
+            );
+        }
+    }
+}

--- a/src/ui/local_header.rs
+++ b/src/ui/local_header.rs
@@ -18,13 +18,17 @@
 //!
 //! **Line 1** — identity row:
 //! ```text
-//! Host <hostname> · <cpu_model> · arch <arch> · up <uptime>    ● Live
+//! Host <hostname> · up <uptime>                             ● Live
 //! ```
 //!
-//! **Line 2** — metrics sparkline row (8-cell braille sparklines):
+//! **Line 2** — metrics sparkline row (8-cell braille sparklines when they fit):
 //! ```text
 //! CPU <pct>%<t> ⣿⣷⣶…  GPU <pct>%<t> ⣿⣷…  RAM <used>/<total>GB<t> ⣿…  Pwr <W>W<t> ⣿…  Tmp <°C>°C<t> ⣿…
 //! ```
+//!
+//! The row progressively drops sparklines and then switches to short labels
+//! as width decreases. Below 40 columns it intentionally uses two complete
+//! metric rows instead of allowing the terminal to wrap one oversized row.
 //!
 //! Each metric carries a one-cell trend glyph `<t>` (`↑ ↗ → ↘ ↓`) immediately
 //! after its latest value, coloured in the metric's theme colour, derived from
@@ -44,11 +48,12 @@ use crossterm::{queue, style::Color, style::Print};
 use crate::app_state::AppState;
 use crate::common::config::ThemeConfig;
 use crate::ui::braille::sparkline_braille;
+use crate::ui::buffer::BufferWriter;
 use crate::ui::scale::{
     PERCENT_DOMAIN, PERCENT_SOFT_GRID, PERCENT_SOFT_MIN_SPAN, TEMP_SOFT_GRID, TEMP_SOFT_MIN_SPAN,
     power_range, power_soft_grid, power_soft_min_span, soft_range, temp_range,
 };
-use crate::ui::text::print_colored_text;
+use crate::ui::text::{ansi_display_width, print_colored_text, truncate_to_width};
 
 /// Width in braille cells for each metric sparkline.
 const SPARKLINE_WIDTH: usize = 8;
@@ -68,20 +73,34 @@ const TREND_POWER: (f64, f64) = (0.2, 1.0);
 /// How many samples back the trend slope is measured over.
 const TREND_LOOKBACK: usize = 5;
 
-/// Render the two-line local-mode host summary bar.
+#[derive(Debug, Clone, Copy)]
+struct MetricPresentation {
+    color: Color,
+    range: Option<(f64, f64)>,
+    trend: (f64, f64),
+    sparkline_width: Option<usize>,
+}
+
+/// Render the local-mode host summary bar.
 ///
 /// This function is called from `render_main()` in `frame_renderer.rs` when
 /// `view_state.is_local_mode` is `true`, in place of the Cluster Overview.
-pub fn draw_local_header_bar<W: Write>(stdout: &mut W, state: &AppState, _cols: u16) {
-    draw_identity_line(stdout, state);
-    draw_metrics_line(stdout, state);
+pub fn draw_local_header_bar<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
+    draw_identity_line(stdout, state, cols);
+    draw_metrics_line(stdout, state, cols);
+}
+
+/// Number of rows emitted by [`draw_local_header_bar`] at `cols`.
+#[must_use]
+pub fn local_header_line_count(cols: u16) -> u16 {
+    if cols < 40 { 3 } else { 2 }
 }
 
 // ─── Line 1: identity ────────────────────────────────────────────────────────
 
 /// Render the identity line:
-/// `Host <hostname> · <cpu_model> · arch <arch> · up <uptime>    ● Live`
-fn draw_identity_line<W: Write>(stdout: &mut W, state: &AppState) {
+/// `Host <hostname> · up <uptime>    ● Live`
+fn draw_identity_line<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
     // Hostname — use the first CPU entry's hostname (always available in local mode)
     let hostname = state
         .cpu_info
@@ -89,40 +108,33 @@ fn draw_identity_line<W: Write>(stdout: &mut W, state: &AppState) {
         .map(|c| c.hostname.as_str())
         .unwrap_or("localhost");
 
-    // CPU model — first CPU entry
-    let cpu_model = state
-        .cpu_info
-        .first()
-        .map(|c| c.cpu_model.as_str())
-        .unwrap_or("unknown");
-
-    // Architecture — first CPU entry
-    let arch = state
-        .cpu_info
-        .first()
-        .map(|c| c.architecture.as_str())
-        .unwrap_or("unknown");
-
     // Uptime — read from sysinfo (cheap: sysinfo re-reads /proc/uptime on each call on Linux,
     // uses sysctl kern.boottime on macOS; both are lightweight system calls)
     let uptime_secs = sysinfo::System::uptime();
     let uptime_str = format_uptime(uptime_secs);
 
-    // Print: "Host <hostname>"
+    let width = cols as usize;
+    let live_width = 6; // "● Live"
+    let host_prefix_width = 5; // "Host "
+    let uptime_suffix = format!(" · up {uptime_str}");
+
+    // Keep the liveness signal visible even when the host name is unusually
+    // long. At ordinary widths uptime is the only identity metadata carried
+    // here; CPU identity belongs to the non-repeating hardware detail row.
+    let show_uptime = width >= host_prefix_width + 4 + uptime_suffix.len() + 2 + live_width;
+    let suffix_width = if show_uptime { uptime_suffix.len() } else { 0 };
+    let hostname_budget = width
+        .saturating_sub(host_prefix_width + suffix_width + 2 + live_width)
+        .max(1);
+    let hostname_display = truncate_to_width(hostname, hostname_budget);
+
+    // Print: "Host <hostname> [· up <uptime>]"
     print_colored_text(stdout, "Host ", Color::DarkGrey, None, None);
-    print_colored_text(stdout, hostname, Color::White, None, None);
-
-    // " · <cpu_model>"
-    print_colored_text(stdout, " · ", Color::DarkGrey, None, None);
-    print_colored_text(stdout, cpu_model, Color::White, None, None);
-
-    // " · arch <arch>"
-    print_colored_text(stdout, " · arch ", Color::DarkGrey, None, None);
-    print_colored_text(stdout, arch, ThemeConfig::accent_color(), None, None);
-
-    // " · up <uptime>"
-    print_colored_text(stdout, " · up ", Color::DarkGrey, None, None);
-    print_colored_text(stdout, &uptime_str, ThemeConfig::memory_color(), None, None);
+    print_colored_text(stdout, &hostname_display, Color::White, None, None);
+    if show_uptime {
+        print_colored_text(stdout, " · up ", Color::DarkGrey, None, None);
+        print_colored_text(stdout, &uptime_str, ThemeConfig::memory_color(), None, None);
+    }
 
     // Right-side "● Live" indicator — blinks on even frame counts
     // `frame_counter` is incremented on every render tick by the UI loop
@@ -131,7 +143,9 @@ fn draw_identity_line<W: Write>(stdout: &mut W, state: &AppState) {
     } else {
         Color::DarkGreen
     };
-    print_colored_text(stdout, "    ", Color::White, None, None);
+    let used = host_prefix_width + hostname_display.chars().count() + suffix_width;
+    let gap = width.saturating_sub(used + live_width).max(1);
+    print_colored_text(stdout, &" ".repeat(gap), Color::White, None, None);
     print_colored_text(stdout, "●", live_color, None, None);
     print_colored_text(stdout, " Live", Color::DarkGrey, None, None);
 
@@ -141,54 +155,81 @@ fn draw_identity_line<W: Write>(stdout: &mut W, state: &AppState) {
 // ─── Line 2: metrics sparklines ──────────────────────────────────────────────
 
 /// Render the metrics sparkline row.
-fn draw_metrics_line<W: Write>(stdout: &mut W, state: &AppState) {
+fn draw_metrics_line<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
+    let width = cols as usize;
+    let detailed = render_metrics_line(state, Some(SPARKLINE_WIDTH));
+    if ansi_display_width(&detailed) <= width {
+        stdout.write_all(detailed.as_bytes()).unwrap();
+        queue!(stdout, Print("\r\n")).unwrap();
+        return;
+    }
+
+    let values_only = render_metrics_line(state, None);
+    if ansi_display_width(&values_only) <= width {
+        stdout.write_all(values_only.as_bytes()).unwrap();
+        queue!(stdout, Print("\r\n")).unwrap();
+        return;
+    }
+
+    draw_tiny_metrics(stdout, state, width);
+}
+
+fn render_metrics_line(state: &AppState, sparkline_width: Option<usize>) -> String {
+    let mut stdout = BufferWriter::new();
+
     // CPU% — theme color Cyan
     let cpu_history: Vec<f64> = state.cpu_utilization_history.iter().copied().collect();
     draw_metric_sparkline(
-        stdout,
+        &mut stdout,
         "CPU",
         &cpu_history,
         format_pct(state.cpu_utilization_history.back().copied()),
-        ThemeConfig::cpu_color(),
-        Some(soft_range(
-            &cpu_history,
-            PERCENT_SOFT_MIN_SPAN,
-            PERCENT_SOFT_GRID,
-            PERCENT_DOMAIN,
-        )),
-        TREND_PERCENT,
+        MetricPresentation {
+            color: ThemeConfig::cpu_color(),
+            range: Some(soft_range(
+                &cpu_history,
+                PERCENT_SOFT_MIN_SPAN,
+                PERCENT_SOFT_GRID,
+                PERCENT_DOMAIN,
+            )),
+            trend: TREND_PERCENT,
+            sparkline_width,
+        },
     );
 
-    print_colored_text(stdout, "  ", Color::White, None, None);
+    print_colored_text(&mut stdout, "  ", Color::White, None, None);
 
     // GPU% — theme color Blue
     let gpu_history: Vec<f64> = state.utilization_history.iter().copied().collect();
     draw_metric_sparkline(
-        stdout,
+        &mut stdout,
         "GPU",
         &gpu_history,
         format_pct(state.utilization_history.back().copied()),
-        ThemeConfig::gpu_color(),
-        Some(soft_range(
-            &gpu_history,
-            PERCENT_SOFT_MIN_SPAN,
-            PERCENT_SOFT_GRID,
-            PERCENT_DOMAIN,
-        )),
-        TREND_PERCENT,
+        MetricPresentation {
+            color: ThemeConfig::gpu_color(),
+            range: Some(soft_range(
+                &gpu_history,
+                PERCENT_SOFT_MIN_SPAN,
+                PERCENT_SOFT_GRID,
+                PERCENT_DOMAIN,
+            )),
+            trend: TREND_PERCENT,
+            sparkline_width,
+        },
     );
 
-    print_colored_text(stdout, "  ", Color::White, None, None);
+    print_colored_text(&mut stdout, "  ", Color::White, None, None);
 
     // RAM used/total — theme color Green
-    draw_ram_sparkline(stdout, state);
+    draw_ram_sparkline(&mut stdout, state, sparkline_width);
 
-    print_colored_text(stdout, "  ", Color::White, None, None);
+    print_colored_text(&mut stdout, "  ", Color::White, None, None);
 
     // Package power — theme color Red
-    draw_power_sparkline(stdout, state);
+    draw_power_sparkline(&mut stdout, state, sparkline_width);
 
-    print_colored_text(stdout, "  ", Color::White, None, None);
+    print_colored_text(&mut stdout, "  ", Color::White, None, None);
 
     // Temperature — theme color Magenta
     let temp_history: Vec<f64> = state.cpu_temperature_history.iter().copied().collect();
@@ -197,21 +238,76 @@ fn draw_metrics_line<W: Write>(stdout: &mut W, state: &AppState) {
     // cool sensor can zoom below 30°C. The window then tracks small changes.
     let temp_ceiling = temp_range(None).1;
     draw_metric_sparkline(
-        stdout,
+        &mut stdout,
         "Tmp",
         &temp_history,
         format_temp(state.cpu_temperature_history.back().copied()),
-        ThemeConfig::thermal_color(),
-        Some(soft_range(
-            &temp_history,
-            TEMP_SOFT_MIN_SPAN,
-            TEMP_SOFT_GRID,
-            (0.0, temp_ceiling),
-        )),
-        TREND_TEMP,
+        MetricPresentation {
+            color: ThemeConfig::thermal_color(),
+            range: Some(soft_range(
+                &temp_history,
+                TEMP_SOFT_MIN_SPAN,
+                TEMP_SOFT_GRID,
+                (0.0, temp_ceiling),
+            )),
+            trend: TREND_TEMP,
+            sparkline_width,
+        },
     );
 
+    stdout.get_buffer().to_string()
+}
+
+fn draw_tiny_metrics<W: Write>(stdout: &mut W, state: &AppState, width: usize) {
+    let cpu = compact_pct(state.cpu_utilization_history.back().copied());
+    let gpu = compact_pct(state.utilization_history.back().copied());
+    let memory = compact_memory_pct(state);
+    let power = format!("{:.0}W", current_power_watts(state));
+    let temp = state
+        .cpu_temperature_history
+        .back()
+        .map_or_else(|| "N/A".to_string(), |value| format!("{value:.0}°"));
+
+    draw_tiny_metric(stdout, "C", &cpu, ThemeConfig::cpu_color());
+    print_colored_text(stdout, " ", Color::White, None, None);
+    draw_tiny_metric(stdout, "G", &gpu, ThemeConfig::gpu_color());
+
+    if width < 40 {
+        print_colored_text(stdout, " ", Color::White, None, None);
+        draw_tiny_metric(stdout, "M", &memory, ThemeConfig::memory_color());
+        queue!(stdout, Print("\r\n")).unwrap();
+        draw_tiny_metric(stdout, "P", &power, ThemeConfig::power_color());
+        print_colored_text(stdout, " ", Color::White, None, None);
+        draw_tiny_metric(stdout, "T", &temp, ThemeConfig::thermal_color());
+    } else {
+        print_colored_text(stdout, " ", Color::White, None, None);
+        draw_tiny_metric(stdout, "M", &memory, ThemeConfig::memory_color());
+        print_colored_text(stdout, " ", Color::White, None, None);
+        draw_tiny_metric(stdout, "P", &power, ThemeConfig::power_color());
+        print_colored_text(stdout, " ", Color::White, None, None);
+        draw_tiny_metric(stdout, "T", &temp, ThemeConfig::thermal_color());
+    }
+
     queue!(stdout, Print("\r\n")).unwrap();
+}
+
+fn draw_tiny_metric<W: Write>(stdout: &mut W, label: &str, value: &str, color: Color) {
+    print_colored_text(stdout, label, color, None, None);
+    print_colored_text(stdout, value, Color::White, None, None);
+}
+
+fn compact_pct(value: Option<f64>) -> String {
+    value.map_or_else(|| "N/A".to_string(), |value| format!("{value:.0}%"))
+}
+
+fn compact_memory_pct(state: &AppState) -> String {
+    let total = state.memory_info.iter().map(|m| m.total_bytes).sum::<u64>();
+    let used = state.memory_info.iter().map(|m| m.used_bytes).sum::<u64>();
+    if total == 0 {
+        "N/A".to_string()
+    } else {
+        format!("{:.0}%", used as f64 / total as f64 * 100.0)
+    }
 }
 
 /// Draw a single labelled metric with a braille sparkline.
@@ -223,19 +319,25 @@ fn draw_metric_sparkline<W: Write>(
     label: &str,
     history: &[f64],
     value_str: String,
-    color: Color,
-    range: Option<(f64, f64)>,
-    trend: (f64, f64),
+    presentation: MetricPresentation,
 ) {
-    let sparkline = sparkline_braille(history, SPARKLINE_WIDTH, range);
+    let MetricPresentation {
+        color,
+        range,
+        trend,
+        sparkline_width,
+    } = presentation;
     let glyph = trend_glyph(history, trend.0, trend.1);
 
     print_colored_text(stdout, label, color, None, None);
     print_colored_text(stdout, " ", Color::White, None, None);
     print_colored_text(stdout, &value_str, Color::White, None, None);
     print_colored_text(stdout, glyph, color, None, None);
-    print_colored_text(stdout, " ", Color::DarkGrey, None, None);
-    print_colored_text(stdout, &sparkline, color, None, None);
+    if let Some(width) = sparkline_width {
+        let sparkline = sparkline_braille(history, width, range);
+        print_colored_text(stdout, " ", Color::DarkGrey, None, None);
+        print_colored_text(stdout, &sparkline, color, None, None);
+    }
 }
 
 /// Classify the recent slope of `history` into one of five trend glyphs.
@@ -278,7 +380,7 @@ fn trend_glyph(history: &[f64], flat: f64, steep: f64) -> &'static str {
 /// Draw the RAM metric: `RAM <used>/<total>GB <sparkline>`.
 ///
 /// The sparkline tracks `system_memory_history` (memory utilization %).
-fn draw_ram_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
+fn draw_ram_sparkline<W: Write>(stdout: &mut W, state: &AppState, sparkline_width: Option<usize>) {
     let total_gb = state.memory_info.iter().map(|m| m.total_bytes).sum::<u64>() as f64
         / (1024.0 * 1024.0 * 1024.0);
 
@@ -297,15 +399,17 @@ fn draw_ram_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
         PERCENT_SOFT_GRID,
         PERCENT_DOMAIN,
     );
-    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some(range));
     let glyph = trend_glyph(&history, TREND_PERCENT.0, TREND_PERCENT.1);
 
     print_colored_text(stdout, "RAM", ThemeConfig::memory_color(), None, None);
     print_colored_text(stdout, " ", Color::White, None, None);
     print_colored_text(stdout, &value_str, Color::White, None, None);
     print_colored_text(stdout, glyph, ThemeConfig::memory_color(), None, None);
-    print_colored_text(stdout, " ", Color::DarkGrey, None, None);
-    print_colored_text(stdout, &sparkline, ThemeConfig::memory_color(), None, None);
+    if let Some(width) = sparkline_width {
+        let sparkline = sparkline_braille(&history, width, Some(range));
+        print_colored_text(stdout, " ", Color::DarkGrey, None, None);
+        print_colored_text(stdout, &sparkline, ThemeConfig::memory_color(), None, None);
+    }
 }
 
 /// Draw the power metric: `Pwr <W>W <sparkline>`.
@@ -315,31 +419,12 @@ fn draw_ram_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
 ///
 /// The sparkline tracks the dedicated package-power history maintained by the
 /// data aggregator.
-fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
-    let is_apple_silicon = state.gpu_info.iter().any(|gpu| {
-        gpu.detail
-            .get("architecture")
-            .map(|arch| arch == "Apple Silicon")
-            .unwrap_or(false)
-    });
-
-    let power_watts = if is_apple_silicon {
-        // Apple Silicon: combined CPU+GPU+ANE power from the native metrics manager
-        state
-            .gpu_info
-            .iter()
-            .filter_map(|gpu| {
-                gpu.detail
-                    .get("combined_power_mw")
-                    .and_then(|s| s.parse::<f64>().ok())
-                    .map(|mw| mw / 1000.0)
-            })
-            .next()
-            .unwrap_or_else(|| crate::metrics::gpu_readings::total_power_watts(&state.gpu_info))
-    } else {
-        // Linux/NVIDIA: aggregate GPU power
-        crate::metrics::gpu_readings::total_power_watts(&state.gpu_info)
-    };
+fn draw_power_sparkline<W: Write>(
+    stdout: &mut W,
+    state: &AppState,
+    sparkline_width: Option<usize>,
+) {
+    let power_watts = current_power_watts(state);
 
     let value_str = format!("{power_watts:>5.1}W");
 
@@ -355,15 +440,44 @@ fn draw_power_sparkline<W: Write>(stdout: &mut W, state: &AppState) {
         power_soft_grid(ceiling),
         (0.0, ceiling),
     );
-    let sparkline = sparkline_braille(&history, SPARKLINE_WIDTH, Some(range));
     let glyph = trend_glyph(&history, TREND_POWER.0, TREND_POWER.1);
 
     print_colored_text(stdout, "Pwr", ThemeConfig::power_color(), None, None);
     print_colored_text(stdout, " ", Color::White, None, None);
     print_colored_text(stdout, &value_str, Color::White, None, None);
     print_colored_text(stdout, glyph, ThemeConfig::power_color(), None, None);
-    print_colored_text(stdout, " ", Color::DarkGrey, None, None);
-    print_colored_text(stdout, &sparkline, ThemeConfig::power_color(), None, None);
+    if let Some(width) = sparkline_width {
+        let sparkline = sparkline_braille(&history, width, Some(range));
+        print_colored_text(stdout, " ", Color::DarkGrey, None, None);
+        print_colored_text(stdout, &sparkline, ThemeConfig::power_color(), None, None);
+    }
+}
+
+fn current_power_watts(state: &AppState) -> f64 {
+    let is_apple_silicon = state.gpu_info.iter().any(|gpu| {
+        gpu.detail
+            .get("architecture")
+            .map(|arch| arch == "Apple Silicon")
+            .unwrap_or(false)
+    });
+
+    if is_apple_silicon {
+        // Apple Silicon: combined CPU+GPU+ANE power from the native metrics manager
+        state
+            .gpu_info
+            .iter()
+            .filter_map(|gpu| {
+                gpu.detail
+                    .get("combined_power_mw")
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .map(|mw| mw / 1000.0)
+            })
+            .next()
+            .unwrap_or_else(|| crate::metrics::gpu_readings::total_power_watts(&state.gpu_info))
+    } else {
+        // Linux/NVIDIA: aggregate GPU power
+        crate::metrics::gpu_readings::total_power_watts(&state.gpu_info)
+    }
 }
 
 // ─── Formatting helpers ───────────────────────────────────────────────────────
@@ -620,6 +734,43 @@ mod tests {
         draw_local_header_bar(&mut buf, &state, 120);
         // Buffer must be non-empty
         assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn local_header_uses_only_intentional_rows_and_never_overflows() {
+        use crate::app_state::AppState;
+        use crate::ui::text::ansi_display_width;
+
+        let mut state = AppState::new();
+        for value in [10.0, 20.0, 30.0] {
+            state.cpu_utilization_history.push_back(value);
+            state.utilization_history.push_back(value);
+            state.system_memory_history.push_back(value);
+            state.package_power_history.push_back(value);
+            state.cpu_temperature_history.push_back(40.0 + value);
+        }
+
+        for cols in [20, 39, 40, 64, 80, 110, 160] {
+            let mut buffer = Vec::new();
+            draw_local_header_bar(&mut buffer, &state, cols);
+            let rendered = String::from_utf8(buffer).unwrap();
+            let lines: Vec<_> = rendered
+                .split("\r\n")
+                .filter(|line| !line.is_empty())
+                .collect();
+
+            assert_eq!(
+                lines.len(),
+                local_header_line_count(cols) as usize,
+                "header row accounting drifted at {cols} columns"
+            );
+            for line in lines {
+                assert!(
+                    ansi_display_width(line) <= cols as usize,
+                    "header overflowed {cols} columns: {line:?}"
+                );
+            }
+        }
     }
 
     /// [`trend_glyph`] is covered in isolation above, but nothing previously

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,6 +25,7 @@ pub mod gpu_sparkline_panel;
 pub mod help;
 pub mod layout;
 pub mod led_grid;
+pub mod local_details;
 pub mod local_header;
 pub mod notification;
 pub mod process_renderer;

--- a/src/ui/renderers/gpu_renderer.rs
+++ b/src/ui/renderers/gpu_renderer.rs
@@ -740,6 +740,16 @@ fn render_hardware_details_row<W: Write>(stdout: &mut W, info: &GpuInfo) {
     queue!(stdout, Print("\r\n")).unwrap();
 }
 
+/// Render the optional GPU diagnostic rows without the live-value header or
+/// gauges. Local mode uses this after its compact inventory row so NVML
+/// health/topology data remains available while current values stay owned by
+/// the summary and Activity panel.
+#[allow(dead_code)] // Called by the binary-only view module; absent from lib.rs.
+pub(crate) fn print_gpu_diagnostic_rows<W: Write>(stdout: &mut W, info: &GpuInfo) {
+    render_thermal_pstate_row(stdout, info);
+    render_hardware_details_row(stdout, info);
+}
+
 /// Tally NvLinks by remote-type classification for the summary column.
 /// Returns `(gpu, switch, ibmnpu, unknown)` counts.
 fn count_nvlink_remote_types(

--- a/src/ui/text.rs
+++ b/src/ui/text.rs
@@ -35,6 +35,118 @@ pub fn display_width(s: &str) -> usize {
     s.chars().map(char_display_width).sum()
 }
 
+/// Calculate the visible width of text containing ANSI escape sequences.
+///
+/// Crossterm emits CSI sequences for colors and styles. Those bytes do not
+/// occupy terminal cells and therefore must not participate in responsive
+/// layout calculations.
+pub fn ansi_display_width(s: &str) -> usize {
+    let mut width = 0;
+    let mut chars = s.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            skip_ansi_sequence(&mut chars);
+        } else if c != '\r' && c != '\n' {
+            width += char_display_width(c);
+        }
+    }
+
+    width
+}
+
+/// Truncate ANSI-styled text to at most `max_width` visible terminal cells.
+///
+/// Escape sequences are copied atomically and do not consume width. A reset
+/// sequence is appended only on the truncating path so a clipped colored span
+/// cannot leak its style into the next terminal row.
+pub fn truncate_ansi_to_width(s: &str, max_width: usize) -> Cow<'_, str> {
+    if ansi_display_width(s) <= max_width {
+        return Cow::Borrowed(s);
+    }
+
+    let mut output = String::with_capacity(s.len().min(max_width.saturating_mul(2)) + 4);
+    let mut visible_width = 0;
+    let mut chars = s.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            output.push(c);
+            copy_ansi_sequence(&mut chars, &mut output);
+            continue;
+        }
+
+        if c == '\r' || c == '\n' {
+            break;
+        }
+
+        let char_width = char_display_width(c);
+        if visible_width + char_width > max_width {
+            break;
+        }
+        output.push(c);
+        visible_width += char_width;
+    }
+
+    output.push_str("\x1b[0m");
+    Cow::Owned(output)
+}
+
+fn skip_ansi_sequence(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    let Some(kind) = chars.next() else {
+        return;
+    };
+
+    match kind {
+        '[' => {
+            for c in chars.by_ref() {
+                if ('@'..='~').contains(&c) {
+                    break;
+                }
+            }
+        }
+        ']' => {
+            let mut previous_was_escape = false;
+            for c in chars.by_ref() {
+                if c == '\u{7}' || (previous_was_escape && c == '\\') {
+                    break;
+                }
+                previous_was_escape = c == '\x1b';
+            }
+        }
+        _ => {}
+    }
+}
+
+fn copy_ansi_sequence(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, output: &mut String) {
+    let Some(kind) = chars.next() else {
+        return;
+    };
+    output.push(kind);
+
+    match kind {
+        '[' => {
+            for c in chars.by_ref() {
+                output.push(c);
+                if ('@'..='~').contains(&c) {
+                    break;
+                }
+            }
+        }
+        ']' => {
+            let mut previous_was_escape = false;
+            for c in chars.by_ref() {
+                output.push(c);
+                if c == '\u{7}' || (previous_was_escape && c == '\\') {
+                    break;
+                }
+                previous_was_escape = c == '\x1b';
+            }
+        }
+        _ => {}
+    }
+}
+
 // Helper function to truncate a string to fit within a given display width.
 //
 // Returns `Cow::Borrowed` when the string already fits, avoiding allocation.
@@ -215,6 +327,29 @@ mod tests {
     #[test]
     fn test_display_width_empty() {
         assert_eq!(display_width(""), 0);
+    }
+
+    #[test]
+    fn test_ansi_display_width_ignores_style_sequences() {
+        assert_eq!(ansi_display_width("\x1b[31mGPU 42%\x1b[0m"), 7);
+        assert_eq!(ansi_display_width("\x1b]0;title\u{7}CPU"), 3);
+    }
+
+    #[test]
+    fn test_truncate_ansi_to_width_preserves_complete_sequences() {
+        let input = "\x1b[31mGPU 42%\x1b[0m trailing";
+        let truncated = truncate_ansi_to_width(input, 7);
+
+        assert_eq!(ansi_display_width(&truncated), 7);
+        assert!(truncated.starts_with("\x1b[31mGPU 42%"));
+        assert!(truncated.ends_with("\x1b[0m"));
+        assert!(!truncated.contains("trailing"));
+    }
+
+    #[test]
+    fn test_truncate_ansi_to_width_borrows_when_text_fits() {
+        let input = "\x1b[32mok\x1b[0m";
+        assert!(matches!(truncate_ansi_to_width(input, 2), Cow::Borrowed(_)));
     }
 
     // -----------------------------------------------------------------------

--- a/src/view/frame_renderer.rs
+++ b/src/view/frame_renderer.rs
@@ -36,12 +36,16 @@ use crate::ui::buffer::BufferWriter;
 use crate::ui::dashboard::{draw_dashboard_items, draw_system_view};
 use crate::ui::gpu_sparkline_panel;
 use crate::ui::layout::LayoutCalculator;
+use crate::ui::local_details::{
+    print_chassis_details, print_cpu_details, print_gpu_details, print_memory_details,
+};
 use crate::ui::local_header::draw_local_header_bar;
 use crate::ui::renderer::{
     print_chassis_info, print_cpu_info, print_function_keys, print_gpu_info,
     print_loading_indicator, print_memory_info, print_mig_section, print_process_info,
     print_storage_info, print_vgpu_section,
 };
+use crate::ui::renderers::gpu_renderer::print_gpu_diagnostic_rows;
 use crate::ui::renderers::print_chassis_energy_row;
 use crate::ui::tabs::draw_tabs;
 use crate::ui::text::print_colored_text;
@@ -376,15 +380,20 @@ impl FrameRenderer {
 
             if matched && !flashing {
                 // Fast path: no filter mismatch, no flash — emit directly.
-                print_gpu_info(
-                    buffer,
-                    i,
-                    gpu_info,
-                    cols as usize,
-                    device_name_scroll_offset,
-                    hostname_scroll_offset,
-                    !view_state.is_local_mode,
-                );
+                if view_state.is_local_mode {
+                    print_gpu_details(buffer, gpu_info, cols as usize);
+                    print_gpu_diagnostic_rows(buffer, gpu_info);
+                } else {
+                    print_gpu_info(
+                        buffer,
+                        i,
+                        gpu_info,
+                        cols as usize,
+                        device_name_scroll_offset,
+                        hostname_scroll_offset,
+                        true,
+                    );
+                }
                 if let Some(vgpu_host) =
                     lookup_vgpu_host(&vgpu_lookup, &snapshot.vgpu_info, gpu_info)
                 {
@@ -398,15 +407,20 @@ impl FrameRenderer {
                 // (dim for filter-mismatch, prefix for flash) before the
                 // bytes reach the main output.
                 let mut scratch = BufferWriter::new();
-                print_gpu_info(
-                    &mut scratch,
-                    i,
-                    gpu_info,
-                    cols as usize,
-                    device_name_scroll_offset,
-                    hostname_scroll_offset,
-                    !view_state.is_local_mode,
-                );
+                if view_state.is_local_mode {
+                    print_gpu_details(&mut scratch, gpu_info, cols as usize);
+                    print_gpu_diagnostic_rows(&mut scratch, gpu_info);
+                } else {
+                    print_gpu_info(
+                        &mut scratch,
+                        i,
+                        gpu_info,
+                        cols as usize,
+                        device_name_scroll_offset,
+                        hostname_scroll_offset,
+                        true,
+                    );
+                }
                 if let Some(vgpu_host) =
                     lookup_vgpu_host(&vgpu_lookup, &snapshot.vgpu_info, gpu_info)
                 {
@@ -461,7 +475,11 @@ impl FrameRenderer {
                     .get(&chassis.host_id)
                     .copied()
                     .unwrap_or(0);
-                print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
+                if snapshot.is_local_mode {
+                    print_chassis_details(buffer, chassis, width);
+                } else {
+                    print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
+                }
                 // Energy session + cost row (issue #191). Self-hides
                 // when no chassis samples have been recorded yet.
                 print_chassis_energy_row(
@@ -496,7 +514,11 @@ impl FrameRenderer {
                 .get(&chassis.host_id)
                 .copied()
                 .unwrap_or(0);
-            print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
+            if snapshot.is_local_mode {
+                print_chassis_details(buffer, chassis, width);
+            } else {
+                print_chassis_info(buffer, i, chassis, width, hostname_scroll_offset);
+            }
             // Energy session + cost row (issue #191). Self-hides when no
             // chassis samples have been recorded yet.
             print_chassis_energy_row(
@@ -721,40 +743,16 @@ impl FrameRenderer {
     ) -> usize {
         let width = cols as usize;
 
-        // CPU information for local mode
-        // Per-core bars are now always shown in the Activity panel above,
-        // so we pass show_per_core=false here to avoid duplication.
-        for (i, cpu_info) in snapshot.cpu_info.iter().enumerate() {
-            let cpu_name_scroll_offset = snapshot
-                .cpu_name_scroll_offsets
-                .get(&format!("{}-{}", cpu_info.hostname, cpu_info.cpu_model))
-                .copied()
-                .unwrap_or(0);
-            let hostname_scroll_offset = snapshot
-                .host_id_scroll_offsets
-                .get(&cpu_info.host_id)
-                .copied()
-                .unwrap_or(0);
-            print_cpu_info(
-                buffer,
-                i,
-                cpu_info,
-                width,
-                false,
-                cpu_name_scroll_offset,
-                hostname_scroll_offset,
-                false,
-            );
+        // The header owns live CPU values and the Activity panel owns
+        // utilization history, so this row is inventory-only.
+        for cpu_info in &snapshot.cpu_info {
+            print_cpu_details(buffer, cpu_info, width);
         }
 
-        // Memory information for local mode
-        for (i, memory_info) in snapshot.memory_info.iter().enumerate() {
-            let hostname_scroll_offset = snapshot
-                .host_id_scroll_offsets
-                .get(&memory_info.host_id)
-                .copied()
-                .unwrap_or(0);
-            print_memory_info(buffer, i, memory_info, width, hostname_scroll_offset, false);
+        // Host RAM used/total is already in the summary. Swap pressure is
+        // separate information and appears only when swap exists.
+        for memory_info in &snapshot.memory_info {
+            print_memory_details(buffer, memory_info, width);
         }
 
         // Storage information for local mode
@@ -1317,6 +1315,27 @@ mod tests {
             content.contains("h:Help"),
             "the status bar must render on a resolved zero-size pty"
         );
+    }
+
+    #[test]
+    fn local_frame_assigns_live_values_to_the_summary_only() {
+        let snapshot = make_populated_snapshot();
+        let args = make_local_args();
+        let (content, _) = FrameRenderer::render_main(&snapshot, &args, 120, 40, None);
+
+        // Inventory rows remain, but the former NODE/GPU/CPU/Memory live
+        // fields and duplicate gauges do not compete with the summary and
+        // Activity panel anymore.
+        assert!(
+            content.contains("Cores "),
+            "hardware details missing: {content}"
+        );
+        for repeated in [" Util:", " VRAM:", "Host Memory", " Pwr:"] {
+            assert!(
+                !content.contains(repeated),
+                "duplicate local metric {repeated:?} remained: {content}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Prevent narrow terminal output from auto-wrapping ANSI-styled metric rows into neighboring sections.
- Separate the local view into a live summary, trend panels, and unique hardware details so CPU, GPU, memory, temperature, and power values are not repeated.
- Adapt the local header from sparklines to values and compact intentional rows as width decreases while preserving the existing remote CPU, GPU, memory, and storage gauges.
- Clamp every differential-renderer line to the terminal's visible width as a final layout safety boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `cargo test --bin all-smi`
- Manual local rendering check in a 100-column PTY

## Risk

The presentation hierarchy changes only for local mode. Remote device renderers and their bar graphs remain unchanged; the shared output clamp only prevents content beyond the current terminal width from triggering physical line wraps.
