### PR TITLE
docs(cli): remove implementation churn from user-facing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The canonical schema carries `schema_version = 1` at the top level and nine sect
 |-----|------|---------|---------|-------------|
 | `default_mode` | string | `"local"` | `ALL_SMI_GENERAL_DEFAULT_MODE` | Which subcommand runs when none is specified: `"local"`, `"view"`, or `"api"`. |
 | `theme` | string | `"auto"` | `ALL_SMI_GENERAL_THEME` | TUI colour theme: `"auto"`, `"light"`, `"dark"`, `"high-contrast"`, `"mono"`. |
-| `locale` | string | `"en"` | `ALL_SMI_GENERAL_LOCALE` | Display locale (reserved for future i18n). |
+| `locale` | string | `"en"` | `ALL_SMI_GENERAL_LOCALE` | Display locale setting. It is accepted but currently has no effect; output remains in English. |
 
 **`[local]`** — options for `all-smi local`
 
@@ -266,7 +266,7 @@ The canonical schema carries `schema_version = 1` at the top level and nine sect
 | `price_per_kwh` | float | `0.12` | `ALL_SMI_ENERGY_PRICE_PER_KWH` | Electricity price in $/kWh for cost estimation. |
 | `currency` | string | `"USD"` | `ALL_SMI_ENERGY_CURRENCY` | Currency symbol shown in the TUI. |
 | `show_cost` | bool | `true` | `ALL_SMI_ENERGY_SHOW_COST` | Toggle cost column in the TUI. |
-| `wal_path` | string | platform cache dir + `all-smi/energy-wal.bin` [^cache] | `ALL_SMI_ENERGY_WAL_PATH` | Path to the energy write-ahead log for persistent kWh accumulation. Operator override is resolved with `~` expansion; unset uses the platform cache helper (#229). |
+| `wal_path` | string | platform cache dir + `all-smi/energy-wal.bin` [^cache] | `ALL_SMI_ENERGY_WAL_PATH` | Path to the energy write-ahead log for persistent kWh accumulation. Operator overrides support `~` expansion; when unset, the platform cache directory is used. |
 | `gap_interpolate_seconds` | integer | `10` | `ALL_SMI_ENERGY_GAP_INTERPOLATE_SECONDS` | Max gap (1–3600 s) to interpolate across when the WAL has a hole. |
 | `wal_enabled` | bool | `true` | `ALL_SMI_ENERGY_WAL_ENABLED` | Enable the WAL. Disable in read-only container environments. |
 
@@ -282,9 +282,9 @@ The canonical schema carries `schema_version = 1` at the top level and nine sect
 
 | Key | Type | Default | Env var | Description |
 |-----|------|---------|---------|-------------|
-| `output_dir` | string | platform cache dir + `all-smi/records` [^cache] | `ALL_SMI_RECORD_OUTPUT_DIR` | Directory where recording segments are written. Operator override is resolved with `~` expansion; unset uses the platform cache helper (#229). |
+| `output_dir` | string | platform cache dir + `all-smi/records` [^cache] | `ALL_SMI_RECORD_OUTPUT_DIR` | Directory where recording segments are written. Operator overrides support `~` expansion; when unset, the platform cache directory is used. |
 
-[^cache]: The platform cache directory is `$XDG_CACHE_HOME` (or `~/.cache`) on Linux, `~/Library/Caches` on macOS, and `%LOCALAPPDATA%` on Windows. All three cache consumers (record output, energy WAL, users-CSV export) go through `dirs::cache_dir()` so the layout is consistent across platforms.
+[^cache]: The platform cache directory is `$XDG_CACHE_HOME` (or `~/.cache`) on Linux, `~/Library/Caches` on macOS, and `%LOCALAPPDATA%` on Windows. Record output, the energy WAL, and users-CSV exports use this location consistently when no explicit path is configured.
 | `compress` | string | `"zstd"` | `ALL_SMI_RECORD_COMPRESS` | Compression codec: `"zstd"`, `"gzip"`, or `"none"`. |
 
 **`[snapshot]`** — defaults for `all-smi snapshot`
@@ -1025,8 +1025,10 @@ message without committing.
 
 **Threshold alerts**
 
-Alert thresholds live in the compiled defaults today (the config-file loader
-lands in a separate issue). Override them with CLI flags:
+Alert settings follow the standard precedence order: CLI flags, environment
+variables, the `[alerts]` section of the TOML config file, then built-in
+defaults. The CLI exposes direct overrides for warning temperature and idle
+duration:
 
 ```bash
 all-smi local --alert-temp 75 --alert-util-low-mins 10

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,7 @@ pub enum Commands {
     /// `snapshot` subcommand (same serializer). Subsequent `all-smi view
     /// --replay <file>` invocations reconstruct the exact TUI frames the
     /// operator would have seen live, making post-hoc incident investigation
-    /// possible without a Prometheus retention store. See issue #187.
+    /// possible without a Prometheus retention store.
     Record(RecordArgs),
     /// Run self-diagnosis checks and optionally produce a support bundle.
     ///
@@ -93,13 +93,13 @@ pub enum Commands {
     /// Intel GPU, Apple, Gaudi, TPU, Tenstorrent, Rebellions, Furiosa,
     /// Windows), the relevant environment variables, and optional remote
     /// endpoint connectivity. Every check is read-only and bounded by a
-    /// hard 3-second timeout. See issue #188.
+    /// hard 3-second timeout.
     Doctor(DoctorArgs),
-    /// Inspect, initialise, or validate the TOML configuration file
-    /// (issue #192). See `all-smi config --help` for subcommands.
+    /// Inspect, initialise, or validate the TOML configuration file.
+    /// See `all-smi config --help` for subcommands.
     Config(ConfigArgs),
     /// Install and control `all-smi api` as a supervised background
-    /// service (issue #309).
+    /// service.
     ///
     /// On Linux and macOS, the system scope requires root and registers
     /// the service machine-wide; `--user` installs a per-user service
@@ -133,11 +133,8 @@ pub struct ApiArgs {
     /// Use `--processes` or `--processes=true` to force-enable,
     /// `--processes=false` to force-disable. When omitted, value is
     /// taken from the config file or the `ALL_SMI_API_PROCESSES` env
-    /// var. Modelled as `Option<bool>` (not `bool`) so the CLI can
-    /// express the third state "no explicit override" — without this
-    /// an operator could not turn the flag OFF from the CLI when the
-    /// config file already set `processes = true`, since a bare
-    /// `--processes` flag has no natural "disable" spelling.
+    /// var. An explicit CLI value overrides either source, including
+    /// turning off a value enabled by the config file.
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub processes: Option<bool>,
     /// Unix domain socket path for local IPC (Unix only).
@@ -196,7 +193,7 @@ pub struct ViewArgs {
     /// Accepts `.ndjson`, `.ndjson.zst`, `.ndjson.gz` — compression is
     /// auto-detected from the file extension. In replay mode `--hosts`
     /// and `--hostfile` are ignored; tabs and GPUs come entirely from the
-    /// recorded frames. See issue #187.
+    /// recorded frames.
     #[arg(long)]
     pub replay: Option<PathBuf>,
     /// Playback speed multiplier for `--replay`. Valid discrete values:
@@ -210,8 +207,7 @@ pub struct ViewArgs {
     #[arg(long)]
     pub start: Option<String>,
     /// Loop playback: when the last frame is reached, jump back to the
-    /// first frame and continue. Renamed from `loop` to avoid the Rust
-    /// keyword; the CLI surface remains `--loop`.
+    /// first frame and continue.
     #[arg(long = "loop")]
     pub replay_loop: bool,
 
@@ -235,8 +231,9 @@ pub struct ViewArgs {
     #[arg(long = "ssh-key")]
     pub ssh_key: Option<PathBuf>,
 
-    /// OpenSSH config file (`~/.ssh/config`). Currently unused but
-    /// reserved so the flag is stable across versions.
+    /// OpenSSH config file path. This option is accepted for compatibility
+    /// but currently has no effect; connection settings are taken from the
+    /// other SSH flags.
     #[arg(long = "ssh-config")]
     pub ssh_config: Option<PathBuf>,
 
@@ -245,8 +242,8 @@ pub struct ViewArgs {
     #[arg(long = "ssh-strict-host-key", default_value = "yes")]
     pub ssh_strict_host_key: String,
 
-    /// Per-target SSH connect timeout in seconds. Exec timeouts are
-    /// bounded separately by [`crate::network::ssh_client::DEFAULT_EXEC_TIMEOUT`].
+    /// Per-target SSH connect timeout in seconds. Remote commands have a
+    /// separate fixed 15-second execution timeout.
     #[arg(long = "ssh-timeout-secs", default_value_t = 10)]
     pub ssh_timeout_secs: u64,
 
@@ -372,8 +369,7 @@ pub struct SnapshotArgs {
     /// path already exists as a symlink. The write is atomic: output first
     /// goes to a sibling `<path>.tmp` file, is fsynced, then renamed over
     /// the destination. On Windows the file is opened with exclusive
-    /// sharing; symlink-based TOCTOU has different mitigations on that
-    /// platform which are out of scope for this flag.
+    /// sharing to prevent concurrent access while it is written.
     #[arg(long, short)]
     pub output: Option<String>,
 }
@@ -518,8 +514,8 @@ pub struct RecordArgs {
 
     /// Rotation threshold for the active segment. Accepts a size in bytes
     /// (`1048576`) or with suffix (`1K`, `10M`, `2G`). `0` disables
-    /// rotation. Matches the issue spec: `--max-size 1K --max-files 3`
-    /// caps total on-disk footprint to three segments.
+    /// rotation. For example, `--max-size 1K --max-files 3` caps the
+    /// retained stream to three segments of at most 1 KiB each.
     #[arg(long, default_value = "100M")]
     pub max_size: String,
 
@@ -559,15 +555,12 @@ impl RecordArgs {
     }
 }
 
-/// Arguments for the `doctor` subcommand (issue #188).
-///
-/// The flag surface intentionally mirrors the issue spec so scripts and
-/// support templates can depend on stable names across versions.
+/// Arguments for the `doctor` subcommand.
 #[derive(Parser, Clone, Debug)]
 pub struct DoctorArgs {
     /// Emit a machine-readable JSON report instead of the human-readable
     /// text output. The JSON schema is versioned via a top-level `schema`
-    /// field; see `src/doctor/report.rs` for the current version.
+    /// field so consumers can detect incompatible changes.
     #[arg(long)]
     pub json: bool,
 

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -52,7 +52,7 @@ pub enum ConfigAction {
     Validate(ConfigValidateArgs),
     /// Print the active config-file path and the candidate search
     /// order. Read-only — performs no file writes. Pass `--json` for
-    /// scripts. (Issue #213.)
+    /// scripts.
     Path(ConfigPathArgs),
 }
 

--- a/src/cli_service.rs
+++ b/src/cli_service.rs
@@ -65,7 +65,7 @@ pub enum ServiceAction {
     /// but stopped or not installed at all, mirroring the `systemctl
     /// is-active` convention.
     Status(ServiceStatusArgs),
-    /// Service Control Manager entry point (Windows only, issue #311).
+    /// Run as the registered Windows service process.
     ///
     /// Hidden from `--help`: this is not something an operator runs. The
     /// Windows SCM starts the registered binary with these arguments and
@@ -74,9 +74,7 @@ pub enum ServiceAction {
     /// explanation rather than starting a server, because there is no
     /// dispatcher to connect to. Use `all-smi api` for that.
     ///
-    /// The variant exists on every platform so the argument surface does
-    /// not change shape per target; non-Windows builds answer with the
-    /// standard "not supported" error.
+    /// Non-Windows builds exit with a clear "not supported" error.
     #[command(hide = true)]
     Run(ServiceRunArgs),
 }

--- a/src/doctor/checks/amd.rs
+++ b/src/doctor/checks/amd.rs
@@ -359,8 +359,8 @@ fn check_adl_per_adapter(_ctx: &CheckCtx) -> CheckResult {
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn per_card_verdict(per_card_first: &[Option<String>], card_count: usize) -> String {
     if card_count < 2 {
-        return "1 physical card, so per-card differentiation is unobservable on this host \
-                (issue #370 tracks confirming it on a two-card host)"
+        return "1 physical card, so per-card differentiation is unobservable on this host; \
+                at least 2 physical cards must answer to verify distinct per-card telemetry"
             .to_string();
     }
     let seen: Vec<&String> = per_card_first.iter().flatten().collect();
@@ -631,6 +631,14 @@ mod tests {
         assert!(
             !verdict.contains("IDENTICAL") && !verdict.contains("DISTINCT"),
             "single-card verdict must claim neither outcome, got: {verdict}"
+        );
+        assert!(
+            verdict.contains("at least 2 physical cards"),
+            "single-card verdict must explain how to verify differentiation, got: {verdict}"
+        );
+        assert!(
+            !verdict.to_ascii_lowercase().contains("issue") && !verdict.contains('#'),
+            "single-card verdict must not depend on an internal tracker reference, got: {verdict}"
         );
     }
 

--- a/tests/user_facing_text_test.rs
+++ b/tests/user_facing_text_test.rs
@@ -1,0 +1,130 @@
+// Copyright 2025 Lablup Inc. and Jeongkyu Shin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use all_smi::cli::build_command_with_runtime_help;
+use clap::Command;
+use regex::Regex;
+
+const IMPLEMENTATION_PHRASES: &[(&str, &str)] = &[
+    ("Rust optional type", "option<bool>"),
+    ("Rust module path", "crate::"),
+    ("source-tree path", "src/"),
+    ("Rust keyword rationale", "rust keyword"),
+    ("review-scope wording", "out of scope"),
+    ("implementation specification", "issue spec"),
+    ("tracker-status wording", "tracked separately"),
+    ("internal cache helper", "dirs::cache_dir"),
+];
+
+fn tracker_reference() -> Regex {
+    Regex::new(
+        r"(?i)\b(?:issue|pr|pull request)\s*#?\s*\d+\b|(?:^|[^[:alnum:]_/])#\d+\b|\bissue spec(?:ification)?\b",
+    )
+    .expect("tracker-reference regex must compile")
+}
+
+fn collect_help(command: &Command, path: &str, surfaces: &mut Vec<(String, String)>) {
+    let mut short = command.clone();
+    surfaces.push((format!("{path} -h"), short.render_help().to_string()));
+
+    let mut long = command.clone();
+    surfaces.push((
+        format!("{path} --help"),
+        long.render_long_help().to_string(),
+    ));
+
+    for subcommand in command.get_subcommands() {
+        collect_help(
+            subcommand,
+            &format!("{path} {}", subcommand.get_name()),
+            surfaces,
+        );
+    }
+}
+
+fn assert_surface_is_operator_facing(surface: &str, text: &str) {
+    let tracker = tracker_reference();
+    assert!(
+        tracker.find(text).is_none(),
+        "{surface} contains an internal tracker reference {:?}:\n{text}",
+        tracker.find(text).map(|found| found.as_str())
+    );
+
+    let lowercase = text.to_ascii_lowercase();
+    for (kind, phrase) in IMPLEMENTATION_PHRASES {
+        assert!(
+            !lowercase.contains(phrase),
+            "{surface} contains {kind} `{phrase}`:\n{text}"
+        );
+    }
+}
+
+fn installed_roff_text(manpage: &str) -> String {
+    manpage
+        .lines()
+        .filter(|line| !line.trim_start().starts_with(".\\\""))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn every_directly_addressable_help_page_is_operator_facing() {
+    let command = build_command_with_runtime_help();
+    let mut surfaces = Vec::new();
+    collect_help(&command, command.get_name(), &mut surfaces);
+
+    assert!(
+        surfaces
+            .iter()
+            .any(|(path, _)| path == "all-smi service run -h"),
+        "recursive help traversal must include the hidden `service run` command"
+    );
+
+    for (surface, text) in surfaces {
+        assert_surface_is_operator_facing(&surface, &text);
+    }
+}
+
+#[test]
+fn readme_operator_text_is_free_of_internal_churn() {
+    assert_surface_is_operator_facing("README.md", include_str!("../README.md"));
+}
+
+#[test]
+fn installed_manpage_is_free_of_internal_churn() {
+    let source = include_str!("../docs/man/all-smi.1");
+    let installed_text = installed_roff_text(source);
+
+    assert_surface_is_operator_facing("docs/man/all-smi.1", &installed_text);
+    assert!(
+        installed_text.contains("https://github.com/lablup/all-smi/issues"),
+        "docs/man/all-smi.1 must retain the official bug-report URL"
+    );
+}
+
+#[test]
+fn tracker_guard_ignores_normal_operator_prose_and_roff_comments() {
+    let ordinary = "## Configuration\nReport bugs at https://github.com/lablup/all-smi/issues.\nDependency issues are reported at startup.";
+    assert!(
+        tracker_reference().find(ordinary).is_none(),
+        "tracker guard must not match Markdown headings, the official issues URL, or ordinary prose"
+    );
+
+    let roff = ".\\\" Maintainer note for issue #123\n.SH BUGS\nReport bugs at: https://github.com/lablup/all-smi/issues";
+    let installed_text = installed_roff_text(roff);
+    assert!(
+        tracker_reference().find(&installed_text).is_none(),
+        "tracker guard must ignore roff comments that are absent from the installed manpage"
+    );
+}

--- a/tests/user_facing_text_test.rs
+++ b/tests/user_facing_text_test.rs
@@ -29,7 +29,7 @@ const IMPLEMENTATION_PHRASES: &[(&str, &str)] = &[
 
 fn tracker_reference() -> Regex {
     Regex::new(
-        r"(?i)\b(?:issue|pr|pull request)\s*#?\s*\d+\b|(?:^|[^[:alnum:]_/])#\d+\b|\bissue spec(?:ification)?\b",
+        r"(?i)\b(?:issue|pr|pull request)\s*#?\s*\d+\b|/(?:issues|pull)/\d+\b|(?:^|[^[:alnum:]_/])#\d+\b|\bissue spec(?:ification)?\b",
     )
     .expect("tracker-reference regex must compile")
 }
@@ -78,6 +78,13 @@ fn installed_roff_text(manpage: &str) -> String {
         .join("\n")
 }
 
+fn readme_operator_text(readme: &str) -> &str {
+    readme
+        .split_once("\n## Changelog\n")
+        .map(|(operator_text, _)| operator_text)
+        .expect("README.md must retain a distinct historical changelog section")
+}
+
 #[test]
 fn every_directly_addressable_help_page_is_operator_facing() {
     let command = build_command_with_runtime_help();
@@ -98,7 +105,10 @@ fn every_directly_addressable_help_page_is_operator_facing() {
 
 #[test]
 fn readme_operator_text_is_free_of_internal_churn() {
-    assert_surface_is_operator_facing("README.md", include_str!("../README.md"));
+    assert_surface_is_operator_facing(
+        "README.md operator guidance",
+        readme_operator_text(include_str!("../README.md")),
+    );
 }
 
 #[test]
@@ -127,4 +137,23 @@ fn tracker_guard_ignores_normal_operator_prose_and_roff_comments() {
         tracker_reference().find(&installed_text).is_none(),
         "tracker guard must ignore roff comments that are absent from the installed manpage"
     );
+
+    let readme = "# Tool\nOperator guidance.\n\n## Changelog\n\n- Fixed issue #123.";
+    assert_surface_is_operator_facing("README.md operator guidance", readme_operator_text(readme));
+}
+
+#[test]
+fn tracker_guard_rejects_numbered_references_in_text_and_urls() {
+    for reference in [
+        "issue #123",
+        "PR 456",
+        "pull request #789",
+        "https://github.com/lablup/all-smi/issues/123",
+        "https://github.com/lablup/all-smi/pull/456",
+    ] {
+        assert!(
+            tracker_reference().find(reference).is_some(),
+            "tracker guard must reject numbered reference `{reference}`"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Replace internal issue references and Rust/review terminology across the complete rendered CLI help tree with durable descriptions of command behavior, including the directly requested hidden `service run --help` surface.
- Make the AMD single-card diagnostic self-contained by explaining that at least two answering physical cards are required to verify per-card telemetry distinction.
- Correct README locale, cache-path, and alert-precedence guidance, and protect README plus the installed manpage from unexplained tracker or implementation references.
- Add a recursive regression test that renders short and long help for every visible and hidden Clap command while retaining intentional maintainer provenance outside user-facing surfaces.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --test user_facing_text_test`
- [x] `cargo test --lib cli::tests::`
- [x] `cargo test --lib doctor::checks::amd::tests::one_card_reports_the_question_as_unobservable`
- [x] `cargo clippy --lib --test user_facing_text_test -- -D warnings`

Closes #405
