### PR TITLE
fix: validate remote host lists before startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ sudo all-smi local
 
 # Remote monitoring (requires API endpoints)
 all-smi view --hosts http://node1:9090 http://node2:9090
+all-smi view --hosts http://node1:9090,http://node2:9090
 all-smi view --hostfile hosts.csv
 
 # API mode (expose metrics server)
@@ -163,12 +164,13 @@ The `view` mode monitors multiple remote systems that are running in API mode. T
 ```bash
 # Direct host specification (required)
 all-smi view --hosts http://gpu-node1:9090 http://gpu-node2:9090
+all-smi view --hosts http://gpu-node1:9090,http://gpu-node2:9090
 
 # Using host file (required)
 all-smi view --hostfile hosts.csv --interval 2
 ```
 
-**Note:** The `view` command requires either `--hosts` or `--hostfile`. For local monitoring, use `all-smi local` instead.
+**Note:** The `view` command requires either `--hosts` or `--hostfile`. `--hosts` accepts endpoints separated by spaces, commas, or a mixture of both; explicit `http://` and `https://` schemes are preserved. Invalid endpoint syntax is reported before the TUI starts. For local monitoring, use `all-smi local` instead.
 
 Host file format (CSV):
 ```
@@ -1348,7 +1350,7 @@ all-smi record --output trace.ndjson.zst --max-size 100M --max-files 10
 
 # Record remote cluster scrapes (same HTTP path as `view`).
 all-smi record --source remote \
-  --hosts http://gpu-node1:9090 http://gpu-node2:9090 \
+  --hosts http://gpu-node1:9090,http://gpu-node2:9090 \
   --output cluster.ndjson.gz --compress gzip --duration 1h
 
 # Replay a captured file — identical TUI to the live view.
@@ -1385,7 +1387,7 @@ operator can filter the visible GPUs mid-playback.
 | `--interval` / `-i` | `3`                             | Seconds between frames.                          |
 | `--duration`      | `0` (= record until SIGTERM)      | Accepts `30s`, `5m`, `1h`, `1d`, or bare seconds. |
 | `--source`        | `local`                           | `local` (hardware readers) or `remote` (HTTP scrape). |
-| `--hosts` / `--hostfile` | (none)                     | Required when `--source=remote`.                 |
+| `--hosts` / `--hostfile` | (none)                     | Required when `--source=remote`; `--hosts` accepts space-separated, comma-separated, or mixed endpoints. |
 | `--include`       | `gpu,cpu,memory,chassis`          | Comma-separated sections (plus `process`).       |
 | `--max-size`      | `100M`                            | Rotation threshold per segment (`1K`, `10M`, `2G`). `0` disables rotation. |
 | `--max-files`     | `10`                              | Max segments on disk (active + rotated).         |

--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -90,7 +90,7 @@ Default: 1 second (Apple Silicon) or 2 seconds (others)
 .SS View Mode Options (Remote Monitoring)
 .TP
 .B \-\-hosts \fIURL\fR...
-(Required) A list of host addresses to connect to for remote monitoring. Multiple hosts can be specified.
+(Required) A list of host addresses to connect to for remote monitoring. Separate endpoints with spaces, commas, or a mixture of both. Explicit HTTP and HTTPS schemes are preserved, and invalid endpoint syntax is rejected before the terminal interface starts.
 Format: http://hostname:port or https://hostname:port
 .TP
 .B \-\-hostfile \fIFILE\fR
@@ -573,6 +573,12 @@ Monitor local hardware with custom interval:
 .TP
 Monitor remote hosts (requires API endpoints):
 .B all-smi view --hosts http://node1:9090 http://node2:9090
+.TP
+Monitor remote hosts with comma-separated endpoints:
+.B all-smi view --hosts http://node1:9090,http://node2:9090
+.TP
+Record remote hosts (the same space/comma separator rules apply):
+.B all-smi record --source=remote --hosts http://node1:9090,http://node2:9090 --output cluster.ndjson.zst
 .TP
 Monitor hosts from file:
 .B all-smi view --hostfile cluster_hosts.csv

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -167,7 +167,11 @@ pub struct LocalArgs {
 
 #[derive(Parser, Clone)]
 pub struct ViewArgs {
-    /// A list of host addresses to connect to for remote monitoring.
+    /// Remote HTTP endpoints separated by spaces and/or commas.
+    ///
+    /// Examples: `--hosts node-a:9090 node-b:9090`,
+    /// `--hosts node-a:9090,node-b:9090`, or a mixture of both forms.
+    /// Explicit `http://` and `https://` schemes are preserved.
     #[arg(long, num_args = 1..)]
     pub hosts: Option<Vec<String>>,
     /// A file containing a list of host addresses to connect to for remote monitoring.
@@ -498,7 +502,8 @@ pub struct RecordArgs {
     #[arg(long, value_enum, default_value_t = RecordSource::Local)]
     pub source: RecordSource,
 
-    /// Remote hosts to scrape when `--source=remote`.
+    /// Remote HTTP endpoints separated by spaces and/or commas when
+    /// `--source=remote`. Explicit HTTP and HTTPS schemes are preserved.
     #[arg(long, num_args = 1..)]
     pub hosts: Option<Vec<String>>,
 
@@ -851,6 +856,22 @@ mod tests {
                 "help" => {}
                 other => assert!(!hidden, "`service {other}` must stay visible in --help"),
             }
+        }
+    }
+
+    #[test]
+    fn remote_host_help_documents_space_and_comma_separators() {
+        let mut command = build_command_with_runtime_help();
+        for subcommand in ["view", "record"] {
+            let help = command
+                .find_subcommand_mut(subcommand)
+                .expect("remote-capable subcommand must exist")
+                .render_long_help()
+                .to_string();
+            assert!(
+                help.contains("spaces and/or commas"),
+                "{subcommand} help must document both host separators:\n{help}"
+            );
         }
     }
 

--- a/src/common/config_env.rs
+++ b/src/common/config_env.rs
@@ -91,11 +91,7 @@ fn apply_env_view(settings: &mut Settings) {
     if let Ok(v) = env::var("ALL_SMI_VIEW_HOSTS")
         && !v.trim().is_empty()
     {
-        settings.view.hosts = v
-            .split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect();
+        settings.view.hosts = v.split(',').map(|s| s.trim().to_string()).collect();
     }
     if let Ok(v) = env::var("ALL_SMI_VIEW_INTERVAL_SECS")
         && let Ok(n) = v.parse::<u64>()

--- a/src/common/http_hosts.rs
+++ b/src/common/http_hosts.rs
@@ -1,0 +1,214 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use thiserror::Error;
+use url::Url;
+
+/// A syntactically invalid HTTP remote endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid remote host `{value}`: {reason}")]
+pub struct HttpHostError {
+    value: String,
+    reason: String,
+}
+
+impl HttpHostError {
+    fn new(value: &str, reason: impl Into<String>) -> Self {
+        Self {
+            value: if value.is_empty() {
+                "<empty>".to_string()
+            } else {
+                value.to_string()
+            },
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Split a host list on commas, trim each element, and validate every endpoint.
+///
+/// Whitespace-separated CLI values already arrive as separate vector elements,
+/// so applying comma splitting to each element supports whitespace, comma, and
+/// mixed invocations while preserving the operator's ordering and explicit
+/// scheme spelling.
+pub fn normalize_http_hosts(hosts: &[String]) -> Result<Vec<String>, HttpHostError> {
+    let mut normalized = Vec::new();
+
+    for raw in hosts {
+        for element in raw.split(',') {
+            let host = element.trim();
+            if host.is_empty() {
+                return Err(HttpHostError::new(
+                    raw.trim(),
+                    "host list contains an empty entry",
+                ));
+            }
+            parse_http_host_url(host)?;
+            normalized.push(host.to_string());
+        }
+    }
+
+    Ok(normalized)
+}
+
+/// Parse one endpoint without performing DNS lookup or any network I/O.
+pub(crate) fn parse_http_host_url(host: &str) -> Result<Url, HttpHostError> {
+    if let Some((prefix, _)) = host.split_once(':')
+        && matches!(prefix.to_ascii_lowercase().as_str(), "http" | "https")
+        && !host.contains("://")
+    {
+        return Err(HttpHostError::new(
+            host,
+            "malformed URL: HTTP and HTTPS schemes must be followed by `://`",
+        ));
+    }
+
+    let candidate = if let Some((scheme, remainder)) = host.split_once("://") {
+        if !matches!(scheme.to_ascii_lowercase().as_str(), "http" | "https") {
+            return Err(HttpHostError::new(
+                host,
+                format!("unsupported scheme `{scheme}`; expected http or https"),
+            ));
+        }
+        if remainder.is_empty() {
+            return Err(HttpHostError::new(host, "missing host"));
+        }
+        host.to_string()
+    } else {
+        format!("http://{host}")
+    };
+
+    let url = Url::parse(&candidate)
+        .map_err(|error| HttpHostError::new(host, format!("malformed URL: {error}")))?;
+
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(HttpHostError::new(
+            host,
+            format!(
+                "unsupported scheme `{}`; expected http or https",
+                url.scheme()
+            ),
+        ));
+    }
+    if url.host_str().is_none_or(str::is_empty) {
+        return Err(HttpHostError::new(host, "missing host"));
+    }
+    if url.port() == Some(0) {
+        return Err(HttpHostError::new(host, "port must be between 1 and 65535"));
+    }
+
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn accepts_whitespace_comma_and_mixed_lists_in_order() {
+        assert_eq!(
+            normalize_http_hosts(&strings(&["host-a:9090", "host-b:9090"])).unwrap(),
+            strings(&["host-a:9090", "host-b:9090"])
+        );
+        assert_eq!(
+            normalize_http_hosts(&strings(&["host-a:9090,host-b:9090"])).unwrap(),
+            strings(&["host-a:9090", "host-b:9090"])
+        );
+        assert_eq!(
+            normalize_http_hosts(&strings(&[
+                " host-a:9090, https://host-b:9443 ",
+                "http://[2001:db8::1]:9090"
+            ]))
+            .unwrap(),
+            strings(&[
+                "host-a:9090",
+                "https://host-b:9443",
+                "http://[2001:db8::1]:9090"
+            ])
+        );
+    }
+
+    #[test]
+    fn rejects_empty_elements() {
+        for input in [
+            "",
+            ",host-a:9090",
+            "host-a:9090,,host-b:9090",
+            "host-a:9090,",
+        ] {
+            let error = normalize_http_hosts(&strings(&[input])).unwrap_err();
+            assert!(error.to_string().contains("empty entry"), "{error}");
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_port_and_names_the_value() {
+        let error = normalize_http_hosts(&strings(&["host-a:9090,host-b:not-a-port"]))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("host-b:not-a-port"), "{error}");
+        assert!(error.contains("invalid port"), "{error}");
+    }
+
+    #[test]
+    fn rejects_unsupported_scheme_missing_host_and_malformed_url() {
+        let unsupported = normalize_http_hosts(&strings(&["ftp://host-a:9090"]))
+            .unwrap_err()
+            .to_string();
+        assert!(unsupported.contains("ftp://host-a:9090"), "{unsupported}");
+        assert!(unsupported.contains("unsupported scheme"), "{unsupported}");
+
+        let missing = normalize_http_hosts(&strings(&["http://"]))
+            .unwrap_err()
+            .to_string();
+        assert!(missing.contains("http://"), "{missing}");
+        assert!(missing.contains("missing host"), "{missing}");
+
+        let malformed = normalize_http_hosts(&strings(&["http://[2001:db8::1"]))
+            .unwrap_err()
+            .to_string();
+        assert!(malformed.contains("http://[2001:db8::1"), "{malformed}");
+        assert!(malformed.contains("malformed URL"), "{malformed}");
+
+        let missing_slashes = normalize_http_hosts(&strings(&["https:/host-a:9090"]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            missing_slashes.contains("https:/host-a:9090"),
+            "{missing_slashes}"
+        );
+        assert!(
+            missing_slashes.contains("must be followed by `://`"),
+            "{missing_slashes}"
+        );
+    }
+
+    #[test]
+    fn preserves_https_and_accepts_unreachable_or_bracketed_ipv6_hosts() {
+        let hosts = normalize_http_hosts(&strings(&[
+            "https://does-not-exist.invalid:9443",
+            "[2001:db8::2]:9090",
+        ]))
+        .unwrap();
+        assert_eq!(
+            hosts,
+            strings(&["https://does-not-exist.invalid:9443", "[2001:db8::2]:9090"])
+        );
+        assert_eq!(parse_http_host_url(&hosts[0]).unwrap().scheme(), "https");
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -25,6 +25,8 @@ pub mod config_file;
 pub mod config_schema;
 pub mod error_handling;
 #[cfg(feature = "cli")]
+pub mod http_hosts;
+#[cfg(feature = "cli")]
 pub mod paths;
 #[cfg(feature = "cli")]
 pub mod progress_bar;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,9 @@ pub mod common {
     /// On-disk schema types for the TOML configuration file.
     #[cfg(feature = "cli")]
     pub mod config_schema;
+    /// HTTP remote-host list normalization and syntax validation.
+    #[cfg(feature = "cli")]
+    pub mod http_hosts;
     /// Platform-aware configuration path resolution.
     #[cfg(feature = "cli")]
     pub mod paths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,6 +603,21 @@ async fn run_command(cli: Cli, settings: Settings) {
                     std::process::exit(1);
                 }
             }
+
+            // Normalize and validate the fully-resolved inline host list only
+            // after CLI/config/environment/auto-discovery precedence has been
+            // applied, but before the view runner initializes the terminal.
+            // This check is syntax-only: DNS and endpoint reachability remain
+            // the background collector's responsibility.
+            if let Some(hosts) = args.hosts.as_ref() {
+                match common::http_hosts::normalize_http_hosts(hosts) {
+                    Ok(normalized) => args.hosts = Some(normalized),
+                    Err(error) => {
+                        eprintln!("error: {error}");
+                        std::process::exit(2);
+                    }
+                }
+            }
             view::run_view_mode(&args, &settings).await;
 
             // Cleanup after view mode exits

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -22,7 +22,6 @@ use std::time::{Duration, Instant};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use regex::Regex;
 use tokio::sync::RwLock;
-use url::Url;
 
 use crate::app_state::ConnectionStatus;
 use crate::common::config::{AppConfig, EnvConfig};
@@ -134,21 +133,10 @@ impl NetworkClient {
 
     /// Validate and build a secure URL from the host string
     fn validate_and_build_url(host: &str) -> Result<String, String> {
-        // Prevent SSRF attacks by validating the host
-        let base_url = if host.starts_with("http://") || host.starts_with("https://") {
-            host.to_string()
-        } else {
-            format!("http://{host}")
-        };
-
-        // Parse and validate URL
-        let mut url = Url::parse(&base_url).map_err(|e| format!("Invalid URL format: {e}"))?;
-
-        // Check for suspicious schemes
-        match url.scheme() {
-            "http" | "https" => {}
-            scheme => return Err(format!("Invalid scheme: {scheme}. Only http/https allowed")),
-        }
+        // Use the same syntax contract as startup validation so collector
+        // retries cannot reinterpret an endpoint that was accepted earlier.
+        let mut url = crate::common::http_hosts::parse_http_host_url(host)
+            .map_err(|error| error.to_string())?;
 
         // Validate host is not localhost or private IP (unless explicitly allowed)
         if let Some(host_str) = url.host_str() {
@@ -188,15 +176,6 @@ impl NetworkClient {
                     }
                 }
             }
-
-            // Check port is in reasonable range (port 0 is invalid)
-            if let Some(port) = url.port()
-                && port == 0
-            {
-                return Err(format!("Invalid port number: {port}"));
-            }
-        } else {
-            return Err("Missing host in URL".to_string());
         }
 
         // Set the path to /metrics

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -122,7 +122,12 @@ impl RecorderOptions {
             bail!("--max-files must be >= 1");
         }
 
-        let hosts: Vec<String> = args.hosts.clone().unwrap_or_default();
+        let raw_hosts: Vec<String> = args.hosts.clone().unwrap_or_default();
+        let hosts = if args.source == RecordSource::Remote {
+            crate::common::http_hosts::normalize_http_hosts(&raw_hosts)?
+        } else {
+            raw_hosts
+        };
         if args.source == RecordSource::Remote && hosts.is_empty() && args.hostfile.is_none() {
             bail!("--source=remote requires --hosts or --hostfile");
         }
@@ -581,6 +586,22 @@ mod tests {
             max_files: 10,
             compress: None,
         }
+    }
+
+    #[test]
+    fn remote_record_normalizes_mixed_host_separators() {
+        let mut args = record_args(Some(PathBuf::from("cluster.ndjson")));
+        args.source = RecordSource::Remote;
+        args.hosts = Some(vec![
+            "host-a:9090, https://host-b:9443".to_string(),
+            "[2001:db8::1]:9090".to_string(),
+        ]);
+
+        let opts = RecorderOptions::from_args(&args).unwrap();
+        assert_eq!(
+            opts.hosts,
+            vec!["host-a:9090", "https://host-b:9443", "[2001:db8::1]:9090"]
+        );
     }
 
     /// No `-o`, no config: the default basename should resolve to the

--- a/src/view/data_collection/remote_collector.rs
+++ b/src/view/data_collection/remote_collector.rs
@@ -366,24 +366,12 @@ impl RemoteCollectorBuilder {
                     return None;
                 }
 
-                // Validate host format (basic validation)
-                let host = if let Some(stripped) = s.strip_prefix("http://") {
-                    stripped.to_string()
-                } else if let Some(stripped) = s.strip_prefix("https://") {
-                    stripped.to_string()
-                } else {
-                    s.to_string()
-                };
-
-                // Basic validation: must contain valid characters
-                if host
-                    .chars()
-                    .all(|c| c.is_ascii() && (c.is_alphanumeric() || ".-:_".contains(c)))
-                {
-                    Some(host)
-                } else {
-                    eprintln!("Warning: Invalid host format skipped: {s}");
-                    None
+                match crate::common::http_hosts::parse_http_host_url(s) {
+                    Ok(_) => Some(s.to_string()),
+                    Err(error) => {
+                        eprintln!("Warning: {error}; skipping hostfile entry");
+                        None
+                    }
                 }
             })
             .collect();

--- a/src/view/data_collector.rs
+++ b/src/view/data_collector.rs
@@ -211,23 +211,9 @@ impl DataCollector {
     pub async fn run_remote_mode(
         &self,
         args: ViewArgs,
-        mut hosts: Vec<String>,
+        hosts: Vec<String>,
         hostfile: Option<String>,
     ) {
-        // Strip protocol prefix from command line hosts
-        hosts = hosts
-            .into_iter()
-            .map(|host| {
-                if let Some(stripped) = host.strip_prefix("http://") {
-                    stripped.to_string()
-                } else if let Some(stripped) = host.strip_prefix("https://") {
-                    stripped.to_string()
-                } else {
-                    host
-                }
-            })
-            .collect();
-
         // Load hosts from file if specified
         let mut builder = RemoteCollectorBuilder::new().with_hosts(hosts.clone());
 
@@ -264,22 +250,9 @@ impl DataCollector {
                                 .filter(|s| !s.starts_with('#'))
                                 .take(MAX_HOSTS)
                                 .filter_map(|s| {
-                                    let host = if let Some(stripped) = s.strip_prefix("http://") {
-                                        stripped.to_string()
-                                    } else if let Some(stripped) = s.strip_prefix("https://") {
-                                        stripped.to_string()
-                                    } else {
-                                        s.to_string()
-                                    };
-
-                                    // Basic host validation
-                                    if host.chars().all(|c| {
-                                        c.is_ascii() && (c.is_alphanumeric() || ".-:_".contains(c))
-                                    }) {
-                                        Some(host)
-                                    } else {
-                                        None
-                                    }
+                                    crate::common::http_hosts::parse_http_host_url(s)
+                                        .ok()
+                                        .map(|_| s.to_string())
                                 })
                                 .collect();
                             hosts_vec.extend(file_hosts);

--- a/tests/remote_hosts_cli_test.rs
+++ b/tests/remote_hosts_cli_test.rs
@@ -34,6 +34,14 @@ fn run_all_smi(home: &Path, args: &[&str]) -> Output {
         .expect("run all-smi")
 }
 
+fn entered_alternate_screen(output: &Output) -> bool {
+    const ENTER_ALTERNATE_SCREEN: &[u8] = b"\x1b[?1049h";
+    output
+        .stdout
+        .windows(ENTER_ALTERNATE_SCREEN.len())
+        .any(|bytes| bytes == ENTER_ALTERNATE_SCREEN)
+}
+
 #[test]
 fn view_rejects_invalid_host_before_entering_the_tui() {
     let home = tempfile::tempdir().expect("create isolated home");
@@ -47,7 +55,7 @@ fn view_rejects_invalid_host_before_entering_the_tui() {
     assert!(stderr.contains("host-b:not-a-port"), "{stderr}");
     assert!(stderr.contains("invalid port"), "{stderr}");
     assert!(
-        !output.stdout.windows(6).any(|bytes| bytes == b"\x1b[?1049"),
+        !entered_alternate_screen(&output),
         "invalid host must be rejected before alternate-screen output"
     );
 }
@@ -64,12 +72,7 @@ fn view_validates_config_and_environment_hosts_before_entering_the_tui() {
     assert!(!from_config.status.success());
     assert!(config_stderr.contains("http://"), "{config_stderr}");
     assert!(config_stderr.contains("missing host"), "{config_stderr}");
-    assert!(
-        !from_config
-            .stdout
-            .windows(6)
-            .any(|bytes| bytes == b"\x1b[?1049")
-    );
+    assert!(!entered_alternate_screen(&from_config));
 
     let from_env = all_smi_command(home.path())
         .env("ALL_SMI_VIEW_HOSTS", "host-a:9090,,https://host-b:9443")
@@ -79,12 +82,7 @@ fn view_validates_config_and_environment_hosts_before_entering_the_tui() {
     let env_stderr = String::from_utf8_lossy(&from_env.stderr);
     assert!(!from_env.status.success());
     assert!(env_stderr.contains("empty entry"), "{env_stderr}");
-    assert!(
-        !from_env
-            .stdout
-            .windows(6)
-            .any(|bytes| bytes == b"\x1b[?1049")
-    );
+    assert!(!entered_alternate_screen(&from_env));
 }
 
 #[test]

--- a/tests/remote_hosts_cli_test.rs
+++ b/tests/remote_hosts_cli_test.rs
@@ -1,0 +1,115 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use all_smi::utils::command::new_command;
+
+fn all_smi_command(home: &Path) -> Command {
+    let mut command = new_command(env!("CARGO_BIN_EXE_all-smi"));
+    command
+        .env("HOME", home)
+        .env("XDG_CACHE_HOME", home.join("cache"))
+        .env("XDG_CONFIG_HOME", home.join("config"))
+        .env_remove("ALL_SMI_VIEW_HOSTS");
+    command
+}
+
+fn run_all_smi(home: &Path, args: &[&str]) -> Output {
+    all_smi_command(home)
+        .args(args)
+        .output()
+        .expect("run all-smi")
+}
+
+#[test]
+fn view_rejects_invalid_host_before_entering_the_tui() {
+    let home = tempfile::tempdir().expect("create isolated home");
+    let output = run_all_smi(
+        home.path(),
+        &["view", "--hosts", "host-a:9090,host-b:not-a-port"],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("host-b:not-a-port"), "{stderr}");
+    assert!(stderr.contains("invalid port"), "{stderr}");
+    assert!(
+        !output.stdout.windows(6).any(|bytes| bytes == b"\x1b[?1049"),
+        "invalid host must be rejected before alternate-screen output"
+    );
+}
+
+#[test]
+fn view_validates_config_and_environment_hosts_before_entering_the_tui() {
+    let home = tempfile::tempdir().expect("create isolated home");
+    let config = home.path().join("config.toml");
+    std::fs::write(&config, "[view]\nhosts = [\"host-a:9090\", \"http://\"]\n")
+        .expect("write config");
+    let config_arg = config.to_string_lossy().into_owned();
+    let from_config = run_all_smi(home.path(), &["--config", &config_arg, "view"]);
+    let config_stderr = String::from_utf8_lossy(&from_config.stderr);
+    assert!(!from_config.status.success());
+    assert!(config_stderr.contains("http://"), "{config_stderr}");
+    assert!(config_stderr.contains("missing host"), "{config_stderr}");
+    assert!(
+        !from_config
+            .stdout
+            .windows(6)
+            .any(|bytes| bytes == b"\x1b[?1049")
+    );
+
+    let from_env = all_smi_command(home.path())
+        .env("ALL_SMI_VIEW_HOSTS", "host-a:9090,,https://host-b:9443")
+        .arg("view")
+        .output()
+        .expect("run all-smi with environment hosts");
+    let env_stderr = String::from_utf8_lossy(&from_env.stderr);
+    assert!(!from_env.status.success());
+    assert!(env_stderr.contains("empty entry"), "{env_stderr}");
+    assert!(
+        !from_env
+            .stdout
+            .windows(6)
+            .any(|bytes| bytes == b"\x1b[?1049")
+    );
+}
+
+#[test]
+fn remote_record_rejects_invalid_host_before_creating_output() {
+    let home = tempfile::tempdir().expect("create isolated home");
+    let recording = home.path().join("must-not-exist.ndjson");
+    let recording_arg = recording.to_string_lossy().into_owned();
+    let output = run_all_smi(
+        home.path(),
+        &[
+            "record",
+            "--source=remote",
+            "--hosts",
+            "host-a:9090,ftp://host-b:9090",
+            "--output",
+            &recording_arg,
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("ftp://host-b:9090"), "{stderr}");
+    assert!(stderr.contains("unsupported scheme"), "{stderr}");
+    assert!(
+        !recording.exists(),
+        "invalid host must be rejected before output creation"
+    );
+}


### PR DESCRIPTION
## Summary

- Accept space-separated, comma-separated, and mixed remote HTTP host lists while preserving input order and explicit HTTP or HTTPS schemes.
- Reject malformed endpoints before the view TUI or remote recorder output initializes, while leaving reachability checks to the normal collector path.
- Document the accepted syntax in CLI help, README examples, and the manpage.

## Test plan

- [x] `cargo test --lib common::http_hosts::tests`
- [x] `cargo test --lib cli::tests::remote_host_help_documents_space_and_comma_separators`
- [x] `cargo test --bin all-smi record::tests::remote_record_normalizes_mixed_host_separators`
- [x] `cargo test --test remote_hosts_cli_test`
- [x] `cargo clippy --bin all-smi --test remote_hosts_cli_test -- -D warnings`
- [x] `cargo fmt --check`

Closes #404
